### PR TITLE
fix: use correct Octokit method names for invitation API

### DIFF
--- a/scripts/handle-invitation.test.ts
+++ b/scripts/handle-invitation.test.ts
@@ -3,10 +3,10 @@ import {describe, expect, it, vi} from 'vitest'
 import {handleInvitations, InvitationHandlingError} from './handle-invitation.ts'
 
 function mockOctokit(overrides?: {
-  listRepositoryInvitations?: () => Promise<{
+  listInvitationsForAuthenticatedUser?: () => Promise<{
     data: Invitation[]
   }>
-  acceptInvitation?: (params: {invitation_id: number}) => Promise<void>
+  acceptInvitationForAuthenticatedUser?: (params: {invitation_id: number}) => Promise<void>
   starRepo?: (params: {owner: string; repo: string}) => Promise<void>
   createWorkflowDispatch?: (params: {
     owner: string
@@ -26,21 +26,19 @@ function mockOctokit(overrides?: {
           data: {type: 'file' as const, sha: 'repos-sha', content: 'dmVyc2lvbjogMQpyZXBvczogW10K', encoding: 'base64'},
         }),
         createOrUpdateFileContents: async () => ({data: {commit: {sha: 'metadata-commit-sha'}}}),
-      },
-      git: {
-        createRef: async () => ({data: {ref: 'refs/heads/data'}}),
-      },
-      users: {
-        listRepositoryInvitations:
-          overrides?.listRepositoryInvitations ??
+        listInvitationsForAuthenticatedUser:
+          overrides?.listInvitationsForAuthenticatedUser ??
           (async () => ({
             data: [],
           })),
-        acceptInvitation:
-          overrides?.acceptInvitation ??
+        acceptInvitationForAuthenticatedUser:
+          overrides?.acceptInvitationForAuthenticatedUser ??
           (async () => {
             return undefined
           }),
+      },
+      git: {
+        createRef: async () => ({data: {ref: 'refs/heads/data'}}),
       },
       activity: {
         starRepo:
@@ -73,28 +71,7 @@ interface Invitation {
   }
 }
 
-interface HandleInvitationsOctokit extends OctokitClient {
-  rest: OctokitClient['rest'] & {
-    users: {
-      listRepositoryInvitations: () => Promise<{
-        data: Invitation[]
-      }>
-      acceptInvitation: (params: {invitation_id: number}) => Promise<void>
-    }
-    activity: {
-      starRepo: (params: {owner: string; repo: string}) => Promise<void>
-    }
-    actions: {
-      createWorkflowDispatch: (params: {
-        owner: string
-        repo: string
-        workflow_id: string
-        ref: string
-        inputs?: Record<string, string>
-      }) => Promise<void>
-    }
-  }
-}
+type HandleInvitationsOctokit = OctokitClient
 
 describe('handleInvitations', () => {
   it('accepts approved invitations, stars repos, updates metadata, and dispatches survey', async () => {
@@ -103,7 +80,7 @@ describe('handleInvitations', () => {
     const createWorkflowDispatch = vi.fn(async () => undefined)
     const commitMetadata = vi.fn(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
     const octokit = mockOctokit({
-      listRepositoryInvitations: async () => ({
+      listInvitationsForAuthenticatedUser: async () => ({
         data: [
           {
             id: 101,
@@ -115,7 +92,7 @@ describe('handleInvitations', () => {
           },
         ],
       }),
-      acceptInvitation,
+      acceptInvitationForAuthenticatedUser: acceptInvitation,
       starRepo,
       createWorkflowDispatch,
     })
@@ -168,7 +145,7 @@ describe('handleInvitations', () => {
     const acceptInvitation = vi.fn(async () => undefined)
     const commitMetadata = vi.fn(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
     const octokit = mockOctokit({
-      listRepositoryInvitations: async () => ({
+      listInvitationsForAuthenticatedUser: async () => ({
         data: [
           {
             id: 102,
@@ -180,7 +157,7 @@ describe('handleInvitations', () => {
           },
         ],
       }),
-      acceptInvitation,
+      acceptInvitationForAuthenticatedUser: acceptInvitation,
     })
 
     // #given an unapproved inviter
@@ -230,7 +207,7 @@ describe('handleInvitations', () => {
     const createWorkflowDispatch = vi.fn(async () => undefined)
     const commitMetadata = vi.fn(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
     const octokit = mockOctokit({
-      listRepositoryInvitations: async () => ({
+      listInvitationsForAuthenticatedUser: async () => ({
         data: [
           {
             id: 103,
@@ -244,7 +221,7 @@ describe('handleInvitations', () => {
           },
         ],
       }),
-      acceptInvitation,
+      acceptInvitationForAuthenticatedUser: acceptInvitation,
       starRepo,
       createWorkflowDispatch,
     })
@@ -294,7 +271,7 @@ describe('handleInvitations', () => {
     const createWorkflowDispatch = vi.fn(async () => undefined)
     const commitMetadata = vi.fn(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
     const octokit = mockOctokit({
-      listRepositoryInvitations: async () => ({
+      listInvitationsForAuthenticatedUser: async () => ({
         data: [
           {
             id: 105,
@@ -303,7 +280,7 @@ describe('handleInvitations', () => {
           },
         ],
       }),
-      acceptInvitation,
+      acceptInvitationForAuthenticatedUser: acceptInvitation,
       starRepo,
       createWorkflowDispatch,
     })
@@ -346,7 +323,7 @@ describe('handleInvitations', () => {
 
   it('throws a structured error when polling is rate limited', async () => {
     const octokit = mockOctokit({
-      listRepositoryInvitations: async () => {
+      listInvitationsForAuthenticatedUser: async () => {
         throw Object.assign(new Error('Too Many Requests'), {status: 429})
       },
     })
@@ -382,7 +359,7 @@ describe('handleInvitations', () => {
   it('returns an empty result when there are no invitations', async () => {
     const commitMetadata = vi.fn(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
     const octokit = mockOctokit({
-      listRepositoryInvitations: async () => ({data: []}),
+      listInvitationsForAuthenticatedUser: async () => ({data: []}),
     })
 
     // #given no pending invitations

--- a/scripts/handle-invitation.ts
+++ b/scripts/handle-invitation.ts
@@ -42,11 +42,11 @@ export interface RepositoryInvitation {
 export interface OctokitClient extends CommitMetadataOctokitClient {
   rest: CommitMetadataOctokitClient['rest'] & {
     git: BootstrapOctokitClient['rest']['git']
-    users: {
-      listRepositoryInvitations: () => Promise<{
+    repos: CommitMetadataOctokitClient['rest']['repos'] & {
+      listInvitationsForAuthenticatedUser: () => Promise<{
         data: RepositoryInvitation[]
       }>
-      acceptInvitation: (params: {invitation_id: number}) => Promise<void>
+      acceptInvitationForAuthenticatedUser: (params: {invitation_id: number}) => Promise<void>
     }
     activity: {
       starRepo: (params: {owner: string; repo: string}) => Promise<void>
@@ -251,7 +251,7 @@ async function processInvitation(params: {
 
 async function pollInvitations(octokit: OctokitClient): Promise<RepositoryInvitation[]> {
   try {
-    const response = await octokit.rest.users.listRepositoryInvitations()
+    const response = await octokit.rest.repos.listInvitationsForAuthenticatedUser()
     return response.data
   } catch (error: unknown) {
     throw normalizePollingError(error)
@@ -260,7 +260,7 @@ async function pollInvitations(octokit: OctokitClient): Promise<RepositoryInvita
 
 async function acceptInvitation(octokit: OctokitClient, invitationId: number): Promise<void> {
   try {
-    await octokit.rest.users.acceptInvitation({invitation_id: invitationId})
+    await octokit.rest.repos.acceptInvitationForAuthenticatedUser({invitation_id: invitationId})
   } catch (error: unknown) {
     if (isApiStatus(error, 404) || isApiStatus(error, 410)) {
       return


### PR DESCRIPTION
## Summary

Fixes scheduled `Poll invitations` workflow failure ([run #24552752433](https://github.com/fro-bot/.github/actions/runs/24552752433/job/71781983720)).

**Root cause**: `octokit.rest.users.listRepositoryInvitations` and `octokit.rest.users.acceptInvitation` don't exist in `@octokit/rest`. The correct methods are:
- `octokit.rest.repos.listInvitationsForAuthenticatedUser()`
- `octokit.rest.repos.acceptInvitationForAuthenticatedUser()`

**Changes**:
- `handle-invitation.ts`: Fixed OctokitClient interface — moved invitation methods from `users` namespace to `repos` namespace with correct method names
- `handle-invitation.test.ts`: Updated mockOctokit to match (merged duplicate `repos` block, renamed all override keys and call sites)

## Testing

- 83 tests pass
- `pnpm check-types` clean (0 LSP errors on changed files)
- `pnpm lint` clean

## Post-Deploy Monitoring & Validation

- **What to monitor**: Next scheduled `Poll invitations` run (hourly cron)
- **Expected healthy behavior**: Job completes with exit code 0, processes any pending invitations
- **Failure signal**: Same `InvitationHandlingError: ... is not a function` in logs
- **Validation window**: Next hourly run after merge