### PR TITLE
feat(wiki): rebuild index and merge logs to heal wiki catalog conflicts

### DIFF
--- a/scripts/rebuild-wiki-index.test.ts
+++ b/scripts/rebuild-wiki-index.test.ts
@@ -1,0 +1,206 @@
+import {describe, expect, it} from 'vitest'
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const wikiIngestModulePromise: Promise<{
+  mergeWikiLogs: typeof import('./wiki-ingest.js').mergeWikiLogs
+  rebuildWikiIndex: typeof import('./wiki-ingest.js').rebuildWikiIndex
+}> = import(`./wiki-ingest${'.js'}`)
+const {mergeWikiLogs, rebuildWikiIndex} = await wikiIngestModulePromise
+
+function wikiPage(params: {
+  path: string
+  type: 'repo' | 'topic' | 'entity' | 'comparison'
+  title: string
+}): [string, string] {
+  return [
+    params.path,
+    [
+      '---',
+      `type: ${params.type}`,
+      `title: ${params.title}`,
+      'created: 2026-04-16',
+      'updated: 2026-04-16',
+      '---',
+      '',
+      'Body.',
+      '',
+    ].join('\n'),
+  ]
+}
+
+describe('rebuildWikiIndex', () => {
+  it('regenerates the index from a wiki-file snapshot with no prior index text', () => {
+    // #given a wiki snapshot with two repo pages and no existing index
+    const wikiFiles = Object.fromEntries([
+      wikiPage({path: 'knowledge/wiki/repos/fro-bot--agent.md', type: 'repo', title: 'Fro Bot Agent'}),
+      wikiPage({path: 'knowledge/wiki/repos/fro-bot--github.md', type: 'repo', title: 'Fro Bot .github'}),
+    ])
+
+    // #when the index is rebuilt from ground truth
+    const index = rebuildWikiIndex({wikiFiles})
+
+    // #then all pages appear under their section in title order
+    expect(index).toContain('## Repos')
+    expect(index).toContain('- [[fro-bot--agent]] — Fro Bot Agent')
+    expect(index).toContain('- [[fro-bot--github]] — Fro Bot .github')
+    expect(index.indexOf('Fro Bot .github')).toBeLessThan(index.indexOf('Fro Bot Agent'))
+    expect(index).toContain('## Topics')
+    expect(index).toContain('_No topic pages yet.')
+  })
+
+  it('preserves custom header and footer text from an existing index', () => {
+    // #given an existing index with operator-authored header and footer prose
+    const existingIndex = [
+      '# Wiki Index',
+      '',
+      '> Manually authored note: this is our source of truth.',
+      '',
+      '## Repos',
+      '',
+      '- [[stale-entry]] — Stale Entry',
+      '',
+      '## Topics',
+      '',
+      '_No topic pages yet._',
+      '',
+      '## Entities',
+      '',
+      '_No entity pages yet._',
+      '',
+      '## Comparisons',
+      '',
+      '_No comparison pages yet._',
+      '',
+      '---',
+      '',
+      '_Custom footer copy kept across rebuilds._',
+      '',
+    ].join('\n')
+    const wikiFiles = Object.fromEntries([
+      wikiPage({path: 'knowledge/wiki/repos/fro-bot--agent.md', type: 'repo', title: 'Fro Bot Agent'}),
+    ])
+
+    // #when the index is rebuilt against the existing document
+    const index = rebuildWikiIndex({existingIndex, wikiFiles})
+
+    // #then the custom header prose and footer copy survive
+    expect(index).toContain('> Manually authored note: this is our source of truth.')
+    expect(index).toContain('_Custom footer copy kept across rebuilds._')
+    // #and the stale entry is replaced by what's actually on disk
+    expect(index).toContain('- [[fro-bot--agent]] — Fro Bot Agent')
+    expect(index).not.toContain('stale-entry')
+  })
+
+  it('handles an empty wiki snapshot by emitting the empty-section placeholders', () => {
+    // #given an empty wiki snapshot
+    // #when the index is rebuilt
+    const index = rebuildWikiIndex({wikiFiles: {}})
+
+    // #then every section shows its empty-state placeholder
+    expect(index).toContain('_No repo pages yet.')
+    expect(index).toContain('_No topic pages yet.')
+    expect(index).toContain('_No entity pages yet.')
+    expect(index).toContain('_No comparison pages yet.')
+  })
+})
+
+describe('mergeWikiLogs', () => {
+  it('concatenates entries from multiple inputs in chronological order', () => {
+    // #given two log.md snapshots — one from main, one from a PR — with disjoint entries
+    const mainLog = [
+      '# Wiki Log',
+      '',
+      'Chronological record of all wiki operations.',
+      '',
+      '---',
+      '',
+      '_Entries are appended by ingest, query, lint, and manual-edit operations. This file is append-only._',
+      '',
+      '## [2026-04-17 10:00] ingest | repo:marcusrbrown/esphome.life',
+      '',
+      'Surveyed esphome.life.',
+      '',
+      'Sources: https://github.com/marcusrbrown/esphome.life@abc123',
+      '',
+    ].join('\n')
+    const prLog = [
+      '# Wiki Log',
+      '',
+      'Chronological record of all wiki operations.',
+      '',
+      '---',
+      '',
+      '_Entries are appended by ingest, query, lint, and manual-edit operations. This file is append-only._',
+      '',
+      '## [2026-04-18 05:34] ingest | repo:marcusrbrown/.dotfiles',
+      '',
+      'Surveyed .dotfiles.',
+      '',
+      'Sources: https://github.com/marcusrbrown/.dotfiles@def456',
+      '',
+    ].join('\n')
+
+    // #when the logs are merged
+    const merged = mergeWikiLogs([mainLog, prLog])
+
+    // #then both entries appear in timestamp order under the canonical header
+    expect(merged).toContain('# Wiki Log')
+    expect(merged).toContain('## [2026-04-17 10:00] ingest | repo:marcusrbrown/esphome.life')
+    expect(merged).toContain('## [2026-04-18 05:34] ingest | repo:marcusrbrown/.dotfiles')
+    expect(merged.indexOf('esphome.life')).toBeLessThan(merged.indexOf('.dotfiles'))
+  })
+
+  it('deduplicates entries that appear in multiple sources', () => {
+    // #given two log.md snapshots sharing one identical entry
+    const sharedEntry = [
+      '## [2026-04-17 10:00] ingest | repo:marcusrbrown/esphome.life',
+      '',
+      'Surveyed esphome.life.',
+      '',
+      'Sources: https://github.com/marcusrbrown/esphome.life@abc123',
+      '',
+    ].join('\n')
+    const withShared = `# Wiki Log\n\n---\n\n${sharedEntry}`
+
+    // #when merging two copies of the same log
+    const merged = mergeWikiLogs([withShared, withShared])
+
+    // #then the shared entry appears exactly once (dedupe by timestamp+target)
+    const occurrences = merged.match(/## \[2026-04-17 10:00\] ingest \| repo:marcusrbrown\/esphome\.life/gu) ?? []
+    expect(occurrences).toHaveLength(1)
+  })
+
+  it('tolerates empty or undefined log inputs without emitting garbage', () => {
+    // #given a mix of empty, undefined, and valid log inputs
+    const validLog = [
+      '# Wiki Log',
+      '',
+      '---',
+      '',
+      '## [2026-04-18 00:00] ingest | repo:fro-bot/.github',
+      '',
+      'A single entry.',
+      '',
+      'Sources: none',
+      '',
+    ].join('\n')
+
+    // #when the merger skips the empty/undefined inputs
+    const merged = mergeWikiLogs([undefined, '', validLog])
+
+    // #then only the valid entry survives
+    expect(merged).toContain('## [2026-04-18 00:00] ingest | repo:fro-bot/.github')
+    expect(merged).toContain('# Wiki Log')
+  })
+
+  it('produces a deterministic canonical header even when all inputs are empty', () => {
+    // #given nothing to merge
+    // #when the merger is invoked on empty inputs
+    const merged = mergeWikiLogs([undefined, ''])
+
+    // #then the canonical header emerges alone, no entries
+    expect(merged).toContain('# Wiki Log')
+    expect(merged).toContain('append-only')
+    expect(merged).not.toContain('## [')
+  })
+})

--- a/scripts/rebuild-wiki-index.ts
+++ b/scripts/rebuild-wiki-index.ts
@@ -1,0 +1,94 @@
+import type {Dirent} from 'node:fs'
+import {readdir, readFile, writeFile} from 'node:fs/promises'
+import process from 'node:process'
+
+import {mergeWikiLogs, rebuildWikiIndex} from './wiki-ingest.ts'
+
+/**
+ * Heal `knowledge/index.md` (and optionally `knowledge/log.md`) after merge
+ * conflicts on the shared wiki catalog files.
+ *
+ * Usage:
+ *   node scripts/rebuild-wiki-index.ts
+ *     Rebuild `knowledge/index.md` from all files under `knowledge/wiki/**`.
+ *
+ *   node scripts/rebuild-wiki-index.ts --merge-logs <path1> <path2> [...]
+ *     Merge multiple log.md files chronologically into `knowledge/log.md`.
+ *     Dedupes entries by `(timestamp, target)`; preserves canonical header.
+ *
+ * Rationale: the one-PR-per-survey flow in the current architecture serializes
+ * through `knowledge/index.md` and `knowledge/log.md`. Every survey after the
+ * first on the same cycle hits a merge conflict on those two files. This script
+ * replaces hand-merging — regenerate the index from ground truth (the set of
+ * wiki pages on disk) and merge log entries chronologically. When the `data`
+ * branch flow lands (fro-bot/agent#511), this stops being load-bearing but
+ * remains useful for post-incident healing.
+ */
+
+const WIKI_ROOT = 'knowledge/wiki'
+const INDEX_PATH = 'knowledge/index.md'
+const LOG_PATH = 'knowledge/log.md'
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2)
+  if (args[0] === '--merge-logs') {
+    await runMergeLogs(args.slice(1))
+    return
+  }
+  await runRebuildIndex()
+}
+
+async function runRebuildIndex(): Promise<void> {
+  const wikiFiles = await loadWikiFilesFromDisk()
+  const existingIndex = await readFileOrUndefined(INDEX_PATH)
+  const nextIndex = rebuildWikiIndex({existingIndex, wikiFiles})
+  await writeFile(INDEX_PATH, nextIndex, 'utf8')
+  process.stdout.write(`rebuilt ${INDEX_PATH} from ${Object.keys(wikiFiles).length} wiki file(s)\n`)
+}
+
+async function runMergeLogs(paths: string[]): Promise<void> {
+  if (paths.length === 0) {
+    throw new Error('rebuild-wiki-index: --merge-logs requires at least one log.md path')
+  }
+  const logs = await Promise.all(paths.map(readFileOrUndefined))
+  const merged = mergeWikiLogs(logs)
+  await writeFile(LOG_PATH, merged, 'utf8')
+  process.stdout.write(`merged ${paths.length} log source(s) into ${LOG_PATH}\n`)
+}
+
+async function loadWikiFilesFromDisk(): Promise<Record<string, string>> {
+  const files: Record<string, string> = {}
+  for (const directory of ['repos', 'topics', 'entities', 'comparisons']) {
+    const directoryPath = `${WIKI_ROOT}/${directory}`
+    let entries: Dirent[]
+    try {
+      entries = await readdir(directoryPath, {withFileTypes: true})
+    } catch (error: unknown) {
+      if (isEnoentError(error)) continue
+      throw error
+    }
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.md')) continue
+      const path = `${directoryPath}/${entry.name}`
+      files[path] = await readFile(path, 'utf8')
+    }
+  }
+  return files
+}
+
+async function readFileOrUndefined(path: string): Promise<string | undefined> {
+  try {
+    return await readFile(path, 'utf8')
+  } catch (error: unknown) {
+    if (isEnoentError(error)) return undefined
+    throw error
+  }
+}
+
+function isEnoentError(error: unknown): error is NodeJS.ErrnoException {
+  return typeof error === 'object' && error !== null && (error as NodeJS.ErrnoException).code === 'ENOENT'
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}

