### PR TITLE
refactor(scripts): derive OctokitClient from real @octokit/rest

### DIFF
--- a/scripts/commit-metadata.test.ts
+++ b/scripts/commit-metadata.test.ts
@@ -15,11 +15,25 @@ function encode(value: unknown): string {
   return Buffer.from(text, 'utf8').toString('base64')
 }
 
-function mockOctokit(overrides?: {
-  getBranch?: OctokitClient['rest']['repos']['getBranch']
-  getContent?: OctokitClient['rest']['repos']['getContent']
-  createOrUpdateFileContents?: OctokitClient['rest']['repos']['createOrUpdateFileContents']
-}): OctokitClient {
+interface MockOverrides {
+  getBranch?: (params: {owner: string; repo: string; branch: string}) => Promise<unknown>
+  getContent?: (params: {owner: string; repo: string; ref: string; path: string}) => Promise<unknown>
+  createOrUpdateFileContents?: (params: {
+    owner: string
+    repo: string
+    branch: string
+    path: string
+    message: string
+    sha: string
+    content: string
+  }) => Promise<unknown>
+}
+
+// Tests construct a minimal shape and cast to OctokitClient (the real @octokit/rest
+// type is massive and includes internals like `endpoint`/`defaults` we never exercise).
+// Production call sites still enforce SDK method-name and nullability correctness —
+// the cast here only relaxes what test mocks must implement, not what prod code sees.
+function mockOctokit(overrides?: MockOverrides): OctokitClient {
   return {
     rest: {
       repos: {
@@ -35,7 +49,7 @@ function mockOctokit(overrides?: {
           overrides?.createOrUpdateFileContents ?? (async () => ({data: {commit: {sha: 'new-sha-456'}}})),
       },
     },
-  }
+  } as unknown as OctokitClient
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/commit-metadata.ts
+++ b/scripts/commit-metadata.ts
@@ -1,3 +1,4 @@
+import type {Octokit} from '@octokit/rest'
 import {Buffer} from 'node:buffer'
 import process from 'node:process'
 
@@ -74,46 +75,20 @@ export interface CommitMetadataResult {
   attempts: number
 }
 
-export interface OctokitClient {
-  rest: {
-    repos: {
-      getBranch: (params: {owner: string; repo: string; branch: string}) => Promise<{
-        data: {
-          name: string
-          protected?: boolean
-          protection?: {
-            enabled?: boolean
-          }
-        }
-      }>
-      getContent: (params: {owner: string; repo: string; ref: string; path: string}) => Promise<{
-        data: FileContentResponse | unknown[]
-      }>
-      createOrUpdateFileContents: (params: {
-        owner: string
-        repo: string
-        branch: string
-        path: string
-        message: string
-        sha: string
-        content: string
-      }) => Promise<{
-        data: {
-          commit: {
-            sha: string
-          }
-        }
-      }>
-    }
-  }
-}
-
-interface FileContentResponse {
-  type: 'file'
-  sha: string
-  content?: string
-  encoding?: string
-}
+/**
+ * Narrow Octokit client type derived from the real `@octokit/rest` SDK.
+ *
+ * Why derived, not handwritten: handwritten interfaces can declare methods that
+ * don't exist on the real SDK (past bugs: `listRepositoryInvitations`, `starRepo`),
+ * and can silently tighten nullability (past bug: non-null `inviter`). Deriving
+ * from `Octokit` forces `tsc` to catch both classes of drift at compile time.
+ *
+ * The full `Octokit` type is large; callers use `as unknown as OctokitClient`
+ * when constructing partial mocks in tests. That cast is acceptable because the
+ * invariant we care about — SDK surface correctness — is enforced on production
+ * call sites, not on mocks.
+ */
+export type OctokitClient = Octokit
 
 interface FileSnapshot {
   sha: string

--- a/scripts/data-branch-bootstrap.test.ts
+++ b/scripts/data-branch-bootstrap.test.ts
@@ -2,10 +2,12 @@ import type {OctokitClient} from './data-branch-bootstrap.ts'
 import {describe, expect, it, vi} from 'vitest'
 import {bootstrapDataBranch, DataBranchBootstrapError} from './data-branch-bootstrap.ts'
 
-function mockOctokit(overrides?: {
-  getBranch?: OctokitClient['rest']['repos']['getBranch']
-  createRef?: OctokitClient['rest']['git']['createRef']
-}): OctokitClient {
+interface MockOverrides {
+  getBranch?: (params: {owner: string; repo: string; branch: string}) => Promise<unknown>
+  createRef?: (params: {owner: string; repo: string; ref: string; sha: string}) => Promise<unknown>
+}
+
+function mockOctokit(overrides?: MockOverrides): OctokitClient {
   return {
     rest: {
       repos: {
@@ -22,7 +24,7 @@ function mockOctokit(overrides?: {
         createRef: overrides?.createRef ?? (async () => ({data: {ref: 'refs/heads/data'}})),
       },
     },
-  }
+  } as unknown as OctokitClient
 }
 
 describe('bootstrapDataBranch', () => {

--- a/scripts/data-branch-bootstrap.ts
+++ b/scripts/data-branch-bootstrap.ts
@@ -1,3 +1,4 @@
+import type {Octokit} from '@octokit/rest'
 import process from 'node:process'
 
 const DEFAULT_OWNER = 'fro-bot'
@@ -21,27 +22,11 @@ export interface DataBranchBootstrapResult {
   sha: string
 }
 
-export interface OctokitClient {
-  rest: {
-    repos: {
-      getBranch: (params: {owner: string; repo: string; branch: string}) => Promise<{
-        data: {
-          name: string
-          commit: {
-            sha: string
-          }
-        }
-      }>
-    }
-    git: {
-      createRef: (params: {owner: string; repo: string; ref: string; sha: string}) => Promise<{
-        data: {
-          ref: string
-        }
-      }>
-    }
-  }
-}
+/**
+ * Narrow Octokit client type derived from the real `@octokit/rest` SDK.
+ * See commit-metadata.ts for the rationale behind deriving rather than handwriting.
+ */
+export type OctokitClient = Octokit
 
 export type DataBranchBootstrapErrorCode =
   | 'MISSING_TOKEN'

--- a/scripts/handle-invitation.test.ts
+++ b/scripts/handle-invitation.test.ts
@@ -15,7 +15,7 @@ function mockOctokit(overrides?: {
     ref: string
     inputs?: Record<string, string>
   }) => Promise<void>
-}): HandleInvitationsOctokit {
+}): OctokitClient {
   return {
     rest: {
       repos: {
@@ -55,7 +55,7 @@ function mockOctokit(overrides?: {
           }),
       },
     },
-  }
+  } as unknown as OctokitClient
 }
 
 interface Invitation {
@@ -70,8 +70,6 @@ interface Invitation {
     }
   }
 }
-
-type HandleInvitationsOctokit = OctokitClient
 
 describe('handleInvitations', () => {
   it('accepts approved invitations, stars repos, updates metadata, and dispatches survey', async () => {

--- a/scripts/handle-invitation.ts
+++ b/scripts/handle-invitation.ts
@@ -4,17 +4,8 @@ import process from 'node:process'
 import {Octokit} from '@octokit/rest'
 import {parse} from 'yaml'
 
-import {
-  commitMetadata,
-  type OctokitClient as CommitMetadataOctokitClient,
-  type CommitMetadataParams,
-  type CommitMetadataResult,
-} from './commit-metadata.ts'
-import {
-  bootstrapDataBranch,
-  type OctokitClient as BootstrapOctokitClient,
-  type DataBranchBootstrapParams,
-} from './data-branch-bootstrap.ts'
+import {commitMetadata, type CommitMetadataParams, type CommitMetadataResult} from './commit-metadata.ts'
+import {bootstrapDataBranch, type DataBranchBootstrapParams} from './data-branch-bootstrap.ts'
 import {assertAllowlistFile, assertReposFile, SchemaValidationError, type ReposFile} from './schemas.ts'
 
 const DEFAULT_OWNER = 'fro-bot'
@@ -43,29 +34,11 @@ export interface RepositoryInvitation {
   }
 }
 
-export interface OctokitClient extends CommitMetadataOctokitClient {
-  rest: CommitMetadataOctokitClient['rest'] & {
-    git: BootstrapOctokitClient['rest']['git']
-    repos: CommitMetadataOctokitClient['rest']['repos'] & {
-      listInvitationsForAuthenticatedUser: () => Promise<{
-        data: RepositoryInvitation[]
-      }>
-      acceptInvitationForAuthenticatedUser: (params: {invitation_id: number}) => Promise<void>
-    }
-    activity: {
-      starRepoForAuthenticatedUser: (params: {owner: string; repo: string}) => Promise<void>
-    }
-    actions: {
-      createWorkflowDispatch: (params: {
-        owner: string
-        repo: string
-        workflow_id: string
-        ref: string
-        inputs?: Record<string, string>
-      }) => Promise<void>
-    }
-  }
-}
+/**
+ * Narrow Octokit client type derived from the real `@octokit/rest` SDK.
+ * See commit-metadata.ts for the rationale behind deriving rather than handwriting.
+ */
+export type OctokitClient = Octokit
 
 export interface HandleInvitationsParams {
   octokit?: OctokitClient
@@ -151,9 +124,7 @@ export async function handleInvitations(params: HandleInvitationsParams = {}): P
   const bootstrap = params.bootstrapDataBranch ?? bootstrapDataBranch
 
   // Ensure data branch exists before any metadata writes (idempotent — no-op if already present).
-  // The bootstrap needs getBranch to return commit.sha; the real Octokit does, but our typed
-  // subset omits it. Safe to cast since bootstrapDataBranch only reads repos.getBranch + git.createRef.
-  await bootstrap({octokit: octokit as unknown as BootstrapOctokitClient, owner, repo})
+  await bootstrap({octokit, owner, repo})
 
   const allowlist = await loadAllowlist(readMetadata, allowlistPath)
   const approvedInviters = new Set(allowlist.approved_inviters.map(inviter => inviter.username))

--- a/scripts/merge-data-pr.test.ts
+++ b/scripts/merge-data-pr.test.ts
@@ -13,14 +13,28 @@ function isoDaysAgo(daysAgo: number): string {
   return new Date(Date.UTC(2026, 3, 16 - daysAgo, 0, 0, 0)).toISOString()
 }
 
-function mockOctokit(overrides?: {
-  compareCommitsWithBasehead?: OctokitClient['rest']['repos']['compareCommitsWithBasehead']
-  listPullRequestsAssociatedWithCommit?: OctokitClient['rest']['repos']['listPullRequestsAssociatedWithCommit']
-  createPullRequest?: OctokitClient['rest']['pulls']['create']
-  addLabels?: OctokitClient['rest']['issues']['addLabels']
-  createIssue?: OctokitClient['rest']['issues']['create']
-  listForRepo?: OctokitClient['rest']['issues']['listForRepo']
-}): OctokitClient {
+interface MockOverrides {
+  compareCommitsWithBasehead?: (params: {owner: string; repo: string; basehead: string}) => Promise<unknown>
+  listPullRequestsAssociatedWithCommit?: (params: {owner: string; repo: string; commit_sha: string}) => Promise<unknown>
+  createPullRequest?: (params: {
+    owner: string
+    repo: string
+    title: string
+    head: string
+    base: string
+    body: string
+  }) => Promise<unknown>
+  addLabels?: (params: {owner: string; repo: string; issue_number: number; labels: string[]}) => Promise<unknown>
+  createIssue?: (params: {owner: string; repo: string; title: string; body: string}) => Promise<unknown>
+  listForRepo?: (params: {
+    owner: string
+    repo: string
+    state: 'open' | 'closed' | 'all'
+    per_page?: number
+  }) => Promise<unknown>
+}
+
+function mockOctokit(overrides?: MockOverrides): OctokitClient {
   return {
     rest: {
       repos: {
@@ -56,7 +70,7 @@ function mockOctokit(overrides?: {
         listForRepo: overrides?.listForRepo ?? (async () => ({data: []})),
       },
     },
-  }
+  } as unknown as OctokitClient
 }
 
 describe('mergeDataPr', () => {

--- a/scripts/merge-data-pr.ts
+++ b/scripts/merge-data-pr.ts
@@ -1,3 +1,4 @@
+import type {Octokit} from '@octokit/rest'
 import process from 'node:process'
 
 const DEFAULT_OWNER = 'fro-bot'
@@ -28,92 +29,11 @@ export interface MergeDataPrResult {
   staleAlertIssueNumber: number | null
 }
 
-export interface OctokitClient {
-  rest: {
-    repos: {
-      compareCommitsWithBasehead: (params: {owner: string; repo: string; basehead: string}) => Promise<{
-        data: {
-          files?: {
-            filename: string
-          }[]
-          merge_base_commit?: {
-            sha: string
-            commit?: {
-              committer?: {
-                date?: string | null
-              }
-            }
-          }
-          commits: {
-            sha: string
-            commit?: {
-              committer?: {
-                date?: string | null
-              }
-            }
-          }[]
-          ahead_by: number
-          behind_by: number
-          total_commits: number
-        }
-      }>
-      listPullRequestsAssociatedWithCommit: (params: {owner: string; repo: string; commit_sha: string}) => Promise<{
-        data: {
-          number: number
-          html_url: string
-          head?: {
-            ref?: string
-          }
-          base?: {
-            ref?: string
-          }
-        }[]
-      }>
-    }
-    pulls: {
-      create: (params: {
-        owner: string
-        repo: string
-        title: string
-        head: string
-        base: string
-        body: string
-      }) => Promise<{
-        data: {
-          number: number
-          html_url: string
-        }
-      }>
-    }
-    issues: {
-      addLabels: (params: {owner: string; repo: string; issue_number: number; labels: string[]}) => Promise<{
-        data: {
-          labels: {
-            name: string
-          }[]
-        }
-      }>
-      create: (params: {owner: string; repo: string; title: string; body: string}) => Promise<{
-        data: {
-          number: number
-          html_url: string
-        }
-      }>
-      listForRepo: (params: {
-        owner: string
-        repo: string
-        state: 'open' | 'closed' | 'all'
-        per_page?: number
-      }) => Promise<{
-        data: {
-          number: number
-          title: string
-          state: string
-        }[]
-      }>
-    }
-  }
-}
+/**
+ * Narrow Octokit client type derived from the real `@octokit/rest` SDK.
+ * See commit-metadata.ts for the rationale behind deriving rather than handwriting.
+ */
+export type OctokitClient = Octokit
 
 export type MergeDataPrErrorCode = 'MISSING_TOKEN' | 'OCTOKIT_LOAD_FAILED' | 'API_ERROR'
 

--- a/scripts/wiki-ingest.test.ts
+++ b/scripts/wiki-ingest.test.ts
@@ -1,3 +1,4 @@
+import type {OctokitClient} from './wiki-ingest.ts'
 import {Buffer} from 'node:buffer'
 
 import {describe, expect, it, vi} from 'vitest'
@@ -10,44 +11,27 @@ const wikiIngestModulePromise: Promise<{
 }> = import(`./wiki-ingest${'.js'}`)
 const {buildWikiIngestChanges, commitWikiChanges, WikiIngestError} = await wikiIngestModulePromise
 
-interface GitClient {
-  rest: {
-    git: {
-      getRef: (params: {owner: string; repo: string; ref: string}) => Promise<{data: {object: {sha: string}}}>
-      getCommit: (params: {owner: string; repo: string; commit_sha: string}) => Promise<{
-        data: {sha: string; tree: {sha: string}}
-      }>
-      createBlob: (params: {owner: string; repo: string; content: string; encoding: 'utf-8'}) => Promise<{
-        data: {sha: string}
-      }>
-      createTree: (params: {
-        owner: string
-        repo: string
-        base_tree: string
-        tree: {path: string; mode: '100644'; type: 'blob'; sha: string}[]
-      }) => Promise<{data: {sha: string}}>
-      createCommit: (params: {
-        owner: string
-        repo: string
-        message: string
-        tree: string
-        parents: string[]
-      }) => Promise<{data: {sha: string}}>
-      updateRef: (params: {owner: string; repo: string; ref: string; sha: string; force: false}) => Promise<{
-        data: {ref: string}
-      }>
-    }
-  }
+interface MockOverrides {
+  getRef?: (params: {owner: string; repo: string; ref: string}) => Promise<unknown>
+  getCommit?: (params: {owner: string; repo: string; commit_sha: string}) => Promise<unknown>
+  createBlob?: (params: {owner: string; repo: string; content: string; encoding: 'utf-8'}) => Promise<unknown>
+  createTree?: (params: {
+    owner: string
+    repo: string
+    base_tree: string
+    tree: {path: string; mode: '100644'; type: 'blob'; sha: string}[]
+  }) => Promise<unknown>
+  createCommit?: (params: {
+    owner: string
+    repo: string
+    message: string
+    tree: string
+    parents: string[]
+  }) => Promise<unknown>
+  updateRef?: (params: {owner: string; repo: string; ref: string; sha: string; force: false}) => Promise<unknown>
 }
 
-function createOctokitMock(overrides?: {
-  getRef?: GitClient['rest']['git']['getRef']
-  getCommit?: GitClient['rest']['git']['getCommit']
-  createBlob?: GitClient['rest']['git']['createBlob']
-  createTree?: GitClient['rest']['git']['createTree']
-  createCommit?: GitClient['rest']['git']['createCommit']
-  updateRef?: GitClient['rest']['git']['updateRef']
-}): GitClient {
+function createOctokitMock(overrides?: MockOverrides): OctokitClient {
   return {
     rest: {
       git: {
@@ -68,7 +52,7 @@ function createOctokitMock(overrides?: {
         updateRef: overrides?.updateRef ?? (async () => ({data: {ref: 'refs/heads/data'}})),
       },
     },
-  }
+  } as unknown as OctokitClient
 }
 
 function createEmptyWikiFiles(): Record<string, string> {
@@ -487,7 +471,7 @@ describe('commitWikiChanges', () => {
     const createTree = vi.fn(async () => ({data: {sha: 'tree-after-write'}}))
     const createCommit = vi.fn(async () => ({data: {sha: 'commit-after-write'}}))
     const updateRef = vi
-      .fn<GitClient['rest']['git']['updateRef']>()
+      .fn<(params: {owner: string; repo: string; ref: string; sha: string; force: false}) => Promise<unknown>>()
       .mockRejectedValueOnce(Object.assign(new Error('Reference update failed'), {status: 409}))
       .mockResolvedValueOnce({data: {ref: 'refs/heads/data'}})
     const octokit = createOctokitMock({createBlob, createTree, createCommit, updateRef})
@@ -522,7 +506,7 @@ describe('commitWikiChanges', () => {
   it('backs off exponentially before retrying a 409 ref conflict', async () => {
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0)
     const updateRef = vi
-      .fn<GitClient['rest']['git']['updateRef']>()
+      .fn<(params: {owner: string; repo: string; ref: string; sha: string; force: false}) => Promise<unknown>>()
       .mockRejectedValueOnce(Object.assign(new Error('Reference update failed'), {status: 409}))
       .mockResolvedValueOnce({data: {ref: 'refs/heads/data'}})
 
@@ -554,7 +538,7 @@ describe('commitWikiChanges', () => {
     vi.useFakeTimers()
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0)
     const updateRef = vi
-      .fn<GitClient['rest']['git']['updateRef']>()
+      .fn<(params: {owner: string; repo: string; ref: string; sha: string; force: false}) => Promise<unknown>>()
       .mockRejectedValue(Object.assign(new Error('Reference update failed'), {status: 409}))
 
     try {
@@ -583,7 +567,7 @@ describe('commitWikiChanges', () => {
 
   it('does not retry 422 updateRef failures', async () => {
     const updateRef = vi
-      .fn<GitClient['rest']['git']['updateRef']>()
+      .fn<(params: {owner: string; repo: string; ref: string; sha: string; force: false}) => Promise<unknown>>()
       .mockRejectedValue(Object.assign(new Error('Validation failed'), {status: 422}))
 
     // #given a non-conflict updateRef failure from GitHub

--- a/scripts/wiki-ingest.ts
+++ b/scripts/wiki-ingest.ts
@@ -1,4 +1,5 @@
 import type {Dirent} from 'node:fs'
+import type {Octokit} from '@octokit/rest'
 import {execFile} from 'node:child_process'
 import {readdir, readFile} from 'node:fs/promises'
 import {basename} from 'node:path'
@@ -65,63 +66,11 @@ export interface CommitWikiChangesResult {
   attempts: number
 }
 
-export interface OctokitClient {
-  rest: {
-    git: {
-      getRef: (params: {owner: string; repo: string; ref: string}) => Promise<{
-        data: {
-          object: {
-            sha: string
-          }
-        }
-      }>
-      getCommit: (params: {owner: string; repo: string; commit_sha: string}) => Promise<{
-        data: {
-          sha: string
-          tree: {
-            sha: string
-          }
-        }
-      }>
-      createBlob: (params: {owner: string; repo: string; content: string; encoding: 'utf-8'}) => Promise<{
-        data: {
-          sha: string
-        }
-      }>
-      createTree: (params: {
-        owner: string
-        repo: string
-        base_tree: string
-        tree: {
-          path: string
-          mode: '100644'
-          type: 'blob'
-          sha: string
-        }[]
-      }) => Promise<{
-        data: {
-          sha: string
-        }
-      }>
-      createCommit: (params: {
-        owner: string
-        repo: string
-        message: string
-        tree: string
-        parents: string[]
-      }) => Promise<{
-        data: {
-          sha: string
-        }
-      }>
-      updateRef: (params: {owner: string; repo: string; ref: string; sha: string; force: false}) => Promise<{
-        data: {
-          ref: string
-        }
-      }>
-    }
-  }
-}
+/**
+ * Narrow Octokit client type derived from the real `@octokit/rest` SDK.
+ * See commit-metadata.ts for the rationale behind deriving rather than handwriting.
+ */
+export type OctokitClient = Octokit
 
 export type WikiIngestErrorCode =
   | 'INVALID_PAYLOAD'


### PR DESCRIPTION
## Summary

Replaces five handwritten `OctokitClient` interfaces with type aliases to the real `Octokit` class. Makes both classes of SDK-drift bug into compile errors:

1. **Hallucinated method names** (e.g. `listRepositoryInvitations`, `acceptInvitation`, `starRepo` — all landed in production previously). Handwritten interfaces satisfy `tsc` when they match the call site, even if the method doesn't exist on the real SDK. Deriving from `Octokit` catches this at compile time.
2. **Nullability narrowing** (e.g. `RepositoryInvitation.inviter` declared non-null when GitHub's schema is `nullable-simple-user`). Handwritten interfaces can silently tighten null variants that the real schema declares. Deriving preserves nullability faithfully.

Implements prevention rule #5 in [docs/solutions/runtime-errors/octokit-invitation-method-names-2026-04-17.md](https://github.com/fro-bot/.github/blob/main/docs/solutions/runtime-errors/octokit-invitation-method-names-2026-04-17.md).

## Changes

### Production scripts (all 5)
Each `export interface OctokitClient { ... }` → `export type OctokitClient = Octokit`:
- `scripts/commit-metadata.ts`
- `scripts/data-branch-bootstrap.ts`
- `scripts/handle-invitation.ts` — also removed the multi-interface extension chain (`CommitMetadataOctokitClient` + `BootstrapOctokitClient`) and the cross-script `as unknown as BootstrapOctokitClient` cast, since all three now resolve to the same type
- `scripts/merge-data-pr.ts`
- `scripts/wiki-ingest.ts`

### Test files (all 5)
The real `Octokit` type is vast and includes internals (`endpoint`/`defaults`/`request`/`graphql`/`hook`/`auth`/`log`) that mocks would never exercise. Mocks keep narrow-handwritten shapes via a local `MockOverrides` interface, and cast the return value with `as unknown as OctokitClient` at the boundary.

**Key invariant**: production call sites still see the real SDK surface. The cast only relaxes what mocks must implement, not what production code is typed against. A hallucinated method name in production is still a compile error.

- `scripts/commit-metadata.test.ts`
- `scripts/data-branch-bootstrap.test.ts`
- `scripts/handle-invitation.test.ts` — also removed the redundant `HandleInvitationsOctokit = OctokitClient` alias
- `scripts/merge-data-pr.test.ts`
- `scripts/wiki-ingest.test.ts` — also removed the test-local `GitClient` interface (shadow copy of the production interface)

## Net Diff

**-188 lines** of handwritten interface types removed. Replaced with 5 one-line type aliases and local `MockOverrides` helpers in tests.

## Verification

- `pnpm check-types`: clean
- `pnpm lint scripts`: clean
- `pnpm test`: 84/84 passing

## Proof

Sanity check while writing this:

```typescript
// In scripts/handle-invitation.ts
await params.octokit.rest.activity.starRepo({owner, repo})
```

Before this PR: `tsc` clean, runtime throws.
After this PR: `tsc` errors at the call site because `starRepo` isn't a method on the real `Octokit['rest']['activity']`.

## Post-Deploy Monitoring

No runtime behavior changes — pure type-level refactor. Existing tests exercise every call site through the mock boundary, so any latent issue would surface in `pnpm test`.

- **Monitor**: next `Poll invitations` and `Merge Data Branch` runs after merge — confirm no regression in real Octokit usage
- **Failure signal**: runtime `X is not a function` error would indicate a missed call site