### PR TITLE
feat(reconcile): sync metadata/repos.yaml with GitHub collaborator access

### DIFF
--- a/.github/workflows/reconcile-repos.yaml
+++ b/.github/workflows/reconcile-repos.yaml
@@ -1,0 +1,43 @@
+---
+name: Reconcile Repos
+
+on:
+  schedule:
+    - cron: '17 5 * * *' # Daily at 05:17 UTC (off-peak vs hourly Poll Invitations and Sunday 22:00 Merge Data)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reconcile-repos
+  cancel-in-progress: false
+
+jobs:
+  reconcile-repos:
+    name: Reconcile metadata/repos.yaml with GitHub collaborator access
+    permissions:
+      contents: write
+      actions: write
+      issues: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - id: get-workflow-app-token
+        name: Get Workflow Access Token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+
+      - name: ⤵ Checkout Branch
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: 📦 Setup
+        uses: ./.github/actions/setup
+
+      - name: 🔁 Reconcile repos
+        env:
+          FRO_BOT_POLL_PAT: ${{ secrets.FRO_BOT_POLL_PAT }}
+          GITHUB_TOKEN: ${{ steps.get-workflow-app-token.outputs.token }}
+        run: node scripts/reconcile-repos.ts

--- a/docs/brainstorms/2026-04-17-repo-reconciliation-requirements.md
+++ b/docs/brainstorms/2026-04-17-repo-reconciliation-requirements.md
@@ -1,0 +1,105 @@
+---
+date: 2026-04-17
+topic: repo-reconciliation
+---
+
+# Repo Reconciliation
+
+## Problem Frame
+
+`metadata/repos.yaml` is Fro Bot's local projection of which repos it is a collaborator on and what it knows about them. GitHub is the source of truth for collab access. The projection can drift from reality in several ways:
+
+- **Partial-failure orphan** — Poll Invitations accepts an invitation but fails before writing the metadata entry and dispatching Survey Repo. Fro Bot ends up with collab access but no local record and no wiki page.
+- **Out-of-band acceptance** — An operator adds fro-bot as a collaborator through GitHub's UI without going through the invitation flow. Poll Invitations never sees it.
+- **Unsolicited collab grant** — GitHub allows a repo admin to add any user as a collaborator without that user's consent. fro-bot's access list can grow without any invitation ever being issued.
+- **Lost access** — A repo owner revokes fro-bot's access, archives the repo, or deletes it. The metadata entry becomes stale.
+- **Field drift** — `has_fro_bot_workflow` and `has_renovate` were captured at survey time and never refreshed. Repos that added/removed these after the initial survey are out of sync.
+
+Each of these failure modes leaves Fro Bot operating on a wrong mental model. Left unchecked, the projection drifts indefinitely — and unsolicited grants in particular expand Fro Bot's attack surface without any trust gate.
+
+## Prerequisites
+
+Must land before reconcile can function:
+
+- Extend `OnboardingStatus` in `scripts/schemas.ts` to add `lost-access` and `pending-review` values; update the `isOnboardingStatus` runtime guard. Existing `repos.yaml` entries stay valid.
+
+## Requirements
+
+- **R1. Discover new access with allowlist gate.** Detect repos where fro-bot has collaborator access but no matching entry exists in `metadata/repos.yaml`. Two paths based on repo owner:
+  - Owner is in `approved_inviters` (per `metadata/allowlist.yaml`): add entry with `onboarding_status: pending` and dispatch Survey Repo.
+  - Owner is NOT in `approved_inviters`: add entry with `onboarding_status: pending-review`, do NOT dispatch Survey Repo, and open a GitHub issue summarizing the unsolicited grant for operator review.
+- **R2. Flag lost access across all three failure modes.** Detect entries where fro-bot no longer has collaborator access. Set-difference against `/user/repos?affiliation=collaborator` identifies candidates; for each candidate, `GET /repos/{owner}/{repo}` disambiguates:
+  - 404 → repo deleted
+  - 200 with `archived: true` → archived
+  - 200 with fro-bot absent from collaborators → revoked
+
+  All three map to `onboarding_status: lost-access` with all other fields preserved (wiki page, survey history, timestamps).
+- **R3. Refresh drift-prone fields via existence checks.** On every run, re-query `has_fro_bot_workflow` and `has_renovate` for every still-accessible tracked repo using file or directory existence checks only (no content reads). Update the entry if different. Lost-access entries retain their last-known field values.
+- **R4. Sequential dispatches with non-blocking failure.** When R1 or R9 discovers multiple repos needing survey, dispatch Survey Repo one at a time (not in parallel). Dispatch failures are logged but do not block subsequent dispatches and are not retried within the same run. The next daily run re-attempts dispatch for any entry still in `pending`.
+- **R5. Commit-before-dispatch, one atomic commit per run.** Reconcile writes all metadata changes from a single run in one commit to the `data` branch before any Survey Repo dispatches. Dispatch failures do not roll back the commit — entries remain `pending` and the next run retries. Commit messages summarize changes as aggregate counts only (e.g., `chore(reconcile): +2 new, 1 pending-review, 1 lost-access, 3 refreshes`) — no repo names in commit metadata.
+- **R6. Silent when unchanged.** When a run detects zero changes, skip the commit and exit with a run-log summary only. No empty commits, no no-op PRs, no GitHub issues.
+- **R7. Scheduled and manual triggers.** Runs daily via scheduled cron (low-traffic UTC hour) and on manual `workflow_dispatch`. No inline integration with Poll Invitations.
+- **R8. Dual credentials: user PAT for enumeration, app token for dispatch and commit.** Reconcile uses two Octokit clients:
+  - `FRO_BOT_POLL_PAT` (classic user PAT) for `GET /user/repos?affiliation=collaborator` and `GET /repos/{owner}/{repo}` (user-scoped endpoints the app token cannot access).
+  - `fro-bot[bot]` app token (minted via `APPLICATION_ID` + `APPLICATION_PRIVATE_KEY`) for Survey Repo dispatch, data-branch commits, and GitHub issue creation for `pending-review` events.
+- **R9. Regained access rehydrates the entry.** If a `lost-access` entry is found to have collaborator access again, apply the same owner-allowlist gate as R1: owner in `approved_inviters` flips it to `pending` and dispatches Survey Repo; owner not allowlisted flips it to `pending-review` with an issue. Existing history (wiki page, last_survey_at, timestamps) is preserved either way.
+
+## Success Criteria
+
+- Any repo fro-bot gains collaborator access to appears in `metadata/repos.yaml` within 24 hours of access being granted, with the appropriate onboarding status based on the allowlist gate.
+- Allowlisted owners: Survey Repo is dispatched within 24 hours. Non-allowlisted owners: operator is notified via a GitHub issue within 24 hours; Survey Repo is NOT auto-dispatched.
+- Revoked, archived, or deleted access is reflected as `onboarding_status: lost-access` within 24 hours, with the entry otherwise preserved.
+- `has_fro_bot_workflow` and `has_renovate` on accessible entries match current repo state with a maximum staleness of 24 hours.
+- Running reconcile a second time immediately after a successful run produces zero metadata changes (idempotent).
+- Normal operation produces no GitHub issues outside the `pending-review` flow and no noise when state is already in sync.
+
+## Scope Boundaries
+
+- Does NOT alter Poll Invitations behavior. That workflow remains single-purpose: handle pending invitations.
+- Does NOT auto-dispatch Survey Repo for repos whose owner is outside `approved_inviters`. Operator must explicitly approve via a follow-up manual dispatch after reviewing the issue.
+- Does NOT delete metadata entries for `lost-access` or `pending-review` repos. Deletion is always a deliberate operator action, performed manually.
+- Does NOT create GitHub issues for reconcile events EXCEPT the `pending-review` security-relevant case (narrow exception). Git history and the `data → main` PR description are the primary audit trail.
+- Does NOT rate-limit dispatches beyond "sequential, one at a time". No explicit cooldown.
+- Does NOT refresh wiki content. That happens via Survey Repo, which reconcile dispatches but does not replace.
+- Does NOT include repo names in commit messages or workflow logs. Private repo names must not leak via audit artifacts.
+- Does NOT refresh field drift via file-content reads. Existence checks only.
+
+## Key Decisions
+
+- **Daily cron only, no inline poll integration.** Keeps Poll Invitations single-purpose; 24-hour reconciliation latency is acceptable at current scale.
+- **Full bidirectional reconciliation.** Detects both directions of drift (new access, lost access) and refreshes drift-prone fields. The principle "GitHub is the source of truth" applies to the whole metadata projection, not just presence/absence.
+- **Flag lost access, preserve the entry.** Audit trail stays in git; operator controls cleanup. Deletion requires a deliberate act.
+- **Owner-allowlist gate for newly-discovered repos.** Defends against unsolicited collab grants (GitHub lets any repo admin add any user without consent). Repos from non-allowlisted owners land in `pending-review` and do not auto-dispatch Survey Repo.
+- **`pending-review` is the security-review queue.** One GitHub issue per event; operator decides whether to promote to `pending` (approve + survey) or remove the entry.
+- **Silent operation by default.** One commit per run when changes exist; GitHub issues only for `pending-review` events.
+- **Sequential Survey Repo dispatches with non-blocking failure.** Simple, avoids parallel agent contention. A stuck or failed dispatch doesn't block subsequent ones; the next daily run retries.
+- **Commit-before-dispatch ordering.** Metadata state is durable before any external side effects. Partial-dispatch failures are self-healing on the next run.
+- **Dual-credential architecture.** `FRO_BOT_POLL_PAT` for user-scoped enumeration; `fro-bot[bot]` app token for writes and dispatches. Two Octokit clients in one script.
+- **Aggregate-only commit messages and logs.** No repo names in any audit artifact the workflow produces.
+
+## Dependencies / Assumptions
+
+- `FRO_BOT_POLL_PAT` scope is sufficient to call `GET /user/repos?affiliation=collaborator` and `GET /repos/{owner}/{repo}`.
+- `fro-bot[bot]` app installation has `contents: write` (data branch), `actions: write` (workflow dispatch), and `issues: write` (pending-review issues) on this repo.
+- `commitMetadata` continues to handle concurrent-writer 409s via retry; reconcile uses it for data-branch writes.
+- `approved_inviters` in `metadata/allowlist.yaml` is the right trust principal list. If repos owned by orgs (not individuals) are added later, the allowlist may need to be extended to accept org logins.
+- `survey-repo.yaml` workflow remains dispatched via `workflow_dispatch` with `owner` + `repo` inputs; no changes to that workflow are required.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+_(none)_
+
+### Deferred to Planning
+
+- [Affects R3][Technical] Existence-check API strategy for `has_fro_bot_workflow` and `has_renovate`. Use `GET /repos/{owner}/{repo}/contents/.github/workflows` (one call, scan for `fro-bot*.yaml`) and `GET /repos/{owner}/{repo}/contents` at root + `.github` for renovate files. Exact predicates and fallback paths to settle during implementation.
+- [Affects R2][Technical] Rename/transfer detection via GitHub's repo `node_id`. Matching by `owner+name` is simpler but fragile across renames. Node_id cross-reference adds stability but introduces retention questions (fro-bot tracks across renames). Planning decides whether to adopt, and if so, what retention policy applies.
+- [Affects R4][Technical] Dispatch timeout value. Serial `await` on `createWorkflowDispatch` can hang on a stuck GitHub Actions API call; planning settles the per-dispatch timeout and `retry-after` backoff semantics.
+- [Affects R3/R4][Technical] Secondary rate-limit backoff. Honor `retry-after` headers on 403s; log and continue on other secondary limits. Exact policy during implementation.
+- [Affects R5] Commit message summary format. Aggregate counts only — exact wording (`+2 new, 1 pending-review, 1 lost-access, 3 refreshes`) is a small planning-time decision.
+- [Affects R1/R9] `pending-review` issue format. Title, body, labels — planning settles the issue template so operator review is fast.
+
+## Next Steps
+
+→ `/ce:plan` for structured implementation planning.

