### PR TITLE
chore: allowlist mrbro-bot[bot] as approved inviter

### DIFF
--- a/metadata/allowlist.yaml
+++ b/metadata/allowlist.yaml
@@ -4,5 +4,8 @@
 version: 1
 approved_inviters:
   - username: marcusrbrown
-    added: 2025-04-15
+    added: 2026-04-15
     role: owner
+  - username: mrbro-bot[bot]
+    added: 2026-04-17
+    role: bot


### PR DESCRIPTION
## Summary

Adds \`mrbro-bot[bot]\` to \`approved_inviters\` in \`metadata/allowlist.yaml\`. The app is scoped to @marcusrbrown's GitHub account and can send invitations on his behalf.

Also fixes a typo in the \`added\` date for \`marcusrbrown\` (2025 → 2026).

## Why

In [run 24556694182](https://github.com/fro-bot/.github/actions/runs/24556694182/job/71794867129), an invitation to \`marcusrbrown/ha-config\` was skipped with \`reason: inviter-not-allowlisted\` because the inviter was \`mrbro-bot[bot]\`, not a human user.

GitHub reports bot logins with the literal \`[bot]\` suffix, so \`approved_inviters[].username\` matches against \`mrbro-bot[bot]\` exactly. The \`role: bot\` field is informational.

## Verification

- Schema validates: \`assertAllowlistFile\` accepts the entry (all three fields are strings, version is 1)
- Matches the inviter login format from \`invitation.inviter.login\` as reported by GitHub's API

## Post-Deploy Monitoring & Validation

- **What to monitor**: Next scheduled \`Poll invitations\` run (hourly cron)
- **Expected healthy behavior**: Invitations from \`mrbro-bot[bot]\` now process as \`status: accepted\` instead of \`status: skipped, reason: inviter-not-allowlisted\`
- **Failure signal**: Same \`inviter-not-allowlisted\` for \`mrbro-bot[bot]\` invitations after merge (would indicate username format mismatch)
- **Validation window**: Next hourly run after merge; the pending \`marcusrbrown/ha-config\` invitation should be accepted and trigger a survey dispatch