### PR TITLE
fix: use media.githubusercontent.com URL for LFS-tracked PNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <h3 align="center">
+
   <img alt="transparent" src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/misc/transparent.png" height="30" width="0px"/>
   .github
   <img alt="transparent" src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/misc/transparent.png" height="30" width="0px"/>
@@ -14,10 +15,8 @@
   Community health files and automated control center for <a href="https://github.com/fro-bot">@fro-bot</a>
 </p>
 
-&nbsp;
-
 <p align="center">
-  <img alt="Fro Bot" src="https://raw.githubusercontent.com/fro-bot/.github/main/assets/fro-bot.png" height="100" />
+  <img alt="Fro Bot" src="https://media.githubusercontent.com/media/fro-bot/.github/main/assets/fro-bot.png" height="200" />
 </p>
 
 ## What is Fro Bot?


### PR DESCRIPTION
- Changes fro-bot.png URL from raw.githubusercontent.com to media.githubusercontent.com
- Fixes image display issue where LFS pointer was shown instead of actual PNG
- GitHub's media domain properly serves LFS file content