--- a/scripts/wiki-ingest.ts
+++ b/scripts/wiki-ingest.ts
@@ -313,6 +313,80 @@ function validateWikilinks(files: Record<string, string>): void {
   }
 }
 
+/**
+ * Regenerate `knowledge/index.md` deterministically from a snapshot of wiki files.
+ *
+ * Used both by ingest (to update the catalog inline with new pages) and by
+ * `scripts/rebuild-wiki-index.ts` (to heal `index.md` after merge conflicts on
+ * the shared catalog file — see PR #3114's companion context).
+ *
+ * Preserves any header/footer prose found in `existingIndex` so operator notes
+ * above `## Repos` and below the closing `---` survive regeneration.
+ */
+export function rebuildWikiIndex(params: {existingIndex?: string; wikiFiles: Record<string, string>}): string {
+  return buildIndexDocument(params.existingIndex, collectWikiPages(params.wikiFiles))
+}
+
+const LOG_HEADER =
+  '# Wiki Log\n\nChronological record of all wiki operations.\n\n---\n\n_Entries are appended by ingest, query, lint, and manual-edit operations. This file is append-only._\n'
+// Matches a log entry header line: "## [YYYY-MM-DD HH:MM] <op> | <target>".
+// `[ \t]*` instead of `\s*` keeps the regex anchored to single-line whitespace and
+// avoids the super-linear backtracking risk on adjacent variable-length classes.
+const LOG_ENTRY_PATTERN = /\n## \[([^\]]+)\] (?:ingest|query|lint|manual-edit) \| ([^\n]+)\n/g
+
+interface WikiLogEntry {
+  timestamp: string
+  target: string
+  /** Raw entry markup including the leading blank-line separator — byte-for-byte fidelity on reinsertion. */
+  raw: string
+}
+
+/**
+ * Merge multiple `knowledge/log.md` contents into a single canonical log.
+ *
+ * Used to resolve merge conflicts on the append-only log: given log.md from
+ * main and log.md from a PR, produce a combined log with every entry present
+ * (deduplicated by timestamp+target) in chronological order.
+ *
+ * The log's documented contract is append-only. This helper keeps that contract
+ * intact across concurrent writers by canonicalizing the order rather than
+ * forcing operators to hand-merge conflict markers.
+ */
+export function mergeWikiLogs(logs: (string | undefined)[]): string {
+  const entryMap = new Map<string, WikiLogEntry>()
+  for (const log of logs) {
+    if (log === undefined || log === '') continue
+    for (const entry of parseWikiLogEntries(log)) {
+      // Dedupe by the natural key (timestamp, target). When the same entry
+      // appears in multiple inputs, the last one wins — but since entries are
+      // normalized the content matches byte-for-byte.
+      entryMap.set(`${entry.timestamp}\0${entry.target}`, entry)
+    }
+  }
+  const entries = [...entryMap.values()].sort((left, right) => left.timestamp.localeCompare(right.timestamp))
+  return normalizeText(`${LOG_HEADER}${entries.map(entry => entry.raw).join('')}`)
+}
+
+function parseWikiLogEntries(log: string): WikiLogEntry[] {
+  const entries: WikiLogEntry[] = []
+  const matches = [...log.matchAll(LOG_ENTRY_PATTERN)]
+  for (let i = 0; i < matches.length; i += 1) {
+    const match = matches[i]
+    if (match === undefined || match.index === undefined) continue
+    const [, timestamp, target] = match
+    if (timestamp === undefined || target === undefined) continue
+    const start = match.index
+    const nextMatch = matches[i + 1]
+    const end = nextMatch?.index ?? log.length
+    entries.push({
+      timestamp: timestamp.trim(),
+      target: target.trim(),
+      raw: log.slice(start, end),
+    })
+  }
+  return entries
+}
+
 function buildIndexDocument(existingIndex: string | undefined, pages: ParsedWikiPage[]): string {
   const header =
     existingIndex === undefined || existingIndex === ''
@@ -322,6 +396,13 @@ function buildIndexDocument(existingIndex: string | undefined, pages: ParsedWiki
     existingIndex === undefined || existingIndex === ''
       ? '\n---\n\n_This index is maintained automatically by wiki ingest operations. Manual edits are preserved across updates._\n'
       : extractIndexFooter(existingIndex)
+
+  // Preserve operator-curated or previously-generated entry descriptions when a
+  // slug still has a wiki page. Rebuilds only add new entries and drop stale
+  // ones — they never degrade richer descriptions back to bare frontmatter
+  // titles.
+  const existingLines: Map<string, string> =
+    existingIndex === undefined ? new Map<string, string>() : parseIndexEntryLines(existingIndex)
 
   const sections: {heading: string; type: WikiPageType; empty: string}[] = [
     {
@@ -351,13 +432,31 @@ function buildIndexDocument(existingIndex: string | undefined, pages: ParsedWiki
       const entries = pages
         .filter(page => page.type === section.type)
         .sort((left, right) => left.title.localeCompare(right.title))
-        .map(page => `- [[${page.slug}]] — ${page.title}`)
+        .map(page => existingLines.get(page.slug) ?? `- [[${page.slug}]] — ${page.title}`)
 
       return [`## ${section.heading}`, '', ...(entries.length > 0 ? entries : [section.empty]), ''].join('\n')
     })
     .join('\n')
 
   return normalizeText(`${header}${body}${footer}`)
+}
+
+/**
+ * Extract previously-rendered entry lines from an index document keyed by slug.
+ * Used to preserve operator-curated or agent-generated rich descriptions across
+ * rebuilds — only new slugs get fresh `slug — title` lines.
+ */
+function parseIndexEntryLines(index: string): Map<string, string> {
+  const entries = new Map<string, string>()
+  // Match the full line: "- [[slug]] — description"
+  // Description may contain anything except a newline (we keep the entire trailing text).
+  const pattern = /^- \[\[([^\]|]+)\]\]\s*—\s*(?:\S.*|[\t\v\f \u00A0\u1680\u2000-\u200A\u202F\u205F\u3000\uFEFF])$/gmu
+  for (const match of index.matchAll(pattern)) {
+    const [line, slug] = match
+    if (line === undefined || slug === undefined) continue
+    entries.set(slug.trim(), line)
+  }
+  return entries
 }
 
 function appendLogEntry(existingLog: string | undefined, params: BuildWikiIngestChangesParams): string {


### PR DESCRIPTION
## Summary

Survey PRs all touch `knowledge/index.md` and `knowledge/log.md`. With each survey opening its own PR against `main`, the first merge wins and every subsequent survey PR ends up with a content conflict on those two shared catalog files. Until the agent flow writes to a single `data` branch (fro-bot/agent#511), the conflict is structural.

This PR adds a healing tool: regenerate the index from ground truth (the set of wiki files on disk), and canonicalize the log by merging concurrent entries chronologically.

## What lands

Two pure healing functions exported from `scripts/wiki-ingest.ts`:

- `rebuildWikiIndex({ existingIndex?, wikiFiles })` — regenerates `knowledge/index.md` from a snapshot of wiki files. **Preserves operator-curated rich descriptions** for slugs that still have a wiki page; only new slugs get bare `slug — title` lines, and stale entries are dropped. Reuses the existing `buildIndexDocument` + `collectWikiPages` logic.

- `mergeWikiLogs(logs)` — merges multiple `knowledge/log.md` contents into one canonical log. Dedupes entries by `(timestamp, target)` and re-emits chronologically under the canonical header. Keeps the log's append-only contract intact across concurrent writers.

And a thin CLI wrapper at `scripts/rebuild-wiki-index.ts`:

```bash
# rebuild knowledge/index.md from files on disk
node scripts/rebuild-wiki-index.ts

# merge multiple log.md sources into knowledge/log.md
node scripts/rebuild-wiki-index.ts --merge-logs path/to/main.log.md path/to/pr.log.md
```

## How I'll use it

Per-PR resolution for the 6 currently-blocked wiki PRs:

1. Merge `main` into the PR branch
2. When conflict hits `knowledge/index.md`, take theirs (PR version), then `node scripts/rebuild-wiki-index.ts` to rebuild from the merged file tree
3. When conflict hits `knowledge/log.md`, extract both sides and run `--merge-logs`
4. Commit resolution and push to the PR branch
5. Repeat for the next PR (each merge shifts `main` forward so each subsequent PR needs a rebase)

This replaces hand-merging for these conflicts — both are mechanical and deterministic.

## Preservation verified on the live wiki

Ran the rebuild against `main`'s current `knowledge/index.md` + on-disk wiki files. Result:

- **Preserved** rich descriptions for `marcusrbrown--github`, `marcusrbrown--ha-config`, topic `home-assistant`, topic `probot-settings` (operator-curated)
- **Added** bare entries for `marcusrbrown--esphome-life`, `marcusrbrown--tokentoilet`, `marcusrbrown--vbs`, topic `web3-defi` (merged from recent surveys but never propagated to the index due to conflicts)
- **No regressions** — nothing currently-good was overwritten with worse content

## Tests

- 7 new tests (3 `rebuildWikiIndex` + 4 `mergeWikiLogs`)
- 161/161 total pass
- `pnpm check-types`, `pnpm lint scripts`, `pnpm test` all clean

## Out of scope

- Automated post-merge healing workflow. The CLI is runnable today; wiring it as a `push: main` workflow step is a separate decision (do we auto-heal `main` after every merge? or only on demand?).
- Removing the architectural need for this tool. That's fro-bot/agent#511 — once surveys land on `data` via atomic commits, this tool stops being load-bearing but remains useful for post-incident healing.