### PR TITLE
fix(reconcile): skip integrity check on just-bootstrapped data branch

### DIFF
--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -1343,6 +1343,43 @@ describe('handleReconcile (I/O shell)', () => {
       expect(result.integrityCheck).toBe('skipped-no-data-branch')
       expect(commitMetadata).toHaveBeenCalledOnce()
     })
+
+    it('skips the integrity check when data branch was just bootstrapped this run', async () => {
+      // bootstrapDataBranch returns created:true when it created the branch from main HEAD
+      // this run. The branch now exists but its tip commit is inherited from main — authored
+      // by whoever merged the last PR, not fro-bot[bot]. The check must be skipped to avoid
+      // a false-positive DATA_BRANCH_TAMPER on every first run after a main merge.
+      const bootstrap = vi.fn(async () => ({created: true, ref: 'refs/heads/data', sha: 'new-data-sha'}))
+      const getBranch = vi.fn(async () => ({
+        data: {name: 'data', commit: {sha: 'main-sha', author: {login: 'human-merger'}}},
+      }))
+      const commitMetadata = vi.fn(async () => ({committed: true, sha: 's', attempts: 1}))
+      const issuesCreate = vi.fn(async () => ({data: {number: 1}}))
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [{owner: {login: 't'}, name: 'r', archived: false, private: false, node_id: 'R_1'}],
+        }),
+      })
+
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({getBranch, issuesCreate}),
+          readMetadata: makeReadMetadata({allowlist: makeAllowlist(['t'])}),
+          commitMetadata: commitMetadata as never,
+          bootstrapDataBranch: bootstrap as never,
+          operatorLogins: [], // no operators — would normally reject 'human-merger'
+        }),
+      )
+
+      expect(result.integrityCheck).toBe('skipped-just-bootstrapped')
+      expect(commitMetadata).toHaveBeenCalledOnce()
+      // getBranch would normally be called by verifyDataBranchIntegrity — but we're skipping
+      // that step entirely on bootstrap, so it should never be invoked. No getBranch call
+      // also means no path to file a reconcile:integrity-alert issue.
+      expect(getBranch).not.toHaveBeenCalled()
+      expect(issuesCreate).not.toHaveBeenCalled()
+    })
   })
 
   describe('commit error handling', () => {

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -494,7 +494,13 @@ export interface HandleReconcileResult {
   closedStaleIssues: number
   /** Count of field probes that failed and were treated as no-change. */
   probesFailed: number
-  integrityCheck: 'ok' | 'skipped-no-data-branch'
+  /**
+   * Status of the pre-commit data-branch integrity check.
+   * - `'ok'` — check ran and passed.
+   * - `'skipped-no-data-branch'` — `data` branch does not exist (fresh first run before bootstrap); check is not applicable.
+   * - `'skipped-just-bootstrapped'` — `data` was created this run from `main`'s HEAD, so the author check would falsely flag the inherited commit.
+   */
+  integrityCheck: 'ok' | 'skipped-no-data-branch' | 'skipped-just-bootstrapped'
   committed: boolean
 }
 
@@ -519,8 +525,13 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
   const userOctokit = params.userOctokit ?? (await createOctokitFromEnv('FRO_BOT_POLL_PAT'))
   const appOctokit = params.appOctokit ?? (await createOctokitFromEnv('GITHUB_TOKEN'))
 
-  // 1. Bootstrap data branch (idempotent).
-  await bootstrap({octokit: appOctokit, owner, repo})
+  // 1. Bootstrap data branch (idempotent). On first run, this creates `data` from `main`'s
+  //    HEAD. The new branch inherits `main`'s history, so its tip commit is authored by
+  //    whoever merged the most recent PR — not `fro-bot[bot]`. Track the `created` flag so
+  //    we can skip the author-integrity check on bootstrap runs; once fro-bot makes its
+  //    first commit on `data`, subsequent runs enforce the check normally.
+  const bootstrapResult = await bootstrap({octokit: appOctokit, owner, repo})
+  const justBootstrapped = bootstrapResult.created === true
 
   // 2. Read metadata from disk (main branch checkout).
   const allowlist = await loadAllowlist(readMetadata, allowlistPath)
@@ -541,29 +552,36 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
   const plan = reconcileRepos({currentRepos, accessList, perRepoStatus, allowlist, fieldProbes, now})
 
   const hasChanges = planHasChanges(plan)
-  let integrityCheck: 'ok' | 'skipped-no-data-branch' = 'ok'
+  let integrityCheck: 'ok' | 'skipped-no-data-branch' | 'skipped-just-bootstrapped' = 'ok'
   let committed = false
 
   if (hasChanges) {
-    // 7. Pre-commit integrity check — fail closed on unexpected authors.
-    const integrity = await verifyDataBranchIntegrity({appOctokit, owner, repo, operatorLogins})
-    if (!integrity.ok) {
-      await fileIntegrityAlert({
-        appOctokit,
-        owner,
-        repo,
-        authorLogin: integrity.authorLogin,
-        sha: integrity.sha,
-        logger,
-      })
-      throw new ReconcileError({
-        code: 'DATA_BRANCH_TAMPER',
-        message: `Unexpected author on data branch tip commit: ${integrity.authorLogin ?? 'unknown'} (sha: ${integrity.sha})`,
-        remediation:
-          'Investigate who has contents:write on this repo. If legitimate, add the login to RECONCILE_OPERATOR_LOGINS and rerun.',
-      })
+    // 7. Pre-commit integrity check — fail closed on unexpected authors. Skipped entirely
+    //    when `data` was just bootstrapped this run: its tip commit is inherited from
+    //    `main` and is by definition authored by whoever merged the most recent PR, not
+    //    `fro-bot[bot]`. The check activates on the next run after fro-bot commits.
+    if (justBootstrapped) {
+      integrityCheck = 'skipped-just-bootstrapped'
+    } else {
+      const integrity = await verifyDataBranchIntegrity({appOctokit, owner, repo, operatorLogins})
+      if (!integrity.ok) {
+        await fileIntegrityAlert({
+          appOctokit,
+          owner,
+          repo,
+          authorLogin: integrity.authorLogin,
+          sha: integrity.sha,
+          logger,
+        })
+        throw new ReconcileError({
+          code: 'DATA_BRANCH_TAMPER',
+          message: `Unexpected author on data branch tip commit: ${integrity.authorLogin ?? 'unknown'} (sha: ${integrity.sha})`,
+          remediation:
+            'Investigate who has contents:write on this repo. If legitimate, add the login to RECONCILE_OPERATOR_LOGINS and rerun.',
+        })
+      }
+      integrityCheck = integrity.status
     }
-    integrityCheck = integrity.status
 
     // 8. Commit via mutator closure. Mutator re-runs reconcileRepos on each invocation,
     //    so 409-retry in commitMetadata absorbs concurrent writes correctly.
@@ -575,23 +593,26 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
         assertReposFile(currentParsed, 'repos')
         // Re-verify data-branch integrity inside the mutator to close the TOCTOU window
         // between the initial check (step 7) and the first commit attempt. Each 409 retry
-        // also re-verifies, catching any tamper that lands during the retry loop.
-        const retryIntegrity = await verifyDataBranchIntegrity({appOctokit, owner, repo, operatorLogins})
-        if (!retryIntegrity.ok) {
-          await fileIntegrityAlert({
-            appOctokit,
-            owner,
-            repo,
-            authorLogin: retryIntegrity.authorLogin,
-            sha: retryIntegrity.sha,
-            logger,
-          })
-          throw new ReconcileError({
-            code: 'DATA_BRANCH_TAMPER',
-            message: `Unexpected author on data branch tip commit during commit retry: ${retryIntegrity.authorLogin ?? 'unknown'} (sha: ${retryIntegrity.sha})`,
-            remediation:
-              'Investigate who has contents:write on this repo. If legitimate, add the login to RECONCILE_OPERATOR_LOGINS and rerun.',
-          })
+        // also re-verifies, catching any tamper that lands during the retry loop. Skipped
+        // on bootstrap runs for the same reason as the initial check.
+        if (!justBootstrapped) {
+          const retryIntegrity = await verifyDataBranchIntegrity({appOctokit, owner, repo, operatorLogins})
+          if (!retryIntegrity.ok) {
+            await fileIntegrityAlert({
+              appOctokit,
+              owner,
+              repo,
+              authorLogin: retryIntegrity.authorLogin,
+              sha: retryIntegrity.sha,
+              logger,
+            })
+            throw new ReconcileError({
+              code: 'DATA_BRANCH_TAMPER',
+              message: `Unexpected author on data branch tip commit during commit retry: ${retryIntegrity.authorLogin ?? 'unknown'} (sha: ${retryIntegrity.sha})`,
+              remediation:
+                'Investigate who has contents:write on this repo. If legitimate, add the login to RECONCILE_OPERATOR_LOGINS and rerun.',
+            })
+          }
         }
         const rerun = reconcileRepos({
           currentRepos: currentParsed,


### PR DESCRIPTION
## Summary

The first real reconcile run surfaced a false-positive on the data-branch integrity check. `bootstrapDataBranch` creates `data` from `main`'s HEAD on first run, so the new branch's tip commit is inherited from `main` — authored by whoever merged the most recent PR, not `fro-bot[bot]`. The integrity check at step 7 then rejects the author and throws `DATA_BRANCH_TAMPER`, blocking the very commit that would establish fro-bot's author identity on the data branch.

This fix tracks the `created` flag returned by `bootstrapDataBranch` and skips both the initial integrity check and the mutator re-check inside `commitMetadata` when `data` was just created this run. On subsequent runs, `data`'s tip is a `fro-bot[bot]` commit and the check enforces normally.

## Why this is safe

- The first commit on a freshly-bootstrapped `data` branch has nothing to tamper with — fro-bot hasn't operated on `data` yet. The attack surface the integrity check defends against (unauthorized writes to `data` between legitimate fro-bot runs) doesn't exist on the bootstrap run.
- After the first reconcile commit lands, `data`'s tip becomes a `fro-bot[bot]` commit and the check passes normally on the next run.
- `data` is auto-deleted after every successful `Merge Data Branch` PR, so the bootstrap-skip path is exercised after every weekly data merge. This is by design.

## Observed failure

Run https://github.com/fro-bot/.github/actions/runs/24593622954/job/71919329979:

```
ReconcileError: Unexpected author on data branch tip commit: marcusrbrown (sha: 5609e52...)
    at handleReconcile (scripts/reconcile-repos.ts:559:13)
```

`5609e52` is the squash-merge of #3096 on `main`; author `marcusrbrown` is the PR merger.

## Changes

- `scripts/reconcile-repos.ts` — capture `bootstrapResult.created`; wrap the initial integrity check and the mutator re-check in `if (!justBootstrapped)`; add `'skipped-just-bootstrapped'` to the `integrityCheck` status union with JSDoc explaining the three variants.
- `scripts/reconcile-repos.test.ts` — new test scenario covering the bootstrap-skip path: bootstrap returns `created: true`, getBranch is never called, no integrity alert issue is filed, `integrityCheck === 'skipped-just-bootstrapped'`, commit proceeds.

## Testing

- **147/147 tests pass** (was 146 before fix; +1 new).
- Existing bootstrap test (`data branch does not exist`, bootstrap returns `created: false` + getBranch 404) continues to pass and still produces `'skipped-no-data-branch'`.
- `pnpm check-types`, `pnpm lint scripts`, `pnpm test` all clean.

## Post-merge

Manually dispatch `Reconcile Repos` once to confirm the fix. Expected first-run behavior now:

- `integrityCheck: 'skipped-just-bootstrapped'`
- `committed: true` if any drift is detected against the current `metadata/repos.yaml`
- `data` branch now has fro-bot[bot] as tip commit author
- Next daily run: `integrityCheck: 'ok'`