### PR TITLE
feat(workflows): upgrade fro-bot/agent to v0.41.0 with working-dir output mode

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -206,7 +206,7 @@ jobs:
 
       - name: Run Fro Bot
         id: fro-bot-agent
-        uses: fro-bot/agent@4247f5e4d1fbd1857617ebe00040f1f95be0071f # v0.40.0
+        uses: fro-bot/agent@fc1387ec5c25afed73b11b8b26c482b90b3ad9cd # v0.41.0
         env:
           OPENCODE_PROMPT_ARTIFACT: 'true'
           PERSONA: ${{ steps.persona.outputs.content }}

--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -101,13 +101,20 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Run Fro Bot survey ingest
-        uses: fro-bot/agent@4247f5e4d1fbd1857617ebe00040f1f95be0071f # v0.40.0
+        uses: fro-bot/agent@fc1387ec5c25afed73b11b8b26c482b90b3ad9cd # v0.41.0
         with:
           github-token: ${{ secrets.FRO_BOT_POLL_PAT }}
           auth-json: ${{ secrets.OPENCODE_AUTH_JSON }}
           model: ${{ vars.FRO_BOT_MODEL }}
           omo-providers: ${{ secrets.OMO_PROVIDERS }}
           opencode-config: ${{ secrets.OPENCODE_CONFIG }}
+          # Write wiki updates to the workflow's working tree so the next step can
+          # commit them to the `data` branch via scripts/wiki-ingest.ts. Without
+          # `working-dir`, the agent's skill-layer defaults push a side branch +
+          # PR per survey, which serializes through knowledge/index.md and
+          # knowledge/log.md — the root cause of the N-way merge conflicts this
+          # workflow used to produce.
+          output-mode: working-dir
           prompt: |
             <persona>
             ${{ steps.persona.outputs.content }}


### PR DESCRIPTION
## Summary

Adopts [fro-bot/agent v0.41.0](https://github.com/fro-bot/agent/releases/tag/v0.41.0), which adds an `output-mode` action input that controls whether the agent writes to the workflow checkout or creates a side branch and PR. Sets `output-mode: working-dir` explicitly on Survey Repo so concurrent surveys land on the `data` branch via the existing atomic commit flow instead of opening individual per-survey PRs.

Closes the root cause of the wiki merge conflicts we've been resolving by hand.

## The bug v0.41.0 fixes

Before: manual-trigger runs (`schedule`, `workflow_dispatch`) silently delivered file changes via side branches (the agent's skill-layer default from Systematic's `git-commit-push-pr`). `survey-repo.yaml`'s Detect + Commit steps checked `git diff` against the working tree, found nothing, and skipped. A separate PR opened per survey — serializing through `knowledge/index.md` and `knowledge/log.md` and producing N-way merge conflicts.

After: `output-mode: working-dir` makes the agent write directly to the workflow's checked-out working tree. The existing `Commit wiki ingest to data branch` step picks up those changes and commits them to `data` via `scripts/wiki-ingest.ts` — atomic Git Data API commit with 409-retry. Concurrent surveys serialize naturally through `data` the way the pipeline was designed.

## Changes

- **`.github/workflows/survey-repo.yaml`**
  - SHA bumped to `fc1387ec5c25afed73b11b8b26c482b90b3ad9cd` (v0.41.0)
  - Added `output-mode: working-dir` with an inline comment documenting the rationale

- **`.github/workflows/fro-bot.yaml`**
  - SHA bumped to `fc1387ec5c25afed73b11b8b26c482b90b3ad9cd` (v0.41.0)
  - No `output-mode` change — this workflow runs primarily for `pull_request` / `issue_comment` / `pull_request_review_comment` events where `output-mode` is not applicable. For the `workflow_dispatch` / `schedule` paths it also handles, the default `auto` mode resolves to `working-dir` for the existing PR_REVIEW_PROMPT and SCHEDULE_PROMPT (no branch/PR keywords in either). Behavior is unchanged.

## What v0.41.0 also brings (not load-bearing here)

- Durable S3-compatible object-store backend for agent state (future persistence work)
- Dependency bumps: Node 24.15.0, opencode 1.4.11, @fro.bot/systematic 2.4.0

## Testing

- 161/161 tests pass
- `pnpm check-types`, `pnpm lint scripts`, `pnpm test` all clean
- Workflow syntax validated by CI actionlint

## Post-merge verification

The daily reconcile cron (05:17 UTC) will re-dispatch all 19 tracked surveys tomorrow with the upgraded agent. Expected behavior:

- Surveys write directly to the workflow checkout (no more empty `git diff`)
- `scripts/wiki-ingest.ts` commits to `data` branch with 409-retry under concurrent load
- Zero new per-survey PRs against `main` from scheduled runs
- Next weekly `merge-data.yaml` cron (Sunday 22:00 UTC) rolls up all accumulated `data` changes into one `data → main` promotion PR

If a survey run still opens its own PR against `main` after this lands, the bug is upstream in the agent's `output-mode` handling and should go back to fro-bot/agent.