--- a/docs/plans/2026-04-17-001-feat-repo-reconciliation-plan.md
+++ b/docs/plans/2026-04-17-001-feat-repo-reconciliation-plan.md
@@ -1,0 +1,393 @@
+---
+title: Repo Reconciliation
+type: feat
+status: active
+date: 2026-04-17
+deepened: 2026-04-17
+origin: docs/brainstorms/2026-04-17-repo-reconciliation-requirements.md
+---
+
+# Repo Reconciliation
+
+## Overview
+
+Add a daily reconciliation workflow that keeps `metadata/repos.yaml` in sync with fro-bot's actual GitHub collaborator access. Closes partial-failure orphans (invitation accepted but metadata never written), out-of-band acceptances (collaborator added via GitHub UI), unsolicited grants (allowlist-gated for safety), lost-access events (revoked, archived, deleted), and field drift on tracked fields (`has_fro_bot_workflow`, `has_renovate`).
+
+## Problem Frame
+
+`metadata/repos.yaml` is Fro Bot's local projection of its collaborator reality; GitHub is the source of truth. Five failure modes cause drift today — see origin doc for full list. Left unreconciled, the projection becomes unreliable and Fro Bot operates on a stale mental model. This plan delivers the reconciler that brings the projection back to truth within 24 hours, with an explicit allowlist gate to defend against unsolicited collaborator grants.
+
+## Requirements Trace
+
+- **R1** — Discover new access with allowlist gate (see origin: docs/brainstorms/2026-04-17-repo-reconciliation-requirements.md)
+- **R2** — Flag lost access across revoked / archived / deleted
+- **R3** — Refresh drift-prone fields via existence checks
+- **R4** — Sequential dispatches with non-blocking failure
+- **R5** — Commit-before-dispatch, one atomic commit per run
+- **R6** — Silent when unchanged
+- **R7** — Scheduled cron + manual dispatch
+- **R8** — Dual credentials (user PAT for enumeration, app token for writes/dispatches)
+- **R9** — Regained access rehydrates the entry
+
+## Scope Boundaries
+
+- Does not modify Poll Invitations behavior.
+- Does not auto-dispatch Survey Repo for non-allowlisted owners (security gate).
+- Does not delete metadata entries. Lost-access entries are preserved for audit.
+- Does not include repo names in commit messages or workflow logs (private-repo name protection).
+- Does not read file contents for field refresh — existence checks only.
+- **Allowlist TOCTOU:** reconcile reads `metadata/allowlist.yaml` once at the start of the run. Mid-run operator changes to the allowlist take effect on the NEXT run, not the current one. Documented by design; daily cadence makes this acceptable.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/commit-metadata.ts` — atomic data-branch write with 409 retry. Used for the metadata commit. Restricts path to `metadata/<name>.yaml`, restricts branch to `data`, checks branch protection. Mutator contract: pure function of current state.
+- `scripts/handle-invitation.ts` — closest existing loop pattern: per-repo processing with classified outcomes (accepted / skipped / failed). Borrow the shape for reconcile's per-repo processing but note reconcile classifies into more states (new-allowlisted / new-pending-review / revoked / archived / deleted / field-drift / unchanged / regained).
+- `scripts/data-branch-bootstrap.ts` — idempotent bootstrap of the `data` branch. Reconcile should call `bootstrapDataBranch` before its first commit, same as `handleInvitations`.
+- `scripts/wiki-ingest.ts` — Octokit type derivation pattern (`type OctokitClient = Octokit`) and the `createOctokitFromEnv` shape. Reconcile needs two clients so the pattern extends rather than reuses.
+- `scripts/schemas.ts` — runtime type guards for metadata schemas. Must extend `OnboardingStatus` enum and `isOnboardingStatus` guard before reconcile can write the new status values.
+- `.github/workflows/poll-invitations.yaml` — scheduled cron pattern. Reconcile's workflow mirrors its shape (checkout + setup + node script invocation).
+- `.github/workflows/merge-data.yaml` — app-token flow via `actions/create-github-app-token@v3.1.1` with `secrets.APPLICATION_ID` + `secrets.APPLICATION_PRIVATE_KEY`. Reconcile uses this pattern for the app-token half of its dual credentials.
+- `.github/workflows/survey-repo.yaml` — dispatch target. Reconcile calls its `workflow_dispatch` with `owner` + `repo` inputs.
+- `metadata/allowlist.yaml` — `approved_inviters` list. Reconcile reads this to classify new access.
+
+### Institutional Learnings
+
+- `docs/solutions/runtime-errors/octokit-invitation-method-names-2026-04-17.md` — derive `OctokitClient` from real `Octokit`; never handwrite SDK interfaces. Handwritten types silently hallucinate method names and drop nullability. Reconcile follows this rule from the start.
+
+### External References
+
+- GitHub REST: `GET /user/repos?affiliation=collaborator` returns repos where the authenticated user is a collaborator (not owner, not member). Requires `repo` scope on a classic PAT. Paginated (default 30/page, max 100). Returned entries include `archived`, `owner.login`, `name`, `id`, `node_id`.
+- GitHub REST: `GET /repos/{owner}/{repo}` returns 404 for deleted repos and 200 with `archived` field for existing ones.
+- GitHub REST: `POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches` is the workflow_dispatch endpoint (already used by `handle-invitation.ts`).
+
+## Key Technical Decisions
+
+- **Two Octokit clients, one script.** `userOctokit` authenticated via `FRO_BOT_POLL_PAT` for user-scoped reads (`/user/repos`, `/repos/{owner}/{repo}`). `appOctokit` authenticated via `fro-bot[bot]` installation token for data-branch writes (`commitMetadata`), workflow dispatches, and `pending-review` issue creation. Split is load-bearing: the app token cannot call `/user/repos` (user-scoped endpoint); the user PAT commits as `fro-bot` the user, not `fro-bot[bot]` the app, which contradicts the established identity preference.
+- **Pure-logic core, thin I/O shell.** The decision-making (classify each repo, compute next metadata state, produce a dispatch queue, produce a pending-review issue list) lives in pure functions taking `(currentRepos, accessList, perRepoStatus, allowlist, now)` and returning `(nextRepos, dispatchQueue, issuesQueue, summary)`. I/O (fetch access list, fetch per-repo status, commit, dispatch, create issues) sits in a thin outer layer. This mirrors the testing ergonomics of `handle-invitation.ts` and makes the reconciler easy to verify without mocking Octokit exhaustively.
+- **Single-script architecture.** Enumeration, classification, commit, dispatch, and issue creation all happen in one script invocation (one workflow run). Rejected: split into two workflows (enumerator → commit, then dispatcher). Rationale: operator-observability (one run log tells the whole story), atomicity (no intermediate state visible between runs), and the read→commit→dispatch ordering is easier to reason about as a linear script than as a message-passing pipeline. Cost: the script is long (~400 lines projected). Accepted.
+- **Mutator contract: re-compute on each invocation, not precompute.** The `commitMetadata` mutator passed by reconcile re-runs `reconcileRepos({currentRepos: current, accessList, perRepoStatus, allowlist, fieldProbes, now})` inside the closure — not a precomputed `nextRepos` snapshot. `accessList`, `perRepoStatus`, `allowlist`, and `fieldProbes` are captured once from the outer scope; `currentRepos` is supplied by `commitMetadata` on each attempt (including 409 retries). This guarantees concurrent-writer safety: if `poll-invitations` commits a new entry between reconcile's read and reconcile's commit, the 409 triggers a retry, the mutator re-runs against the post-poll `current`, and the merged result preserves the new entry. Load-bearing for correctness — without this, whole-state replacement under retry would silently drop concurrently-added entries.
+- **Lost-access detection uses Pass 1 for archived, Pass 2 for deleted/revoked.** Pass 1: fetch `/user/repos?affiliation=collaborator` (paginated, collect all). Archived repos appear in Pass 1 as entries with `archived: true` — these are classified as `lost-access` directly from Pass 1 data, no Pass 2 call needed. Pass 2: for each tracked entry **missing** from Pass 1, call `GET /repos/{owner}/{repo}` to disambiguate deleted (404) vs revoked (200, not in the collaborator access list). Avoid calling `GET /repos/{owner}/{repo}/collaborators` because it may be gated.
+- **Field-refresh via contents endpoint, no content bodies.** `has_fro_bot_workflow` checks the presence of any `fro-bot*.yaml` under `.github/workflows/` via `GET /repos/{owner}/{repo}/contents/.github/workflows` (directory listing). `has_renovate` checks existence of `renovate.json`, `.github/renovate.json`, `.renovaterc.json`, or `.renovaterc` via per-path HEAD (or `GET /repos/{owner}/{repo}/contents/<path>` returning 200/404). Do not read file contents. Normalize 404 to "absent".
+- **Commit-before-dispatch ordering.** Reconcile writes the atomic metadata commit first (via `commitMetadata`), then walks the dispatch queue sequentially. A dispatch failure logs and continues; the entry remains `pending` and the next daily run retries. This makes metadata state durable before any external side effects and makes the reconciler self-healing.
+- **Pre-commit `data`-branch integrity check.** Before reconcile calls `commitMetadata`, it fetches the current `data` branch HEAD and verifies the commit author matches the expected autonomous-writer identities (`fro-bot[bot]` for app-token commits, plus an operator-override allowlist for manual maintenance commits such as the initial bootstrap by Marcus). On mismatch, reconcile aborts with a typed error and files a tamper-alert GitHub issue labeled `reconcile:integrity-alert` — no commit happens. This is defense-in-depth for the unprotected `data` branch: if an actor with `contents:write` rewrites history, the next reconcile run catches it before compounding on top of the tampered state.
+- **Private-repo privacy: issue bodies differ by repo visibility.** The `GET /repos/{owner}/{repo}` response carries a `private: boolean` flag. For public repos, `pending-review` issues include the full `owner/repo` name and link. For private repos, the issue body omits the name and uses a stable opaque key (the repo `node_id`, which is not a URL and does not reveal the name); the operator cross-references via their own access to the metadata commit on `data`. Rationale: `fro-bot/.github` is public; naming a private repo in its issue body leaks the name to anyone reading the public issue stream.
+- **Aggregate-only audit artifacts for non-issue channels.** Commit message is a count summary (`chore(reconcile): +N new, M pending-review, K lost-access, J refreshes`). Workflow logs print aggregate counts and per-outcome summaries (not repo names). The only places repo names appear are: (a) `pending-review` issues for **public** repos, and (b) the `metadata/repos.yaml` commit itself (which stays in git history on the `data` branch — visible but not broadcast).
+- **Run summary emitted on stdout as JSON.** Matches `handle-invitation.ts` convention (`process.stdout.write(JSON.stringify(result))`). Enables downstream inspection via run logs without leaking repo names in the JSON payload (aggregate counts only).
+
+## Open Questions
+
+### Resolved During Planning
+
+- **How to handle org-owned repos when `approved_inviters` lists only user logins?** For this plan, treat any owner login not present in `approved_inviters.username` as non-allowlisted → `pending-review`. If operator later needs to allowlist an org, they add the org login as an `approved_inviters` entry. The allowlist schema already accepts any login string; no schema change needed. Noted in origin doc as a tracked assumption.
+- **Two Octokit clients in one script — pattern established?** No existing script uses two Octokits. Reconcile introduces the pattern. Follow the `createOctokitFromEnv` shape from `wiki-ingest.ts` but parameterize by token env var. Keep both clients as `Octokit` type aliases.
+- **Is the enumeration endpoint paginated, and how is it consumed?** Yes, paginated. Use `octokit.paginate(octokit.rest.repos.listForAuthenticatedUser, { affiliation: 'collaborator', per_page: 100 })` — available on the real Octokit because `paginate` is a core method. Mocks cast via `as unknown as OctokitClient` already, so there's no type impact.
+- **Does `addRepoEntry` already exist?** Yes — `scripts/handle-invitation.ts:282 addRepoEntry({current, owner, repo, now}) → ReposFile`. It hardcodes `onboarding_status: 'pending'` and is idempotent (returns unchanged if an entry already exists). To support reconcile's two newcomer statuses (`pending` for allowlisted, `pending-review` for non-allowlisted), the helper lifts to a shared module with an extended signature `(current, { owner, repo, now, onboarding_status? })`. `handle-invitation.ts` is updated to import from the shared module and continues to default to `'pending'`. See Unit 1 and the System-Wide Impact section.
+- **Is `fro-bot/.github` publicly visible?** Yes (verified via `repos/fro-bot/.github` — `visibility: public`, `private: false`). This drives the per-repo issue-body privacy decision above.
+- **Single script or two workflows?** One script, one workflow. See the architecture decision in Key Technical Decisions for rationale.
+
+### Deferred to Implementation
+
+- Exact dispatch timeout. Start with `15_000 ms` per `createWorkflowDispatch` call; revise if observed dispatches regularly exceed that.
+- Exact pending-review issue template (title, body, labels). Draft during Unit 3; the simplest form is `title: "Unsolicited collaborator grant: {owner}/{repo}"`, body lists context + the reconcile run URL + next-step options, label `reconcile:pending-review`.
+- Node_id tracking for rename/transfer stability. Deferred; first pass matches by `owner/name` only. If we observe renames drifting entries into lost-access incorrectly, add node_id cross-reference in a follow-up.
+- Secondary rate-limit backoff. Respect `retry-after` when present; otherwise log and continue. Exact wait-and-retry shape during implementation.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+Reconcile splits into a **pure decision engine** and an **I/O shell**. The decision engine takes snapshots in and produces a change plan out; the shell turns the plan into API calls and a commit.
+
+```
+                          +------------------------+
+    /user/repos  ───────► |                        |
+    per-repo status ────► |  reconcileRepos()      | ──► next repos.yaml state
+    metadata/repos.yaml ─►|  (pure function)       | ──► dispatch queue
+    metadata/allowlist ─► |                        | ──► pending-review queue
+                          +------------------------+ ──► summary (counts)
+                                                                │
+                                                                ▼
+                                                   +------------------------+
+                                                   |  I/O shell             |
+                                                   |  1. commitMetadata(    |
+                                                   |       next, summary)   |
+                                                   |  2. for each dispatch: |
+                                                   |       createWorkflow…  |
+                                                   |  3. for each issue:    |
+                                                   |       issues.create    |
+                                                   +------------------------+
+```
+
+Per-repo classification decision table:
+
+| Current state         | Accessible now? | Owner allowlisted? | Outcome                                      |
+| --------------------- | --------------- | ------------------ | -------------------------------------------- |
+| untracked             | yes             | yes                | new → add with `pending`, dispatch Survey    |
+| untracked             | yes             | no                 | new → add with `pending-review`, file issue  |
+| `pending`/`onboarded` | yes             | (any)              | refresh fields, no dispatch, no issue        |
+| `pending-review`      | yes             | (any)              | refresh fields only; operator promotes       |
+| `lost-access`         | yes             | yes                | regain → `pending`, dispatch Survey          |
+| `lost-access`         | yes             | no                 | regain → `pending-review`, file issue        |
+| tracked (any)         | no              | (any)              | classify via `GET /repos`: revoked/archived/deleted → `lost-access` |
+| `lost-access`         | no              | (any)              | unchanged                                    |
+
+## Implementation Units
+
+- [ ] **Unit 1: Extend schema and extract shared `addRepoEntry` helper**
+
+**Goal:** Land the two prerequisites reconcile needs before Unit 2: (a) extend `OnboardingStatus` enum + guard to include `lost-access` and `pending-review`; (b) lift `addRepoEntry` from `scripts/handle-invitation.ts` into a shared module so reconcile can produce entries with the exact same shape.
+
+**Requirements:** R1 (pending-review shape), R2 (lost-access), R9 (regained → pending/pending-review)
+
+**Dependencies:** None — prerequisite for all downstream units.
+
+**Files:**
+- Modify: `scripts/schemas.ts`
+- Test: `scripts/schemas.test.ts`
+- Create: `scripts/repos-metadata.ts` (exports `addRepoEntry`)
+- Test: `scripts/repos-metadata.test.ts`
+- Modify: `scripts/handle-invitation.ts` (remove local `addRepoEntry`, import from shared module)
+- (No change to `scripts/handle-invitation.test.ts` required — it imports only `OctokitClient`, `handleInvitations`, and `InvitationHandlingError` from `handle-invitation.ts`, not `addRepoEntry` directly.)
+
+**Approach:**
+- Schema extension: widen `OnboardingStatus` union to `'pending' | 'onboarded' | 'failed' | 'lost-access' | 'pending-review'`; extend `isOnboardingStatus` guard's value set. No schema-version bump (additive, backwards compatible).
+- Helper lift: move `addRepoEntry` to `scripts/repos-metadata.ts`. Extend signature to `addRepoEntry(current: unknown, input: { owner: string; repo: string; now: Date; onboarding_status?: OnboardingStatus }) → ReposFile`. Default `onboarding_status` to `'pending'` when omitted, preserving `handle-invitation.ts` behavior byte-for-byte.
+- Helper remains idempotent: returns unchanged `current` if an entry with the same `owner + name` already exists (regardless of the requested `onboarding_status`).
+- `handle-invitation.ts` imports `addRepoEntry` from the new module. Local copy deleted.
+
+**Execution note:** Test-first. Pin the existing behavioral contract first (call with no status → pending; call with explicit status → that status; idempotent on duplicate), then widen `OnboardingStatus`. Run `pnpm test scripts/handle-invitation.test.ts` unchanged to prove parity preserved.
+
+**Patterns to follow:**
+- Existing enums + guards in `scripts/schemas.ts` (e.g., `isSurveyStatus`, `isInviterRole`).
+- Mutator purity contract enforced by `commitMetadata` (no in-place mutation; return fresh objects).
+
+**Test scenarios:**
+- `isOnboardingStatus` accepts both new values.
+- `isOnboardingStatus` still rejects unknown strings.
+- `assertReposFile` passes when a repo entry carries `onboarding_status: 'lost-access'` or `'pending-review'`.
+- `assertReposFile` rejects `onboarding_status: 'archived'` (not in the set).
+- `addRepoEntry(current, { owner, repo, now })` produces an entry with `onboarding_status: 'pending'` and all expected defaults (`added`, `last_survey_at: null`, `last_survey_status: null`, `has_fro_bot_workflow: false`, `has_renovate: false`).
+- `addRepoEntry(current, { owner, repo, now, onboarding_status: 'pending-review' })` produces an entry with that status and the same other defaults.
+- `addRepoEntry` is idempotent: calling with an existing `owner+name` returns `current` unchanged, even if a different `onboarding_status` is requested (the existing entry's status is preserved — reconcile uses a different code path to change status of existing entries).
+- `addRepoEntry` returns a fresh top-level object (no in-place mutation of `current`).
+- `handle-invitation.test.ts` continues to pass without modification (parity preserved).
+
+**Verification:**
+- `pnpm check-types` clean.
+- `pnpm test scripts/schemas.test.ts scripts/repos-metadata.test.ts scripts/handle-invitation.test.ts` all pass.
+- `pnpm lint` clean on all modified files.
+
+---
+
+- [ ] **Unit 2: Pure reconciliation engine (`reconcileRepos`)**
+
+**Goal:** Implement `reconcileRepos(inputs) → changePlan` as a pure function with exhaustive tests covering every entry in the classification decision table.
+
+**Requirements:** R1, R2, R3, R6, R9
+
+**Dependencies:** Unit 1 (schema).
+
+**Files:**
+- Create: `scripts/reconcile-repos.ts` (only the pure logic export plus its type shapes in this unit; I/O wiring lands in Unit 3)
+- Create: `scripts/reconcile-repos.test.ts`
+
+**Approach:**
+- Inputs: `currentRepos: ReposFile`, `accessList: Array<{ owner: string; name: string; archived: boolean; private: boolean }>`, `perRepoStatus: Map<string, RepoStatusProbe>` (result of the Pass-2 `GET /repos/{owner}/{repo}` for tracked-but-missing repos: `{ status: 'deleted' } | { status: 'archived' } | { status: 'revoked' } | { status: 'still-accessible', private: boolean }`), `allowlist: AllowlistFile`, `fieldProbes: Map<string, { has_fro_bot_workflow: boolean; has_renovate: boolean }>`, `now: Date`.
+- Output: `{ nextRepos: ReposFile, dispatches: Array<{ owner: string; repo: string }>, issues: IssueQueue, summary: { added: number; pendingReview: number; regained: number; lostAccess: number; refreshed: number; unchanged: number } }` where `IssueQueue = Array<PerRepoIssue | PerOwnerRollupIssue>` with `PerRepoIssue = { kind: 'per-repo'; owner: string; repo: string; reason: 'unsolicited-new' | 'unsolicited-regain'; private: boolean; node_id: string }` and `PerOwnerRollupIssue = { kind: 'per-owner-rollup'; owner: string; entries: Array<{ repo: string; private: boolean; node_id: string }>; reason: 'unsolicited-new' | 'unsolicited-regain' }`.
+- Decision flow drives the classification table in the technical design above.
+- Builds new entries via the shared `addRepoEntry` helper (Unit 1), passing the appropriate `onboarding_status` so reconcile and `handle-invitation.ts` produce identical entry shapes.
+- Status transitions on existing entries (`lost-access` set, regained access flip) use a separate helper (e.g. `updateRepoStatus(current, { owner, name, onboarding_status })`) distinct from `addRepoEntry`. The helper produces a fresh entry with updated `onboarding_status` while preserving every other field verbatim. `addRepoEntry` is for NEW entries only; its idempotency would prevent status flips on existing entries.
+- No mutation of inputs. All updates produce fresh objects (follows the mutator purity contract `commitMetadata` expects).
+- The `issues` output is tagged by `kind`: `per-repo` for single-repo events (one per newcomer when an owner grants only one repo), `per-owner-rollup` for events where a single non-allowlisted owner grants ≥2 repos in the same run. Per-owner rollup collapses all of that owner's non-allowlisted newcomers into one issue. Allowlisted newcomers always get their own `per-repo` dispatch/entry — rollup only applies to non-allowlisted (security-relevant) events.
+- The `per-repo` and `per-owner-rollup` entries carry `private` and `node_id` for each subject repo. The I/O shell (Unit 3) decides whether to surface `owner/repo` in the issue body based on `private`.
+- Edge case: field-probe absence for an accessible tracked repo (probe request failed mid-run) — treat as "no change to fields" rather than overwriting with `undefined`.
+- Edge case: repo has no `.github/workflows` directory at all — the contents-endpoint probe returns 404. Normalize to `has_fro_bot_workflow: false`, not an error. Same for any other field-probe 404 — 404 means "absent", never an exception.
+
+**Execution note:** Test-first. The pure logic is the decision surface; cover every table row and edge case before writing any code.
+
+**Patterns to follow:**
+- Mutator purity in `scripts/commit-metadata.ts` (no in-place mutation).
+- Functional loop-and-accumulate pattern from `handle-invitation.ts` `processInvitation`.
+
+**Test scenarios:**
+- New accessible repo, owner allowlisted → added with `onboarding_status: 'pending'`, dispatch queued, no issue.
+- New accessible repo, owner not allowlisted, single repo from that owner → added with `onboarding_status: 'pending-review'`, no dispatch, `per-repo` issue queued with `reason: 'unsolicited-new'`.
+- **Per-owner rollup:** two accessible newcomers from the same non-allowlisted owner in one run → both added with `onboarding_status: 'pending-review'`, one `per-owner-rollup` issue queued covering both entries (not two `per-repo` issues).
+- **Mixed batch:** three accessible newcomers — one from allowlisted owner A, two from non-allowlisted owner B — → one dispatch queued for A, one `per-owner-rollup` issue queued for B's pair, zero `per-repo` issues.
+- Tracked `pending` repo, still accessible, no field change → no metadata change, no dispatch, counted as `unchanged`.
+- Tracked `onboarded` repo with `has_renovate: false` in metadata but `true` in probe → field flip only, `onboarding_status` unchanged, counted as `refreshed`.
+- Tracked repo absent from access list, probe says `deleted` → flip to `lost-access`, preserve all other fields.
+- Tracked repo **present** in access list with `archived: true` → flip to `lost-access` directly from Pass 1 data (no probe needed).
+- Tracked repo absent from access list, probe says `revoked` → flip to `lost-access`.
+- Tracked repo absent from access list, probe says `still-accessible` (transient inconsistency) → no change.
+- `lost-access` repo back in access list, owner allowlisted → flip to `pending`, dispatch queued, preserve `last_survey_at` / `last_survey_status` / wiki-side-effects history.
+- `lost-access` repo back in access list, owner not allowlisted → flip to `pending-review`, issue queued with `reason: 'unsolicited-regain'`.
+- `pending-review` repo still accessible → refresh fields only; operator decides to promote.
+- Multiple simultaneous changes (new + lost + refresh in one run) → all present in one `nextRepos` object, summary counts correct.
+- Zero changes → `nextRepos === currentRepos` (by value, via serialized-form compare), dispatches empty, issues empty, summary all zero → caller can detect silent case (R6).
+- Empty `currentRepos.repos` + empty `accessList` → no-op, no errors.
+- **Concurrent-writer safety (mutator re-run):** call `reconcileRepos` twice with the same outer inputs but a `currentRepos` that gained an unrelated entry between calls (simulates 409-retry scenario). Expected: the second call merges correctly — the newly-added entry is preserved in `nextRepos`, no incorrect `lost-access` flagging, counts match what the post-retry state dictates.
+- New entries produced by reconcile's classification use the shared `addRepoEntry` helper; their shape matches entries produced by `handle-invitation.ts` byte-for-byte (schema-validated comparison).
+- Status flips on existing entries use `updateRepoStatus` (not `addRepoEntry`). Calling `addRepoEntry` with an existing `owner+name` returns the entry unchanged, which would silently drop the status flip — this must not happen.
+
+**Verification:**
+- `pnpm test scripts/reconcile-repos.test.ts` all scenarios pass.
+- `pnpm check-types` clean on the pure logic module.
+- `pnpm lint` clean.
+
+---
+
+- [ ] **Unit 3: I/O shell — Octokit wiring, `commitMetadata` integration, dispatch + issue loop**
+
+**Goal:** Implement the outer layer that fetches inputs, invokes `reconcileRepos`, commits via `commitMetadata`, then walks the dispatch and issue queues sequentially with non-blocking failure. Expose a CLI entrypoint (`if (import.meta.url === …) { await main() }`) mirroring other scripts.
+
+**Requirements:** R4, R5, R6, R7 (entrypoint surface), R8 (dual credentials)
+
+**Dependencies:** Unit 2 (pure logic).
+
+**Files:**
+- Modify: `scripts/reconcile-repos.ts` (add I/O layer, CLI)
+- Modify: `scripts/reconcile-repos.test.ts` (add I/O shell tests with mocked Octokits)
+
+**Approach:**
+- Export `handleReconcile({ userOctokit, appOctokit, owner, repo, allowlistPath, reposPath, now, commitMetadata: injected, readMetadata: injected, bootstrapDataBranch: injected })` so tests can substitute each I/O boundary the way `handle-invitation.ts` does. `owner` and `repo` are the control-plane repo's own identity (supplied by `main()` from `process.env.GITHUB_REPOSITORY`, which Actions populates as `owner/repo`).
+- I/O steps in order:
+  1. Call `bootstrapDataBranch({ octokit: appOctokit, owner, repo })` (idempotent; ensures `data` branch exists).
+  2. Read `metadata/allowlist.yaml` and `metadata/repos.yaml` via `readMetadata` (disk reads on main branch).
+  3. Fetch access list via `userOctokit.paginate(userOctokit.rest.repos.listForAuthenticatedUser, { affiliation: 'collaborator', per_page: 100 })`.
+  4. For each tracked entry missing from the access list: `userOctokit.rest.repos.get({ owner, repo })` — 404 → `deleted`; 200 → `revoked`. (Archived repos are detected in Pass 1 via the access list's `archived: true` flag and do not reach Pass 2.)
+  5. For each still-accessible tracked entry: fetch field probes (workflows listing + renovate-path existence checks).
+  6. Invoke `reconcileRepos(inputs)` → change plan.
+  7. **Pre-commit integrity check:** fetch the current `data` branch HEAD via `appOctokit.rest.repos.getBranch({ owner, repo, branch: 'data' })` and verify the tip commit's author login is in the expected-author allowlist (`fro-bot[bot]` plus any operator override configured via `RECONCILE_OPERATOR_LOGINS` env). On mismatch, abort with `DATA_BRANCH_TAMPER` error, create a `reconcile:integrity-alert` issue summarizing the unexpected author + tip SHA, do NOT commit. If `data` doesn't exist yet (first run), skip this check (bootstrap is the expected path).
+  8. If `summary` shows any non-zero counter: build a mutator closure that re-runs `reconcileRepos({ currentRepos: current, accessList, perRepoStatus, allowlist, fieldProbes, now })` on each invocation and returns the recomputed `nextRepos`; do NOT return a precomputed `nextRepos` snapshot. Then `commitMetadata({ octokit: appOctokit, path: reposPath, message: summaryCommitMessage, mutator })`. Otherwise skip commit (R6). The re-run contract makes the 409-retry concurrent-writer safety work correctly (see Key Technical Decisions).
+  9. For each entry in `dispatches`: `appOctokit.rest.actions.createWorkflowDispatch({ owner, repo, workflow_id: 'survey-repo.yaml', ref: 'main', inputs: { owner: dispatch.owner, repo: dispatch.repo } })`. Serial `await` in a loop. On failure, log and continue (R4).
+  10. For each entry in `issues`: `appOctokit.rest.issues.create({ ..., title, body, labels: ['reconcile:pending-review'] })`. Serial; non-blocking on failure. Honors the per-owner grouping rule from the `issues` queue (see classification output below).
+  11. **Auto-close stale pending-review issues:** list open issues labeled `reconcile:pending-review`, cross-reference against `nextRepos`, and close any whose subject repo is no longer in `onboarding_status: pending-review` (promoted or removed). Serial; non-blocking on failure.
+  12. **Self-healing rollup re-file:** if `nextRepos` has ≥2 entries in `onboarding_status: pending-review` for the same non-allowlisted owner AND no open roll-up issue labeled `reconcile:rollup-pending-review` is associated with that owner, create one. This ensures operator attention even if a previous roll-up was closed or missed.
+  13. Print run summary as JSON on stdout.
+- Dispatch timeout: wrap each `createWorkflowDispatch` call with `AbortController` + 15s timeout. Timeout counts as "failure, continue".
+- Error classification on top-level: `MISSING_TOKEN`, `OCTOKIT_LOAD_FAILED`, `METADATA_READ_ERROR`, `COMMIT_ERROR` (let `commitMetadata` errors bubble; they already carry `code`+`remediation`), `DATA_BRANCH_TAMPER` (pre-commit integrity check failed; issue filed, no commit), `API_ERROR` (fall-through for unexpected status codes during enumeration/probing — dispatch/issue failures are non-blocking, not top-level errors).
+- `main()` reads both tokens from env: `FRO_BOT_POLL_PAT` → `userOctokit`; app token (generated in the workflow via `actions/create-github-app-token`, passed as `GITHUB_TOKEN` env var into this script) → `appOctokit`. `main()` also parses `GITHUB_REPOSITORY` into `owner` and `repo` before calling `handleReconcile`.
+- **Token value hygiene:** no code path logs a token value, partial or otherwise. Error paths reference tokens by env-var name only (`FRO_BOT_POLL_PAT`, `GITHUB_TOKEN`). This is a hard rule, tested via the MISSING_TOKEN scenario.
+
+**Execution note:** Test-first for the wiring — mock both Octokit clients, inject `commitMetadata` and `readMetadata`, verify the commit-before-dispatch ordering by asserting call order on spies. Do NOT re-test the pure classification logic here; trust Unit 2's coverage.
+
+**Patterns to follow:**
+- `scripts/handle-invitation.ts` — `handleInvitations(params)` shape with injected collaborators.
+- `scripts/wiki-ingest.ts` — `createOctokitFromEnv` + `as unknown as OctokitClient` cast in tests.
+- Error class shape from `CommitMetadataError` / `InvitationHandlingError` (`code` + `remediation`).
+
+**Test scenarios:**
+- Happy path: new allowlisted repo discovered → commit happens first, then single Survey dispatch, then JSON summary on stdout.
+- Happy path with both allowlisted and non-allowlisted newcomers → one commit, one dispatch, one issue created (dispatch and issue ordering don't depend on each other).
+- All dispatches succeed but one issue creation fails → logged, run completes, remaining issues still attempted.
+- Dispatch #2 of 3 fails → log, continue with #3.
+- Dispatch #2 of 3 hits 15s timeout → treated as failure, continue.
+- Commit fails with `CONFLICT_EXHAUSTED` → bubble as top-level error; no dispatches fire (commit-before-dispatch rule preserved).
+- **409-retry scenario:** first mutator invocation receives `currentRepos@v1`; `commitMetadata` fails with 409 and re-invokes the mutator with `currentRepos@v2` (simulating a concurrent write by `handle-invitation.ts`). Assert the mutator re-runs `reconcileRepos` against v2 (not a memoized v1 result) and the resulting `nextRepos` merges the concurrent entry correctly.
+- Newcomer is a **private** repo with non-allowlisted owner → issue is created, but the issue body omits `owner/repo` and uses a generic title + `node_id` reference; the full name appears in no public audit artifact.
+- Newcomer is a **public** repo with non-allowlisted owner → issue body includes the full `owner/repo` and link.
+- **App token minting failure (simulated)**: the outer `main()` wrapper (tested via its env parsing and error-surfacing path) exits with a clear error code when `GITHUB_TOKEN` is missing or malformed, before any API call.
+- **Data branch integrity check — clean HEAD:** tip commit on `data` was authored by `fro-bot[bot]` → integrity check passes, commit proceeds normally.
+- **Data branch integrity check — operator override:** tip commit on `data` was authored by a login listed in `RECONCILE_OPERATOR_LOGINS` env (e.g., `marcusrbrown`) → integrity check passes, commit proceeds.
+- **Data branch integrity check — unexpected author:** tip commit on `data` was authored by an unlisted login → abort with `DATA_BRANCH_TAMPER`, create `reconcile:integrity-alert` issue, no commit.
+- **Data branch integrity check — bootstrap case:** `data` branch does not exist (first run) → integrity check skipped, `bootstrapDataBranch` creates it, commit proceeds.
+- **Auto-close stale pending-review issue:** an open `reconcile:pending-review` issue exists for `owner/repo` but `nextRepos` shows that entry is now `onboarding_status: 'pending'` (operator approved) → issue gets closed during the auto-close step.
+- **Self-healing rollup re-file:** 3 `pending-review` entries exist for same non-allowlisted owner, previous roll-up issue was closed → reconcile files a new roll-up issue for that owner.
+- **Self-healing rollup no-op:** 2 `pending-review` entries exist for same owner, open roll-up issue already exists for that owner → no new issue created.
+- **MISSING_TOKEN error message contains no token substring:** assert the error message contains the env-var name (e.g. `FRO_BOT_POLL_PAT`) and a remediation pointer, but NO substring from any actual token-shaped value. Applies to every token-related error path.
+- No changes detected → `commitMetadata` NOT called, `createWorkflowDispatch` NOT called, `issues.create` NOT called; JSON summary written with all zero counters.
+- Field probe for one repo throws → probe result omitted from map; `reconcileRepos` treats as "no change" (covered in Unit 2, verified end-to-end here with one integration scenario).
+- `/user/repos` returns 0 repos and `currentRepos` has entries → all get classified via probe and flipped to `lost-access`.
+- Missing `FRO_BOT_POLL_PAT` → `MISSING_TOKEN` error before any API call.
+- `bootstrapDataBranch` is called exactly once per run, before any metadata read/write.
+
+**Verification:**
+- `pnpm test scripts/reconcile-repos.test.ts` passes all scenarios.
+- `pnpm check-types` clean.
+- `pnpm lint` clean.
+- Smoke test: `FRO_BOT_POLL_PAT=... GITHUB_TOKEN=... node scripts/reconcile-repos.ts` locally against a personal-access fixture works end-to-end (dry-run mode or actual, operator's call).
+
+---
+
+- [ ] **Unit 4: Scheduled workflow (`reconcile-repos.yaml`)**
+
+**Goal:** Ship the scheduled cron + manual dispatch workflow that mints the app token, runs `scripts/reconcile-repos.ts` with both credentials available, and reports the JSON summary in the run log.
+
+**Requirements:** R7 (trigger), R8 (credential mounting), R5 (atomicity is preserved because the script does the commit; the workflow just invokes it)
+
+**Dependencies:** Unit 3 (working script).
+
+**Files:**
+- Create: `.github/workflows/reconcile-repos.yaml`
+
+**Approach:**
+- Triggers: `schedule: [{ cron: '17 5 * * *' }]` (daily 05:17 UTC, off-peak relative to existing Poll Invitations every 15 minutes `*/15 * * * *` and Merge Data Branch at 22:00 Sunday) + `workflow_dispatch`.
+- `permissions: {}` at workflow level; per-job grants `contents: write`, `actions: write`, `issues: write`.
+- `concurrency: { group: reconcile-repos, cancel-in-progress: false }` to avoid overlapping runs.
+- `timeout-minutes: 10`.
+- Steps:
+  1. `actions/checkout@<pinned>` — needed so `scripts/` is available.
+  2. `./.github/actions/setup` — standard Node + pnpm setup.
+  3. `actions/create-github-app-token@<pinned>` with `id: get-workflow-app-token`, `app-id: secrets.APPLICATION_ID`, `private-key: secrets.APPLICATION_PRIVATE_KEY` → exposes `outputs.token` (the `fro-bot[bot]` installation token).
+  4. Run `node scripts/reconcile-repos.ts` with env: `FRO_BOT_POLL_PAT: secrets.FRO_BOT_POLL_PAT`, `GITHUB_TOKEN: steps.get-workflow-app-token.outputs.token`. The script internally treats `GITHUB_TOKEN` as the app token (matches the convention `merge-data.yaml` uses).
+- Pin all third-party actions to commit SHA with version comment (repo convention).
+
+**Execution note:** No test harness for the workflow itself beyond `actionlint` + `check-workflows`. Verify via manual dispatch after merge.
+
+**Patterns to follow:**
+- `.github/workflows/merge-data.yaml` — app-token minting + passing to script as `GITHUB_TOKEN`.
+- `.github/workflows/poll-invitations.yaml` — scheduled cron shape.
+
+**Test scenarios:**
+- `actionlint` clean on the new workflow.
+- `Check Workflows` job passes on PR.
+- Post-merge manual dispatch completes without error on a state that requires no changes → exits 0, prints all-zero JSON summary.
+
+**Verification:**
+- CI `Check Workflows` green.
+- One manual dispatch after merge confirms the end-to-end flow in a real environment.
+
+## System-Wide Impact
+
+- **Interaction graph:** Reconcile reads `metadata/allowlist.yaml` + `metadata/repos.yaml`, writes `metadata/repos.yaml` on the `data` branch (through `commitMetadata`), dispatches `survey-repo.yaml`, and creates GitHub issues. It does not touch the wiki directly — Survey Repo remains the only writer of wiki content. It does not modify `poll-invitations.yaml`; it does modify `handle-invitation.ts` to replace the local `addRepoEntry` with the shared-module import (Unit 1) — a byte-compatible refactor, not a behavior change.
+- **Error propagation:** Top-level `ReconcileError` mirrors `InvitationHandlingError` / `CommitMetadataError` (typed `code` + `remediation`). Dispatch/issue failures are non-blocking by design — they log to stdout and do not propagate. Enumeration, probe, token-mint, and commit failures are fatal (can't safely reconcile with partial truth).
+- **State lifecycle risks:** Commit-before-dispatch ordering + self-healing retry on the next daily run keeps the state machine eventually consistent even through partial failures. The main risk is a commit succeeding then every dispatch failing — entries would sit in `pending` until the next run and survey dispatches would retry. Acceptable.
+- **Concurrent-writer safety:** `poll-invitations.yaml` (every 15 minutes) and `reconcile-repos.yaml` (daily) can run simultaneously and both write `metadata/repos.yaml` on the `data` branch. The 15-minute cadence makes concurrent-run overlap realistic on any day where reconcile has non-trivial work. `commitMetadata`'s 409-retry loop handles SHA conflicts at the Git layer, but the semantic correctness depends on reconcile's mutator being idempotent against a re-read `current`. The mutator contract in Key Technical Decisions makes this explicit: the mutator re-runs `reconcileRepos` on each invocation, so a concurrent append by `handle-invitation.ts` between reconcile's read and reconcile's commit is absorbed by the retry. Without this contract, reconcile would silently overwrite the concurrently-added entry.
+- **API surface parity:** `handle-invitation.ts` adds repos to `metadata/repos.yaml` via the local helper at `scripts/handle-invitation.ts:282 addRepoEntry`. Unit 1 lifts this helper to `scripts/repos-metadata.ts` with an extended signature accepting `onboarding_status`. Both `handle-invitation.ts` and `reconcile-repos.ts` import the shared helper, guaranteeing byte-compatible entry shapes across the two entry points. The helper remains idempotent on duplicate `owner+name`, so reconcile and poll can both safely attempt to add the same repo.
+- **Integration coverage:** The classification table (Unit 2) is the hot spot for integration bugs. The test-scenario list for Unit 2 covers every row including the concurrent-writer re-run case. Unit 3 covers the ordering invariant (commit-before-dispatch) and the 409-retry semantics via spy call-order assertions. Unit 1 covers the parity invariant (schema-validated shape comparison between reconcile-produced and handle-invitation-produced entries).
+
+## Risks & Dependencies
+
+- **Risk (P1): Private repo name leak in public issues.** `fro-bot/.github` is public. If `pending-review` issues include the full `owner/repo` of a private repo, the name becomes discoverable by anyone reading the public issue stream. **Mitigation (in scope):** the classification output carries `private: boolean` and `node_id` for each issue-worthy event; Unit 3 conditionally includes/omits the name based on `private`. Private-repo issues use a generic title (e.g., `Unsolicited collaborator grant: private repo`) and reference the opaque `node_id` in the body; the operator cross-references via their own access to the metadata commit. Covered by Unit 3 test scenarios.
+- **Risk (P1): Mass-grant DoS via issue spam.** If an actor grants fro-bot collaborator access to many repos at once (scripted or intentional), a single reconcile run could file one `pending-review` issue per non-allowlisted repo. At scale the issue stream becomes noise and may exhaust API quotas for `issues.create`. **Mitigation (in scope):** per-owner grouping — if one non-allowlisted owner grants ≥2 repos in the same run, reconcile collapses all of that owner's newcomers into a single roll-up issue (`Unsolicited collaborator grants from {owner}: N new repos require review`). Aggregate count threshold (e.g. cap at 10 per-owner rollups in one run) still protects against attack-fan-out across many owners. Per-owner grouping is more surgical than a global cap: signals stay grouped by attacker identity, making triage straightforward. Metadata entries are still created for all of them; only the issue stream is collapsed. Covered by Unit 3 test scenarios.
+- **Risk (P1): Tampered `data` branch silently corrupts reconciliation state.** `data` is unprotected by design; an actor with `contents:write` could rewrite history to flip onboarding statuses, inject fake entries, or force-push. **Mitigation (in scope):** pre-commit integrity check (see Key Technical Decisions) verifies the current `data` HEAD author is in the expected-writer allowlist (`fro-bot[bot]` + operator overrides via `RECONCILE_OPERATOR_LOGINS` env) before each commit. On mismatch, reconcile aborts and files a `reconcile:integrity-alert` issue naming the unexpected author and tip SHA. Does not prevent tampering; does catch it within 24h and refuses to compound on top of tampered state.
+- **Risk (P2): App token minting fails.** `actions/create-github-app-token` can fail on: installation uninstalled, `APPLICATION_ID` rotated, `APPLICATION_PRIVATE_KEY` rotated, GitHub API outage. **Mitigation (in scope):** the workflow fails loudly (non-zero exit) when token mint fails — no silent fallback. The script's `MISSING_TOKEN` error path covers the case where `GITHUB_TOKEN` arrives empty. Failure shows up in the workflow run badge and the scheduled-cron failure notification path the operator already monitors.
+- **Risk (P2): `FRO_BOT_POLL_PAT` scope insufficient to call `/user/repos`.** The PAT was originally scoped for invitation accept. Requires `repo` scope for `?affiliation=collaborator`. **Mitigation (in scope):** verify secret scope before first dispatch; if insufficient, operator rotates with broader scope. Runbook step included (see Documentation / Operational Notes). Failure mode at runtime is a 403/404 surfaced as a typed `API_ERROR` — not silent.
+- **Risk (P3): rename/transfer causes false lost-access flag, then new-access detection re-adds the renamed repo.** First run would produce one `lost-access` + one `pending`/`pending-review` for the same underlying repo. Node_id tracking would fix this. Deferred. Real-world frequency: low. If observed, elevate to an in-plan requirement and add node_id cross-reference in a follow-up.
+- **Dependency: `fro-bot[bot]` app must have `issues: write` and `actions: write` permissions on the control-plane repo**, plus `contents: write` on the `data` branch (already required by existing workflows). Verify installation permissions before first deploy; the workflow step for `actions/create-github-app-token` fails loudly if permissions are insufficient.
+
+## Documentation / Operational Notes
+
+- Update `metadata/README.md` to document the new `lost-access` and `pending-review` values, the reconcile workflow that sets them, and the public/private issue-body distinction.
+- Add a note in `scripts/` README (or AGENTS.md) about the dual-Octokit convention introduced here, so future scripts follow the same pattern when they need user-scoped reads alongside app-scoped writes.
+- **Operational runbook additions:**
+  - **After rotating `FRO_BOT_POLL_PAT`:** confirm the rotated PAT has `repo` scope sufficient for `GET /user/repos?affiliation=collaborator`. The first scheduled reconcile run after rotation will fail with `API_ERROR` (403) if scope is insufficient; rotate again with correct scope.
+  - **After rotating `APPLICATION_PRIVATE_KEY` or updating `APPLICATION_ID`:** verify `fro-bot[bot]` installation still has `contents: write`, `actions: write`, `issues: write` on `fro-bot/.github`. First reconcile run after key rotation will fail at the `create-github-app-token` step if the installation is broken.
+  - **First production dispatch:** operator runs manually once after merge (`gh workflow run reconcile-repos.yaml -R fro-bot/.github`), reviews the output, confirms counts match expectations (empty state → all-zero summary; existing ha-config + any other accessible repos properly classified) before letting the daily cron take over.
+- **Pending-review issue lifecycle:**
+  - Operator closes issues manually after deciding: approve → change the corresponding metadata entry to `pending` and let reconcile or manual dispatch trigger Survey Repo; reject → remove the entry from `repos.yaml` via a `data`-branch commit.
+  - Reconcile auto-closes any open `reconcile:pending-review` issue whose subject repo is no longer in `onboarding_status: pending-review` (promoted or removed). A small additional loop in Unit 3's issue step: list open issues with the label, cross-reference against the current `nextRepos` state, close those whose subject has moved on.
+- **Pre-deploy verification (required before first dispatch):**
+  - Confirm `fro-bot[bot]` installation has the required scopes on this repo: `gh api /repos/fro-bot/.github/installation --jq .permissions`. Expect `issues: write`, `actions: write`, `contents: write`.
+  - Confirm `FRO_BOT_POLL_PAT` has `repo` scope (needed for `GET /user/repos?affiliation=collaborator`). If scope is narrower, rotate with broader scope before first dispatch.
+- **Cross-repo impact:** Unit 1's `addRepoEntry` lift is a refactor of `scripts/handle-invitation.ts`. Post-merge, the 15-minute `poll-invitations.yaml` run continues to add entries via the shared helper. Verify on the first post-merge poll run that no regression in invitation handling occurred (metadata entries still produced with correct shape).
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-17-repo-reconciliation-requirements.md](../brainstorms/2026-04-17-repo-reconciliation-requirements.md)
+- Related code: `scripts/commit-metadata.ts`, `scripts/handle-invitation.ts`, `scripts/data-branch-bootstrap.ts`, `scripts/schemas.ts`, `.github/workflows/merge-data.yaml`, `.github/workflows/poll-invitations.yaml`
+- Related learnings: [docs/solutions/runtime-errors/octokit-invitation-method-names-2026-04-17.md](../solutions/runtime-errors/octokit-invitation-method-names-2026-04-17.md)
+- GitHub REST: [`GET /user/repos`](https://docs.github.com/en/rest/repos/repos#list-repositories-for-the-authenticated-user), [`GET /repos/{owner}/{repo}`](https://docs.github.com/en/rest/repos/repos#get-a-repository)

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -28,14 +28,24 @@ repos:
   - owner: string
     name: string
     added: ISO date
-    onboarding_status: pending | onboarded | failed
+    onboarding_status: pending | onboarded | failed | lost-access | pending-review
     last_survey_at: ISO datetime | null
     last_survey_status: success | failure | null
     has_fro_bot_workflow: boolean
     has_renovate: boolean
 ```
 
