### PR TITLE
fix(survey): preserve double-dash in wiki repo slugs

### DIFF
--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -88,7 +88,7 @@ jobs:
         run: |
           delimiter="EOF_$(openssl rand -hex 8)"
           target_repository="$TARGET_OWNER/$TARGET_REPO"
-          target_slug="$(printf '%s--%s' "$TARGET_OWNER" "$TARGET_REPO" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-')"
+          target_slug="$(node scripts/wiki-slug.ts "$TARGET_OWNER" "$TARGET_REPO")"
           export TARGET_REPOSITORY="$target_repository"
           export TARGET_SLUG="$target_slug"
           resolved=$(printf '%s' "$PROMPT_TEMPLATE" | perl -0pe 's/\$TARGET_REPOSITORY/$ENV{TARGET_REPOSITORY}/g; s/\$TARGET_SLUG/$ENV{TARGET_SLUG}/g')

--- a/scripts/wiki-slug.test.ts
+++ b/scripts/wiki-slug.test.ts
@@ -1,0 +1,52 @@
+import {describe, expect, it} from 'vitest'
+
+import {computeRepoSlug} from './wiki-slug.ts'
+
+describe('computeRepoSlug', () => {
+  it('preserves the double-dash separator between owner and repo', () => {
+    // #given a standard owner/repo pair that would previously be squeezed to single-dash
+    // #when the slug is computed
+    // #then the canonical `{owner}--{repo}` form is preserved
+    expect(computeRepoSlug('marcusrbrown', 'ha-config')).toBe('marcusrbrown--ha-config')
+  })
+
+  it('lowercases segments without mangling internal dashes', () => {
+    // #given mixed-case owner and repo with internal dashes
+    // #when the slug is computed
+    // #then each segment is lowered and internal dashes are preserved
+    expect(computeRepoSlug('Marcus-R', 'Hello-World')).toBe('marcus-r--hello-world')
+  })
+
+  it('replaces non-alphanumeric characters with single dashes per segment', () => {
+    // #given segments containing characters outside [a-z0-9-] (spaces, dots, underscores)
+    // #when the slug is computed
+    // #then non-kept runs collapse to a single dash within each segment, then segments join with --
+    expect(computeRepoSlug('fro-bot', '.github')).toBe('fro-bot--github')
+    expect(computeRepoSlug('my org', 'weird  name')).toBe('my-org--weird-name')
+    expect(computeRepoSlug('under_score', 'dot.name')).toBe('under-score--dot-name')
+  })
+
+  it('trims leading and trailing dashes within each segment before joining', () => {
+    // #given segments whose sanitization would leave leading or trailing dashes
+    // #when the slug is computed
+    // #then those dashes are trimmed so the final form never has 3+ consecutive dashes
+    expect(computeRepoSlug('__weird', 'trailing-')).toBe('weird--trailing')
+    expect(computeRepoSlug('-leading', 'ok')).toBe('leading--ok')
+  })
+
+  it('throws when a segment sanitizes to an empty string', () => {
+    // #given a segment that consists entirely of non-kept characters
+    // #when the slug is computed
+    // #then the helper refuses rather than producing an invalid slug
+    expect(() => computeRepoSlug('___', 'valid')).toThrow(/empty/)
+    expect(() => computeRepoSlug('valid', '')).toThrow(/empty/)
+  })
+
+  it('handles segments with dots in repo names (GitHub permits them)', () => {
+    // #given a repo name like `.github` where GitHub's server convention keeps the leading dot
+    // #when the slug is computed
+    // #then we strip the dot-induced leading dash so the slug stays valid
+    expect(computeRepoSlug('fro-bot', '.github')).toBe('fro-bot--github')
+    expect(computeRepoSlug('marcusrbrown', 'esphome.life')).toBe('marcusrbrown--esphome-life')
+  })
+})

