### PR TITLE
fix(workflows): use fro-bot[bot] app identity instead of github-actions[bot]

### DIFF
--- a/.github/workflows/manage-cache.yaml
+++ b/.github/workflows/manage-cache.yaml
@@ -31,9 +31,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - if: env.REF != ''
+        id: get-workflow-app-token
+        name: Get Workflow Access Token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+
+      - if: env.REF != ''
         name: Deleting workflow caches on ${{ env.REF }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.get-workflow-app-token.outputs.token }}
         run: |
           CACHE_KEYS="$(gh cache list -R "${{ github.repository }}" --ref "${{ env.REF }}" --limit 100 --order asc --sort last_accessed_at | cut -f 2 | tr '\n' ' ')"
           for key in $CACHE_KEYS; do

--- a/.github/workflows/merge-data.yaml
+++ b/.github/workflows/merge-data.yaml
@@ -19,6 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - id: get-workflow-app-token
+        name: Get Workflow Access Token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+
       - name: ⤵ Checkout Branch
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
@@ -27,5 +34,5 @@ jobs:
 
       - name: 🔀 Open weekly data merge PR
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get-workflow-app-token.outputs.token }}
         run: node scripts/merge-data-pr.ts


### PR DESCRIPTION
## Summary

Automated workflows that mutate repo state should act as **[fro-bot[bot]](https://github.com/apps/fro-bot)**, not the default `github-actions[bot]`. Aligns these two workflows with the identity pattern already established in `manage-issues.yaml`, `renovate.yaml`, and `update-repo-settings.yaml`.

## Changes

### `merge-data.yaml`
Mints an app installation token via `actions/create-github-app-token@v3.1.1` and passes it as `GITHUB_TOKEN` to `scripts/merge-data-pr.ts`. The weekly `data → main` PR (and any manual dispatch) will now be authored by `fro-bot[bot]`. Concretely: PR #3089 showed up as `github-actions[bot]` — future merge-data PRs will not.

### `manage-cache.yaml`
Same flow for the `cleanup-cache` job. Cache `gh cache list` / `gh cache delete` calls now run under the app identity.

## What's Intentionally Not Changed

PAT-based workflows remain on user-scoped PATs because those flows require **user identity** operations that GitHub Apps cannot perform:

- `poll-invitations.yaml` — `FRO_BOT_POLL_PAT` — repository invitations can only be accepted by a user
- `survey-repo.yaml` — `FRO_BOT_PAT` — writes to `data` branch as fro-bot user
- `fro-bot.yaml` — `FRO_BOT_PAT` — reusable workflow consumed by the one-workflow pattern

## Verification

- `pnpm lint` clean on both files
- Secret naming matches existing workflows: `secrets.APPLICATION_ID` + `secrets.APPLICATION_PRIVATE_KEY`
- Required permissions already declared at job level (`contents: write, pull-requests: write, issues: write` for merge-data; `actions: write` for cleanup-cache)

## Post-Deploy Monitoring

- **Next `Merge Data Branch` dispatch** — confirm PR author shows `fro-bot[bot]` instead of `github-actions[bot]`
- **Next `Manage Cache` run** (on PR close or Sunday 00:00 UTC) — confirm cache delete completes under the app token
- **Failure signal**: 403 on token use → app permissions missing; 401 → secret naming mismatch