### PR TITLE
rewrite: drop github-actions[bot] commit from main history

### DIFF
--- a/.github/workflows/manage-cache.yaml
+++ b/.github/workflows/manage-cache.yaml
@@ -31,9 +31,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - if: env.REF != ''
+        id: get-workflow-app-token
+        name: Get Workflow Access Token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+
+      - if: env.REF != ''
         name: Deleting workflow caches on ${{ env.REF }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.get-workflow-app-token.outputs.token }}
         run: |
           CACHE_KEYS="$(gh cache list -R "${{ github.repository }}" --ref "${{ env.REF }}" --limit 100 --order asc --sort last_accessed_at | cut -f 2 | tr '\n' ' ')"
           for key in $CACHE_KEYS; do

--- a/.github/workflows/merge-data.yaml
+++ b/.github/workflows/merge-data.yaml
@@ -19,6 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - id: get-workflow-app-token
+        name: Get Workflow Access Token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+
       - name: ⤵ Checkout Branch
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
@@ -27,5 +34,5 @@ jobs:
 
       - name: 🔀 Open weekly data merge PR
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get-workflow-app-token.outputs.token }}
         run: node scripts/merge-data-pr.ts


### PR DESCRIPTION
Transient PR to run required status checks against the rebased commit (`6a9d34f`) before force-pushing main to it. **Do not merge** — will be closed after force-push.