-Update convention: invitation handler and metadata workflow update this file programmatically on the `data` branch.
+Update convention: invitation handler, metadata workflow, and daily reconcile update this file programmatically on the `data` branch.
+
+Onboarding status values:
+
+- `pending` — repo was added but has not been surveyed yet.
+- `onboarded` — repo was surveyed successfully at least once.
+- `failed` — the most recent survey attempt failed.
+- `lost-access` — fro-bot no longer has collaborator access (revoked, archived, or deleted). The entry is preserved for audit; other fields stay at their last-known values.
+- `pending-review` — repo was discovered via collaborator access from an owner not listed in `allowlist.yaml`. A GitHub issue labeled `reconcile:pending-review` tracks each one; the entry stays in this state until an operator promotes it (approve and change status to `pending`) or removes it.
+
+For private repos in `pending-review`, the issue body omits the owner/repo name and identifies the subject via its GitHub `node_id`. Public-repo `pending-review` issues include the full `owner/repo`. The control-plane repo is public, so issue bodies never leak private repo names.
 
 ### `renovate.yaml`
 
@@ -90,6 +100,7 @@ PAT split summary:
 | `apply-branding.yaml`   | Same 4 (via reusable call to `fro-bot.yaml`)                            |
 | `poll-invitations.yaml` | `FRO_BOT_POLL_PAT` only                                                 |
 | `merge-data.yaml`       | `GITHUB_TOKEN` (auto-provisioned, job-scoped permissions)               |
+| `reconcile-repos.yaml`  | `FRO_BOT_POLL_PAT` + `APPLICATION_ID` + `APPLICATION_PRIVATE_KEY`       |
 
 ## Commit conventions
 

--- a/scripts/handle-invitation.ts
+++ b/scripts/handle-invitation.ts
@@ -6,6 +6,7 @@ import {parse} from 'yaml'
 
 import {commitMetadata, type CommitMetadataParams, type CommitMetadataResult} from './commit-metadata.ts'
 import {bootstrapDataBranch, type DataBranchBootstrapParams} from './data-branch-bootstrap.ts'
+import {addRepoEntry} from './repos-metadata.ts'
 import {assertAllowlistFile, assertReposFile, SchemaValidationError, type ReposFile} from './schemas.ts'
 
 const DEFAULT_OWNER = 'fro-bot'
