### PR TITLE
docs: add fro-bot.png with Git LFS tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,26 @@
 </p>
 
 <p align="center">
-  Community health files for <a href="https://github.com/fro-bot">@fro-bot</a>
+  Community health files and automated control center for <a href="https://github.com/fro-bot">@fro-bot</a>
 </p>
 
 &nbsp;
+
+<p align="center">
+  <img alt="Fro Bot" src="https://raw.githubusercontent.com/fro-bot/.github/main/assets/fro-bot.png" height="100" />
+</p>
+
+## What is Fro Bot?
+
+Fro Bot is an AI-powered GitHub bot designed to enhance the repository management experience. It leverages advanced AI technologies to automate tasks, improve code quality, and streamline collaboration within select projects.
+
+This repository contains the configuration files and workflows that power Fro Bot's functionality across its managed repositories:
+
+- Review pull requests and provide feedback
+- Monitor repository activity and provide insights and recommendations
+- Keep documentation and links up to date
+- Automatically star repositories contributed to by followed users
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/assets/fro-bot.png
+++ b/assets/fro-bot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b4dcdce3faea182e2200261952070218d2da343bfcb78748ced54b82e818ecb
+size 1432541

--- a/package.json
+++ b/package.json
@@ -2,12 +2,14 @@
   "name": "@fro-bot/.github",
   "version": "0.0.0",
   "private": true,
-  "description": "Community health files for @fro-bot",
+  "description": "Community health files and automated control center for @fro-bot",
   "keywords": [
     "actions",
-    "renovate-config",
+    "ai",
+    "automation",
     "github-actions",
-    "fro-bot"
+    "fro-bot",
+    "renovate-config"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
- PNG files are now tracked with Git LFS via .gitattributes
- Adds the Fro Bot avatar image for use in README and documentation