### PR TITLE
docs(solutions): expand octokit runtime-errors entry with second occurrence

### DIFF
--- a/docs/solutions/runtime-errors/octokit-invitation-method-names-2026-04-17.md
+++ b/docs/solutions/runtime-errors/octokit-invitation-method-names-2026-04-17.md
@@ -1,13 +1,15 @@
 ---
-title: Incorrect Octokit Invitation API Method Names
+title: Hallucinated Octokit Method Names and Nullability Drift in Handwritten Interfaces
+category: runtime-errors
 problem_type: runtime_error
 component: tooling
 root_cause: wrong_api
 resolution_type: code_fix
 severity: high
 date: 2026-04-17
+last_updated: 2026-04-17
 module: scripts/handle-invitation.ts
-tags: [octokit, github-api, invitation-api, runtime-error, ai-hallucination]
+tags: [octokit, github-api, invitation-api, runtime-error, ai-hallucination, type-safety, handwritten-interface]
 verified: true
 ---
 
@@ -84,8 +86,108 @@ import('@octokit/rest').then(m => {
 
 4. **For subagent-generated code**, treat SDK method names as claims to verify before merging — especially when the project uses custom type interfaces that can't catch naming errors.
 
+## Second Occurrence (2026-04-17) — `starRepo` and Nullable Inviter
+
+Same class of bug, different method. The next scheduled `Poll invitations` run (after PR #3083 merged) failed at runtime with:
+
+```
+params.octokit.rest.activity.starRepo is not a function
+```
+
+[Failed run](https://github.com/fro-bot/.github/actions/runs/24560380936/job/71807245854). `octokit.rest.activity.starRepo` does not exist on `@octokit/rest` — the correct method is `starRepoForAuthenticatedUser`. Same discovery method, same fix shape:
+
+```typescript
+// BEFORE (broken)
+await params.octokit.rest.activity.starRepo({owner, repo})
+
+// AFTER (correct)
+await params.octokit.rest.activity.starRepoForAuthenticatedUser({owner, repo})
+```
+
+The handwritten `OctokitClient` interface declared `starRepo` on the `activity` namespace, so `tsc` was satisfied. Real `@octokit/rest` only exposes the `ForAuthenticatedUser` variant.
+
+### Audit Triggered by the Second Hit
+
+After two occurrences in the same file, an Oracle audit verified every `octokit.rest.X.Y(...)` call site across all scripts against the real generated types in `node_modules/@octokit/plugin-rest-endpoint-methods/dist-types/generated/method-types.d.ts`. 22 of 23 call sites were clean; one additional latent risk surfaced:
+
+### Nullability Drift — Handwritten Interfaces Also Lie About Null
+
+The same `OctokitClient` interface declared:
+
+```typescript
+interface RepositoryInvitation {
+  id: number
+  inviter: { login: string }  // never-null
+  repository: { name: string; owner: { login: string } }
+}
+```
+
+GitHub's real schema types `inviter` as `nullable-simple-user` — it is `null` when the inviting user's account has been deleted. Unguarded `invitation.inviter.login` access would throw.
+
+Fix:
+
+```typescript
+export interface RepositoryInvitation {
+  id: number
+  /**
+   * GitHub's schema types inviter as `nullable-simple-user` — it can be `null` when the inviting
+   * user account has been deleted. Always guard before dereferencing `inviter.login`.
+   */
+  inviter: { login: string } | null
+  repository: { name: string; owner: { login: string } }
+}
+
+// Guard in processInvitation — skip with reason rather than throw
+const inviter = params.invitation.inviter?.login ?? null
+if (inviter === null) {
+  return {
+    invitationId: params.invitation.id,
+    inviter: null,
+    owner: repoOwner,
+    repo: repoName,
+    status: 'skipped',
+    reason: 'inviter-unknown',
+  }
+}
+```
+
+**Lesson:** handwritten SDK interfaces don't just hallucinate method existence — they also silently tighten nullability, dropping `null` variants that the real schema declares. The compiler faithfully enforces the lie.
+
+## Prevention Update — Derive Interfaces from Real SDK Types
+
+The four prevention rules above still apply. Add a fifth, stronger rule:
+
+5. **Replace handwritten SDK interfaces with derived types.** `@octokit/rest` exposes types that can be narrowed at the call site without reimplementing them:
+
+   ```typescript
+   import type { Octokit } from '@octokit/rest'
+
+   type OctokitRest = InstanceType<typeof Octokit>['rest']
+
+   // Narrow to just the namespaces you use — hallucinated method names and
+   // tightened nullability both become compile errors.
+   export type InvitationsClient = {
+     rest: Pick<OctokitRest, 'repos' | 'activity' | 'actions'>
+   }
+   ```
+
+   This preserves the "narrow client" ergonomics (you don't drag the full Octokit type through every module) while making the SDK surface the single source of truth. Neither hallucinated methods nor dropped `null`s survive `tsc`.
+
+6. **After the first hallucinated-method hit, audit every SDK call site in the repo.** The first bug is usually a signal of a class, not an isolated one. Targets of the audit: grep for `octokit.rest.*.*(` and verify each method exists in `node_modules/@octokit/plugin-rest-endpoint-methods/dist-types/generated/method-types.d.ts`. Also flag any handwritten types whose nullability looks narrower than the real schema (a spot-check of 2–3 endpoints' generated parameter/response types usually surfaces these).
+
 ## References
+
+### First occurrence (PR #3083)
 
 - Failed run: https://github.com/fro-bot/.github/actions/runs/24552752433/job/71781983720
 - Fix PR: https://github.com/fro-bot/.github/pull/3083
+
+### Second occurrence (PR #3087)
+
+- Failed run: https://github.com/fro-bot/.github/actions/runs/24560380936/job/71807245854
+- Fix PR: https://github.com/fro-bot/.github/pull/3087
+
+### External
+
 - GitHub REST API docs: https://docs.github.com/en/rest/collaborators/invitations
+- `@octokit/rest` generated method types: `node_modules/@octokit/plugin-rest-endpoint-methods/dist-types/generated/method-types.d.ts`


### PR DESCRIPTION
## Summary

Updates `docs/solutions/runtime-errors/octokit-invitation-method-names-2026-04-17.md` in-place rather than creating a new doc, because the latest fix (`starRepo` → `starRepoForAuthenticatedUser` and nullable `inviter` guard) is the same root cause and calls for the same prevention as the existing entry. Two docs covering the same problem and solution would drift apart.

## Additions

### Second occurrence section
Covers the `octokit.rest.activity.starRepo` → `starRepoForAuthenticatedUser` fix shipped in #3087. Structurally identical to the original `listRepositoryInvitations` / `acceptInvitation` bug — same file, same handwritten `OctokitClient` interface satisfying `tsc` while the real SDK lacks the declared method, same discovery method.

### Nullability drift finding
`RepositoryInvitation.inviter` was declared non-null but GitHub's real schema types it as `nullable-simple-user`. Documents the guarded-skip fix (`reason: 'inviter-unknown'`). Handwritten interfaces don't just hallucinate method existence — they also silently tighten nullability.

### Two new prevention rules
5. **Replace handwritten SDK interfaces with derived types** — `Pick<InstanceType<typeof Octokit>['rest'], ...>`. Hallucinated method names and dropped `null`s both become `tsc` errors. Code example included.
6. **After the first hallucinated-method hit, audit every SDK call site.** The first bug is usually a signal of a class.

## Frontmatter Changes

- Added `category: runtime-errors`
- Added `last_updated: 2026-04-17`
- Broadened title to include nullability drift
- Added tags: `type-safety`, `handwritten-interface`
- References section split into first-occurrence / second-occurrence / external