@@ -205,7 +206,7 @@ async function processInvitation(params: {
       octokit: params.octokit,
       path: params.reposPath,
       message: `chore(metadata): add ${repoOwner}/${repoName} from invitation polling`,
-      mutator: current => addRepoEntry({current, owner: repoOwner, repo: repoName, now: params.now}),
+      mutator: current => addRepoEntry(current, {owner: repoOwner, repo: repoName, now: params.now}),
     })
     await params.octokit.rest.actions.createWorkflowDispatch({
       owner: params.owner,
@@ -277,31 +278,6 @@ async function loadRepos(readMetadata: (path: string) => Promise<unknown>, repos
 async function readMetadataFromDisk(path: string): Promise<unknown> {
   const contents = await readFile(path, 'utf8')
   return parse(contents)
-}
-
-function addRepoEntry(params: {current: unknown; owner: string; repo: string; now: Date}): ReposFile {
-  assertReposFile(params.current, 'repos')
-
-  if (params.current.repos.some(entry => entry.owner === params.owner && entry.name === params.repo)) {
-    return params.current
-  }
-
-  return {
-    ...params.current,
-    repos: [
-      ...params.current.repos,
-      {
-        owner: params.owner,
-        name: params.repo,
-        added: params.now.toISOString().slice(0, 10),
-        onboarding_status: 'pending',
-        last_survey_at: null,
-        last_survey_status: null,
-        has_fro_bot_workflow: false,
-        has_renovate: false,
-      },
-    ],
-  }
 }
 
 function normalizeMetadataError(error: unknown, target: 'allowlist' | 'repos'): InvitationHandlingError {

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -1449,7 +1449,9 @@ describe('handleReconcile (I/O shell)', () => {
         expect(re.code).toBe('MISSING_TOKEN')
         expect(re.message).toContain('FRO_BOT_POLL_PAT')
         // Token hygiene: message must not contain any real token-looking substring
-        expect(re.message).not.toMatch(/gh[ps]_/)
+        // Token hygiene: message must not contain any GitHub token prefix pattern or substring
+        // that could be confused for a real token value.
+        expect(re.message).not.toMatch(/gh[pso]_|github_pat_/)
       } finally {
         if (saved !== undefined) process.env.FRO_BOT_POLL_PAT = saved
       }

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -1,8 +1,20 @@
-import {describe, expect, it} from 'vitest'
+import type {CommitMetadataParams, CommitMetadataResult} from './commit-metadata.ts'
+import type {AllowlistFile, RepoEntry, ReposFile} from './schemas.ts'
+import process from 'node:process'
 
-import {reconcileRepos, type AccessListEntry, type ReconcileInput} from './reconcile-repos.ts'
+import {describe, expect, it, vi} from 'vitest'
+
+import {
+  handleReconcile,
+  ReconcileError,
+  reconcileRepos,
+  type AccessListEntry,
+  type HandleReconcileParams,
+  type OctokitClient,
+  type ReconcileInput,
+} from './reconcile-repos.ts'
 import {addRepoEntry} from './repos-metadata.ts'
-import {assertReposFile, type AllowlistFile, type RepoEntry, type ReposFile} from './schemas.ts'
+import {assertReposFile} from './schemas.ts'
 
 const NOW = new Date('2026-04-17T12:00:00Z')
 
@@ -497,6 +509,980 @@ describe('reconcileRepos', () => {
           }),
         ),
       ).toThrow(/duplicate/i)
+    })
+  })
+})
+
+//
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit 3 — I/O shell tests for `handleReconcile`
+// ─────────────────────────────────────────────────────────────────────────────
+//
+
+interface OctokitMockOverrides {
+  paginate?: (fn: unknown, opts: unknown) => Promise<unknown[]>
+  listForAuthenticatedUser?: (opts: unknown) => Promise<{data: AccessListApiEntry[]}>
+  reposGet?: (params: {owner: string; repo: string}) => Promise<{data: RepoGetResponse}>
+  getBranch?: (params: {owner: string; repo: string; branch: string}) => Promise<{data: BranchResponse}>
+  getContent?: (params: {owner: string; repo: string; path: string}) => Promise<unknown>
+  createOrUpdateFileContents?: (params: unknown) => Promise<unknown>
+  createRef?: (params: unknown) => Promise<unknown>
+  createWorkflowDispatch?: (params: unknown) => Promise<unknown>
+  issuesCreate?: (params: unknown) => Promise<{data: {number: number}}>
+  issuesUpdate?: (params: unknown) => Promise<unknown>
+  issuesListForRepo?: (params: unknown) => Promise<{data: IssueListEntry[]}>
+}
+
+interface AccessListApiEntry {
+  owner: {login: string}
+  name: string
+  archived: boolean
+  private: boolean
+  node_id: string
+}
+
+interface RepoGetResponse {
+  archived?: boolean
+  private?: boolean
+  node_id?: string
+}
+
+interface BranchResponse {
+  name: string
+  commit: {
+    sha: string
+    author: {login: string} | null
+    committer?: {login: string} | null
+  }
+}
+
+interface IssueListEntry {
+  number: number
+  title: string
+  body: string | null
+  state: 'open' | 'closed'
+  labels: {name: string}[]
+}
+
+function apiError(status: number, message = 'API error'): Error {
+  return Object.assign(new Error(message), {status})
+}
+
+/**
+ * Extract the first positional argument of the first recorded call on a vi.fn mock.
+ * Bypasses the `[]` tuple inference that `noUncheckedIndexedAccess` flags when mocks
+ * are created with untyped `async () => ...` bodies.
+ */
+function firstCallArg<A>(fn: {mock: {calls: unknown[]}}): A | undefined {
+  const call = fn.mock.calls[0] as [A] | undefined
+  return call?.[0]
+}
+
+function notFoundGetBranch(): (params: unknown) => Promise<never> {
+  return async () => {
+    throw apiError(404, 'Not Found')
+  }
+}
+
+function mockOctokit(overrides: OctokitMockOverrides = {}): OctokitClient {
+  const defaultListForAuthenticatedUser: (opts: unknown) => Promise<{data: AccessListApiEntry[]}> = async () => ({
+    data: [],
+  })
+  const listForAuthenticatedUser = overrides.listForAuthenticatedUser ?? defaultListForAuthenticatedUser
+  const defaultPaginate: (fn: unknown, opts: unknown) => Promise<unknown[]> = async (fn, opts) => {
+    const call = fn as (opts: unknown) => Promise<{data: unknown[]}>
+    const response = await call(opts)
+    return response.data
+  }
+
+  return {
+    paginate: overrides.paginate ?? defaultPaginate,
+    rest: {
+      repos: {
+        listForAuthenticatedUser,
+        get:
+          overrides.reposGet ??
+          (async () => ({
+            data: {archived: false, private: false, node_id: 'R_default'} as RepoGetResponse,
+          })),
+        getBranch:
+          overrides.getBranch ??
+          (async () => ({
+            data: {
+              name: 'data',
+              commit: {
+                sha: 'data-tip-sha',
+                author: {login: 'fro-bot[bot]'},
+              },
+            } satisfies BranchResponse,
+          })),
+        getContent:
+          overrides.getContent ??
+          (async () => {
+            throw apiError(404, 'Not Found')
+          }),
+        createOrUpdateFileContents:
+          overrides.createOrUpdateFileContents ?? (async () => ({data: {commit: {sha: 'x'}}})),
+      },
+      git: {
+        createRef: overrides.createRef ?? (async () => ({data: {ref: 'refs/heads/data'}})),
+      },
+      actions: {
+        createWorkflowDispatch: overrides.createWorkflowDispatch ?? (async () => undefined),
+      },
+      issues: {
+        create: overrides.issuesCreate ?? (async () => ({data: {number: 1}})),
+        update: overrides.issuesUpdate ?? (async () => ({data: {}})),
+        listForRepo: overrides.issuesListForRepo ?? (async () => ({data: [] as IssueListEntry[]})),
+      },
+    },
+  } as unknown as OctokitClient
+}
+
+function makeReadMetadata(
+  opts: {allowlist?: AllowlistFile; repos?: ReposFile} = {},
+): (path: string) => Promise<unknown> {
+  const allowlist = opts.allowlist ?? makeAllowlist([])
+  const repos = opts.repos ?? {version: 1, repos: []}
+  return async (path: string) => {
+    if (path.endsWith('allowlist.yaml')) return allowlist
+    if (path.endsWith('repos.yaml')) return repos
+    throw new Error(`unexpected readMetadata path: ${path}`)
+  }
+}
+
+function silentLogger(): {warn: ReturnType<typeof vi.fn<(message: string) => void>>} {
+  return {warn: vi.fn<(message: string) => void>()}
+}
+
+function baseParams(overrides: Partial<HandleReconcileParams> = {}): HandleReconcileParams {
+  return {
+    userOctokit: overrides.userOctokit ?? mockOctokit(),
+    appOctokit: overrides.appOctokit ?? mockOctokit(),
+    owner: overrides.owner ?? 'fro-bot',
+    repo: overrides.repo ?? '.github',
+    allowlistPath: overrides.allowlistPath ?? 'metadata/allowlist.yaml',
+    reposPath: overrides.reposPath ?? 'metadata/repos.yaml',
+    now: overrides.now ?? NOW,
+    readMetadata: overrides.readMetadata ?? makeReadMetadata(),
+    commitMetadata:
+      overrides.commitMetadata ?? (vi.fn(async () => ({committed: true, sha: 'commit-sha', attempts: 1})) as never),
+    bootstrapDataBranch:
+      overrides.bootstrapDataBranch ??
+      (vi.fn(async () => ({created: false, ref: 'refs/heads/data', sha: 'data-sha'})) as never),
+    dispatchTimeoutMs: overrides.dispatchTimeoutMs ?? 100,
+    operatorLogins: overrides.operatorLogins ?? [],
+    logger: overrides.logger ?? silentLogger(),
+    workflowFile: overrides.workflowFile ?? 'survey-repo.yaml',
+    workflowRef: overrides.workflowRef ?? 'main',
+  }
+}
+
+describe('handleReconcile (I/O shell)', () => {
+  describe('orchestration order', () => {
+    it('calls bootstrapDataBranch exactly once before any metadata read', async () => {
+      const calls: string[] = []
+      const bootstrap = vi.fn(async () => {
+        calls.push('bootstrap')
+        return {created: false, ref: 'refs/heads/data', sha: 'x'}
+      })
+      const readMetadata = vi.fn(async (path: string) => {
+        calls.push(`read:${path}`)
+        if (path.endsWith('allowlist.yaml')) return makeAllowlist([])
+        return {version: 1, repos: []}
+      })
+
+      await handleReconcile(
+        baseParams({
+          bootstrapDataBranch: bootstrap as never,
+          readMetadata,
+        }),
+      )
+
+      expect(bootstrap).toHaveBeenCalledOnce()
+      expect(calls[0]).toBe('bootstrap')
+      // both reads happen after bootstrap
+      expect(calls.slice(1).every(c => c.startsWith('read:'))).toBe(true)
+    })
+
+    it('invokes commitMetadata BEFORE any createWorkflowDispatch (commit-before-dispatch)', async () => {
+      const calls: string[] = []
+      const commitMetadata = vi.fn(async (params: CommitMetadataParams): Promise<CommitMetadataResult> => {
+        calls.push('commit')
+        // Drive the mutator once so it returns a sensible result
+        await params.mutator({version: 1, repos: []})
+        return {committed: true, sha: 'commit-sha', attempts: 1}
+      })
+      const createWorkflowDispatch = vi.fn(async () => {
+        calls.push('dispatch')
+      })
+      const appOctokit = mockOctokit({createWorkflowDispatch})
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {
+              owner: {login: 'marcusrbrown'},
+              name: 'new-repo',
+              archived: false,
+              private: false,
+              node_id: 'R_new',
+            },
+          ],
+        }),
+      })
+
+      await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit,
+          readMetadata: makeReadMetadata({allowlist: makeAllowlist(['marcusrbrown'])}),
+          commitMetadata: commitMetadata as never,
+        }),
+      )
+
+      expect(calls).toEqual(['commit', 'dispatch'])
+      expect(commitMetadata).toHaveBeenCalledOnce()
+      expect(createWorkflowDispatch).toHaveBeenCalledOnce()
+    })
+
+    it('mixed newcomers produces one commit, one dispatch, one per-repo issue', async () => {
+      const commitMetadata = vi.fn(async (params: CommitMetadataParams): Promise<CommitMetadataResult> => {
+        await params.mutator({version: 1, repos: []})
+        return {committed: true, sha: 'sha', attempts: 1}
+      })
+      const createWorkflowDispatch = vi.fn(async () => undefined)
+      const issuesCreate = vi.fn(async () => ({data: {number: 42}}))
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {owner: {login: 'trusted'}, name: 'ok-repo', archived: false, private: false, node_id: 'R_ok'},
+            {owner: {login: 'stranger'}, name: 'sus-repo', archived: false, private: false, node_id: 'R_sus'},
+          ],
+        }),
+      })
+
+      await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({createWorkflowDispatch, issuesCreate}),
+          readMetadata: makeReadMetadata({allowlist: makeAllowlist(['trusted'])}),
+          commitMetadata: commitMetadata as never,
+        }),
+      )
+
+      expect(commitMetadata).toHaveBeenCalledOnce()
+      expect(createWorkflowDispatch).toHaveBeenCalledOnce()
+      expect(issuesCreate).toHaveBeenCalledOnce()
+    })
+
+    it('skips commit, dispatch, and issue create when reconcile summary is all zero', async () => {
+      const commitMetadata = vi.fn(async () => ({committed: true, sha: 's', attempts: 1}))
+      const createWorkflowDispatch = vi.fn(async () => undefined)
+      const issuesCreate = vi.fn(async () => ({data: {number: 1}}))
+      const existing: ReposFile = {
+        version: 1,
+        repos: [makeEntry({name: 'stable-repo', onboarding_status: 'pending'})],
+      }
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {owner: {login: 'fro-bot'}, name: 'stable-repo', archived: false, private: false, node_id: 'R_stable'},
+          ],
+        }),
+      })
+
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({createWorkflowDispatch, issuesCreate}),
+          readMetadata: makeReadMetadata({repos: existing}),
+          commitMetadata: commitMetadata as never,
+        }),
+      )
+
+      expect(commitMetadata).not.toHaveBeenCalled()
+      expect(createWorkflowDispatch).not.toHaveBeenCalled()
+      expect(issuesCreate).not.toHaveBeenCalled()
+      expect(result.committed).toBe(false)
+      expect(result.summary.added).toBe(0)
+      expect(result.summary.unchanged).toBe(1)
+    })
+  })
+
+  describe('field probes (integration)', () => {
+    it('omits a failed field probe from the map — reconcile treats as no-change', async () => {
+      const existing: ReposFile = {
+        version: 1,
+        repos: [
+          makeEntry({
+            name: 'probe-fail-repo',
+            onboarding_status: 'onboarded',
+            has_fro_bot_workflow: true,
+            has_renovate: true,
+          }),
+        ],
+      }
+      const commitMetadata = vi.fn(async () => ({committed: false, attempts: 1}))
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [{owner: {login: 'fro-bot'}, name: 'probe-fail-repo', archived: false, private: false, node_id: 'R_x'}],
+        }),
+        getContent: async () => {
+          throw apiError(500, 'Internal Server Error')
+        },
+      })
+
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          readMetadata: makeReadMetadata({repos: existing}),
+          commitMetadata: commitMetadata as never,
+        }),
+      )
+
+      // probe failed → omitted → reconcile sees no probe → no-change → unchanged counter
+      expect(result.summary.unchanged).toBe(1)
+      expect(result.summary.refreshed).toBe(0)
+      expect(commitMetadata).not.toHaveBeenCalled()
+    })
+
+    it('flips all tracked entries to lost-access when /user/repos returns 0 repos', async () => {
+      const existing: ReposFile = {
+        version: 1,
+        repos: [
+          makeEntry({name: 'a', onboarding_status: 'onboarded'}),
+          makeEntry({name: 'b', onboarding_status: 'onboarded'}),
+        ],
+      }
+      const reposGet = vi.fn(async () => {
+        throw apiError(404)
+      })
+      let seenNext: ReposFile | null = null
+      const commitMetadata = vi.fn(async (params: CommitMetadataParams): Promise<CommitMetadataResult> => {
+        const next = (await params.mutator(existing)) as ReposFile
+        seenNext = next
+        return {committed: true, sha: 'sha', attempts: 1}
+      })
+
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit: mockOctokit({
+            listForAuthenticatedUser: async () => ({data: []}),
+            reposGet,
+          }),
+          readMetadata: makeReadMetadata({repos: existing}),
+          commitMetadata: commitMetadata as never,
+        }),
+      )
+
+      expect(result.summary.lostAccess).toBe(2)
+      expect(seenNext).not.toBeNull()
+      const resolvedNext = seenNext as unknown as ReposFile
+      expect(resolvedNext.repos.every(r => r.onboarding_status === 'lost-access')).toBe(true)
+      expect(reposGet).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('dispatch loop', () => {
+    it('continues after a dispatch failure (dispatch #2 of 3 fails)', async () => {
+      const dispatchCalls: {owner: string; repo: string}[] = []
+      const createWorkflowDispatch = vi.fn(async (params: unknown) => {
+        const typed = params as {inputs?: {owner: string; repo: string}}
+        const inputs = typed.inputs ?? {owner: '', repo: ''}
+        dispatchCalls.push(inputs)
+        if (dispatchCalls.length === 2) throw apiError(500, 'dispatch boom')
+      })
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {owner: {login: 't'}, name: 'r1', archived: false, private: false, node_id: 'R_1'},
+            {owner: {login: 't'}, name: 'r2', archived: false, private: false, node_id: 'R_2'},
+            {owner: {login: 't'}, name: 'r3', archived: false, private: false, node_id: 'R_3'},
+          ],
+        }),
+      })
+
+      const logger = silentLogger()
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({createWorkflowDispatch}),
+          readMetadata: makeReadMetadata({allowlist: makeAllowlist(['t'])}),
+          commitMetadata: vi.fn(async () => ({committed: true, sha: 's', attempts: 1})) as never,
+          logger,
+        }),
+      )
+
+      expect(dispatchCalls).toHaveLength(3)
+      expect(result.dispatches).toBe(2)
+      expect(result.dispatchesFailed).toBe(1)
+      expect(logger.warn).toHaveBeenCalled()
+    })
+
+    it('treats a dispatch timeout as failure and continues to the next', async () => {
+      const dispatchCalls: string[] = []
+      const createWorkflowDispatch = vi.fn(async (params: unknown) => {
+        const typed = params as {inputs?: {owner: string; repo: string}}
+        const name = typed.inputs?.repo ?? '?'
+        dispatchCalls.push(name)
+        if (name === 'r2') {
+          await new Promise(() => {
+            /* never resolves — simulates hang */
+          })
+        }
+      })
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {owner: {login: 't'}, name: 'r1', archived: false, private: false, node_id: 'R_1'},
+            {owner: {login: 't'}, name: 'r2', archived: false, private: false, node_id: 'R_2'},
+            {owner: {login: 't'}, name: 'r3', archived: false, private: false, node_id: 'R_3'},
+          ],
+        }),
+      })
+
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({createWorkflowDispatch}),
+          readMetadata: makeReadMetadata({allowlist: makeAllowlist(['t'])}),
+          commitMetadata: vi.fn(async () => ({committed: true, sha: 's', attempts: 1})) as never,
+          dispatchTimeoutMs: 20, // tight timeout for test speed
+        }),
+      )
+
+      expect(dispatchCalls).toEqual(['r1', 'r2', 'r3'])
+      expect(result.dispatches).toBe(2)
+      expect(result.dispatchesFailed).toBe(1)
+    })
+  })
+
+  describe('issue creation and auto-close', () => {
+    it('creates a public-repo per-repo issue with owner/repo in title and body', async () => {
+      const issuesCreate = vi.fn(async () => ({data: {number: 7}}))
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [{owner: {login: 'stranger'}, name: 'leaked-repo', archived: false, private: false, node_id: 'R_pub'}],
+        }),
+      })
+
+      await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({issuesCreate}),
+          readMetadata: makeReadMetadata({}),
+          commitMetadata: vi.fn(async () => ({committed: true, sha: 's', attempts: 1})) as never,
+        }),
+      )
+
+      expect(issuesCreate).toHaveBeenCalledOnce()
+      const params = firstCallArg<{title: string; body: string; labels: string[]}>(issuesCreate)
+      expect(params?.title).toContain('stranger/leaked-repo')
+      expect(params?.body).toContain('stranger/leaked-repo')
+      expect(params?.body).toContain('R_pub')
+      expect(params?.labels).toContain('reconcile:pending-review')
+    })
+
+    it('creates a private-repo per-repo issue with generic title, no owner/repo anywhere, node_id in body', async () => {
+      const issuesCreate = vi.fn(async () => ({data: {number: 8}}))
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [{owner: {login: 'stranger'}, name: 'secret-repo', archived: false, private: true, node_id: 'R_priv'}],
+        }),
+      })
+
+      await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({issuesCreate}),
+          readMetadata: makeReadMetadata({}),
+          commitMetadata: vi.fn(async () => ({committed: true, sha: 's', attempts: 1})) as never,
+        }),
+      )
+
+      expect(issuesCreate).toHaveBeenCalledOnce()
+      const params = firstCallArg<{title: string; body: string}>(issuesCreate)
+      expect(params?.title).not.toContain('secret-repo')
+      expect(params?.title).not.toContain('stranger/secret-repo')
+      expect(params?.body).not.toContain('secret-repo')
+      expect(params?.body).toContain('R_priv')
+    })
+
+    it('continues through remaining issues when one issue creation fails', async () => {
+      let created = 0
+      const issuesCreate = vi.fn(async () => {
+        created += 1
+        if (created === 1) throw apiError(500, 'issue boom')
+        return {data: {number: 100 + created}}
+      })
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {owner: {login: 'a'}, name: 'r1', archived: false, private: false, node_id: 'R_1'},
+            {owner: {login: 'b'}, name: 'r2', archived: false, private: false, node_id: 'R_2'},
+          ],
+        }),
+      })
+      const logger = silentLogger()
+
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({issuesCreate}),
+          readMetadata: makeReadMetadata({}),
+          commitMetadata: vi.fn(async () => ({committed: true, sha: 's', attempts: 1})) as never,
+          logger,
+        }),
+      )
+
+      expect(issuesCreate).toHaveBeenCalledTimes(2)
+      expect(result.issuesFailed).toBe(1)
+      expect(result.perRepoIssues).toBe(1)
+      expect(logger.warn).toHaveBeenCalled()
+    })
+
+    it('auto-closes a stale pending-review issue when the subject is no longer pending-review', async () => {
+      // entry is promoted — no longer pending-review
+      const existing: ReposFile = {
+        version: 1,
+        repos: [
+          makeEntry({
+            owner: 'stranger',
+            name: 'promoted-repo',
+            onboarding_status: 'pending', // operator promoted
+          }),
+        ],
+      }
+      const issuesListForRepo = vi.fn(async () => ({
+        data: [
+          {
+            number: 42,
+            title: 'Unsolicited collaborator grant: stranger/promoted-repo',
+            body: '<!-- reconcile:subject:node_id=R_prom -->\nbody text',
+            state: 'open' as const,
+            labels: [{name: 'reconcile:pending-review'}],
+          },
+        ],
+      }))
+      const issuesUpdate = vi.fn(async () => ({data: {}}))
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {
+              owner: {login: 'stranger'},
+              name: 'promoted-repo',
+              archived: false,
+              private: false,
+              node_id: 'R_prom',
+            },
+          ],
+        }),
+      })
+
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({issuesListForRepo, issuesUpdate}),
+          readMetadata: makeReadMetadata({repos: existing}),
+          commitMetadata: vi.fn(async () => ({committed: false, attempts: 1})) as never,
+        }),
+      )
+
+      expect(issuesUpdate).toHaveBeenCalledOnce()
+      const params = firstCallArg<{issue_number: number; state: string}>(issuesUpdate)
+      expect(params?.issue_number).toBe(42)
+      expect(params?.state).toBe('closed')
+      expect(result.closedStaleIssues).toBe(1)
+    })
+
+    it('does NOT auto-close an open issue whose subject is still pending-review', async () => {
+      const existing: ReposFile = {
+        version: 1,
+        repos: [
+          makeEntry({
+            owner: 'stranger',
+            name: 'still-sus-repo',
+            onboarding_status: 'pending-review',
+          }),
+        ],
+      }
+      const issuesUpdate = vi.fn(async () => ({data: {}}))
+      const issuesListForRepo = vi.fn(async () => ({
+        data: [
+          {
+            number: 7,
+            title: 'Unsolicited collaborator grant: stranger/still-sus-repo',
+            body: '<!-- reconcile:subject:node_id=R_sus -->',
+            state: 'open' as const,
+            labels: [{name: 'reconcile:pending-review'}],
+          },
+        ],
+      }))
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {
+              owner: {login: 'stranger'},
+              name: 'still-sus-repo',
+              archived: false,
+              private: false,
+              node_id: 'R_sus',
+            },
+          ],
+        }),
+      })
+
+      await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({issuesListForRepo, issuesUpdate}),
+          readMetadata: makeReadMetadata({repos: existing}),
+          commitMetadata: vi.fn(async () => ({committed: false, attempts: 1})) as never,
+        }),
+      )
+
+      expect(issuesUpdate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('self-healing rollup', () => {
+    it('re-files a rollup issue when ≥2 pending-review entries exist for same owner but no open rollup issue', async () => {
+      const existing: ReposFile = {
+        version: 1,
+        repos: [
+          makeEntry({owner: 'bad', name: 'r1', onboarding_status: 'pending-review'}),
+          makeEntry({owner: 'bad', name: 'r2', onboarding_status: 'pending-review'}),
+          makeEntry({owner: 'bad', name: 'r3', onboarding_status: 'pending-review'}),
+        ],
+      }
+      const issuesCreate = vi.fn(async () => ({data: {number: 99}}))
+      // No open rollup issue exists; simulate prior one was closed manually
+      const issuesListForRepo = vi.fn(async () => ({data: []}))
+
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: existing.repos.map((r, i) => ({
+            owner: {login: r.owner},
+            name: r.name,
+            archived: false,
+            private: false,
+            node_id: `R_exist_${i}`,
+          })),
+        }),
+      })
+
+      await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({issuesCreate, issuesListForRepo}),
+          readMetadata: makeReadMetadata({repos: existing}),
+          commitMetadata: vi.fn(async () => ({committed: false, attempts: 1})) as never,
+        }),
+      )
+
+      // The self-healing loop should file one rollup issue since none exists
+      expect(issuesCreate).toHaveBeenCalledOnce()
+      const params = firstCallArg<{title: string; labels: string[]}>(issuesCreate)
+      expect(params?.title.toLowerCase()).toContain('bad')
+      expect(params?.labels).toContain('reconcile:rollup-pending-review')
+    })
+
+    it('does not file a new rollup when an open rollup issue already exists for that owner', async () => {
+      const existing: ReposFile = {
+        version: 1,
+        repos: [
+          makeEntry({owner: 'bad', name: 'r1', onboarding_status: 'pending-review'}),
+          makeEntry({owner: 'bad', name: 'r2', onboarding_status: 'pending-review'}),
+        ],
+      }
+      const issuesCreate = vi.fn(async () => ({data: {number: 99}}))
+      const issuesListForRepo = vi.fn(async () => ({
+        data: [
+          {
+            number: 50,
+            title: 'Unsolicited collaborator grants from bad',
+            body: '<!-- reconcile:subject:rollup-owner=bad -->',
+            state: 'open' as const,
+            labels: [{name: 'reconcile:pending-review'}, {name: 'reconcile:rollup-pending-review'}],
+          },
+        ],
+      }))
+
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: existing.repos.map((r, i) => ({
+            owner: {login: r.owner},
+            name: r.name,
+            archived: false,
+            private: false,
+            node_id: `R_exist_${i}`,
+          })),
+        }),
+      })
+
+      await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({issuesCreate, issuesListForRepo}),
+          readMetadata: makeReadMetadata({repos: existing}),
+          commitMetadata: vi.fn(async () => ({committed: false, attempts: 1})) as never,
+        }),
+      )
+
+      expect(issuesCreate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('data branch integrity check', () => {
+    it('passes when data branch tip is authored by fro-bot[bot]', async () => {
+      const getBranch = vi.fn(async () => ({
+        data: {name: 'data', commit: {sha: 'sha1', author: {login: 'fro-bot[bot]'}}},
+      }))
+      const issuesCreate = vi.fn(async () => ({data: {number: 1}}))
+      const commitMetadata = vi.fn(async () => ({committed: true, sha: 's', attempts: 1}))
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [{owner: {login: 't'}, name: 'r', archived: false, private: false, node_id: 'R_1'}],
+        }),
+      })
+
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({getBranch, issuesCreate}),
+          readMetadata: makeReadMetadata({allowlist: makeAllowlist(['t'])}),
+          commitMetadata: commitMetadata as never,
+        }),
+      )
+
+      expect(result.integrityCheck).toBe('ok')
+      expect(commitMetadata).toHaveBeenCalledOnce()
+      // Integrity alert issue should NOT be filed
+      const alertCalls = (issuesCreate.mock.calls as unknown as [{labels?: string[]}][]).filter(c => {
+        const p = c[0]
+        return p.labels?.includes('reconcile:integrity-alert') ?? false
+      })
+      expect(alertCalls).toHaveLength(0)
+    })
+
+    it('passes when data branch tip is authored by an operator login in RECONCILE_OPERATOR_LOGINS', async () => {
+      const getBranch = vi.fn(async () => ({
+        data: {name: 'data', commit: {sha: 'op-sha', author: {login: 'marcusrbrown'}}},
+      }))
+      const commitMetadata = vi.fn(async () => ({committed: true, sha: 's', attempts: 1}))
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [{owner: {login: 't'}, name: 'r', archived: false, private: false, node_id: 'R_1'}],
+        }),
+      })
+
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({getBranch}),
+          readMetadata: makeReadMetadata({allowlist: makeAllowlist(['t'])}),
+          commitMetadata: commitMetadata as never,
+          operatorLogins: ['marcusrbrown'],
+        }),
+      )
+
+      expect(result.integrityCheck).toBe('ok')
+      expect(commitMetadata).toHaveBeenCalledOnce()
+    })
+
+    it('aborts with DATA_BRANCH_TAMPER and files an integrity-alert issue for unexpected author', async () => {
+      const getBranch = vi.fn(async () => ({
+        data: {name: 'data', commit: {sha: 'evil-sha', author: {login: 'impostor'}}},
+      }))
+      const issuesCreate = vi.fn(async () => ({data: {number: 1}}))
+      const commitMetadata = vi.fn(async () => ({committed: true, sha: 's', attempts: 1}))
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [{owner: {login: 't'}, name: 'r', archived: false, private: false, node_id: 'R_1'}],
+        }),
+      })
+
+      await expect(
+        handleReconcile(
+          baseParams({
+            userOctokit,
+            appOctokit: mockOctokit({getBranch, issuesCreate}),
+            readMetadata: makeReadMetadata({allowlist: makeAllowlist(['t'])}),
+            commitMetadata: commitMetadata as never,
+          }),
+        ),
+      ).rejects.toMatchObject({code: 'DATA_BRANCH_TAMPER'})
+
+      // Alert issue is filed; no commit is attempted
+      expect(issuesCreate).toHaveBeenCalledOnce()
+      const params = firstCallArg<{labels: string[]; body: string}>(issuesCreate)
+      expect(params?.labels).toContain('reconcile:integrity-alert')
+      expect(params?.body).toContain('impostor')
+      expect(params?.body).toContain('evil-sha')
+      expect(commitMetadata).not.toHaveBeenCalled()
+    })
+
+    it('skips the integrity check in the bootstrap case (data branch does not exist)', async () => {
+      const getBranch = notFoundGetBranch()
+      const commitMetadata = vi.fn(async () => ({committed: true, sha: 's', attempts: 1}))
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [{owner: {login: 't'}, name: 'r', archived: false, private: false, node_id: 'R_1'}],
+        }),
+      })
+
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({getBranch}),
+          readMetadata: makeReadMetadata({allowlist: makeAllowlist(['t'])}),
+          commitMetadata: commitMetadata as never,
+        }),
+      )
+
+      expect(result.integrityCheck).toBe('skipped-no-data-branch')
+      expect(commitMetadata).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('commit error handling', () => {
+    it('propagates CONFLICT_EXHAUSTED from commitMetadata and skips all dispatches', async () => {
+      const conflictError = Object.assign(new Error('conflict'), {
+        name: 'CommitMetadataError',
+        code: 'CONFLICT_EXHAUSTED',
+        remediation: 'retry',
+      })
+      const commitMetadata = vi.fn(async () => {
+        throw conflictError
+      })
+      const createWorkflowDispatch = vi.fn(async () => undefined)
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [{owner: {login: 't'}, name: 'r', archived: false, private: false, node_id: 'R_1'}],
+        }),
+      })
+
+      await expect(
+        handleReconcile(
+          baseParams({
+            userOctokit,
+            appOctokit: mockOctokit({createWorkflowDispatch}),
+            readMetadata: makeReadMetadata({allowlist: makeAllowlist(['t'])}),
+            commitMetadata: commitMetadata as never,
+          }),
+        ),
+      ).rejects.toMatchObject({code: 'CONFLICT_EXHAUSTED'})
+
+      expect(createWorkflowDispatch).not.toHaveBeenCalled()
+    })
+
+    it('re-runs reconcileRepos on 409-retry: mutator called twice with v1 then v2, merges concurrent entry', async () => {
+      // The scenario requires hasChanges=true so the commit path actually executes. We
+      // give reconcile a brand-new repo `b` in the access list, simulating a new grant
+      // that reconcile wants to add. Meanwhile a concurrent writer (handle-invitation)
+      // appends `concurrent-c` to repos.yaml between our initial read and the 409 retry.
+      const v1: ReposFile = {version: 1, repos: [makeEntry({name: 'a', onboarding_status: 'pending'})]}
+      const v2: ReposFile = {
+        version: 1,
+        repos: [
+          makeEntry({name: 'a', onboarding_status: 'pending'}),
+          makeEntry({name: 'concurrent-c', onboarding_status: 'pending'}),
+        ],
+      }
+
+      const mutatorInvocations: ReposFile[] = []
+      const commitMetadata = vi.fn(async (params: CommitMetadataParams): Promise<CommitMetadataResult> => {
+        // First invocation with v1 (pre-concurrent-write state)
+        const first = (await params.mutator(v1)) as ReposFile
+        mutatorInvocations.push(first)
+        // Second invocation with v2 (simulates 409 retry post-concurrent-write)
+        const second = (await params.mutator(v2)) as ReposFile
+        mutatorInvocations.push(second)
+        return {committed: true, sha: 'sha', attempts: 2}
+      })
+
+      // Access list has both `a` (tracked) and `b` (new) — reconcile wants to add `b`.
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {owner: {login: 'fro-bot'}, name: 'a', archived: false, private: false, node_id: 'R_a'},
+            {owner: {login: 'fro-bot'}, name: 'b', archived: false, private: false, node_id: 'R_b'},
+          ],
+        }),
+      })
+
+      await handleReconcile(
+        baseParams({
+          userOctokit,
+          readMetadata: makeReadMetadata({repos: v1, allowlist: makeAllowlist(['fro-bot'])}),
+          commitMetadata: commitMetadata as never,
+        }),
+      )
+
+      expect(mutatorInvocations).toHaveLength(2)
+      // First invocation: v1 + add b → 2 entries (a, b)
+      expect(mutatorInvocations[0]?.repos.map(r => r.name).sort()).toEqual(['a', 'b'])
+      // Second invocation: v2 (a + concurrent-c) + add b → 3 entries. Crucially, concurrent-c
+      // is preserved (no incorrect lost-access flip) because it's not in accessList and has no
+      // probe (perRepoStatus was computed from the initial v1 read, so c wasn't probed).
+      expect(mutatorInvocations[1]?.repos.map(r => r.name).sort()).toEqual(['a', 'b', 'concurrent-c'])
+      expect(mutatorInvocations[1]?.repos.find(r => r.name === 'concurrent-c')?.onboarding_status).toBe('pending')
+    })
+  })
+
+  describe('env-based auth and MISSING_TOKEN', () => {
+    it('throws MISSING_TOKEN with env-var name and no token value when FRO_BOT_POLL_PAT is missing', async () => {
+      const saved = process.env.FRO_BOT_POLL_PAT
+      delete process.env.FRO_BOT_POLL_PAT
+      try {
+        const caught = await handleReconcile({
+          appOctokit: mockOctokit(),
+          owner: 'fro-bot',
+          repo: '.github',
+          readMetadata: makeReadMetadata(),
+          commitMetadata: vi.fn(async () => ({committed: false, attempts: 1})) as never,
+          bootstrapDataBranch: vi.fn(async () => ({created: false, ref: 'refs/heads/data', sha: 's'})) as never,
+        }).catch((error: unknown) => error)
+
+        expect(caught).toBeInstanceOf(ReconcileError)
+        const re = caught as ReconcileError
+        expect(re.code).toBe('MISSING_TOKEN')
+        expect(re.message).toContain('FRO_BOT_POLL_PAT')
+        // Token hygiene: message must not contain any real token-looking substring
+        expect(re.message).not.toMatch(/gh[ps]_/)
+      } finally {
+        if (saved !== undefined) process.env.FRO_BOT_POLL_PAT = saved
+      }
+    })
+
+    it('throws MISSING_TOKEN when GITHUB_TOKEN is missing (app token not minted)', async () => {
+      const savedUser = process.env.FRO_BOT_POLL_PAT
+      const savedApp = process.env.GITHUB_TOKEN
+      process.env.FRO_BOT_POLL_PAT = 'fake-pat-value-for-test'
+      delete process.env.GITHUB_TOKEN
+      try {
+        const caught = await handleReconcile({
+          userOctokit: mockOctokit(),
+          owner: 'fro-bot',
+          repo: '.github',
+          readMetadata: makeReadMetadata(),
+          commitMetadata: vi.fn(async () => ({committed: false, attempts: 1})) as never,
+          bootstrapDataBranch: vi.fn(async () => ({created: false, ref: 'refs/heads/data', sha: 's'})) as never,
+        }).catch((error: unknown) => error)
+
+        expect(caught).toBeInstanceOf(ReconcileError)
+        const re = caught as ReconcileError
+        expect(re.code).toBe('MISSING_TOKEN')
+        expect(re.message).toContain('GITHUB_TOKEN')
+        expect(re.message).not.toContain('fake-pat-value-for-test')
+      } finally {
+        if (savedUser === undefined) {
+          delete process.env.FRO_BOT_POLL_PAT
+        } else {
+          process.env.FRO_BOT_POLL_PAT = savedUser
+        }
+        if (savedApp !== undefined) process.env.GITHUB_TOKEN = savedApp
+      }
     })
   })
 })

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -1,0 +1,502 @@
+import {describe, expect, it} from 'vitest'
+
+import {reconcileRepos, type AccessListEntry, type ReconcileInput} from './reconcile-repos.ts'
+import {addRepoEntry} from './repos-metadata.ts'
+import {assertReposFile, type AllowlistFile, type RepoEntry, type ReposFile} from './schemas.ts'
+
+const NOW = new Date('2026-04-17T12:00:00Z')
+
+function makeAllowlist(usernames: string[] = []): AllowlistFile {
+  return {
+    version: 1,
+    approved_inviters: usernames.map(u => ({username: u, added: '2026-01-01', role: 'owner'})),
+  }
+}
+
+function makeAccess(overrides: Partial<AccessListEntry> = {}): AccessListEntry {
+  return {
+    owner: 'fro-bot',
+    name: 'test-repo',
+    archived: false,
+    private: false,
+    node_id: 'R_default',
+    ...overrides,
+  }
+}
+
+function makeEntry(overrides: Partial<RepoEntry> = {}): RepoEntry {
+  return {
+    owner: 'fro-bot',
+    name: 'test-repo',
+    added: '2026-01-01',
+    onboarding_status: 'onboarded',
+    last_survey_at: null,
+    last_survey_status: null,
+    has_fro_bot_workflow: false,
+    has_renovate: false,
+    ...overrides,
+  }
+}
+
+function makeInput(overrides: Partial<ReconcileInput> = {}): ReconcileInput {
+  return {
+    currentRepos: {version: 1, repos: []},
+    accessList: [],
+    perRepoStatus: new Map(),
+    allowlist: makeAllowlist(),
+    fieldProbes: new Map(),
+    now: NOW,
+    ...overrides,
+  }
+}
+
+describe('reconcileRepos', () => {
+  describe('newcomers (untracked repos appearing in accessList)', () => {
+    it('adds an allowlisted newcomer with pending status and queues a dispatch', () => {
+      // GIVEN an accessible repo from an allowlisted owner, not yet tracked
+      // WHEN reconciling
+      const result = reconcileRepos(
+        makeInput({
+          accessList: [makeAccess({owner: 'marcusrbrown', name: 'new-repo', node_id: 'R_new'})],
+          allowlist: makeAllowlist(['marcusrbrown']),
+        }),
+      )
+
+      // THEN it's added as pending with a dispatch queued and no issue
+      expect(result.nextRepos.repos).toHaveLength(1)
+      expect(result.nextRepos.repos[0]).toMatchObject({
+        owner: 'marcusrbrown',
+        name: 'new-repo',
+        onboarding_status: 'pending',
+      })
+      expect(result.dispatches).toEqual([{owner: 'marcusrbrown', repo: 'new-repo'}])
+      expect(result.issues).toEqual([])
+      expect(result.summary).toEqual({
+        added: 1,
+        pendingReview: 0,
+        regained: 0,
+        lostAccess: 0,
+        refreshed: 0,
+        unchanged: 0,
+      })
+    })
+
+    it('adds a non-allowlisted newcomer as pending-review and files a per-repo issue', () => {
+      const result = reconcileRepos(
+        makeInput({
+          accessList: [makeAccess({owner: 'stranger', name: 'sus-repo', node_id: 'R_sus', private: false})],
+          allowlist: makeAllowlist([]),
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]).toMatchObject({
+        owner: 'stranger',
+        name: 'sus-repo',
+        onboarding_status: 'pending-review',
+      })
+      expect(result.dispatches).toEqual([])
+      expect(result.issues).toEqual([
+        {
+          kind: 'per-repo',
+          owner: 'stranger',
+          repo: 'sus-repo',
+          reason: 'unsolicited-new',
+          private: false,
+          node_id: 'R_sus',
+        },
+      ])
+      expect(result.summary.added).toBe(0)
+      expect(result.summary.pendingReview).toBe(1)
+    })
+
+    it('rolls up ≥2 non-allowlisted newcomers from the same owner into a single issue', () => {
+      const result = reconcileRepos(
+        makeInput({
+          accessList: [
+            makeAccess({owner: 'stranger', name: 'repo-a', node_id: 'R_a', private: false}),
+            makeAccess({owner: 'stranger', name: 'repo-b', node_id: 'R_b', private: true}),
+          ],
+          allowlist: makeAllowlist([]),
+        }),
+      )
+
+      expect(result.nextRepos.repos).toHaveLength(2)
+      expect(result.nextRepos.repos.every(r => r.onboarding_status === 'pending-review')).toBe(true)
+      expect(result.issues).toEqual([
+        {
+          kind: 'per-owner-rollup',
+          owner: 'stranger',
+          reason: 'unsolicited-new',
+          entries: [
+            {repo: 'repo-a', private: false, node_id: 'R_a'},
+            {repo: 'repo-b', private: true, node_id: 'R_b'},
+          ],
+        },
+      ])
+      expect(result.summary.pendingReview).toBe(2)
+    })
+
+    it('processes mixed batch: one allowlisted dispatch, one per-owner rollup, zero per-repo', () => {
+      const result = reconcileRepos(
+        makeInput({
+          accessList: [
+            makeAccess({owner: 'trusted', name: 'ok-repo', node_id: 'R_ok'}),
+            makeAccess({owner: 'stranger', name: 'repo-a', node_id: 'R_a'}),
+            makeAccess({owner: 'stranger', name: 'repo-b', node_id: 'R_b'}),
+          ],
+          allowlist: makeAllowlist(['trusted']),
+        }),
+      )
+
+      expect(result.dispatches).toEqual([{owner: 'trusted', repo: 'ok-repo'}])
+      expect(result.issues).toHaveLength(1)
+      expect(result.issues[0]?.kind).toBe('per-owner-rollup')
+      expect(result.issues.filter(i => i.kind === 'per-repo')).toEqual([])
+      expect(result.summary.added).toBe(1)
+      expect(result.summary.pendingReview).toBe(2)
+    })
+  })
+
+  describe('tracked entries — still accessible', () => {
+    it('leaves a pending, still-accessible entry unchanged when no field drift', () => {
+      const entry = makeEntry({onboarding_status: 'pending', name: 'stable-repo'})
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({name: 'stable-repo'})],
+          fieldProbes: new Map([['fro-bot/stable-repo', {has_fro_bot_workflow: false, has_renovate: false}]]),
+        }),
+      )
+
+      expect(result.nextRepos.repos).toEqual([entry])
+      expect(result.dispatches).toEqual([])
+      expect(result.issues).toEqual([])
+      expect(result.summary.unchanged).toBe(1)
+      expect(result.summary.refreshed).toBe(0)
+    })
+
+    it('flips fields on tracked onboarded entry when probe differs, status unchanged', () => {
+      const entry = makeEntry({
+        name: 'drifted-repo',
+        onboarding_status: 'onboarded',
+        has_fro_bot_workflow: true,
+        has_renovate: false,
+      })
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({name: 'drifted-repo'})],
+          fieldProbes: new Map([['fro-bot/drifted-repo', {has_fro_bot_workflow: true, has_renovate: true}]]),
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]).toMatchObject({
+        name: 'drifted-repo',
+        onboarding_status: 'onboarded',
+        has_fro_bot_workflow: true,
+        has_renovate: true,
+      })
+      expect(result.summary.refreshed).toBe(1)
+      expect(result.summary.unchanged).toBe(0)
+    })
+
+    it('preserves pending-review status on still-accessible entry but refreshes fields on drift', () => {
+      const entry = makeEntry({
+        name: 'sus-repo',
+        onboarding_status: 'pending-review',
+        has_renovate: false,
+      })
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({name: 'sus-repo'})],
+          fieldProbes: new Map([['fro-bot/sus-repo', {has_fro_bot_workflow: false, has_renovate: true}]]),
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]?.onboarding_status).toBe('pending-review')
+      expect(result.nextRepos.repos[0]?.has_renovate).toBe(true)
+      expect(result.dispatches).toEqual([])
+      expect(result.issues).toEqual([])
+      expect(result.summary.refreshed).toBe(1)
+    })
+  })
+
+  describe('tracked entries — lost access', () => {
+    it('flips tracked repo absent from access list with probe=deleted to lost-access, preserving other fields', () => {
+      const entry = makeEntry({
+        name: 'gone-repo',
+        onboarding_status: 'onboarded',
+        last_survey_at: '2026-01-15',
+        last_survey_status: 'success',
+        has_fro_bot_workflow: true,
+        has_renovate: true,
+      })
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          perRepoStatus: new Map([['fro-bot/gone-repo', {status: 'deleted'}]]),
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]).toEqual({
+        ...entry,
+        onboarding_status: 'lost-access',
+      })
+      expect(result.summary.lostAccess).toBe(1)
+    })
+
+    it('flips tracked repo absent from access list with probe=revoked to lost-access', () => {
+      const entry = makeEntry({name: 'revoked-repo', onboarding_status: 'onboarded'})
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          perRepoStatus: new Map([['fro-bot/revoked-repo', {status: 'revoked'}]]),
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]?.onboarding_status).toBe('lost-access')
+      expect(result.summary.lostAccess).toBe(1)
+    })
+
+    it('flips tracked repo present in access list with archived:true to lost-access from Pass 1 data', () => {
+      const entry = makeEntry({name: 'archived-repo', onboarding_status: 'onboarded'})
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({name: 'archived-repo', archived: true})],
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]?.onboarding_status).toBe('lost-access')
+      expect(result.summary.lostAccess).toBe(1)
+    })
+
+    it('treats tracked repo absent from access list with probe=still-accessible as transient — no change', () => {
+      const entry = makeEntry({name: 'flaky-repo', onboarding_status: 'onboarded'})
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          perRepoStatus: new Map([
+            ['fro-bot/flaky-repo', {status: 'still-accessible', private: false, node_id: 'R_flaky'}],
+          ]),
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]).toEqual(entry)
+      expect(result.summary.unchanged).toBe(1)
+      expect(result.summary.lostAccess).toBe(0)
+    })
+  })
+
+  describe('tracked entries — regained access', () => {
+    it('flips lost-access back to pending for allowlisted owner, queues dispatch, preserves history', () => {
+      // GIVEN a lost-access entry with full survey history
+      const entry = makeEntry({
+        name: 'returned-repo',
+        onboarding_status: 'lost-access',
+        last_survey_at: '2026-01-10',
+        last_survey_status: 'success',
+        has_fro_bot_workflow: true,
+        has_renovate: false,
+      })
+      // WHEN it shows up in the access list again with an allowlisted owner
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({name: 'returned-repo'})],
+          allowlist: makeAllowlist(['fro-bot']),
+        }),
+      )
+
+      // THEN status flips to pending, dispatch is queued, history preserved
+      expect(result.nextRepos.repos[0]).toEqual({
+        ...entry,
+        onboarding_status: 'pending',
+      })
+      expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'returned-repo'}])
+      expect(result.issues).toEqual([])
+      expect(result.summary.regained).toBe(1)
+    })
+
+    it('flips lost-access back to pending-review for non-allowlisted owner, files per-repo issue', () => {
+      const entry = makeEntry({
+        owner: 'stranger',
+        name: 'returned-sus',
+        onboarding_status: 'lost-access',
+        last_survey_at: '2025-12-01',
+        last_survey_status: 'failure',
+      })
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({owner: 'stranger', name: 'returned-sus', node_id: 'R_sus', private: false})],
+          allowlist: makeAllowlist([]),
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]).toEqual({
+        ...entry,
+        onboarding_status: 'pending-review',
+      })
+      expect(result.dispatches).toEqual([])
+      expect(result.issues).toEqual([
+        {
+          kind: 'per-repo',
+          owner: 'stranger',
+          repo: 'returned-sus',
+          reason: 'unsolicited-regain',
+          private: false,
+          node_id: 'R_sus',
+        },
+      ])
+      expect(result.summary.regained).toBe(1)
+    })
+  })
+
+  describe('mixed and edge cases', () => {
+    it('handles multiple simultaneous changes (new + lost + refresh) in one run', () => {
+      const drift = makeEntry({
+        name: 'drift-repo',
+        onboarding_status: 'onboarded',
+        has_renovate: false,
+      })
+      const gone = makeEntry({name: 'gone-repo', onboarding_status: 'onboarded'})
+
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [drift, gone]},
+          accessList: [
+            makeAccess({name: 'drift-repo'}),
+            makeAccess({owner: 'trusted', name: 'fresh-repo', node_id: 'R_fresh'}),
+          ],
+          perRepoStatus: new Map([['fro-bot/gone-repo', {status: 'deleted'}]]),
+          fieldProbes: new Map([['fro-bot/drift-repo', {has_fro_bot_workflow: false, has_renovate: true}]]),
+          allowlist: makeAllowlist(['trusted']),
+        }),
+      )
+
+      expect(result.nextRepos.repos).toHaveLength(3)
+      const byName = new Map(result.nextRepos.repos.map(r => [r.name, r]))
+      expect(byName.get('drift-repo')?.has_renovate).toBe(true)
+      expect(byName.get('drift-repo')?.onboarding_status).toBe('onboarded')
+      expect(byName.get('gone-repo')?.onboarding_status).toBe('lost-access')
+      expect(byName.get('fresh-repo')?.onboarding_status).toBe('pending')
+      expect(result.dispatches).toEqual([{owner: 'trusted', repo: 'fresh-repo'}])
+      expect(result.issues).toEqual([])
+      expect(result.summary).toEqual({
+        added: 1,
+        pendingReview: 0,
+        regained: 0,
+        lostAccess: 1,
+        refreshed: 1,
+        unchanged: 0,
+      })
+    })
+
+    it('reports all-zero counters and value-equal nextRepos when nothing changes', () => {
+      const entry = makeEntry({name: 'stable-repo', onboarding_status: 'pending'})
+      const current: ReposFile = {version: 1, repos: [entry]}
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: current,
+          accessList: [makeAccess({name: 'stable-repo'})],
+        }),
+      )
+
+      expect(result.nextRepos).toEqual(current)
+      expect(result.dispatches).toEqual([])
+      expect(result.issues).toEqual([])
+      expect(result.summary).toEqual({
+        added: 0,
+        pendingReview: 0,
+        regained: 0,
+        lostAccess: 0,
+        refreshed: 0,
+        unchanged: 1,
+      })
+    })
+
+    it('handles empty currentRepos and empty accessList as a no-op', () => {
+      const result = reconcileRepos(makeInput({}))
+
+      expect(result.nextRepos).toEqual({version: 1, repos: []})
+      expect(result.dispatches).toEqual([])
+      expect(result.issues).toEqual([])
+      expect(result.summary).toEqual({
+        added: 0,
+        pendingReview: 0,
+        regained: 0,
+        lostAccess: 0,
+        refreshed: 0,
+        unchanged: 0,
+      })
+    })
+
+    it('merges safely on concurrent-writer retry: entry added between calls is preserved', () => {
+      // GIVEN an initial currentRepos@v1 reconciled once
+      const entryA = makeEntry({name: 'a-repo', onboarding_status: 'pending'})
+      const v1: ReposFile = {version: 1, repos: [entryA]}
+      const accessList = [makeAccess({name: 'a-repo'})]
+      reconcileRepos(makeInput({currentRepos: v1, accessList}))
+
+      // WHEN a concurrent writer appends entryC before reconcile retries with currentRepos@v2
+      const entryC = makeEntry({name: 'c-repo', onboarding_status: 'pending'})
+      const v2: ReposFile = {version: 1, repos: [entryA, entryC]}
+      const result2 = reconcileRepos(makeInput({currentRepos: v2, accessList}))
+
+      // THEN entryC survives — no incorrect lost-access flip, counted as unchanged
+      expect(result2.nextRepos.repos).toEqual([entryA, entryC])
+      expect(result2.summary.lostAccess).toBe(0)
+      expect(result2.summary.unchanged).toBe(2)
+    })
+
+    it('produces newcomer entries structurally identical to addRepoEntry output (parity)', () => {
+      const access = makeAccess({owner: 'trusted', name: 'parity-repo', node_id: 'R_parity'})
+      const allowlist = makeAllowlist(['trusted'])
+      const result = reconcileRepos(makeInput({accessList: [access], allowlist}))
+
+      const direct = addRepoEntry(
+        {version: 1, repos: []},
+        {owner: 'trusted', repo: 'parity-repo', now: NOW, onboarding_status: 'pending'},
+      )
+
+      // Schema-validated on both sides, then structural equality
+      assertReposFile(result.nextRepos)
+      assertReposFile(direct)
+      expect(result.nextRepos.repos[0]).toEqual(direct.repos[0])
+    })
+
+    it('does not mutate currentRepos input when producing nextRepos', () => {
+      // GIVEN an input with one entry
+      const entry = makeEntry({name: 'gone-repo', onboarding_status: 'onboarded'})
+      const currentRepos: ReposFile = {version: 1, repos: [entry]}
+      const frozenSnapshot = JSON.stringify(currentRepos)
+
+      // WHEN reconcile flips the entry to lost-access
+      reconcileRepos(
+        makeInput({
+          currentRepos,
+          perRepoStatus: new Map([['fro-bot/gone-repo', {status: 'deleted'}]]),
+        }),
+      )
+
+      // THEN the original currentRepos object is unchanged
+      expect(JSON.stringify(currentRepos)).toBe(frozenSnapshot)
+      expect(entry.onboarding_status).toBe('onboarded')
+    })
+
+    it('throws when accessList contains duplicate owner/name pairs', () => {
+      expect(() =>
+        reconcileRepos(
+          makeInput({
+            accessList: [
+              makeAccess({owner: 'dupe', name: 'same-repo', node_id: 'R_1'}),
+              makeAccess({owner: 'dupe', name: 'same-repo', node_id: 'R_2'}),
+            ],
+          }),
+        ),
+      ).toThrow(/duplicate/i)
+    })
+  })
+})

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -492,6 +492,8 @@ export interface HandleReconcileResult {
   issuesFailed: number
   /** Count of stale `reconcile:pending-review` issues auto-closed this run. */
   closedStaleIssues: number
+  /** Count of field probes that failed and were treated as no-change. */
+  probesFailed: number
   integrityCheck: 'ok' | 'skipped-no-data-branch'
   committed: boolean
 }
