### PR TITLE
chore: remove plan unit/phase references from implementation files

### DIFF
--- a/knowledge/schema.md
+++ b/knowledge/schema.md
@@ -81,6 +81,6 @@ Operations: `ingest`, `query`, `lint`, `manual-edit`.
 
 ## Maintenance
 
-- **Weekly lint** (Unit 17): scans for broken wikilinks, orphan pages, stale claims, missing cross-references, and knowledge gaps.
+- **Weekly lint**: scans for broken wikilinks, orphan pages, stale claims, missing cross-references, and knowledge gaps.
 - **Ingest validation**: every ingest operation validates output against this schema before committing.
 - **Index consistency**: `index.md` MUST list every page in `wiki/`. Orphan pages (in wiki but not index) are flagged by lint.

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -35,7 +35,7 @@ repos:
     has_renovate: boolean
 ```
 
-Update convention: invitation handler (Unit 7) and metadata workflow (Unit 16) update this file programmatically on the `data` branch.
+Update convention: invitation handler and metadata workflow update this file programmatically on the `data` branch.
 
 ### `renovate.yaml`
 
@@ -51,7 +51,7 @@ repos:
     last_dispatch_status: success | skipped-running | failure | null
 ```
 
-Update convention: metadata workflow (Unit 16) and Renovate dispatch (Unit 15) update this file programmatically on the `data` branch.
+Update convention: metadata workflow and Renovate dispatch update this file programmatically on the `data` branch.
 
 ### `social-cooldowns.yaml`
 
