### PR TITLE
feat(reconcile): stagger Survey Repo dispatches to avoid upstream rate limits

### DIFF
--- a/.github/workflows/reconcile-repos.yaml
+++ b/.github/workflows/reconcile-repos.yaml
@@ -40,4 +40,9 @@ jobs:
         env:
           FRO_BOT_POLL_PAT: ${{ secrets.FRO_BOT_POLL_PAT }}
           GITHUB_TOKEN: ${{ steps.get-workflow-app-token.outputs.token }}
+          # Stagger Survey Repo dispatches by 8 seconds so concurrent surveys don't saturate
+          # the shared Claude max20 OAuth seat (marcusrbrown/infra#144). Raise for larger
+          # access lists; clamp at 60s in the script. Workflow-level 10-minute timeout still
+          # bounds the full run.
+          RECONCILE_DISPATCH_STAGGER_MS: '8000'
         run: node scripts/reconcile-repos.ts

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -671,6 +671,8 @@ function baseParams(overrides: Partial<HandleReconcileParams> = {}): HandleRecon
       overrides.bootstrapDataBranch ??
       (vi.fn(async () => ({created: false, ref: 'refs/heads/data', sha: 'data-sha'})) as never),
     dispatchTimeoutMs: overrides.dispatchTimeoutMs ?? 100,
+    dispatchStaggerMs: overrides.dispatchStaggerMs ?? 0,
+    dispatchSleep: overrides.dispatchSleep,
     operatorLogins: overrides.operatorLogins ?? [],
     logger: overrides.logger ?? silentLogger(),
     workflowFile: overrides.workflowFile ?? 'survey-repo.yaml',
