### PR TITLE
chore: update .gitattributes and markdownlint configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,3 +26,6 @@
 *.so -text
 
 *.json text linguist-language=JSON-with-Comments
+
+.cursorrules text linguist-language=Markdown
+llms.txt text linguist-language=Markdown

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -6,4 +6,6 @@ config:
   MD041: false
 
 globs:
+  - '!.ai/**'
   - '!.cursorrules'
+  - '!.github/copilot-instructions.md'

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -2,6 +2,7 @@ import {defineConfig, type Config} from '@bfra.me/eslint-config'
 
 const config: ReturnType<typeof defineConfig> = defineConfig({
   name: '@fro-bot/.github',
+  ignores: ['.ai/', '.github/copilot-instructions.md'],
   packageJson: true,
   typescript: {
     tsconfigPath: './tsconfig.json',


### PR DESCRIPTION
- Add .cursorrules and llms.txt to .gitattributes for Markdown language
- Update markdownlint configuration to include .ai/** and .github/copilot-instructions.md
- Ensure ESLint ignores .ai/ and .github/copilot-instructions.md