### PR TITLE
ci: update Renovate and update-repo-settings bfra-me/.github versions

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -60,7 +60,7 @@ jobs:
     secrets:
       APPLICATION_ID: ${{ secrets.APPLICATION_ID }}
       APPLICATION_PRIVATE_KEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
-    uses: bfra-me/.github/.github/workflows/renovate.yaml@b70c6593ca657b9cb109428c22e3541d66eb6edf # v4.0.9
+    uses: bfra-me/.github/.github/workflows/renovate.yaml@8e3bfd6117d9de4b0699327cae9e4da6d2887c3e # v4.2.0
     with:
       log-level: ${{ inputs.log-level || 'debug' }}
       print-config: ${{ inputs.print-config || false }}

--- a/.github/workflows/update-repo-settings.yaml
+++ b/.github/workflows/update-repo-settings.yaml
@@ -15,4 +15,4 @@ jobs:
     secrets:
       APPLICATION_ID: ${{ secrets.APPLICATION_ID }}
       APPLICATION_PRIVATE_KEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
-    uses: bfra-me/.github/.github/workflows/update-repo-settings.yaml@b70c6593ca657b9cb109428c22e3541d66eb6edf # v4.0.9
+    uses: bfra-me/.github/.github/workflows/update-repo-settings.yaml@8e3bfd6117d9de4b0699327cae9e4da6d2887c3e # v4.2.0


### PR DESCRIPTION
- Update Renovate workflow to use version v4.2.0
- Update update-repo-settings workflow to use version v4.2.0