--- a/scripts/wiki-slug.ts
+++ b/scripts/wiki-slug.ts
@@ -1,0 +1,55 @@
+import process from 'node:process'
+
+/**
+ * Canonical wiki slug for a repo page.
+ *
+ * Produces `{owner-slug}--{repo-slug}` with:
+ * - each segment lowercased
+ * - runs of characters outside `[a-z0-9-]` collapsed to a single `-`
+ * - leading and trailing `-` trimmed within each segment
+ * - segments joined with a literal `--` separator
+ *
+ * The double-dash between owner and repo is the filename convention declared in
+ * `knowledge/schema.md` (repo pages live at `knowledge/wiki/repos/{owner}--{repo}.md`).
+ * Per-segment sanitization preserves that separator even when owner or repo names
+ * contain dots, spaces, or other characters that must be replaced.
+ *
+ * Throws if either segment sanitizes to an empty string — an empty slug cannot be
+ * validated against the schema and would produce an invalid wiki filename.
+ */
+export function computeRepoSlug(owner: string, repo: string): string {
+  const ownerSlug = sanitizeSegment(owner)
+  const repoSlug = sanitizeSegment(repo)
+
+  if (ownerSlug === '' || repoSlug === '') {
+    throw new Error(
+      `computeRepoSlug: segment sanitized to empty string (owner=${JSON.stringify(owner)} -> ${JSON.stringify(
+        ownerSlug,
+      )}, repo=${JSON.stringify(repo)} -> ${JSON.stringify(repoSlug)})`,
+    )
+  }
+
+  return `${ownerSlug}--${repoSlug}`
+}
+
+function sanitizeSegment(segment: string): string {
+  return segment
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9-]+/g, '-')
+    .replaceAll(/^-+|-+$/g, '')
+}
+
+async function main(): Promise<void> {
+  const [, , owner, repo] = process.argv
+
+  if (owner === undefined || repo === undefined || owner === '' || repo === '') {
+    process.stderr.write('Usage: node scripts/wiki-slug.ts <owner> <repo>\n')
+    process.exit(1)
+  }
+
+  process.stdout.write(computeRepoSlug(owner, repo))
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}


### PR DESCRIPTION
## Summary

Repo wiki pages must live at `knowledge/wiki/repos/{owner}--{repo}.md` per the convention in `knowledge/schema.md`. The Survey Repo workflow's inline shell slug computation squeezed the intentional double-dash down to a single dash:

```bash
# Before
target_slug="$(printf '%s--%s' "$TARGET_OWNER" "$TARGET_REPO" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-')"
```

`tr -cs 'a-z0-9-' '-'` squeezes runs of dashes in the keep set, so `marcusrbrown--ha-config` collapses to `marcusrbrown-ha-config`. The surveyed agent gets a slug that violates the schema, writes a file at the wrong path, and ingest validation rejects it downstream.

## Fix

Extracted slug computation into `scripts/wiki-slug.ts`. Per-segment sanitization lowercases, replaces non-`[a-z0-9-]` runs with a single dash, trims leading/trailing dashes, then joins with a literal `--`. Throws if either segment sanitizes to empty (unusable slug).

```typescript
export function computeRepoSlug(owner: string, repo: string): string {
  const ownerSlug = sanitizeSegment(owner)
  const repoSlug = sanitizeSegment(repo)
  if (ownerSlug === '' || repoSlug === '') { throw new Error(...) }
  return `${ownerSlug}--${repoSlug}`
}
```

Workflow now calls the helper:

```yaml
target_slug="$(node scripts/wiki-slug.ts "$TARGET_OWNER" "$TARGET_REPO")"
```

## Tests

6 new tests covering:
- Standard case (the original failure): `marcusrbrown`, `ha-config` → `marcusrbrown--ha-config`
- Mixed case: `Marcus-R`, `Hello-World` → `marcus-r--hello-world`
- Non-alphanumeric replacement: `.github` → `github`, `dot.name` → `dot-name`, spaces → dashes
- Leading/trailing dash trimming: `__weird` → `weird`, `trailing-` → `trailing`
- Empty segment rejection: throws on `___` / `''`
- Dotfile repo names: `esphome.life` → `esphome-life`

## Verification

- `pnpm check-types`, `pnpm lint`, `pnpm test` all clean (90/90 passing; was 84)
- CLI smoke test: `node scripts/wiki-slug.ts marcusrbrown ha-config` → `marcusrbrown--ha-config`
- CLI edge case: `node scripts/wiki-slug.ts fro-bot .github` → `fro-bot--github`

## Post-Deploy Monitoring

- **Next Survey Repo dispatch** — confirm the resolved slug in the workflow log matches `{owner}--{repo}` canonical form
- **Next wiki ingest commit** — confirm created file lives at `knowledge/wiki/repos/{owner}--{repo}.md` without post-hoc rename