@@ -65,16 +65,16 @@ cooldowns:
     repo: optional scoping string
 ```
 
-Update convention: social broadcast workflow (Unit 14) updates this file programmatically on the `data` branch.
+Update convention: social broadcast workflow updates this file programmatically on the `data` branch.
 
 ## Credential expectations
 
 | File                    | Updated by                                       | Credential         |
 | ----------------------- | ------------------------------------------------ | ------------------ |
 | `allowlist.yaml`        | Human PR                                         | n/a (human commit) |
-| `repos.yaml`            | Invitation handler (U7), Metadata workflow (U16) | `FRO_BOT_PAT`      |
-| `renovate.yaml`         | Metadata workflow (U16), Renovate dispatch (U15) | `FRO_BOT_PAT`      |
-| `social-cooldowns.yaml` | Social broadcast (U14)                           | `FRO_BOT_PAT`      |
+| `repos.yaml`            | Invitation handler, Metadata workflow             | `FRO_BOT_PAT`      |
+| `renovate.yaml`         | Metadata workflow, Renovate dispatch              | `FRO_BOT_PAT`      |
+| `social-cooldowns.yaml` | Social broadcast                                 | `FRO_BOT_PAT`      |
 
 PAT split summary:
 
@@ -88,8 +88,8 @@ PAT split summary:
 | `fro-bot.yaml`          | `FRO_BOT_PAT`, `OPENCODE_AUTH_JSON`, `OMO_PROVIDERS`, `OPENCODE_CONFIG`    |
 | `fro-bot-autoheal.yaml` | Same 4 (via reusable call to `fro-bot.yaml`)                               |
 | `apply-branding.yaml`   | Same 4 (via reusable call to `fro-bot.yaml`)                               |
-| `poll-invitations.yaml` | `FRO_BOT_POLL_PAT` only (Phase 2 Unit 7)                                   |
-| `merge-data.yaml`       | `GITHUB_TOKEN` (auto-provisioned, job-scoped permissions) (Phase 2 Unit 5) |
+| `poll-invitations.yaml` | `FRO_BOT_POLL_PAT` only                                                    |
+| `merge-data.yaml`       | `GITHUB_TOKEN` (auto-provisioned, job-scoped permissions)                  |
 
 ## Commit conventions
 
@@ -99,4 +99,4 @@ PAT split summary:
 
 ## Metrics note
 
-`metrics.yaml` is intentionally not created in this phase. Active-phase operational telemetry is routed through the journal issue system in Unit 13. The metrics pipeline belongs to the deferred self-improvement plan.
+`metrics.yaml` is intentionally deferred. Operational telemetry is routed through the journal issue system. The metrics pipeline belongs to the deferred self-improvement plan.

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -69,12 +69,12 @@ Update convention: social broadcast workflow updates this file programmatically 
 
 ## Credential expectations
 
-| File                    | Updated by                                       | Credential         |
-| ----------------------- | ------------------------------------------------ | ------------------ |
-| `allowlist.yaml`        | Human PR                                         | n/a (human commit) |
-| `repos.yaml`            | Invitation handler, Metadata workflow             | `FRO_BOT_PAT`      |
-| `renovate.yaml`         | Metadata workflow, Renovate dispatch              | `FRO_BOT_PAT`      |
-| `social-cooldowns.yaml` | Social broadcast                                 | `FRO_BOT_PAT`      |
+| File                    | Updated by                            | Credential         |
+| ----------------------- | ------------------------------------- | ------------------ |
+| `allowlist.yaml`        | Human PR                              | n/a (human commit) |
+| `repos.yaml`            | Invitation handler, Metadata workflow | `FRO_BOT_PAT`      |
+| `renovate.yaml`         | Metadata workflow, Renovate dispatch  | `FRO_BOT_PAT`      |
+| `social-cooldowns.yaml` | Social broadcast                      | `FRO_BOT_PAT`      |
 
 PAT split summary:
 
@@ -83,13 +83,13 @@ PAT split summary:
 
 ### Workflow secret mapping
 
-| Workflow                | Secrets passed (explicit, not inherited)                                   |
-| ----------------------- | -------------------------------------------------------------------------- |
-| `fro-bot.yaml`          | `FRO_BOT_PAT`, `OPENCODE_AUTH_JSON`, `OMO_PROVIDERS`, `OPENCODE_CONFIG`    |
-| `fro-bot-autoheal.yaml` | Same 4 (via reusable call to `fro-bot.yaml`)                               |
-| `apply-branding.yaml`   | Same 4 (via reusable call to `fro-bot.yaml`)                               |
-| `poll-invitations.yaml` | `FRO_BOT_POLL_PAT` only                                                    |
-| `merge-data.yaml`       | `GITHUB_TOKEN` (auto-provisioned, job-scoped permissions)                  |
+| Workflow                | Secrets passed (explicit, not inherited)                                |
+| ----------------------- | ----------------------------------------------------------------------- |
+| `fro-bot.yaml`          | `FRO_BOT_PAT`, `OPENCODE_AUTH_JSON`, `OMO_PROVIDERS`, `OPENCODE_CONFIG` |
+| `fro-bot-autoheal.yaml` | Same 4 (via reusable call to `fro-bot.yaml`)                            |
+| `apply-branding.yaml`   | Same 4 (via reusable call to `fro-bot.yaml`)                            |
+| `poll-invitations.yaml` | `FRO_BOT_POLL_PAT` only                                                 |
+| `merge-data.yaml`       | `GITHUB_TOKEN` (auto-provisioned, job-scoped permissions)               |
 
 ## Commit conventions
 

--- a/metadata/renovate.yaml
+++ b/metadata/renovate.yaml
@@ -1,5 +1,5 @@
 # Repos where Fro Bot can dispatch Renovate via workflow_dispatch.
-# Updated by: metadata workflow (Unit 16), Renovate dispatch (Unit 15).
+# Updated by: metadata workflow and Renovate dispatch.
 version: 1
 repos: []
 # Schema for each repo entry:

--- a/metadata/repos.yaml
+++ b/metadata/repos.yaml
@@ -1,5 +1,5 @@
 # Collaborator repositories where Fro Bot is active.
-# Updated by: invitation handler (Unit 7), metadata workflow (Unit 16).
+# Updated by: invitation handler and metadata workflow.
 version: 1
 repos: []
 # Schema for each repo entry:

--- a/metadata/social-cooldowns.yaml
+++ b/metadata/social-cooldowns.yaml
@@ -1,5 +1,5 @@
 # Last broadcast timestamps per event type (and optionally per repo).
-# Updated by: social broadcast workflow (Unit 14).
+# Updated by: social broadcast workflow.
 # Prevents spam by enforcing minimum intervals between broadcasts.
 version: 1
 cooldowns: {}
@@ -7,4 +7,4 @@ cooldowns: {}
 #   <event-type>:
 #     last_broadcast_at: ISO datetime
 #     repo: optional scoping string
-# Event types and default cooldowns are defined in Unit 14
+# Event types and default cooldowns are defined in the social broadcast script.

--- a/persona/README.md
+++ b/persona/README.md
@@ -24,6 +24,4 @@ Visual identity assets (logos, SVG banners, color palettes, and CSS tokens) live
 
 ## See also
 
-- Implementation Plan: `docs/plans/2025-04-15-001-feat-frobot-control-plane-plan.md`
-- Origin Requirements: `docs/brainstorms/2025-04-15-frobot-control-plane-requirements.md`
 - Visual Styleguide: `assets/styleguide.md`

--- a/scripts/commit-metadata.ts
+++ b/scripts/commit-metadata.ts
@@ -11,7 +11,7 @@ const DEFAULT_MAX_RETRIES = 3
 /**
  * Paths this helper is allowed to write. The helper is intentionally scoped to
  * metadata YAML only. Wiki ingest and multi-file updates must use a different
- * helper (see Unit 8 plan — git-based atomic commits).
+ * helper (wiki-ingest.ts uses git-based atomic commits via the Git Data API).
  */
 const METADATA_PATH_PATTERN = /^metadata\/[a-z][a-z0-9-]*\.yaml$/
 


### PR DESCRIPTION
## Summary

Removes plan-specific references (Unit N, Phase N, plan file paths) that leaked into implementation files during Phase 1 and 2 development. These create coupling between living implementation files and point-in-time planning artifacts.

**7 files cleaned:**
- `metadata/README.md` — removed Unit/Phase numbers from update conventions, credential table, workflow mapping, and metrics note
- `metadata/renovate.yaml` — removed Unit numbers from `Updated by` comment
- `metadata/repos.yaml` — removed Unit numbers from `Updated by` comment
- `metadata/social-cooldowns.yaml` — removed Unit numbers from comments
- `knowledge/schema.md` — removed Unit 17 reference from maintenance section
- `persona/README.md` — removed plan/requirements file path references
- `scripts/commit-metadata.ts` — replaced "see Unit 8 plan" with direct code reference

All references now describe what the automation does, not which plan unit created it. Plan references remain only in `docs/` where they belong.

## Testing

- 83 tests pass (no behavior changes — docs/comments only)
- `pnpm check-types` clean
- `pnpm lint` clean

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: documentation and comment changes only, no runtime behavior affected.