@@ -917,6 +919,81 @@ describe('handleReconcile (I/O shell)', () => {
       expect(result.dispatches).toBe(2)
       expect(result.dispatchesFailed).toBe(1)
       expect(logger.warn).toHaveBeenCalled()
+    })
+
+    it('staggers between dispatches but not before the first or after the last', async () => {
+      // Verifies the stagger contract documented in the triage for marcusrbrown/infra#144.
+      // For N dispatches we expect exactly N-1 stagger sleeps, never called before dispatch 1
+      // (to keep first-survey latency unchanged) and never after dispatch N (to avoid trailing
+      // idle time inside the 10-minute workflow job timeout).
+      const dispatchCalls: string[] = []
+      const sleepCalls: number[] = []
+      const createWorkflowDispatch = vi.fn(async (params: unknown) => {
+        const typed = params as {inputs?: {owner: string; repo: string}}
+        dispatchCalls.push(typed.inputs?.repo ?? '?')
+      })
+      const dispatchSleep = vi.fn(async (ms: number) => {
+        sleepCalls.push(ms)
+      })
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {owner: {login: 't'}, name: 'r1', archived: false, private: false, node_id: 'R_1'},
+            {owner: {login: 't'}, name: 'r2', archived: false, private: false, node_id: 'R_2'},
+            {owner: {login: 't'}, name: 'r3', archived: false, private: false, node_id: 'R_3'},
+            {owner: {login: 't'}, name: 'r4', archived: false, private: false, node_id: 'R_4'},
+          ],
+        }),
+      })
+
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({createWorkflowDispatch}),
+          readMetadata: makeReadMetadata({allowlist: makeAllowlist(['t'])}),
+          commitMetadata: vi.fn(async () => ({committed: true, sha: 's', attempts: 1})) as never,
+          dispatchStaggerMs: 5000,
+          dispatchSleep,
+        }),
+      )
+
+      // Exactly 4 dispatches fired in order.
+      expect(dispatchCalls).toEqual(['r1', 'r2', 'r3', 'r4'])
+      expect(result.dispatches).toBe(4)
+      // Exactly 3 sleeps — between r1→r2, r2→r3, r3→r4. Never before r1. Never after r4.
+      expect(sleepCalls).toEqual([5000, 5000, 5000])
+      expect(dispatchSleep).toHaveBeenCalledTimes(3)
+    })
+
+    it('skips stagger entirely when dispatchStaggerMs is 0', async () => {
+      const dispatchSleep = vi.fn(async () => {
+        /* no-op */
+      })
+      const createWorkflowDispatch = vi.fn(async () => undefined)
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {owner: {login: 't'}, name: 'r1', archived: false, private: false, node_id: 'R_1'},
+            {owner: {login: 't'}, name: 'r2', archived: false, private: false, node_id: 'R_2'},
+          ],
+        }),
+      })
+
+      await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({createWorkflowDispatch}),
+          readMetadata: makeReadMetadata({allowlist: makeAllowlist(['t'])}),
+          commitMetadata: vi.fn(async () => ({committed: true, sha: 's', attempts: 1})) as never,
+          dispatchStaggerMs: 0,
+          dispatchSleep,
+        }),
+      )
+
+      // No sleeps at all when stagger is 0 — the conditional `if (params.staggerMs > 0)`
+      // short-circuits before calling sleep. Critical for test-suite speed.
+      expect(dispatchSleep).not.toHaveBeenCalled()
+      expect(createWorkflowDispatch).toHaveBeenCalledTimes(2)
     })
 
     it('treats a dispatch timeout as failure and continues to the next', async () => {

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -419,6 +419,18 @@ const DEFAULT_REPOS_PATH = 'metadata/repos.yaml'
 const DEFAULT_WORKFLOW_FILE = 'survey-repo.yaml'
 const DEFAULT_WORKFLOW_REF = 'main'
 const DEFAULT_DISPATCH_TIMEOUT_MS = 15_000
+/**
+ * Delay (ms) inserted between consecutive Survey Repo dispatches. Surveys share a single
+ * Claude max20 OAuth seat via cliproxy.fro.bot and saturate upstream Anthropic rate limits
+ * when dispatched concurrently (see marcusrbrown/infra#144 diagnosis). Staggering spreads
+ * LLM context-window kickoff over time without exceeding the 10-minute workflow job
+ * timeout for any realistic access-list size.
+ *
+ * Default: 8s between dispatches → ~2 minutes to fan out 16 surveys, well under the
+ * 10-minute cap even if the access list grows to 50+ entries. Override via
+ * `RECONCILE_DISPATCH_STAGGER_MS` env var or `dispatchStaggerMs` param. Tests pass 0.
+ */
+const DEFAULT_DISPATCH_STAGGER_MS = 8_000
 
 const PENDING_REVIEW_LABEL = 'reconcile:pending-review'
 const ROLLUP_LABEL = 'reconcile:rollup-pending-review'
@@ -472,6 +484,18 @@ export interface HandleReconcileParams {
   bootstrapDataBranch?: (params: DataBranchBootstrapParams) => Promise<DataBranchBootstrapResult>
   /** Timeout (ms) applied to each `createWorkflowDispatch` call. Defaults to 15_000. */
   dispatchTimeoutMs?: number
+  /**
+   * Delay (ms) inserted between consecutive dispatches to avoid concurrent LLM requests
+   * against the shared Claude OAuth seat. Default 8_000 (see `DEFAULT_DISPATCH_STAGGER_MS`).
+   * Tests should pass 0 for speed; workflow env can override via `RECONCILE_DISPATCH_STAGGER_MS`.
+   */
+  dispatchStaggerMs?: number
+  /**
+   * Sleep implementation used by the dispatch loop. Test-only injection point — production
+   * uses `setTimeout`-backed Promise. Tests replace with a mock to verify stagger without
+   * real-time waits.
+   */
+  dispatchSleep?: (ms: number) => Promise<void>
   /** Extra authors allowed on the data branch tip commit (beyond `fro-bot[bot]`). */
   operatorLogins?: string[]
   logger?: ReconcileLogger
@@ -517,6 +541,7 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
   const workflowRef = params.workflowRef ?? DEFAULT_WORKFLOW_REF
   const now = params.now ?? new Date()
   const dispatchTimeoutMs = params.dispatchTimeoutMs ?? DEFAULT_DISPATCH_TIMEOUT_MS
+  const dispatchStaggerMs = params.dispatchStaggerMs ?? loadDispatchStaggerFromEnv()
   const logger: ReconcileLogger = params.logger ?? {warn: message => process.stderr.write(`${message}\n`)}
   const operatorLogins = params.operatorLogins ?? loadOperatorLoginsFromEnv()
   const readMetadata = params.readMetadata ?? readMetadataFromDisk
@@ -630,6 +655,8 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
 
   // 9. Dispatch loop (serial, non-blocking on failure, wrapped in a per-call timeout).
   const dispatchOutcome = await runDispatches({
+    staggerMs: dispatchStaggerMs,
+    sleep: params.dispatchSleep,
     appOctokit,
     owner,
     repo,
@@ -962,11 +989,29 @@ async function runDispatches(params: {
   workflowRef: string
   dispatches: DispatchRequest[]
   timeoutMs: number
+  /**
+   * Delay (ms) inserted BETWEEN consecutive dispatches (not before the first, not after
+   * the last). Zero disables staggering entirely — test suites pass 0 for speed.
+   */
+  staggerMs: number
   logger: ReconcileLogger
+  /**
+   * Sleep implementation. Injected for test speed — production uses `setTimeout`-backed
+   * Promise; tests pass a no-op or a deterministic fake clock.
+   */
+  sleep?: (ms: number) => Promise<void>
 }): Promise<{succeeded: number; failed: number}> {
+  const sleep = params.sleep ?? defaultSleep
   let succeeded = 0
   let failed = 0
-  for (const dispatch of params.dispatches) {
+  for (let i = 0; i < params.dispatches.length; i += 1) {
+    const dispatch = params.dispatches[i]
+    if (dispatch === undefined) continue
+    // Stagger BETWEEN dispatches only — never before the first, never after the last.
+    // This keeps the first survey's kickoff latency unchanged and avoids trailing idle time.
+    if (i > 0 && params.staggerMs > 0) {
+      await sleep(params.staggerMs)
+    }
     try {
       await dispatchWithTimeout(
         async () =>
@@ -988,6 +1033,25 @@ async function runDispatches(params: {
     }
   }
   return {succeeded, failed}
+}
+
+async function defaultSleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+/**
+ * Parse `RECONCILE_DISPATCH_STAGGER_MS` from env. Returns the default when unset, empty,
+ * or non-numeric. Negative values clamp to 0 (no stagger). Upper-bounded at 60s to prevent
+ * accidental workflow-timeout triggers from bad operator config.
+ */
+function loadDispatchStaggerFromEnv(): number {
+  const raw = process.env.RECONCILE_DISPATCH_STAGGER_MS
+  if (raw === undefined || raw === '') return DEFAULT_DISPATCH_STAGGER_MS
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed)) return DEFAULT_DISPATCH_STAGGER_MS
+  if (parsed < 0) return 0
+  if (parsed > 60_000) return 60_000
+  return parsed
 }
 
 async function dispatchWithTimeout<T>(work: () => Promise<T>, timeoutMs: number): Promise<T> {


### PR DESCRIPTION
## Summary

First production reconcile fanned out 16 Survey Repo dispatches concurrently; 15 failed within ~40 seconds with `rate_limit_error` from the shared Claude max20 OAuth seat behind `cliproxy.fro.bot`. Triage in marcusrbrown/infra#144 confirmed the rate limiter is upstream Anthropic (not Caddy, not CLIProxyAPI); mitigation is entirely client-side.

This PR adds an 8-second delay between consecutive Survey Repo dispatches so concurrent surveys don't saturate the single-seat limit.

## Design choices

- **Stagger only between dispatches**, never before the first (keeps first-survey kickoff latency unchanged) and never after the last (avoids trailing idle time inside the workflow job timeout).
- **8 seconds between dispatches** — at 19 tracked repos, full fan-out completes in ~2 minutes, well under the 10-minute workflow job timeout. Headroom scales linearly: 50 repos would take ~7 minutes; for 75+ entries operators should bump the env var or shorten the stagger.
- **Configurable via `RECONCILE_DISPATCH_STAGGER_MS` env var** (clamped to `[0, 60_000]`) so ops can tune without code changes.
- **`dispatchSleep` as a test-only injection point** so stagger behavior can be verified without real-time waits. Tests pass a `vi.fn()` and assert call count + arguments.

## Scope boundaries

This PR **does not**:

- Add retry-on-rate-limit to the dispatch loop. The rate limit is on the downstream survey's LLM call, not on our dispatch API call. Dispatches themselves succeed (HTTP 204); it's the agent inside the survey workflow that hits the limit. Retry would have to live in the survey workflow or fro-bot/agent, not here.
- Cap concurrent dispatches via a semaphore. With serial stagger-between, concurrency is bounded at 1 by construction.
- Change the model used for surveys (opus → sonnet). That decision lives in the survey workflow / agent repo.

## Testing

- **149/149 tests pass** (+2 new: stagger-between + skip-stagger-on-zero)
- Dispatched mock verifies exactly N-1 sleep calls for N dispatches, with the exact stagger value
- Zero-stagger test confirms the conditional short-circuit — critical for test-suite speed
- `pnpm check-types`, `pnpm lint scripts`, `pnpm test` all clean

## Operational notes

- Default stagger: `8000ms`. Override via env: `RECONCILE_DISPATCH_STAGGER_MS=12000` in the workflow step.
- Failed surveys from the first production run (15 of them) are still in `pending` status in `metadata/repos.yaml`. They'll retry on the next daily reconcile cron (05:17 UTC) with staggered dispatch, or on a manual workflow_dispatch.
- Clamp: values outside `[0, 60_000]` are silently coerced to avoid accidental workflow-timeout triggers. Operators setting very large values are likely wrong.