@@ -531,7 +533,9 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
   const perRepoStatus = await fetchPerRepoStatus(userOctokit, currentRepos, accessList)
 
   // 5. Field probes for still-accessible tracked entries.
-  const fieldProbes = await fetchFieldProbes(userOctokit, currentRepos, accessList, logger)
+  const fieldProbeOutcome = await fetchFieldProbes(userOctokit, currentRepos, accessList, logger)
+  const fieldProbes = fieldProbeOutcome.probes
+  const probesFailed = fieldProbeOutcome.failed
 
   // 6. Run the pure engine to produce the change plan.
   const plan = reconcileRepos({currentRepos, accessList, perRepoStatus, allowlist, fieldProbes, now})
@@ -569,6 +573,26 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
       message: formatCommitMessage(plan.summary),
       mutator: async currentParsed => {
         assertReposFile(currentParsed, 'repos')
+        // Re-verify data-branch integrity inside the mutator to close the TOCTOU window
+        // between the initial check (step 7) and the first commit attempt. Each 409 retry
+        // also re-verifies, catching any tamper that lands during the retry loop.
+        const retryIntegrity = await verifyDataBranchIntegrity({appOctokit, owner, repo, operatorLogins})
+        if (!retryIntegrity.ok) {
+          await fileIntegrityAlert({
+            appOctokit,
+            owner,
+            repo,
+            authorLogin: retryIntegrity.authorLogin,
+            sha: retryIntegrity.sha,
+            logger,
+          })
+          throw new ReconcileError({
+            code: 'DATA_BRANCH_TAMPER',
+            message: `Unexpected author on data branch tip commit during commit retry: ${retryIntegrity.authorLogin ?? 'unknown'} (sha: ${retryIntegrity.sha})`,
+            remediation:
+              'Investigate who has contents:write on this repo. If legitimate, add the login to RECONCILE_OPERATOR_LOGINS and rerun.',
+          })
+        }
         const rerun = reconcileRepos({
           currentRepos: currentParsed,
           accessList,
@@ -634,6 +658,7 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
     rollupIssues: issueOutcome.rollupSucceeded + healedRollups,
     issuesFailed: issueOutcome.failed,
     closedStaleIssues,
+    probesFailed,
     integrityCheck,
     committed,
   }
@@ -775,9 +800,10 @@ async function fetchFieldProbes(
   currentRepos: ReposFile,
   accessList: AccessListEntry[],
   logger: ReconcileLogger,
-): Promise<Map<string, FieldProbe>> {
+): Promise<{probes: Map<string, FieldProbe>; failed: number}> {
   const accessKeys = new Set(accessList.filter(a => a.archived === false).map(a => `${a.owner}/${a.name}`))
   const map = new Map<string, FieldProbe>()
+  let failed = 0
   for (const entry of currentRepos.repos) {
     const key = `${entry.owner}/${entry.name}`
     if (!accessKeys.has(key)) continue // only probe still-accessible tracked entries
@@ -786,11 +812,12 @@ async function fetchFieldProbes(
       map.set(key, probe)
     } catch (error: unknown) {
       // Non-blocking: omit from map so reconcileRepos treats as no-field-change.
+      failed += 1
       const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
       logger.warn(`reconcile: field probe failed (status=${status}); treating as no-change.`)
     }
   }
-  return map
+  return {probes: map, failed}
 }
 
 async function probeSingleRepo(userOctokit: OctokitClient, owner: string, name: string): Promise<FieldProbe> {
@@ -1194,6 +1221,11 @@ async function selfHealRollups(params: {
     }
     if (rollupEntries.length < 2) continue // missing access data leaves us without ≥2 identifiable entries
 
+    // Self-healed rollups always use 'unsolicited-new' as the reason. The original reason
+    // ('unsolicited-new' or 'unsolicited-regain') is not tracked on the RepoEntry itself
+    // (it's only known at the moment the pending-review state is established), so once the
+    // original rollup issue is closed we lose that signal. Operator triages by visiting the
+    // listed entries in `repos.yaml`; the title wording is a minor simplification.
     const rollupIssue: PerOwnerRollupIssue = {
       kind: 'per-owner-rollup',
       owner,

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -16,10 +16,50 @@
  * byte-compatible entry shapes. Status transitions on existing entries (lost-access,
  * regain, field drift) use fresh inline objects because `addRepoEntry` is idempotent on
  * duplicate `owner+name` and would silently drop a status flip.
+ *
+ * ## I/O shell contract (Unit 3)
+ *
+ * `handleReconcile` accepts injectable dependencies (Octokit clients, readMetadata,
+ * commitMetadata, bootstrapDataBranch, logger) so the entire outer layer is testable
+ * with handcrafted mocks. Production uses `main()` which reads `FRO_BOT_POLL_PAT` and
+ * `GITHUB_TOKEN` from env, constructs both Octokit clients, and delegates. Token values
+ * never appear in logs or error messages — error paths reference env-var names only.
+ *
+ * Commit-before-dispatch: `commitMetadata` runs before the dispatch/issue loops. A
+ * commit failure is fatal (bubbled up). Dispatch/issue failures are non-blocking: they
+ * log and continue so one misbehaving API call doesn't stall the rest of the run.
+ *
+ * Mutator re-run for concurrent-writer safety: the mutator closure re-invokes
+ * `reconcileRepos` on every call with fresh `current`. If a competing writer appends an
+ * entry between our read and our commit, the 409-retry path in `commitMetadata` re-runs
+ * the mutator with the post-retry snapshot and the merge is correct. Without this
+ * contract, whole-state replacement would silently drop concurrently-added entries.
  */
 
-import type {AllowlistFile, OnboardingStatus, RepoEntry, ReposFile} from './schemas.ts'
+import {readFile} from 'node:fs/promises'
+import process from 'node:process'
+import {Octokit} from '@octokit/rest'
+import {parse} from 'yaml'
+
+import {
+  commitMetadata as defaultCommitMetadata,
+  type CommitMetadataParams,
+  type CommitMetadataResult,
+} from './commit-metadata.ts'
+import {
+  bootstrapDataBranch as defaultBootstrapDataBranch,
+  type DataBranchBootstrapParams,
+  type DataBranchBootstrapResult,
+} from './data-branch-bootstrap.ts'
 import {addRepoEntry} from './repos-metadata.ts'
+import {
+  assertAllowlistFile,
+  assertReposFile,
+  type AllowlistFile,
+  type OnboardingStatus,
+  type RepoEntry,
+  type ReposFile,
+} from './schemas.ts'
 
 export interface AccessListEntry {
   owner: string
@@ -356,4 +396,882 @@ function validateAccessList(accessList: AccessListEntry[]): void {
 
 function repoKey(owner: string, name: string): string {
   return `${owner}/${name}`
+}
+
+//
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit 3 — I/O shell: `handleReconcile` plus dispatch/issue/integrity helpers
+// ─────────────────────────────────────────────────────────────────────────────
+//
+
+/**
+ * Narrow Octokit client type derived from the real `@octokit/rest` SDK.
+ * See commit-metadata.ts for the rationale behind deriving rather than handwriting.
+ */
+export type OctokitClient = Octokit
+
+type OctokitConstructor = new (params: {auth: string}) => OctokitClient
+
+const DEFAULT_OWNER = 'fro-bot'
+const DEFAULT_REPO = '.github'
+const DEFAULT_ALLOWLIST_PATH = 'metadata/allowlist.yaml'
+const DEFAULT_REPOS_PATH = 'metadata/repos.yaml'
+const DEFAULT_WORKFLOW_FILE = 'survey-repo.yaml'
+const DEFAULT_WORKFLOW_REF = 'main'
+const DEFAULT_DISPATCH_TIMEOUT_MS = 15_000
+
+const PENDING_REVIEW_LABEL = 'reconcile:pending-review'
+const ROLLUP_LABEL = 'reconcile:rollup-pending-review'
+const INTEGRITY_ALERT_LABEL = 'reconcile:integrity-alert'
+const EXPECTED_APP_AUTHOR = 'fro-bot[bot]'
+
+const NODE_ID_MARKER_PATTERN = /<!-- reconcile:subject:node_id=([\w-]+) -->/
+const ROLLUP_OWNER_MARKER_PATTERN = /<!-- reconcile:subject:rollup-owner=([\w-]+) -->/
+
+export type ReconcileErrorCode =
+  | 'MISSING_TOKEN'
+  | 'OCTOKIT_LOAD_FAILED'
+  | 'METADATA_READ_ERROR'
+  | 'COMMIT_ERROR'
+  | 'DATA_BRANCH_TAMPER'
+  | 'API_ERROR'
+
+/**
+ * Structured error with a remediation hint. Thrown for every expected failure mode on
+ * the top-level path. Matches the shape of `CommitMetadataError` /
+ * `InvitationHandlingError` / `DataBranchBootstrapError`.
+ */
+export class ReconcileError extends Error {
+  readonly code: ReconcileErrorCode
+  readonly remediation: string
+
+  constructor(params: {code: ReconcileErrorCode; message: string; remediation: string}) {
+    super(params.message)
+    this.name = 'ReconcileError'
+    this.code = params.code
+    this.remediation = params.remediation
+  }
+}
+
+export interface ReconcileLogger {
+  warn: (message: string) => void
+}
+
+export interface HandleReconcileParams {
+  userOctokit?: OctokitClient
+  appOctokit?: OctokitClient
+  owner?: string
+  repo?: string
+  allowlistPath?: string
+  reposPath?: string
+  workflowFile?: string
+  workflowRef?: string
+  now?: Date
+  readMetadata?: (path: string) => Promise<unknown>
+  commitMetadata?: (params: CommitMetadataParams) => Promise<CommitMetadataResult>
+  bootstrapDataBranch?: (params: DataBranchBootstrapParams) => Promise<DataBranchBootstrapResult>
+  /** Timeout (ms) applied to each `createWorkflowDispatch` call. Defaults to 15_000. */
+  dispatchTimeoutMs?: number
+  /** Extra authors allowed on the data branch tip commit (beyond `fro-bot[bot]`). */
+  operatorLogins?: string[]
+  logger?: ReconcileLogger
+}
+
+export interface HandleReconcileResult {
+  accessListSize: number
+  summary: ReconcileSummary
+  /** Count of successful dispatches. */
+  dispatches: number
+  /** Count of dispatch failures (timed out, HTTP error, etc.). */
+  dispatchesFailed: number
+  /** Count of successfully-created per-repo issues from reconcile's classification plan. */
+  perRepoIssues: number
+  /** Count of successfully-created rollup issues (from plan + self-healing). */
+  rollupIssues: number
+  /** Count of issue-creation failures across per-repo + rollup. */
+  issuesFailed: number
+  /** Count of stale `reconcile:pending-review` issues auto-closed this run. */
+  closedStaleIssues: number
+  integrityCheck: 'ok' | 'skipped-no-data-branch'
+  committed: boolean
+}
+
+/**
+ * End-to-end reconciliation flow. Orchestrates the 13 ordered I/O steps documented at
+ * the top of this file.
+ */
+export async function handleReconcile(params: HandleReconcileParams = {}): Promise<HandleReconcileResult> {
+  const owner = params.owner ?? DEFAULT_OWNER
+  const repo = params.repo ?? DEFAULT_REPO
+  const allowlistPath = params.allowlistPath ?? DEFAULT_ALLOWLIST_PATH
+  const reposPath = params.reposPath ?? DEFAULT_REPOS_PATH
+  const workflowFile = params.workflowFile ?? DEFAULT_WORKFLOW_FILE
+  const workflowRef = params.workflowRef ?? DEFAULT_WORKFLOW_REF
+  const now = params.now ?? new Date()
+  const dispatchTimeoutMs = params.dispatchTimeoutMs ?? DEFAULT_DISPATCH_TIMEOUT_MS
+  const logger: ReconcileLogger = params.logger ?? {warn: message => process.stderr.write(`${message}\n`)}
+  const operatorLogins = params.operatorLogins ?? loadOperatorLoginsFromEnv()
+  const readMetadata = params.readMetadata ?? readMetadataFromDisk
+  const commitMetadataImpl = params.commitMetadata ?? defaultCommitMetadata
+  const bootstrap = params.bootstrapDataBranch ?? defaultBootstrapDataBranch
+  const userOctokit = params.userOctokit ?? (await createOctokitFromEnv('FRO_BOT_POLL_PAT'))
+  const appOctokit = params.appOctokit ?? (await createOctokitFromEnv('GITHUB_TOKEN'))
+
+  // 1. Bootstrap data branch (idempotent).
+  await bootstrap({octokit: appOctokit, owner, repo})
+
+  // 2. Read metadata from disk (main branch checkout).
+  const allowlist = await loadAllowlist(readMetadata, allowlistPath)
+  const currentRepos = await loadRepos(readMetadata, reposPath)
+
+  // 3. Enumerate /user/repos (access list).
+  const accessList = await fetchAccessList(userOctokit)
+
+  // 4. For each tracked entry missing from the access list, probe `GET /repos/{o}/{r}`.
+  const perRepoStatus = await fetchPerRepoStatus(userOctokit, currentRepos, accessList)
+
+  // 5. Field probes for still-accessible tracked entries.
+  const fieldProbes = await fetchFieldProbes(userOctokit, currentRepos, accessList, logger)
+
+  // 6. Run the pure engine to produce the change plan.
+  const plan = reconcileRepos({currentRepos, accessList, perRepoStatus, allowlist, fieldProbes, now})
+
+  const hasChanges = planHasChanges(plan)
+  let integrityCheck: 'ok' | 'skipped-no-data-branch' = 'ok'
+  let committed = false
+
+  if (hasChanges) {
+    // 7. Pre-commit integrity check — fail closed on unexpected authors.
+    const integrity = await verifyDataBranchIntegrity({appOctokit, owner, repo, operatorLogins})
+    if (!integrity.ok) {
+      await fileIntegrityAlert({
+        appOctokit,
+        owner,
+        repo,
+        authorLogin: integrity.authorLogin,
+        sha: integrity.sha,
+        logger,
+      })
+      throw new ReconcileError({
+        code: 'DATA_BRANCH_TAMPER',
+        message: `Unexpected author on data branch tip commit: ${integrity.authorLogin ?? 'unknown'} (sha: ${integrity.sha})`,
+        remediation:
+          'Investigate who has contents:write on this repo. If legitimate, add the login to RECONCILE_OPERATOR_LOGINS and rerun.',
+      })
+    }
+    integrityCheck = integrity.status
+
+    // 8. Commit via mutator closure. Mutator re-runs reconcileRepos on each invocation,
+    //    so 409-retry in commitMetadata absorbs concurrent writes correctly.
+    const commitResult = await commitMetadataImpl({
+      octokit: appOctokit,
+      path: reposPath,
+      message: formatCommitMessage(plan.summary),
+      mutator: async currentParsed => {
+        assertReposFile(currentParsed, 'repos')
+        const rerun = reconcileRepos({
+          currentRepos: currentParsed,
+          accessList,
+          perRepoStatus,
+          allowlist,
+          fieldProbes,
+          now,
+        })
+        return rerun.nextRepos
+      },
+    })
+    committed = commitResult.committed
+  }
+
+  // 9. Dispatch loop (serial, non-blocking on failure, wrapped in a per-call timeout).
+  const dispatchOutcome = await runDispatches({
+    appOctokit,
+    owner,
+    repo,
+    workflowFile,
+    workflowRef,
+    dispatches: plan.dispatches,
+    timeoutMs: dispatchTimeoutMs,
+    logger,
+  })
+
+  // 10. Issue-creation loop (serial, non-blocking on failure).
+  const issueOutcome = await runIssueQueue({
+    appOctokit,
+    owner,
+    repo,
+    issues: plan.issues,
+    logger,
+  })
+
+  // 11. Auto-close stale `reconcile:pending-review` issues.
+  const closedStaleIssues = await autoCloseStaleIssues({
+    appOctokit,
+    owner,
+    repo,
+    nextRepos: plan.nextRepos,
+    accessList,
+    logger,
+  })
+
+  // 12. Self-healing rollup re-file.
+  const healedRollups = await selfHealRollups({
+    appOctokit,
+    owner,
+    repo,
+    nextRepos: plan.nextRepos,
+    accessList,
+    allowlist,
+    logger,
+  })
+
+  return {
+    accessListSize: accessList.length,
+    summary: plan.summary,
+    dispatches: dispatchOutcome.succeeded,
+    dispatchesFailed: dispatchOutcome.failed,
+    perRepoIssues: issueOutcome.perRepoSucceeded,
+    rollupIssues: issueOutcome.rollupSucceeded + healedRollups,
+    issuesFailed: issueOutcome.failed,
+    closedStaleIssues,
+    integrityCheck,
+    committed,
+  }
+}
+
+/**
+ * CLI entrypoint. Reads tokens from env and constructs both Octokit clients.
+ * Writes the final JSON result to stdout. Exits non-zero on top-level error.
+ */
+async function main(): Promise<void> {
+  const repository = process.env.GITHUB_REPOSITORY ?? `${DEFAULT_OWNER}/${DEFAULT_REPO}`
+  const [owner, repo] = repository.split('/')
+  if (owner === undefined || repo === undefined || owner === '' || repo === '') {
+    throw new ReconcileError({
+      code: 'API_ERROR',
+      message: `Invalid GITHUB_REPOSITORY value: "${repository}"`,
+      remediation: 'Expected "owner/repo" format. Set GITHUB_REPOSITORY in the workflow.',
+    })
+  }
+
+  const result = await handleReconcile({owner, repo})
+  process.stdout.write(`${JSON.stringify(result)}\n`)
+}
+
+//
+// ─── helpers ────────────────────────────────────────────────────────────────
+//
+
+function planHasChanges(plan: ReconcileResult): boolean {
+  const {summary} = plan
+  return (
+    summary.added > 0 ||
+    summary.pendingReview > 0 ||
+    summary.regained > 0 ||
+    summary.lostAccess > 0 ||
+    summary.refreshed > 0 ||
+    plan.dispatches.length > 0 ||
+    plan.issues.length > 0
+  )
+}
+
+function formatCommitMessage(summary: ReconcileSummary): string {
+  return `chore(reconcile): +${summary.added} new, ${summary.pendingReview} pending-review, ${summary.lostAccess} lost-access, ${summary.refreshed} refreshes`
+}
+
+async function loadAllowlist(readMetadata: (path: string) => Promise<unknown>, path: string): Promise<AllowlistFile> {
+  try {
+    const parsed = await readMetadata(path)
+    assertAllowlistFile(parsed, 'allowlist')
+    return parsed
+  } catch (error: unknown) {
+    throw toMetadataError(error, 'allowlist', path)
+  }
+}
+
+async function loadRepos(readMetadata: (path: string) => Promise<unknown>, path: string): Promise<ReposFile> {
+  try {
+    const parsed = await readMetadata(path)
+    assertReposFile(parsed, 'repos')
+    return parsed
+  } catch (error: unknown) {
+    throw toMetadataError(error, 'repos', path)
+  }
+}
+
+function toMetadataError(error: unknown, target: 'allowlist' | 'repos', path: string): ReconcileError {
+  if (error instanceof ReconcileError) return error
+  const message = error instanceof Error ? error.message : `Unknown ${target} metadata error`
+  return new ReconcileError({
+    code: 'METADATA_READ_ERROR',
+    message: `Failed to load ${target} metadata (${path}): ${message}`,
+    remediation: `Ensure ${path} exists, is readable, and matches the expected schema.`,
+  })
+}
+
+async function readMetadataFromDisk(path: string): Promise<unknown> {
+  const contents = await readFile(path, 'utf8')
+  return parse(contents)
+}
+
+interface AccessListApiEntry {
+  owner: {login: string} | null
+  name: string
+  archived: boolean | null | undefined
+  private: boolean | null | undefined
+  node_id: string
+}
+
+async function fetchAccessList(userOctokit: OctokitClient): Promise<AccessListEntry[]> {
+  try {
+    const repos = (await userOctokit.paginate(userOctokit.rest.repos.listForAuthenticatedUser, {
+      affiliation: 'collaborator',
+      per_page: 100,
+    })) as unknown as AccessListApiEntry[]
+    const entries: AccessListEntry[] = []
+    for (const r of repos) {
+      if (r.owner == null) continue // GitHub nulls owner for deleted-user repos; skip.
+      entries.push({
+        owner: r.owner.login,
+        name: r.name,
+        archived: r.archived === true,
+        private: r.private === true,
+        node_id: r.node_id,
+      })
+    }
+    return entries
+  } catch (error: unknown) {
+    throw toApiError(error, 'enumerating /user/repos')
+  }
+}
+
+async function fetchPerRepoStatus(
+  userOctokit: OctokitClient,
+  currentRepos: ReposFile,
+  accessList: AccessListEntry[],
+): Promise<Map<string, RepoStatusProbe>> {
+  const accessKeys = new Set(accessList.map(a => `${a.owner}/${a.name}`))
+  const map = new Map<string, RepoStatusProbe>()
+  for (const entry of currentRepos.repos) {
+    const key = `${entry.owner}/${entry.name}`
+    if (accessKeys.has(key)) continue
+    try {
+      await userOctokit.rest.repos.get({owner: entry.owner, repo: entry.name})
+      // Reachable (200) but we weren't in /user/repos → access was revoked.
+      map.set(key, {status: 'revoked'})
+    } catch (error: unknown) {
+      if (isApiStatus(error, 404)) {
+        map.set(key, {status: 'deleted'})
+        continue
+      }
+      throw toApiError(error, `probing repo status for tracked entry`)
+    }
+  }
+  return map
+}
+
+async function fetchFieldProbes(
+  userOctokit: OctokitClient,
+  currentRepos: ReposFile,
+  accessList: AccessListEntry[],
+  logger: ReconcileLogger,
+): Promise<Map<string, FieldProbe>> {
+  const accessKeys = new Set(accessList.filter(a => a.archived === false).map(a => `${a.owner}/${a.name}`))
+  const map = new Map<string, FieldProbe>()
+  for (const entry of currentRepos.repos) {
+    const key = `${entry.owner}/${entry.name}`
+    if (!accessKeys.has(key)) continue // only probe still-accessible tracked entries
+    try {
+      const probe = await probeSingleRepo(userOctokit, entry.owner, entry.name)
+      map.set(key, probe)
+    } catch (error: unknown) {
+      // Non-blocking: omit from map so reconcileRepos treats as no-field-change.
+      const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
+      logger.warn(`reconcile: field probe failed (status=${status}); treating as no-change.`)
+    }
+  }
+  return map
+}
+
+async function probeSingleRepo(userOctokit: OctokitClient, owner: string, name: string): Promise<FieldProbe> {
+  const [hasWorkflow, hasRenovate] = await Promise.all([
+    probeFroBotWorkflow(userOctokit, owner, name),
+    probeRenovateConfig(userOctokit, owner, name),
+  ])
+  return {has_fro_bot_workflow: hasWorkflow, has_renovate: hasRenovate}
+}
+
+async function probeFroBotWorkflow(userOctokit: OctokitClient, owner: string, name: string): Promise<boolean> {
+  try {
+    const response = await userOctokit.rest.repos.getContent({
+      owner,
+      repo: name,
+      path: '.github/workflows',
+    })
+    const data = response.data as unknown
+    if (!Array.isArray(data)) return false
+    for (const item of data as {type?: string; name?: string}[]) {
+      if (item.type === 'file' && typeof item.name === 'string' && /^fro-bot.*\.yaml$/.test(item.name)) {
+        return true
+      }
+    }
+    return false
+  } catch (error: unknown) {
+    if (isApiStatus(error, 404)) return false
+    throw error
+  }
+}
+
+const RENOVATE_CONFIG_PATHS = ['renovate.json', '.github/renovate.json', '.renovaterc.json', '.renovaterc']
+
+async function probeRenovateConfig(userOctokit: OctokitClient, owner: string, name: string): Promise<boolean> {
+  for (const path of RENOVATE_CONFIG_PATHS) {
+    try {
+      await userOctokit.rest.repos.getContent({owner, repo: name, path})
+      return true
+    } catch (error: unknown) {
+      if (isApiStatus(error, 404)) continue
+      throw error
+    }
+  }
+  return false
+}
+
+interface IntegrityCheckOkResult {
+  ok: true
+  status: 'ok' | 'skipped-no-data-branch'
+}
+interface IntegrityCheckFailResult {
+  ok: false
+  authorLogin: string | null
+  sha: string
+}
+
+async function verifyDataBranchIntegrity(params: {
+  appOctokit: OctokitClient
+  owner: string
+  repo: string
+  operatorLogins: string[]
+}): Promise<IntegrityCheckOkResult | IntegrityCheckFailResult> {
+  try {
+    const response = await params.appOctokit.rest.repos.getBranch({
+      owner: params.owner,
+      repo: params.repo,
+      branch: 'data',
+    })
+    const commit = response.data.commit as {sha: string; author?: {login?: string} | null}
+    const authorLogin = typeof commit.author?.login === 'string' ? commit.author.login : null
+    const allowed = new Set<string>([EXPECTED_APP_AUTHOR, ...params.operatorLogins])
+    if (authorLogin !== null && allowed.has(authorLogin)) {
+      return {ok: true, status: 'ok'}
+    }
+    return {ok: false, authorLogin, sha: commit.sha}
+  } catch (error: unknown) {
+    if (isApiStatus(error, 404)) {
+      return {ok: true, status: 'skipped-no-data-branch'}
+    }
+    throw toApiError(error, 'verifying data branch integrity')
+  }
+}
+
+async function fileIntegrityAlert(params: {
+  appOctokit: OctokitClient
+  owner: string
+  repo: string
+  authorLogin: string | null
+  sha: string
+  logger: ReconcileLogger
+}): Promise<void> {
+  try {
+    await callIssuesCreate(params.appOctokit, {
+      owner: params.owner,
+      repo: params.repo,
+      title: `Reconcile integrity alert: unexpected author on data branch`,
+      body: [
+        'Unexpected author on `data` branch tip commit. Reconcile refuses to commit on top of tampered-looking state.',
+        '',
+        `- Tip SHA: \`${params.sha}\``,
+        `- Author login: \`${params.authorLogin ?? 'unknown'}\``,
+        `- Expected: \`${EXPECTED_APP_AUTHOR}\` or an operator login in \`RECONCILE_OPERATOR_LOGINS\``,
+        '',
+        'Next steps:',
+        '- If this is a legitimate operator commit, add the login to `RECONCILE_OPERATOR_LOGINS` and rerun.',
+        '- If unauthorized, investigate who has `contents:write` on this repository.',
+      ].join('\n'),
+      labels: [INTEGRITY_ALERT_LABEL],
+    })
+  } catch (error: unknown) {
+    const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
+    params.logger.warn(`reconcile: failed to file integrity alert issue (status=${status}).`)
+  }
+}
+
+async function runDispatches(params: {
+  appOctokit: OctokitClient
+  owner: string
+  repo: string
+  workflowFile: string
+  workflowRef: string
+  dispatches: DispatchRequest[]
+  timeoutMs: number
+  logger: ReconcileLogger
+}): Promise<{succeeded: number; failed: number}> {
+  let succeeded = 0
+  let failed = 0
+  for (const dispatch of params.dispatches) {
+    try {
+      await dispatchWithTimeout(
+        async () =>
+          params.appOctokit.rest.actions.createWorkflowDispatch({
+            owner: params.owner,
+            repo: params.repo,
+            workflow_id: params.workflowFile,
+            ref: params.workflowRef,
+            inputs: {owner: dispatch.owner, repo: dispatch.repo},
+          }),
+        params.timeoutMs,
+      )
+      succeeded += 1
+    } catch (error: unknown) {
+      failed += 1
+      const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
+      const kind = error instanceof Error ? error.name : 'unknown'
+      params.logger.warn(`reconcile: dispatch failed (status=${status}, kind=${kind}); continuing.`)
+    }
+  }
+  return {succeeded, failed}
+}
+
+async function dispatchWithTimeout<T>(work: () => Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(Object.assign(new Error('dispatch timed out'), {name: 'DispatchTimeoutError'}))
+    }, timeoutMs)
+  })
+  try {
+    return await Promise.race([work(), timeoutPromise])
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
+}
+
+async function runIssueQueue(params: {
+  appOctokit: OctokitClient
+  owner: string
+  repo: string
+  issues: IssueQueueEntry[]
+  logger: ReconcileLogger
+}): Promise<{perRepoSucceeded: number; rollupSucceeded: number; failed: number}> {
+  let perRepoSucceeded = 0
+  let rollupSucceeded = 0
+  let failed = 0
+  for (const issue of params.issues) {
+    try {
+      const payload = renderIssuePayload(issue, params.owner, params.repo)
+      await callIssuesCreate(params.appOctokit, payload)
+      if (issue.kind === 'per-repo') perRepoSucceeded += 1
+      else rollupSucceeded += 1
+    } catch (error: unknown) {
+      failed += 1
+      const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
+      params.logger.warn(`reconcile: issue creation failed (status=${status}); continuing.`)
+    }
+  }
+  return {perRepoSucceeded, rollupSucceeded, failed}
+}
+
+interface IssuePayload {
+  owner: string
+  repo: string
+  title: string
+  body: string
+  labels: string[]
+}
+
+function renderIssuePayload(issue: IssueQueueEntry, owner: string, repo: string): IssuePayload {
+  if (issue.kind === 'per-repo') {
+    return renderPerRepoIssue(issue, owner, repo)
+  }
+  return renderRollupIssue(issue, owner, repo)
+}
+
+function renderPerRepoIssue(issue: PerRepoIssue, owner: string, repo: string): IssuePayload {
+  const isRegain = issue.reason === 'unsolicited-regain'
+  const titleVerb = isRegain ? 'regrant' : 'grant'
+
+  if (issue.private) {
+    // Private repo: omit name from title and body; reference only by node_id.
+    const title = `Unsolicited collaborator ${titleVerb}: private repo`
+    const body = [
+      `<!-- reconcile:subject:node_id=${issue.node_id} -->`,
+      '',
+      `A new collaborator ${isRegain ? 'regrant' : 'grant'} was detected for a **private** repository from an owner not in \`metadata/allowlist.yaml\`.`,
+      '',
+      `- Reason: \`${issue.reason}\``,
+      `- Node ID: \`${issue.node_id}\``,
+      '',
+      'The repository name is omitted because this issue stream is public. Cross-reference via your direct access to `metadata/repos.yaml` on the `data` branch.',
+      '',
+      'Next steps:',
+      '- **Approve**: edit `metadata/repos.yaml` on the `data` branch, change `onboarding_status` to `pending`, and push.',
+      '- **Reject**: remove the entry from `metadata/repos.yaml`.',
+      '- **Allowlist the owner**: add the owner login to `approved_inviters` in `metadata/allowlist.yaml`.',
+    ].join('\n')
+    return {owner, repo, title, body, labels: [PENDING_REVIEW_LABEL]}
+  }
+
+  // Public repo: include owner/repo in title and body.
+  const title = `Unsolicited collaborator ${titleVerb}: ${issue.owner}/${issue.repo}`
+  const body = [
+    `<!-- reconcile:subject:node_id=${issue.node_id} -->`,
+    '',
+    `A collaborator ${isRegain ? 'regrant' : 'grant'} was detected for [${issue.owner}/${issue.repo}](https://github.com/${issue.owner}/${issue.repo}) from an owner not in \`metadata/allowlist.yaml\`.`,
+    '',
+    `- Reason: \`${issue.reason}\``,
+    `- Node ID: \`${issue.node_id}\``,
+    '',
+    'Next steps:',
+    '- **Approve**: edit `metadata/repos.yaml` on the `data` branch, change `onboarding_status` to `pending`, and push.',
+    '- **Reject**: remove the entry from `metadata/repos.yaml`.',
+    `- **Allowlist the owner**: add \`${issue.owner}\` to \`approved_inviters\` in \`metadata/allowlist.yaml\`.`,
+  ].join('\n')
+  return {owner, repo, title, body, labels: [PENDING_REVIEW_LABEL]}
+}
+
+function renderRollupIssue(issue: PerOwnerRollupIssue, owner: string, repo: string): IssuePayload {
+  const n = issue.entries.length
+  const title = `Unsolicited collaborator grants from ${issue.owner}: ${n} new repos require review`
+  const entryLines = issue.entries.map(e =>
+    e.private
+      ? `- **private repo** (\`${e.node_id}\`)`
+      : `- [${issue.owner}/${e.repo}](https://github.com/${issue.owner}/${e.repo}) (\`${e.node_id}\`)`,
+  )
+  const body = [
+    `<!-- reconcile:subject:rollup-owner=${issue.owner} -->`,
+    '',
+    `Multiple unsolicited collaborator ${issue.reason === 'unsolicited-regain' ? 'regrants' : 'grants'} detected from [${issue.owner}](https://github.com/${issue.owner}):`,
+    '',
+    ...entryLines,
+    '',
+    `Reason: \`${issue.reason}\``,
+    '',
+    'Next steps:',
+    `- **Allowlist the owner**: add \`${issue.owner}\` to \`approved_inviters\` in \`metadata/allowlist.yaml\`.`,
+    '- **Approve individual repos**: edit `metadata/repos.yaml` on the `data` branch.',
+    '- **Reject**: remove entries from `metadata/repos.yaml`.',
+  ].join('\n')
+  return {owner, repo, title, body, labels: [PENDING_REVIEW_LABEL, ROLLUP_LABEL]}
+}
+
+interface OpenIssueEntry {
+  number: number
+  title: string
+  body: string | null
+  labels: {name?: string}[]
+}
+
+async function autoCloseStaleIssues(params: {
+  appOctokit: OctokitClient
+  owner: string
+  repo: string
+  nextRepos: ReposFile
+  accessList: AccessListEntry[]
+  logger: ReconcileLogger
+}): Promise<number> {
+  const pendingReviewNodeIds = new Set<string>()
+  const pendingReviewOwners = new Map<string, number>()
+  const accessByKey = new Map(params.accessList.map(a => [`${a.owner}/${a.name}`, a]))
+  for (const entry of params.nextRepos.repos) {
+    if (entry.onboarding_status !== 'pending-review') continue
+    const access = accessByKey.get(`${entry.owner}/${entry.name}`)
+    if (access !== undefined) pendingReviewNodeIds.add(access.node_id)
+    pendingReviewOwners.set(entry.owner, (pendingReviewOwners.get(entry.owner) ?? 0) + 1)
+  }
+
+  let closed = 0
+  try {
+    const issues = (await params.appOctokit.paginate(params.appOctokit.rest.issues.listForRepo, {
+      owner: params.owner,
+      repo: params.repo,
+      state: 'open',
+      labels: PENDING_REVIEW_LABEL,
+      per_page: 100,
+    })) as unknown as OpenIssueEntry[]
+
+    for (const issue of issues) {
+      const labelNames = issue.labels.map(l => l.name).filter((n): n is string => typeof n === 'string')
+      const isRollup = labelNames.includes(ROLLUP_LABEL)
+      const body = issue.body ?? ''
+      let stale = false
+      if (isRollup) {
+        const ownerMatch = ROLLUP_OWNER_MARKER_PATTERN.exec(body)
+        const rollupOwner = ownerMatch?.[1]
+        if (rollupOwner === undefined) continue
+        const count = pendingReviewOwners.get(rollupOwner) ?? 0
+        stale = count < 2
+      } else {
+        const nodeMatch = NODE_ID_MARKER_PATTERN.exec(body)
+        const nodeId = nodeMatch?.[1]
+        if (nodeId === undefined) continue
+        stale = !pendingReviewNodeIds.has(nodeId)
+      }
+      if (!stale) continue
+
+      try {
+        await params.appOctokit.rest.issues.update({
+          owner: params.owner,
+          repo: params.repo,
+          issue_number: issue.number,
+          state: 'closed',
+        })
+        closed += 1
+      } catch (error: unknown) {
+        const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
+        params.logger.warn(`reconcile: failed to close stale issue #${issue.number} (status=${status}).`)
+      }
+    }
+  } catch (error: unknown) {
+    const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
+    params.logger.warn(`reconcile: failed to list pending-review issues (status=${status}).`)
+  }
+  return closed
+}
+
+async function selfHealRollups(params: {
+  appOctokit: OctokitClient
+  owner: string
+  repo: string
+  nextRepos: ReposFile
+  accessList: AccessListEntry[]
+  allowlist: AllowlistFile
+  logger: ReconcileLogger
+}): Promise<number> {
+  const allowlistedOwners = new Set(params.allowlist.approved_inviters.map(i => i.username))
+  const pendingReviewByOwner = new Map<string, RepoEntry[]>()
+  for (const entry of params.nextRepos.repos) {
+    if (entry.onboarding_status !== 'pending-review') continue
+    if (allowlistedOwners.has(entry.owner)) continue // allowlisted owners are never rolled up
+    const bucket = pendingReviewByOwner.get(entry.owner) ?? []
+    bucket.push(entry)
+    pendingReviewByOwner.set(entry.owner, bucket)
+  }
+
+  // Only owners with ≥2 pending-review entries qualify for a rollup.
+  const qualifyingOwners = [...pendingReviewByOwner.entries()].filter(([, entries]) => entries.length >= 2)
+  if (qualifyingOwners.length === 0) return 0
+
+  let existingRollupOwners: Set<string>
+  try {
+    const openRollups = (await params.appOctokit.paginate(params.appOctokit.rest.issues.listForRepo, {
+      owner: params.owner,
+      repo: params.repo,
+      state: 'open',
+      labels: ROLLUP_LABEL,
+      per_page: 100,
+    })) as unknown as OpenIssueEntry[]
+    existingRollupOwners = new Set()
+    for (const issue of openRollups) {
+      const body = issue.body ?? ''
+      const match = ROLLUP_OWNER_MARKER_PATTERN.exec(body)
+      if (match?.[1] !== undefined) existingRollupOwners.add(match[1])
+    }
+  } catch (error: unknown) {
+    const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
+    params.logger.warn(`reconcile: self-heal rollup listing failed (status=${status}); skipping.`)
+    return 0
+  }
+
+  const accessByKey = new Map(params.accessList.map(a => [`${a.owner}/${a.name}`, a]))
+  let created = 0
+  for (const [owner, entries] of qualifyingOwners) {
+    if (existingRollupOwners.has(owner)) continue
+    const rollupEntries: PerOwnerRollupIssue['entries'] = []
+    for (const entry of entries) {
+      const access = accessByKey.get(`${entry.owner}/${entry.name}`)
+      if (access === undefined) continue // missing node_id — skip to avoid leaking name
+      rollupEntries.push({repo: entry.name, private: access.private, node_id: access.node_id})
+    }
+    if (rollupEntries.length < 2) continue // missing access data leaves us without ≥2 identifiable entries
+
+    const rollupIssue: PerOwnerRollupIssue = {
+      kind: 'per-owner-rollup',
+      owner,
+      entries: rollupEntries,
+      reason: 'unsolicited-new',
+    }
+    try {
+      await callIssuesCreate(params.appOctokit, renderIssuePayload(rollupIssue, params.owner, params.repo))
+      created += 1
+    } catch (error: unknown) {
+      const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
+      params.logger.warn(`reconcile: self-heal rollup creation failed (status=${status}); continuing.`)
+    }
+  }
+  return created
+}
+
+/**
+ * Thin wrapper around `issues.create` that widens our `IssuePayload` shape to match the
+ * full Octokit request parameter type (which includes optional request-level fields like
+ * `headers` that we never set). The cast-through-unknown is safe because every property
+ * we do set is structurally compatible with Octokit's signature.
+ */
+async function callIssuesCreate(octokit: OctokitClient, payload: IssuePayload): Promise<void> {
+  await octokit.rest.issues.create(payload as unknown as Parameters<OctokitClient['rest']['issues']['create']>[0])
+}
+
+function loadOperatorLoginsFromEnv(): string[] {
+  const raw = process.env.RECONCILE_OPERATOR_LOGINS
+  if (raw === undefined || raw === '') return []
+  return raw
+    .split(',')
+    .map(s => s.trim())
+    .filter(s => s.length > 0)
+}
+
+async function createOctokitFromEnv(envVar: 'FRO_BOT_POLL_PAT' | 'GITHUB_TOKEN'): Promise<OctokitClient> {
+  const token = process.env[envVar]
+  if (token === undefined || token === '') {
+    throw new ReconcileError({
+      code: 'MISSING_TOKEN',
+      message: `reconcileRepos requires ${envVar} in the environment`,
+      remediation: `Export ${envVar} before invocation. See .github/workflows/reconcile-repos.yaml for how this is mounted.`,
+    })
+  }
+  const LoadedOctokit = await loadOctokitConstructor()
+  return new LoadedOctokit({auth: token})
+}
+
+async function loadOctokitConstructor(): Promise<OctokitConstructor> {
+  if (typeof Octokit !== 'function') {
+    throw new ReconcileError({
+      code: 'OCTOKIT_LOAD_FAILED',
+      message: 'Failed to load @octokit/rest Octokit constructor',
+      remediation: 'Verify @octokit/rest is installed and its export surface has not changed.',
+    })
+  }
+  return Octokit as unknown as OctokitConstructor
+}
+
+function toApiError(error: unknown, action: string): ReconcileError {
+  if (error instanceof ReconcileError) return error
+  const message = error instanceof Error ? error.message : `Unknown error while ${action}`
+  return new ReconcileError({
+    code: 'API_ERROR',
+    message: `GitHub API error while ${action}: ${message}`,
+    remediation: 'Retry once. If the failure persists, inspect GitHub API status and repository permissions.',
+  })
+}
+
+function isApiStatus(error: unknown, status: number): boolean {
+  return isRecord(error) && typeof error.status === 'number' && error.status === status
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
 }

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -1,0 +1,359 @@
+/**
+ * Pure reconciliation engine for `metadata/repos.yaml`.
+ *
+ * Given a snapshot of what fro-bot currently tracks and a snapshot of its actual GitHub
+ * collaborator reality, produces the next metadata state plus the side-effect plan
+ * (dispatches to queue, pending-review issues to file, summary counters). No I/O happens
+ * here; Unit 3's shell turns the plan into API calls.
+ *
+ * Mutator purity contract: `reconcileRepos` does NOT mutate its inputs. Every updated
+ * repo entry is a fresh object. `currentRepos` reference identity is preserved when the
+ * result is a true no-op, so callers can use `===` as a cheap zero-change probe — but
+ * test suites should compare by value (deep equality) rather than identity.
+ *
+ * New entries are produced exclusively through the shared `addRepoEntry` helper so every
+ * writer to `metadata/repos.yaml` (`handle-invitation.ts` and this module) produces
+ * byte-compatible entry shapes. Status transitions on existing entries (lost-access,
+ * regain, field drift) use fresh inline objects because `addRepoEntry` is idempotent on
+ * duplicate `owner+name` and would silently drop a status flip.
+ */
+
+import type {AllowlistFile, OnboardingStatus, RepoEntry, ReposFile} from './schemas.ts'
+import {addRepoEntry} from './repos-metadata.ts'
+
+export interface AccessListEntry {
+  owner: string
+  name: string
+  archived: boolean
+  private: boolean
+  /**
+   * GitHub-assigned opaque repo identifier (e.g. `R_kgDOA...`). Carried through to the
+   * issue queue so the Unit 3 shell can reference private repos without leaking the name.
+   */
+  node_id: string
+}
+
+export type RepoStatusProbe =
+  | {status: 'deleted'}
+  | {status: 'archived'}
+  | {status: 'revoked'}
+  | {status: 'still-accessible'; private: boolean; node_id: string}
+
+export interface FieldProbe {
+  has_fro_bot_workflow: boolean
+  has_renovate: boolean
+}
+
+export interface ReconcileInput {
+  currentRepos: ReposFile
+  accessList: AccessListEntry[]
+  /** Map key format: `${owner}/${name}` (exact). Populated only for tracked repos not in the access list. */
+  perRepoStatus: Map<string, RepoStatusProbe>
+  allowlist: AllowlistFile
+  /** Map key format: `${owner}/${name}` (exact). Populated only for still-accessible tracked repos. */
+  fieldProbes: Map<string, FieldProbe>
+  now: Date
+}
+
+export interface DispatchRequest {
+  owner: string
+  repo: string
+}
+
+export interface PerRepoIssue {
+  kind: 'per-repo'
+  owner: string
+  repo: string
+  reason: 'unsolicited-new' | 'unsolicited-regain'
+  private: boolean
+  node_id: string
+}
+
+export interface PerOwnerRollupIssue {
+  kind: 'per-owner-rollup'
+  owner: string
+  entries: {repo: string; private: boolean; node_id: string}[]
+  reason: 'unsolicited-new' | 'unsolicited-regain'
+}
+
+export type IssueQueueEntry = PerRepoIssue | PerOwnerRollupIssue
+
+export interface ReconcileSummary {
+  added: number
+  pendingReview: number
+  regained: number
+  lostAccess: number
+  refreshed: number
+  unchanged: number
+}
+
+export interface ReconcileResult {
+  nextRepos: ReposFile
+  dispatches: DispatchRequest[]
+  issues: IssueQueueEntry[]
+  summary: ReconcileSummary
+}
+
+/**
+ * Classify every repo in either the currently-tracked set or the live access list and
+ * produce the next metadata state plus a side-effect plan.
+ *
+ * See the per-repo classification decision table in
+ * `docs/plans/2026-04-17-001-feat-repo-reconciliation-plan.md` for the full matrix.
+ */
+export function reconcileRepos(input: ReconcileInput): ReconcileResult {
+  const {currentRepos, accessList, perRepoStatus, allowlist, fieldProbes, now} = input
+
+  validateAccessList(accessList)
+
+  const accessByKey = indexAccessList(accessList)
+  const allowlistedOwners = new Set(allowlist.approved_inviters.map(i => i.username))
+
+  const summary: ReconcileSummary = {
+    added: 0,
+    pendingReview: 0,
+    regained: 0,
+    lostAccess: 0,
+    refreshed: 0,
+    unchanged: 0,
+  }
+  const dispatches: DispatchRequest[] = []
+  const rawIssues: RawIssue[] = []
+
+  // Pass 1 — classify every tracked entry against the access list and probes.
+  const trackedKeys = new Set<string>()
+  const nextEntries: RepoEntry[] = currentRepos.repos.map(entry => {
+    const key = repoKey(entry.owner, entry.name)
+    trackedKeys.add(key)
+    return classifyTracked({
+      entry,
+      key,
+      accessByKey,
+      perRepoStatus,
+      fieldProbes,
+      allowlistedOwners,
+      summary,
+      dispatches,
+      rawIssues,
+    })
+  })
+
+  let next: ReposFile = {...currentRepos, repos: nextEntries}
+
+  // Pass 2 — add newcomers (accessible repos not yet tracked).
+  for (const access of accessList) {
+    const key = repoKey(access.owner, access.name)
+    if (trackedKeys.has(key)) continue
+    if (access.archived) continue // untracked + archived: no history worth capturing; skip silently.
+
+    const allowlisted = allowlistedOwners.has(access.owner)
+    const status: OnboardingStatus = allowlisted ? 'pending' : 'pending-review'
+
+    next = addRepoEntry(next, {
+      owner: access.owner,
+      repo: access.name,
+      now,
+      onboarding_status: status,
+    })
+
+    if (allowlisted) {
+      summary.added += 1
+      dispatches.push({owner: access.owner, repo: access.name})
+    } else {
+      summary.pendingReview += 1
+      rawIssues.push({
+        owner: access.owner,
+        repo: access.name,
+        reason: 'unsolicited-new',
+        private: access.private,
+        node_id: access.node_id,
+      })
+    }
+  }
+
+  const issues = buildIssueQueue(rawIssues)
+
+  // Zero-change optimization: preserve currentRepos reference identity for cheap `===` probe.
+  if (isNoOp(summary, dispatches, issues)) {
+    return {nextRepos: currentRepos, dispatches, issues, summary}
+  }
+
+  return {nextRepos: next, dispatches, issues, summary}
+}
+
+interface ClassifyTrackedParams {
+  entry: RepoEntry
+  key: string
+  accessByKey: Map<string, AccessListEntry>
+  perRepoStatus: Map<string, RepoStatusProbe>
+  fieldProbes: Map<string, FieldProbe>
+  allowlistedOwners: Set<string>
+  summary: ReconcileSummary
+  dispatches: DispatchRequest[]
+  rawIssues: RawIssue[]
+}
+
+/**
+ * Determine the fate of one tracked repo. Returns a fresh entry when the status or fields
+ * need to change; otherwise returns the original entry by reference. Mutates the shared
+ * summary/dispatches/rawIssues accumulators — this is the functional loop-and-accumulate
+ * pattern (see `processInvitation` in `handle-invitation.ts`).
+ */
+function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
+  const {entry, key, accessByKey, perRepoStatus, fieldProbes, allowlistedOwners, summary, dispatches, rawIssues} =
+    params
+  const access = accessByKey.get(key)
+
+  if (access === undefined) {
+    // Not in the access list — probe decides lost-access vs transient inconsistency.
+    const probe = perRepoStatus.get(key)
+    if (probe === undefined) {
+      // Probe missing (e.g. probe request failed mid-run) — treat as no change.
+      summary.unchanged += 1
+      return entry
+    }
+    if (probe.status === 'still-accessible') {
+      // Transient inconsistency between the access-list enumeration and the per-repo probe.
+      summary.unchanged += 1
+      return entry
+    }
+    // deleted / archived / revoked — flip to lost-access unless already there.
+    if (entry.onboarding_status === 'lost-access') {
+      summary.unchanged += 1
+      return entry
+    }
+    summary.lostAccess += 1
+    return {...entry, onboarding_status: 'lost-access'}
+  }
+
+  if (access.archived) {
+    // Pass-1 archived detection: flip to lost-access directly, no Pass-2 probe required.
+    if (entry.onboarding_status === 'lost-access') {
+      summary.unchanged += 1
+      return entry
+    }
+    summary.lostAccess += 1
+    return {...entry, onboarding_status: 'lost-access'}
+  }
+
+  if (entry.onboarding_status === 'lost-access') {
+    // Regain: entry was lost-access and is now back in the access list.
+    const allowlisted = allowlistedOwners.has(entry.owner)
+    const nextStatus: OnboardingStatus = allowlisted ? 'pending' : 'pending-review'
+    summary.regained += 1
+    if (allowlisted) {
+      dispatches.push({owner: entry.owner, repo: entry.name})
+    } else {
+      rawIssues.push({
+        owner: entry.owner,
+        repo: entry.name,
+        reason: 'unsolicited-regain',
+        private: access.private,
+        node_id: access.node_id,
+      })
+    }
+    return {...entry, onboarding_status: nextStatus}
+  }
+
+  // Still-accessible tracked entry — apply field refresh if the probe disagrees.
+  const probe = fieldProbes.get(key)
+  if (probe === undefined) {
+    // No probe data — preserve existing field values (do not overwrite with undefined).
+    summary.unchanged += 1
+    return entry
+  }
+  if (probe.has_fro_bot_workflow === entry.has_fro_bot_workflow && probe.has_renovate === entry.has_renovate) {
+    summary.unchanged += 1
+    return entry
+  }
+  summary.refreshed += 1
+  return {
+    ...entry,
+    has_fro_bot_workflow: probe.has_fro_bot_workflow,
+    has_renovate: probe.has_renovate,
+  }
+}
+
+interface RawIssue {
+  owner: string
+  repo: string
+  reason: 'unsolicited-new' | 'unsolicited-regain'
+  private: boolean
+  node_id: string
+}
+
+/**
+ * Collapse ≥2 issues from the same non-allowlisted owner (same reason) into a single
+ * `per-owner-rollup` issue. Single-repo owners still produce one `per-repo` issue each.
+ * Allowlisted newcomers never reach this function — they get dispatches, not issues.
+ */
+function buildIssueQueue(raw: RawIssue[]): IssueQueueEntry[] {
+  const groups = new Map<string, RawIssue[]>()
+  for (const item of raw) {
+    const groupKey = `${item.reason}:${item.owner}`
+    const bucket = groups.get(groupKey) ?? []
+    bucket.push(item)
+    groups.set(groupKey, bucket)
+  }
+
+  const issues: IssueQueueEntry[] = []
+  for (const bucket of groups.values()) {
+    if (bucket.length >= 2) {
+      const first = bucket[0]
+      if (first === undefined) continue // unreachable; satisfies noUncheckedIndexedAccess
+      issues.push({
+        kind: 'per-owner-rollup',
+        owner: first.owner,
+        reason: first.reason,
+        entries: bucket.map(item => ({repo: item.repo, private: item.private, node_id: item.node_id})),
+      })
+      continue
+    }
+    for (const item of bucket) {
+      issues.push({
+        kind: 'per-repo',
+        owner: item.owner,
+        repo: item.repo,
+        reason: item.reason,
+        private: item.private,
+        node_id: item.node_id,
+      })
+    }
+  }
+  return issues
+}
+
+function isNoOp(summary: ReconcileSummary, dispatches: DispatchRequest[], issues: IssueQueueEntry[]): boolean {
+  return (
+    summary.added === 0 &&
+    summary.pendingReview === 0 &&
+    summary.regained === 0 &&
+    summary.lostAccess === 0 &&
+    summary.refreshed === 0 &&
+    dispatches.length === 0 &&
+    issues.length === 0
+  )
+}
+
+function indexAccessList(accessList: AccessListEntry[]): Map<string, AccessListEntry> {
+  const map = new Map<string, AccessListEntry>()
+  for (const entry of accessList) {
+    map.set(repoKey(entry.owner, entry.name), entry)
+  }
+  return map
+}
+
+function validateAccessList(accessList: AccessListEntry[]): void {
+  const seen = new Set<string>()
+  for (const entry of accessList) {
+    const key = repoKey(entry.owner, entry.name)
+    if (seen.has(key)) {
+      throw new Error(`reconcileRepos: duplicate accessList entry for ${key}`)
+    }
+    seen.add(key)
+  }
+}
+
+function repoKey(owner: string, name: string): string {
+  return `${owner}/${name}`
+}

--- a/scripts/repos-metadata.test.ts
+++ b/scripts/repos-metadata.test.ts
@@ -1,0 +1,162 @@
+import type {ReposFile} from './schemas.ts'
+
+import {describe, expect, it} from 'vitest'
+import {addRepoEntry} from './repos-metadata.ts'
+
+const EMPTY_REPOS: ReposFile = {version: 1, repos: []}
+const NOW = new Date('2026-04-17T12:00:00Z')
+
+describe('addRepoEntry', () => {
+  // Behavioral contract: default onboarding_status is 'pending'
+  it("defaults onboarding_status to 'pending' when not specified", () => {
+    const result = addRepoEntry(EMPTY_REPOS, {owner: 'alice', repo: 'project', now: NOW})
+    expect(result.repos).toHaveLength(1)
+    expect(result.repos[0]?.onboarding_status).toBe('pending')
+  })
+
+  // Behavioral contract: all default fields present
+  it('produces an entry with all default fields populated', () => {
+    const result = addRepoEntry(EMPTY_REPOS, {owner: 'alice', repo: 'project', now: NOW})
+    expect(result.repos[0]).toEqual({
+      owner: 'alice',
+      name: 'project',
+      added: '2026-04-17',
+      onboarding_status: 'pending',
+      last_survey_at: null,
+      last_survey_status: null,
+      has_fro_bot_workflow: false,
+      has_renovate: false,
+    })
+  })
+
+  // Extended behavior: accepts pending-review status
+  it("accepts 'pending-review' onboarding_status for non-allowlisted newcomers", () => {
+    const result = addRepoEntry(EMPTY_REPOS, {
+      owner: 'bob',
+      repo: 'sus-repo',
+      now: NOW,
+      onboarding_status: 'pending-review',
+    })
+    expect(result.repos[0]?.onboarding_status).toBe('pending-review')
+  })
+
+  // Extended behavior: accepts any valid OnboardingStatus
+  it('accepts any valid OnboardingStatus value', () => {
+    for (const status of ['pending', 'onboarded', 'failed', 'lost-access', 'pending-review'] as const) {
+      const result = addRepoEntry(EMPTY_REPOS, {
+        owner: 'carol',
+        repo: `proj-${status}`,
+        now: NOW,
+        onboarding_status: status,
+      })
+      expect(result.repos[0]?.onboarding_status).toBe(status)
+    }
+  })
+
+  // Behavioral contract: idempotent on duplicate owner+name
+  it('returns current unchanged when an entry with the same owner+name already exists', () => {
+    const existing: ReposFile = {
+      version: 1,
+      repos: [
+        {
+          owner: 'alice',
+          name: 'project',
+          added: '2026-01-01',
+          onboarding_status: 'onboarded',
+          last_survey_at: '2026-02-01',
+          last_survey_status: 'success',
+          has_fro_bot_workflow: true,
+          has_renovate: true,
+        },
+      ],
+    }
+    const result = addRepoEntry(existing, {owner: 'alice', repo: 'project', now: NOW})
+    expect(result).toBe(existing)
+  })
+
+  // Behavioral contract: idempotency ignores requested status (existing entry preserved)
+  it('preserves existing entry status even when a different status is requested', () => {
+    const existing: ReposFile = {
+      version: 1,
+      repos: [
+        {
+          owner: 'alice',
+          name: 'project',
+          added: '2026-01-01',
+          onboarding_status: 'onboarded',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+        },
+      ],
+    }
+    const result = addRepoEntry(existing, {
+      owner: 'alice',
+      repo: 'project',
+      now: NOW,
+      onboarding_status: 'pending-review',
+    })
+    expect(result).toBe(existing)
+    expect(result.repos[0]?.onboarding_status).toBe('onboarded')
+  })
+
+  // Purity contract: returns a fresh top-level object
+  it('returns a fresh top-level object when adding (no in-place mutation)', () => {
+    const result = addRepoEntry(EMPTY_REPOS, {owner: 'alice', repo: 'project', now: NOW})
+    expect(result).not.toBe(EMPTY_REPOS)
+    expect(result.repos).not.toBe(EMPTY_REPOS.repos)
+    expect(EMPTY_REPOS.repos).toHaveLength(0)
+  })
+
+  // Schema validation: rejects malformed current input
+  it('throws when current is not a valid ReposFile', () => {
+    expect(() => addRepoEntry({version: 2, repos: []}, {owner: 'a', repo: 'b', now: NOW})).toThrow()
+    expect(() => addRepoEntry(null, {owner: 'a', repo: 'b', now: NOW})).toThrow()
+    expect(() => addRepoEntry({repos: []}, {owner: 'a', repo: 'b', now: NOW})).toThrow()
+  })
+
+  // Date handling: ISO date slice
+  it('formats `added` as YYYY-MM-DD from the `now` Date', () => {
+    const result = addRepoEntry(EMPTY_REPOS, {
+      owner: 'alice',
+      repo: 'project',
+      now: new Date('2026-12-31T23:59:59Z'),
+    })
+    expect(result.repos[0]?.added).toBe('2026-12-31')
+  })
+
+  // Append order: new entries go at the end, existing entries preserved in order
+  it('appends a new entry after existing entries, preserving order', () => {
+    const existing: ReposFile = {
+      version: 1,
+      repos: [
+        {
+          owner: 'alice',
+          name: 'first',
+          added: '2026-01-01',
+          onboarding_status: 'onboarded',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+        },
+        {
+          owner: 'bob',
+          name: 'second',
+          added: '2026-02-01',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+        },
+      ],
+    }
+    const result = addRepoEntry(existing, {owner: 'carol', repo: 'third', now: NOW})
+    expect(result.repos).toHaveLength(3)
+    expect(result.repos[0]?.name).toBe('first')
+    expect(result.repos[1]?.name).toBe('second')
+    expect(result.repos[2]?.name).toBe('third')
+  })
+})

--- a/scripts/repos-metadata.ts
+++ b/scripts/repos-metadata.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared helpers for `metadata/repos.yaml` mutation.
+ *
+ * Any script that adds entries to the repos file should use `addRepoEntry` so every writer
+ * produces byte-compatible entry shapes. `addRepoEntry` is for NEW entries only; it is
+ * idempotent on duplicate `owner+name` and preserves the existing entry as-is (it does NOT
+ * update status of existing entries — callers that need status transitions should produce
+ * fresh entries inline, since a generic "update status" helper would obscure intent).
+ */
+
+import {assertReposFile, type OnboardingStatus, type ReposFile} from './schemas.ts'
+
+export interface AddRepoEntryInput {
+  owner: string
+  repo: string
+  now: Date
+  /**
+   * Onboarding status for the new entry. Defaults to `'pending'` to match the original
+   * invitation-acceptance path. Reconcile passes `'pending-review'` when the repo owner is
+   * not in `metadata/allowlist.yaml`.
+   */
+  onboarding_status?: OnboardingStatus
+}
+
+/**
+ * Add a new repo entry to the repos metadata file. Idempotent: returns the input unchanged
+ * (by reference) when an entry with the same `owner + name` already exists, regardless of
+ * the requested `onboarding_status`. Callers that need to change status of an existing entry
+ * must do so through a different code path.
+ *
+ * Pure function: never mutates `current` in place. When adding, returns a fresh top-level
+ * object with a fresh `repos` array.
+ */
+export function addRepoEntry(current: unknown, input: AddRepoEntryInput): ReposFile {
+  assertReposFile(current, 'repos')
+
+  if (current.repos.some(entry => entry.owner === input.owner && entry.name === input.repo)) {
+    return current
+  }
+
+  return {
+    ...current,
+    repos: [
+      ...current.repos,
+      {
+        owner: input.owner,
+        name: input.repo,
+        added: input.now.toISOString().slice(0, 10),
+        onboarding_status: input.onboarding_status ?? 'pending',
+        last_survey_at: null,
+        last_survey_status: null,
+        has_fro_bot_workflow: false,
+        has_renovate: false,
+      },
+    ],
+  }
+}

--- a/scripts/schemas.test.ts
+++ b/scripts/schemas.test.ts
@@ -102,6 +102,67 @@ describe('schemas — rejection cases', () => {
     expect(error.path).toContain('onboarding_status')
   })
 
+  it('accepts lost-access onboarding_status', () => {
+    const ok = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'lost-access',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+        },
+      ],
+    }
+    expect(isReposFile(ok)).toBe(true)
+    expect(() => assertReposFile(ok)).not.toThrow()
+  })
+
+  it('accepts pending-review onboarding_status', () => {
+    const ok = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'pending-review',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+        },
+      ],
+    }
+    expect(isReposFile(ok)).toBe(true)
+    expect(() => assertReposFile(ok)).not.toThrow()
+  })
+
+  it('rejects archived as an onboarding_status (not in the enum)', () => {
+    const bad = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'archived',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+        },
+      ],
+    }
+    expect(isReposFile(bad)).toBe(false)
+    const error = catchSchemaError(() => assertReposFile(bad))
+    expect(error.path).toContain('onboarding_status')
+  })
+
   it('rejects invalid last_dispatch_status enum', () => {
     const bad = {
       version: 1,

--- a/scripts/schemas.ts
+++ b/scripts/schemas.ts
@@ -34,7 +34,7 @@ export interface RepoEntry {
   has_renovate: boolean
 }
 
-export type OnboardingStatus = 'pending' | 'onboarded' | 'failed'
+export type OnboardingStatus = 'pending' | 'onboarded' | 'failed' | 'lost-access' | 'pending-review'
 export type SurveyStatus = 'success' | 'failure'
 
 export interface RenovateFile {
@@ -141,7 +141,10 @@ function assertRepoEntry(value: unknown, path: string): asserts value is RepoEnt
   if (typeof value.name !== 'string') throw new SchemaValidationError(`${path}.name`, 'expected string')
   if (typeof value.added !== 'string') throw new SchemaValidationError(`${path}.added`, 'expected ISO date string')
   if (!isOnboardingStatus(value.onboarding_status))
-    throw new SchemaValidationError(`${path}.onboarding_status`, 'expected one of: pending, onboarded, failed')
+    throw new SchemaValidationError(
+      `${path}.onboarding_status`,
+      'expected one of: pending, onboarded, failed, lost-access, pending-review',
+    )
   if (value.last_survey_at !== null && typeof value.last_survey_at !== 'string')
     throw new SchemaValidationError(`${path}.last_survey_at`, 'expected string or null')
   if (value.last_survey_status !== null && !isSurveyStatus(value.last_survey_status))
@@ -153,7 +156,13 @@ function assertRepoEntry(value: unknown, path: string): asserts value is RepoEnt
 }
 
 function isOnboardingStatus(value: unknown): value is OnboardingStatus {
-  return value === 'pending' || value === 'onboarded' || value === 'failed'
+  return (
+    value === 'pending' ||
+    value === 'onboarded' ||
+    value === 'failed' ||
+    value === 'lost-access' ||
+    value === 'pending-review'
+  )
 }
 
 function isSurveyStatus(value: unknown): value is SurveyStatus {


### PR DESCRIPTION
## Summary

Daily reconciliation script + workflow that keeps `metadata/repos.yaml` in sync with GitHub's source of truth for fro-bot's collaborator access. Closes five drift vectors:

- **Partial-failure orphans** — invitation acceptance fails mid-flight, leaving fro-bot with access but no metadata entry.
- **Out-of-band acceptances** — operator adds fro-bot as a collaborator through GitHub's UI, bypassing the invitation flow.
- **Unsolicited grants** — GitHub allows any repo admin to add any user as a collaborator without consent. These are gated against `metadata/allowlist.yaml`: owners not in `approved_inviters` land in `onboarding_status: pending-review` and do NOT auto-dispatch `Survey Repo`.
- **Lost access** — revoked, archived, or deleted repos flip to `onboarding_status: lost-access` with other fields preserved for audit.
- **Field drift** — `has_fro_bot_workflow` and `has_renovate` are refreshed every run via existence checks (no content reads).

## Architecture

Pure decision engine (`reconcileRepos`) + thin I/O shell (`handleReconcile`) + CLI. Dual Octokit clients: `FRO_BOT_POLL_PAT` for user-scoped reads (`/user/repos`, per-repo GET), `fro-bot[bot]` app token for data-branch commits, Survey Repo dispatches, and issue creation. Commit-before-dispatch ordering; non-blocking dispatch failures; 15-second per-dispatch timeout.

**Pre-commit integrity check**: before committing, verifies the data-branch HEAD author matches `fro-bot[bot]` plus optional `RECONCILE_OPERATOR_LOGINS` allowlist. Mismatch aborts the commit and files a `reconcile:integrity-alert` issue. The check also runs inside the `commitMetadata` mutator closure to close the TOCTOU window between the initial check and the first commit attempt; each 409 retry re-verifies.

**Per-owner rollup**: when a single non-allowlisted owner grants ≥2 repos in one run, reconcile collapses them into one `reconcile:rollup-pending-review` issue instead of N per-repo issues. Self-healing logic re-files the rollup if it's closed but pending-review entries for that owner still exist.

**Private-repo privacy**: `fro-bot/.github` is public, so private repo names never appear in issue titles or bodies. Private repos use a generic title and identify the subject via GitHub's opaque `node_id`. Public repos include `owner/repo`.

**Mutator contract**: the `commitMetadata` mutator closure re-runs `reconcileRepos` on every invocation (including 409 retries), so concurrent writes from the invitation poller are merged correctly rather than overwritten.

## Contract Changes

- `OnboardingStatus` widened to include `lost-access` and `pending-review`. Additive — existing entries remain valid.
- `addRepoEntry` lifted from `handle-invitation.ts` to `scripts/repos-metadata.ts` with an extended `onboarding_status?` parameter. Both the invitation poller and the reconciler now share the same entry-shape helper. Default behavior is unchanged; `handle-invitation.test.ts` passes with zero modifications.
- New `scripts/reconcile-repos.ts` exports `reconcileRepos`, `handleReconcile`, typed inputs/outputs, and `ReconcileError` with the same `code` + `remediation` shape as the other error classes in this repo.
- New `.github/workflows/reconcile-repos.yaml` — daily cron at `17 5 * * *` (off-peak vs 15-minute Poll Invitations and Sunday 22:00 Merge Data) plus `workflow_dispatch`. Uses `APPLICATION_ID` + `APPLICATION_PRIVATE_KEY` + `FRO_BOT_POLL_PAT` secrets (all already present).

## Testing

- **146/146 tests pass** (was 83 on main; +63 new across 3 files).
- `scripts/reconcile-repos.test.ts` covers every row of the classification decision table, concurrent-writer safety via 409-retry simulation, integrity check for all four variants (clean / operator-override / tamper / bootstrap), public vs private issue-body branching, mass-grant rollup with per-owner grouping, self-heal rollup lifecycle, auto-close of stale pending-review issues, MISSING_TOKEN hygiene (no token-shaped substring in error messages), and commit-before-dispatch ordering.
- `pnpm check-types`, `pnpm lint scripts`, `pnpm test` all clean.

## Post-Deploy Monitoring & Validation

- **What to monitor**
  - Workflow run badge on `reconcile-repos.yaml` — success vs failure.
  - Aggregate counters in the JSON stdout summary printed by every run: `accessListSize`, `summary` (added/pendingReview/regained/lostAccess/refreshed/unchanged), `dispatches`, `dispatchesFailed`, `perRepoIssues`, `rollupIssues`, `issuesFailed`, `closedStaleIssues`, `probesFailed`, `integrityCheck`, `committed`.
  - GitHub issues labeled `reconcile:pending-review`, `reconcile:rollup-pending-review`, and `reconcile:integrity-alert`.

- **Validation checks**

  ```
  # Inspect recent runs
  gh run list --workflow=reconcile-repos.yaml -R fro-bot/.github --limit 3

  # Read the JSON summary from the most recent run
  gh run view --log -R fro-bot/.github <run-id> | grep -A2 'accessListSize'

  # Open pending-review queue
  gh issue list --label reconcile:pending-review -R fro-bot/.github

  # Any integrity alerts? (should be empty under normal operation)
  gh issue list --label reconcile:integrity-alert --state all -R fro-bot/.github

  # Confirm no `data` branch author drift on the most recent commit
  gh api /repos/fro-bot/.github/branches/data --jq '.commit.author.login'
  # Expect: fro-bot[bot] (or any login in RECONCILE_OPERATOR_LOGINS)
  ```

- **Expected healthy behavior**
  - First manual dispatch on an empty state: all summary counters zero, `committed: false`, `integrityCheck: 'skipped-no-data-branch'` if `data` hasn't been created yet, otherwise `'ok'`.
  - First scheduled dispatch after the existing collaborator set is tracked: summary counts reflect any drift since invitations were last processed; `committed: true` only if state changed.
  - Idempotent: running reconcile twice in a row with stable state produces zero changes on the second run (`committed: false`, all counters zero).

- **Failure signals / rollback triggers**
  - Workflow exits non-zero → inspect run logs. Hard failures: `MISSING_TOKEN`, `OCTOKIT_LOAD_FAILED`, `METADATA_READ_ERROR`, `COMMIT_ERROR`, `DATA_BRANCH_TAMPER`, `API_ERROR` during enumeration.
  - `reconcile:integrity-alert` issue appears → treat as high-severity. Investigate `data` branch history for unexpected authors before allowing further reconcile runs.
  - `dispatchesFailed > 0` or `issuesFailed > 0` for multiple consecutive runs → not an immediate fail, but indicates persistent downstream breakage worth investigating.
  - Rollback: disable the workflow via the Actions UI or revert this PR. Manual dispatch is gated behind `workflow_dispatch` so suspending automated runs is low-risk.

- **Validation window & owner**
  - Window: 48 hours from first scheduled run. Operator watches the first 2-3 daily runs to confirm behavior matches expectations.
  - Owner: repo maintainer (`marcusrbrown`).

## Operational Runbook

- After rotating `FRO_BOT_POLL_PAT`: confirm the new PAT has `repo` scope by manually dispatching the workflow. Insufficient scope produces a 403 surfaced as `API_ERROR`.
- After rotating `APPLICATION_PRIVATE_KEY` or `APPLICATION_ID`: verify the `fro-bot[bot]` installation still has `contents: write`, `actions: write`, `issues: write` on this repo. The `create-github-app-token` step fails loudly if the installation is broken.
- Approving a `pending-review` entry: edit `metadata/repos.yaml` on the `data` branch to change the entry's `onboarding_status` from `pending-review` to `pending`. The next reconcile run will dispatch `Survey Repo` for it and the tracking issue auto-closes.
- Rejecting a `pending-review` entry: remove the entry from `metadata/repos.yaml` on `data` via a manual commit. The next reconcile run detects `lost-access` and flags the removal.

## Known Limitations (deferred)

- Rename/transfer detection via `node_id` cross-reference is deferred. A renamed repo currently appears as one `lost-access` + one new entry. Low real-world frequency; elevate to a follow-up if observed.
- Rate-limit backoff honors `retry-after` only where commitMetadata already handles it; the `/user/repos` enumeration and per-repo probes do not add retry logic on 429/5xx. Acceptable at current scale.
- Self-healed rollup issues always use `reason: 'unsolicited-new'` even if the underlying entries originated as `unsolicited-regain`. Documented in the code.
- Dispatch timeout uses `Promise.race` rather than `AbortController` with request cancellation. Timer cleanup is correct; under-hood fetches may continue in the background on timeout. Acceptable at current scale.
