### PR TITLE
fix: correct Octokit star method name + handle nullable inviter

### DIFF
--- a/scripts/handle-invitation.test.ts
+++ b/scripts/handle-invitation.test.ts
@@ -7,7 +7,7 @@ function mockOctokit(overrides?: {
     data: Invitation[]
   }>
   acceptInvitationForAuthenticatedUser?: (params: {invitation_id: number}) => Promise<void>
-  starRepo?: (params: {owner: string; repo: string}) => Promise<void>
+  starRepoForAuthenticatedUser?: (params: {owner: string; repo: string}) => Promise<void>
   createWorkflowDispatch?: (params: {
     owner: string
     repo: string
@@ -41,8 +41,8 @@ function mockOctokit(overrides?: {
         createRef: async () => ({data: {ref: 'refs/heads/data'}}),
       },
       activity: {
-        starRepo:
-          overrides?.starRepo ??
+        starRepoForAuthenticatedUser:
+          overrides?.starRepoForAuthenticatedUser ??
           (async () => {
             return undefined
           }),
@@ -76,7 +76,7 @@ type HandleInvitationsOctokit = OctokitClient
 describe('handleInvitations', () => {
   it('accepts approved invitations, stars repos, updates metadata, and dispatches survey', async () => {
     const acceptInvitation = vi.fn(async () => undefined)
-    const starRepo = vi.fn(async () => undefined)
+    const starRepoForAuthenticatedUser = vi.fn(async () => undefined)
     const createWorkflowDispatch = vi.fn(async () => undefined)
     const commitMetadata = vi.fn(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
     const octokit = mockOctokit({
@@ -93,7 +93,7 @@ describe('handleInvitations', () => {
         ],
       }),
       acceptInvitationForAuthenticatedUser: acceptInvitation,
-      starRepo,
+      starRepoForAuthenticatedUser,
       createWorkflowDispatch,
     })
 
@@ -130,7 +130,7 @@ describe('handleInvitations', () => {
       status: 'accepted',
     })
     expect(acceptInvitation).toHaveBeenCalledWith({invitation_id: 101})
-    expect(starRepo).toHaveBeenCalledWith({owner: 'fro-bot', repo: 'hello-world'})
+    expect(starRepoForAuthenticatedUser).toHaveBeenCalledWith({owner: 'fro-bot', repo: 'hello-world'})
     expect(createWorkflowDispatch).toHaveBeenCalledWith({
       owner: 'fro-bot',
       repo: '.github',
@@ -203,7 +203,7 @@ describe('handleInvitations', () => {
       .fn<(params: {invitation_id: number}) => Promise<void>>()
       .mockRejectedValueOnce(Object.assign(new Error('boom'), {status: 500}))
       .mockResolvedValueOnce(undefined)
-    const starRepo = vi.fn(async () => undefined)
+    const starRepoForAuthenticatedUser = vi.fn(async () => undefined)
     const createWorkflowDispatch = vi.fn(async () => undefined)
     const commitMetadata = vi.fn(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
     const octokit = mockOctokit({
@@ -222,7 +222,7 @@ describe('handleInvitations', () => {
         ],
       }),
       acceptInvitationForAuthenticatedUser: acceptInvitation,
-      starRepo,
+      starRepoForAuthenticatedUser,
       createWorkflowDispatch,
     })
 
@@ -259,7 +259,7 @@ describe('handleInvitations', () => {
       invitationId: 104,
       status: 'accepted',
     })
-    expect(starRepo).toHaveBeenCalledOnce()
+    expect(starRepoForAuthenticatedUser).toHaveBeenCalledOnce()
     expect(commitMetadata).toHaveBeenCalledOnce()
   })
 
@@ -267,7 +267,7 @@ describe('handleInvitations', () => {
     const acceptInvitation = vi.fn(async () => {
       throw Object.assign(new Error('Gone'), {status: 410})
     })
-    const starRepo = vi.fn(async () => undefined)
+    const starRepoForAuthenticatedUser = vi.fn(async () => undefined)
     const createWorkflowDispatch = vi.fn(async () => undefined)
     const commitMetadata = vi.fn(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
     const octokit = mockOctokit({
@@ -281,7 +281,7 @@ describe('handleInvitations', () => {
         ],
       }),
       acceptInvitationForAuthenticatedUser: acceptInvitation,
-      starRepo,
+      starRepoForAuthenticatedUser,
       createWorkflowDispatch,
     })
 
@@ -317,7 +317,7 @@ describe('handleInvitations', () => {
         status: 'accepted',
       },
     ])
-    expect(starRepo).toHaveBeenCalledWith({owner: 'fro-bot', repo: 'already-accepted'})
+    expect(starRepoForAuthenticatedUser).toHaveBeenCalledWith({owner: 'fro-bot', repo: 'already-accepted'})
     expect(commitMetadata).toHaveBeenCalledOnce()
   })
 

--- a/scripts/handle-invitation.test.ts
+++ b/scripts/handle-invitation.test.ts
@@ -356,6 +356,61 @@ describe('handleInvitations', () => {
     expect((error as InvitationHandlingError).remediation).toContain('Retry after the GitHub API rate limit resets')
   })
 
+  it('skips invitations where GitHub nulled the inviter', async () => {
+    const acceptInvitation = vi.fn(async () => undefined)
+    const commitMetadata = vi.fn(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
+    const octokit = mockOctokit({
+      listInvitationsForAuthenticatedUser: async () => ({
+        data: [
+          {
+            id: 106,
+            // GitHub returns inviter: null when the inviting user's account has been deleted.
+            inviter: null as unknown as {login: string},
+            repository: {name: 'orphaned-repo', owner: {login: 'fro-bot'}},
+          },
+        ],
+      }),
+      acceptInvitationForAuthenticatedUser: acceptInvitation,
+    })
+
+    // #given an invitation from a deleted inviter account (inviter: null)
+    // #when invitation polling runs
+    const result = await handleInvitations({
+      octokit,
+      allowlistPath: 'metadata/allowlist.yaml',
+      reposPath: 'metadata/repos.yaml',
+      now: new Date('2026-04-16T12:00:00.000Z'),
+      workflowFile: 'survey.yaml',
+      workflowRef: 'main',
+      commitMetadata,
+      bootstrapDataBranch: vi.fn(async () => ({})),
+      readMetadata: async (path: string) => {
+        if (path === 'metadata/allowlist.yaml') {
+          return {
+            version: 1,
+            approved_inviters: [{username: 'marcusrbrown', added: '2025-04-15', role: 'owner'}],
+          }
+        }
+
+        return {version: 1, repos: []}
+      },
+    })
+
+    // #then it skips the invitation with inviter-unknown instead of throwing
+    expect(result.processed).toEqual([
+      {
+        invitationId: 106,
+        inviter: null,
+        owner: 'fro-bot',
+        repo: 'orphaned-repo',
+        status: 'skipped',
+        reason: 'inviter-unknown',
+      },
+    ])
+    expect(acceptInvitation).not.toHaveBeenCalled()
+    expect(commitMetadata).not.toHaveBeenCalled()
+  })
+
   it('returns an empty result when there are no invitations', async () => {
     const commitMetadata = vi.fn(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
     const octokit = mockOctokit({

--- a/scripts/handle-invitation.ts
+++ b/scripts/handle-invitation.ts
@@ -28,9 +28,13 @@ type OctokitConstructor = new (params: {auth: string}) => OctokitClient
 
 export interface RepositoryInvitation {
   id: number
+  /**
+   * GitHub's schema types inviter as `nullable-simple-user` — it can be `null` when the inviting
+   * user account has been deleted. Always guard before dereferencing `inviter.login`.
+   */
   inviter: {
     login: string
-  }
+  } | null
   repository: {
     name: string
     owner: {
@@ -94,11 +98,11 @@ export interface AcceptedInvitationResult {
 
 export interface SkippedInvitationResult {
   invitationId: number
-  inviter: string
+  inviter: string | null
   owner: string
   repo: string
   status: 'skipped'
-  reason: 'inviter-not-allowlisted'
+  reason: 'inviter-not-allowlisted' | 'inviter-unknown'
 }
 
 export interface FailedInvitationResult {
@@ -195,9 +199,22 @@ async function processInvitation(params: {
   invitation: RepositoryInvitation
   commitMetadata: (params: CommitMetadataParams) => Promise<CommitMetadataResult>
 }): Promise<InvitationProcessResult> {
-  const inviter = params.invitation.inviter.login
+  const inviter = params.invitation.inviter?.login ?? null
   const repoOwner = params.invitation.repository.owner.login
   const repoName = params.invitation.repository.name
+
+  // Skip invitations where GitHub has nulled the inviter (deleted account). We can't allowlist-check
+  // an unknown inviter, so treat it as a skip rather than failing the whole poll.
+  if (inviter === null) {
+    return {
+      invitationId: params.invitation.id,
+      inviter: null,
+      owner: repoOwner,
+      repo: repoName,
+      status: 'skipped',
+      reason: 'inviter-unknown',
+    }
+  }
 
   if (!params.approvedInviters.has(inviter)) {
     return {

--- a/scripts/handle-invitation.ts
+++ b/scripts/handle-invitation.ts
@@ -49,7 +49,7 @@ export interface OctokitClient extends CommitMetadataOctokitClient {
       acceptInvitationForAuthenticatedUser: (params: {invitation_id: number}) => Promise<void>
     }
     activity: {
-      starRepo: (params: {owner: string; repo: string}) => Promise<void>
+      starRepoForAuthenticatedUser: (params: {owner: string; repo: string}) => Promise<void>
     }
     actions: {
       createWorkflowDispatch: (params: {
@@ -212,7 +212,7 @@ async function processInvitation(params: {
 
   try {
     await acceptInvitation(params.octokit, params.invitation.id)
-    await params.octokit.rest.activity.starRepo({owner: repoOwner, repo: repoName})
+    await params.octokit.rest.activity.starRepoForAuthenticatedUser({owner: repoOwner, repo: repoName})
     await params.commitMetadata({
       octokit: params.octokit,
       path: params.reposPath,


### PR DESCRIPTION
## Summary

Two fixes for the scheduled **Poll invitations** workflow, both stemming from the same class of bug (handwritten `OctokitClient` interfaces lying about the real `@octokit/rest` API).

### 1. `starRepo` → `starRepoForAuthenticatedUser` (runtime failure)

**Evidence**: [run 24560380936](https://github.com/fro-bot/.github/actions/runs/24560380936/job/71807245854) — `params.octokit.rest.activity.starRepo is not a function`.

`octokit.rest.activity.starRepo` doesn't exist on `@octokit/rest`. The correct method is `starRepoForAuthenticatedUser`. `tsc` didn't catch it because our `OctokitClient` interface *declared* `starRepo`, satisfying the compiler while the real Octokit throws at runtime.

Same root-cause pattern as PR #3083 (`users.listRepositoryInvitations` / `users.acceptInvitation` → `repos.listInvitationsForAuthenticatedUser` / `repos.acceptInvitationForAuthenticatedUser`).

### 2. Nullable `inviter` guard

Oracle audit of all remaining Octokit call sites flagged one real runtime risk: our `RepositoryInvitation.inviter` type is non-null, but GitHub's real schema types it as `nullable-simple-user` — `inviter` is `null` when the inviting account has been deleted. Unguarded `invitation.inviter.login` access would throw.

Fix:
- `inviter: { login: string } | null` on `RepositoryInvitation`
- New skip reason `inviter-unknown`; `inviter: string | null` on `SkippedInvitationResult`
- Guard in `processInvitation`: null inviter skips with `reason='inviter-unknown'` instead of throwing
- Test covering the null-inviter skip path

## Oracle Audit Summary

All 23 Octokit call sites across 5 scripts audited against real `@octokit/rest` generated types (`node_modules/@octokit/plugin-rest-endpoint-methods/dist-types/generated/`):

| Result | Count |
| --- | --- |
| ✅ OK | 22 |
| ⚠️ Suspect (fixed in this PR) | 1 (nullable inviter) |
| ❌ Broken (fixed in this PR) | 1 (`starRepo`) |

**Minor drift** (non-blocking, no runtime risk):
- `createWorkflowDispatch.workflow_id` narrowed from `string | number` to `string` — fine for our usage
- `createWorkflowDispatch.inputs` narrowed from `{[k: string]: unknown}` to `Record<string, string>` — fine
- `issues.addLabels` response interface wrong (returns label array, not `{labels: [...]}`) — safe because call site ignores response
- Several `Promise<void>` returns that are actually `OctokitResponse<never, 204>` — doesn't matter

**Meta-recommendation from Oracle** (deferred, separate PR):
Keep narrow interfaces, but derive them from real Octokit types (`InstanceType<typeof Octokit>['rest']` picks or `RestEndpointMethodTypes`) so hallucinated method names fail `tsc` instead of surfacing at runtime. Estimated effort: 1–4h.

## Verification

- 84 tests pass (was 83; +1 for null-inviter skip)
- `pnpm check-types`, `pnpm lint` clean
- All 5 `OctokitClient` interface declarations audited for hallucinated methods — none found

## Post-Deploy Monitoring

- **Next hourly `Poll invitations` run** after merge should succeed end-to-end:
  1. Accept invitation (using classic PAT rotated earlier)
  2. Star `marcusrbrown/ha-config`
  3. Write repo to `metadata/repos.yaml` on `data` branch
  4. Dispatch `Survey Repo` workflow
- **Failure signal**: any `status: failed` in the `{processed: [...]}` JSON output on the scheduled run