### PR TITLE
feat(reconcile): progressive dispatch with staleness gate and per-run cap

### DIFF
--- a/.github/workflows/reconcile-repos.yaml
+++ b/.github/workflows/reconcile-repos.yaml
@@ -21,7 +21,11 @@ jobs:
       actions: write
       issues: write
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Stagger + cap keep fan-out inside this budget even at the maximum configured
+    # dispatch count: 6 dispatches × 90s = 9 minutes of stagger, plus ≤1 minute of
+    # pre-dispatch work (access list, probes, commit). 15 minutes provides headroom
+    # for GitHub API jitter without permitting a truly-stuck run.
+    timeout-minutes: 15
     steps:
       - id: get-workflow-app-token
         name: Get Workflow Access Token
@@ -40,9 +44,12 @@ jobs:
         env:
           FRO_BOT_POLL_PAT: ${{ secrets.FRO_BOT_POLL_PAT }}
           GITHUB_TOKEN: ${{ steps.get-workflow-app-token.outputs.token }}
-          # Stagger Survey Repo dispatches by 8 seconds so concurrent surveys don't saturate
-          # the shared Claude max20 OAuth seat (marcusrbrown/infra#144). Raise for larger
-          # access lists; clamp at 60s in the script. Workflow-level 10-minute timeout still
-          # bounds the full run.
-          RECONCILE_DISPATCH_STAGGER_MS: '8000'
+          # Stagger between Survey Repo dispatches. Each survey run holds upstream LLM
+          # capacity for ~5 minutes; 90 seconds between starts keeps the single seat from
+          # saturating under fan-out (see marcusrbrown/infra#144).
+          RECONCILE_DISPATCH_STAGGER_MS: '90000'
+          # Cap dispatches per reconcile run. Candidates beyond the cap are eligible again
+          # on the next run via the staleness gate, producing a progressive day-over-day
+          # cadence instead of bursty fan-outs that exhaust upstream capacity.
+          RECONCILE_MAX_DISPATCHES_PER_RUN: '6'
         run: node scripts/reconcile-repos.ts

--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -101,6 +101,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Run Fro Bot survey ingest
+        id: survey-agent
         uses: fro-bot/agent@fc1387ec5c25afed73b11b8b26c482b90b3ad9cd # v0.41.0
         with:
           github-token: ${{ secrets.FRO_BOT_POLL_PAT }}
@@ -109,11 +110,7 @@ jobs:
           omo-providers: ${{ secrets.OMO_PROVIDERS }}
           opencode-config: ${{ secrets.OPENCODE_CONFIG }}
           # Write wiki updates to the workflow's working tree so the next step can
-          # commit them to the `data` branch via scripts/wiki-ingest.ts. Without
-          # `working-dir`, the agent's skill-layer defaults push a side branch +
-          # PR per survey, which serializes through knowledge/index.md and
-          # knowledge/log.md — the root cause of the N-way merge conflicts this
-          # workflow used to produce.
+          # commit them to the `data` branch via scripts/wiki-ingest.ts.
           output-mode: working-dir
           prompt: |
             <persona>
@@ -149,3 +146,16 @@ jobs:
           WIKI_COMMIT_MESSAGE: 'feat(knowledge): survey ${{ steps.ingest-prompt.outputs.target-repository }}'
           WIKI_SOURCES: '[{"url":"https://github.com/${{ steps.ingest-prompt.outputs.target-repository }}","accessed":"${{ steps.ts.outputs.now }}"}]'
         run: node scripts/wiki-ingest.ts
+
+      # Write the survey outcome back to metadata/repos.yaml on the data branch so
+      # the reconcile staleness gate (>30d since last survey) can filter this repo out
+      # of tomorrow's candidate list. Runs regardless of whether wiki content changed —
+      # "surveyed and found nothing new" is still a completed survey.
+      - name: Record survey result
+        if: always() && !cancelled() && steps.survey-agent.conclusion != 'skipped'
+        env:
+          GITHUB_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+          REPO_OWNER: ${{ github.event.inputs.owner }}
+          REPO_NAME: ${{ github.event.inputs.repo }}
+          SURVEY_STATUS: ${{ steps.survey-agent.conclusion == 'success' && 'success' || 'failure' }}
+        run: node scripts/record-survey-result.ts

--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -148,9 +148,16 @@ jobs:
         run: node scripts/wiki-ingest.ts
 
       # Write the survey outcome back to metadata/repos.yaml on the data branch so
-      # the reconcile staleness gate (>30d since last survey) can filter this repo out
-      # of tomorrow's candidate list. Runs regardless of whether wiki content changed —
-      # "surveyed and found nothing new" is still a completed survey.
+      # the reconcile staleness gate (30 days or more since last survey) can filter this
+      # repo out of tomorrow's candidate list. Runs regardless of whether wiki content
+      # changed — "surveyed and found nothing new" is still a completed survey.
+      #
+      # Status mapping for the agent step's conclusion:
+      # - 'success'   → 'success' (wiki updated or no-op; either is a completed survey)
+      # - 'failure'   → 'failure' (agent ran but raised an error, e.g. upstream rate limit)
+      # - 'cancelled' → 'failure' (cancelled surveys produce no useful output; retry next run)
+      # The outer `!cancelled()` already excludes job-level cancellation. The `!= 'skipped'`
+      # guard skips the write when an upstream step kept the agent from running at all.
       - name: Record survey result
         if: always() && !cancelled() && steps.survey-agent.conclusion != 'skipped'
         env:

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -5,9 +5,14 @@ import process from 'node:process'
 import {describe, expect, it, vi} from 'vitest'
 
 import {
+  DISPATCH_DEFAULTS,
   handleReconcile,
+  isSurveyStale,
+  loadDispatchStaggerFromEnv,
+  loadMaxDispatchesPerRunFromEnv,
   ReconcileError,
   reconcileRepos,
+  SURVEY_STALENESS_MS,
   type AccessListEntry,
   type HandleReconcileParams,
   type OctokitClient,
@@ -1771,6 +1776,142 @@ describe('handleReconcile (I/O shell)', () => {
         }
         if (savedApp !== undefined) process.env.GITHUB_TOKEN = savedApp
       }
+    })
+  })
+})
+
+describe('isSurveyStale', () => {
+  const JUST_BEFORE = SURVEY_STALENESS_MS - 1
+  const EXACTLY = SURVEY_STALENESS_MS
+  const JUST_AFTER = SURVEY_STALENESS_MS + 1
+
+  it('treats null as stale (never surveyed)', () => {
+    expect(isSurveyStale(null, new Date('2026-04-17T12:00:00Z'))).toBe(true)
+  })
+
+  it('treats a malformed date string as stale (recoverable corruption)', () => {
+    expect(isSurveyStale('not-a-date', new Date('2026-04-17T12:00:00Z'))).toBe(true)
+  })
+
+  it('treats exactly 30 days old as stale (inclusive boundary)', () => {
+    const anchor = new Date('2026-04-01T00:00:00Z')
+    const now = new Date(anchor.getTime() + EXACTLY)
+    expect(isSurveyStale('2026-04-01', now)).toBe(true)
+  })
+
+  it('treats just under 30 days as fresh', () => {
+    const anchor = new Date('2026-04-01T00:00:00Z')
+    const now = new Date(anchor.getTime() + JUST_BEFORE)
+    expect(isSurveyStale('2026-04-01', now)).toBe(false)
+  })
+
+  it('treats just over 30 days as stale', () => {
+    const anchor = new Date('2026-04-01T00:00:00Z')
+    const now = new Date(anchor.getTime() + JUST_AFTER)
+    expect(isSurveyStale('2026-04-01', now)).toBe(true)
+  })
+})
+
+describe('loadDispatchStaggerFromEnv', () => {
+  const ENV_KEY = 'RECONCILE_DISPATCH_STAGGER_MS'
+
+  function withEnv<T>(value: string | undefined, run: () => T): T {
+    const saved = process.env[ENV_KEY]
+    if (value === undefined) delete process.env[ENV_KEY]
+    else process.env[ENV_KEY] = value
+    try {
+      return run()
+    } finally {
+      if (saved === undefined) delete process.env[ENV_KEY]
+      else process.env[ENV_KEY] = saved
+    }
+  }
+
+  it('returns the default when unset', () => {
+    withEnv(undefined, () => {
+      expect(loadDispatchStaggerFromEnv()).toBe(DISPATCH_DEFAULTS.staggerMs)
+    })
+  })
+
+  it('returns the default when empty string', () => {
+    withEnv('', () => {
+      expect(loadDispatchStaggerFromEnv()).toBe(DISPATCH_DEFAULTS.staggerMs)
+    })
+  })
+
+  it('returns the default when non-numeric', () => {
+    withEnv('not-a-number', () => {
+      expect(loadDispatchStaggerFromEnv()).toBe(DISPATCH_DEFAULTS.staggerMs)
+    })
+  })
+
+  it('returns the parsed value within bounds', () => {
+    withEnv('12345', () => {
+      expect(loadDispatchStaggerFromEnv()).toBe(12345)
+    })
+  })
+
+  it('clamps negative values to 0', () => {
+    withEnv('-500', () => {
+      expect(loadDispatchStaggerFromEnv()).toBe(0)
+    })
+  })
+
+  it('clamps values over 300_000 to the 300s ceiling', () => {
+    withEnv('999999', () => {
+      expect(loadDispatchStaggerFromEnv()).toBe(300_000)
+    })
+  })
+})
+
+describe('loadMaxDispatchesPerRunFromEnv', () => {
+  const ENV_KEY = 'RECONCILE_MAX_DISPATCHES_PER_RUN'
+
+  function withEnv<T>(value: string | undefined, run: () => T): T {
+    const saved = process.env[ENV_KEY]
+    if (value === undefined) delete process.env[ENV_KEY]
+    else process.env[ENV_KEY] = value
+    try {
+      return run()
+    } finally {
+      if (saved === undefined) delete process.env[ENV_KEY]
+      else process.env[ENV_KEY] = saved
+    }
+  }
+
+  it('returns the default when unset', () => {
+    withEnv(undefined, () => {
+      expect(loadMaxDispatchesPerRunFromEnv()).toBe(DISPATCH_DEFAULTS.maxDispatchesPerRun)
+    })
+  })
+
+  it('returns the default when empty string', () => {
+    withEnv('', () => {
+      expect(loadMaxDispatchesPerRunFromEnv()).toBe(DISPATCH_DEFAULTS.maxDispatchesPerRun)
+    })
+  })
+
+  it('returns the default when non-numeric', () => {
+    withEnv('not-a-number', () => {
+      expect(loadMaxDispatchesPerRunFromEnv()).toBe(DISPATCH_DEFAULTS.maxDispatchesPerRun)
+    })
+  })
+
+  it('returns the parsed value as-is (positive)', () => {
+    withEnv('10', () => {
+      expect(loadMaxDispatchesPerRunFromEnv()).toBe(10)
+    })
+  })
+
+  it('returns 0 verbatim (disables the cap in the caller)', () => {
+    withEnv('0', () => {
+      expect(loadMaxDispatchesPerRunFromEnv()).toBe(0)
+    })
+  })
+
+  it('returns negative verbatim (disables the cap in the caller)', () => {
+    withEnv('-1', () => {
+      expect(loadMaxDispatchesPerRunFromEnv()).toBe(-1)
     })
   })
 })

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -368,12 +368,20 @@ describe('reconcileRepos', () => {
 
   describe('mixed and edge cases', () => {
     it('handles multiple simultaneous changes (new + lost + refresh) in one run', () => {
+      // Fresh surveys on both — not stale, so no re-survey dispatch from the staleness gate.
       const drift = makeEntry({
         name: 'drift-repo',
         onboarding_status: 'onboarded',
         has_renovate: false,
+        last_survey_at: '2026-04-10',
+        last_survey_status: 'success',
       })
-      const gone = makeEntry({name: 'gone-repo', onboarding_status: 'onboarded'})
+      const gone = makeEntry({
+        name: 'gone-repo',
+        onboarding_status: 'onboarded',
+        last_survey_at: '2026-04-10',
+        last_survey_status: 'success',
+      })
 
       const result = reconcileRepos(
         makeInput({
@@ -672,6 +680,9 @@ function baseParams(overrides: Partial<HandleReconcileParams> = {}): HandleRecon
       (vi.fn(async () => ({created: false, ref: 'refs/heads/data', sha: 'data-sha'})) as never),
     dispatchTimeoutMs: overrides.dispatchTimeoutMs ?? 100,
     dispatchStaggerMs: overrides.dispatchStaggerMs ?? 0,
+    // Tests default to the cap disabled so existing dispatch-count assertions remain valid.
+    // Specific tests that exercise the cap override this.
+    maxDispatchesPerRun: overrides.maxDispatchesPerRun ?? 0,
     dispatchSleep: overrides.dispatchSleep,
     operatorLogins: overrides.operatorLogins ?? [],
     logger: overrides.logger ?? silentLogger(),
@@ -816,11 +827,14 @@ describe('handleReconcile (I/O shell)', () => {
       const existing: ReposFile = {
         version: 1,
         repos: [
+          // Fresh survey — not stale, so the test isolates the field-probe behavior.
           makeEntry({
             name: 'probe-fail-repo',
             onboarding_status: 'onboarded',
             has_fro_bot_workflow: true,
             has_renovate: true,
+            last_survey_at: '2026-04-10',
+            last_survey_status: 'success',
           }),
         ],
       }
@@ -1031,6 +1045,164 @@ describe('handleReconcile (I/O shell)', () => {
       expect(dispatchCalls).toEqual(['r1', 'r2', 'r3'])
       expect(result.dispatches).toBe(2)
       expect(result.dispatchesFailed).toBe(1)
+    })
+  })
+
+  describe('dispatch prioritization and cap', () => {
+    it('dispatches repos with null last_survey_at before any previously-surveyed repo', async () => {
+      // Mixed access list: two never-surveyed (r1, r3), one already surveyed (r2).
+      // Cap of 2 forces the engine to drop one candidate; the dropped candidate MUST
+      // be the already-surveyed one because progressive runs prioritize fresh coverage.
+      const dispatchCalls: string[] = []
+      const createWorkflowDispatch = vi.fn(async (params: unknown) => {
+        const typed = params as {inputs?: {repo: string}}
+        dispatchCalls.push(typed.inputs?.repo ?? '?')
+      })
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {owner: {login: 't'}, name: 'r1', archived: false, private: false, node_id: 'R_1'},
+            {owner: {login: 't'}, name: 'r2', archived: false, private: false, node_id: 'R_2'},
+            {owner: {login: 't'}, name: 'r3', archived: false, private: false, node_id: 'R_3'},
+          ],
+        }),
+      })
+
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({createWorkflowDispatch}),
+          readMetadata: makeReadMetadata({
+            allowlist: makeAllowlist(['t']),
+            repos: {
+              version: 1,
+              repos: [
+                {
+                  // Stale survey (>30d old against NOW=2026-04-17) so r2 is a dispatch
+                  // candidate alongside the null-last-survey-at r1 and r3.
+                  owner: 't',
+                  name: 'r2',
+                  added: '2026-02-01',
+                  onboarding_status: 'onboarded',
+                  last_survey_at: '2026-02-01',
+                  last_survey_status: 'success',
+                  has_fro_bot_workflow: false,
+                  has_renovate: false,
+                },
+              ],
+            },
+          }),
+          commitMetadata: vi.fn(async () => ({committed: true, sha: 's', attempts: 1})) as never,
+          maxDispatchesPerRun: 2,
+        }),
+      )
+
+      expect(dispatchCalls).toEqual(['r1', 'r3'])
+      expect(result.dispatches).toBe(2)
+      expect(result.dispatchesDeferred).toBe(1)
+    })
+
+    it('among repos with non-null last_survey_at, dispatches oldest first', async () => {
+      // Three repos all previously surveyed: oldest (r-old), middle (r-mid), newest (r-new).
+      // Cap of 2 selects the two oldest; newest is deferred to the next run.
+      const dispatchCalls: string[] = []
+      const createWorkflowDispatch = vi.fn(async (params: unknown) => {
+        const typed = params as {inputs?: {repo: string}}
+        dispatchCalls.push(typed.inputs?.repo ?? '?')
+      })
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {owner: {login: 't'}, name: 'r-old', archived: false, private: false, node_id: 'R_old'},
+            {owner: {login: 't'}, name: 'r-mid', archived: false, private: false, node_id: 'R_mid'},
+            {owner: {login: 't'}, name: 'r-new', archived: false, private: false, node_id: 'R_new'},
+          ],
+        }),
+      })
+
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({createWorkflowDispatch}),
+          readMetadata: makeReadMetadata({
+            allowlist: makeAllowlist(['t']),
+            repos: {
+              version: 1,
+              repos: [
+                {
+                  owner: 't',
+                  name: 'r-old',
+                  added: '2026-01-01',
+                  onboarding_status: 'onboarded',
+                  last_survey_at: '2026-01-15',
+                  last_survey_status: 'success',
+                  has_fro_bot_workflow: false,
+                  has_renovate: false,
+                },
+                {
+                  owner: 't',
+                  name: 'r-mid',
+                  added: '2026-02-01',
+                  onboarding_status: 'onboarded',
+                  last_survey_at: '2026-02-15',
+                  last_survey_status: 'success',
+                  has_fro_bot_workflow: false,
+                  has_renovate: false,
+                },
+                {
+                  owner: 't',
+                  name: 'r-new',
+                  added: '2026-03-01',
+                  onboarding_status: 'onboarded',
+                  last_survey_at: '2026-03-15',
+                  last_survey_status: 'success',
+                  has_fro_bot_workflow: false,
+                  has_renovate: false,
+                },
+              ],
+            },
+          }),
+          commitMetadata: vi.fn(async () => ({committed: true, sha: 's', attempts: 1})) as never,
+          maxDispatchesPerRun: 2,
+        }),
+      )
+
+      expect(dispatchCalls).toEqual(['r-old', 'r-mid'])
+      expect(result.dispatches).toBe(2)
+      expect(result.dispatchesDeferred).toBe(1)
+    })
+
+    it('treats cap <= 0 as disabled (dispatches all eligible candidates)', async () => {
+      // Six never-surveyed repos + cap of 0 (disabled) → all six dispatch.
+      const dispatchCount = {n: 0}
+      const createWorkflowDispatch = vi.fn(async () => {
+        dispatchCount.n += 1
+      })
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: Array.from({length: 6}, (_, i) => ({
+            owner: {login: 't'},
+            name: `r${i + 1}`,
+            archived: false,
+            private: false,
+            node_id: `R_${i + 1}`,
+          })),
+        }),
+      })
+
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({createWorkflowDispatch}),
+          readMetadata: makeReadMetadata({allowlist: makeAllowlist(['t'])}),
+          commitMetadata: vi.fn(async () => ({committed: true, sha: 's', attempts: 1})) as never,
+          maxDispatchesPerRun: 0,
+        }),
+      )
+
+      expect(dispatchCount.n).toBe(6)
+      expect(result.dispatches).toBe(6)
+      expect(result.dispatchesDeferred).toBe(0)
     })
   })
 

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -299,7 +299,7 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
 
   // Still-accessible tracked entry.
   //
-  // Periodic re-survey: onboarded entries whose `last_survey_at` is null or older than
+  // Periodic re-survey: onboarded entries whose `last_survey_at` is null or has reached
   // the staleness threshold become dispatch candidates. The actual dispatch may still be
   // deferred by the per-run cap; entries that are genuinely fresh never become candidates
   // so they don't compete for dispatch slots.
@@ -327,12 +327,27 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
 }
 
 /**
- * Milliseconds in the staleness window. Entries whose `last_survey_at` is older than
- * this (or null) are eligible for a re-survey dispatch.
+ * Staleness threshold for survey re-dispatch. Entries are stale (and therefore candidates
+ * for re-survey) when `last_survey_at` is null or when the elapsed time since
+ * `last_survey_at` is 30 days or more. `last_survey_at` is an ISO calendar date, so
+ * "elapsed time" is measured from midnight UTC of that date.
+ *
+ * Exposed for test-only boundary pinning; production callers use the full reconcile flow.
  */
-const SURVEY_STALENESS_MS = 30 * 24 * 60 * 60 * 1000
+export const SURVEY_STALENESS_MS = 30 * 24 * 60 * 60 * 1000
 
-function isSurveyStale(lastSurveyAt: string | null, now: Date): boolean {
+/**
+ * Return true when the entry should be a candidate for the next survey dispatch.
+ *
+ * Boundary semantics: an entry surveyed exactly {@link SURVEY_STALENESS_MS} ago is stale
+ * (inclusive threshold). This keeps the daily cron predictable — a repo last surveyed at
+ * midnight UTC on day D is re-eligible at the day-D+30 cron run, not day-D+31.
+ *
+ * A null `last_survey_at` signals "never surveyed" and is always stale. A malformed date
+ * string is also treated as stale so recoverable metadata corruption doesn't silently
+ * suppress coverage.
+ */
+export function isSurveyStale(lastSurveyAt: string | null, now: Date): boolean {
   if (lastSurveyAt === null) return true
   const lastMs = Date.parse(`${lastSurveyAt}T00:00:00Z`)
   if (!Number.isFinite(lastMs)) return true
@@ -1133,8 +1148,11 @@ async function defaultSleep(ms: number): Promise<void> {
  * Parse `RECONCILE_DISPATCH_STAGGER_MS` from env. Returns the default when unset, empty,
  * or non-numeric. Negative values clamp to 0 (no stagger). Upper-bounded at 300s (5 min)
  * to prevent accidental workflow-timeout triggers from bad operator config.
+ *
+ * Exported for direct env-parsing tests; production callers use it implicitly via
+ * {@link HandleReconcileParams.dispatchStaggerMs}.
  */
-function loadDispatchStaggerFromEnv(): number {
+export function loadDispatchStaggerFromEnv(): number {
   const raw = process.env.RECONCILE_DISPATCH_STAGGER_MS
   if (raw === undefined || raw === '') return DEFAULT_DISPATCH_STAGGER_MS
   const parsed = Number.parseInt(raw, 10)
@@ -1148,14 +1166,26 @@ function loadDispatchStaggerFromEnv(): number {
  * Parse `RECONCILE_MAX_DISPATCHES_PER_RUN` from env. Returns the default when unset, empty,
  * or non-numeric. A value of 0 or negative disables the cap (dispatch all eligible
  * candidates, matching pre-cap behavior).
+ *
+ * Exported for direct env-parsing tests; production callers use it implicitly via
+ * {@link HandleReconcileParams.maxDispatchesPerRun}.
  */
-function loadMaxDispatchesPerRunFromEnv(): number {
+export function loadMaxDispatchesPerRunFromEnv(): number {
   const raw = process.env.RECONCILE_MAX_DISPATCHES_PER_RUN
   if (raw === undefined || raw === '') return DEFAULT_MAX_DISPATCHES_PER_RUN
   const parsed = Number.parseInt(raw, 10)
   if (!Number.isFinite(parsed)) return DEFAULT_MAX_DISPATCHES_PER_RUN
   return parsed
 }
+
+/**
+ * Internal default exposed for test parity with {@link loadDispatchStaggerFromEnv}
+ * and {@link loadMaxDispatchesPerRunFromEnv}.
+ */
+export const DISPATCH_DEFAULTS = {
+  staggerMs: DEFAULT_DISPATCH_STAGGER_MS,
+  maxDispatchesPerRun: DEFAULT_MAX_DISPATCHES_PER_RUN,
+} as const
 
 async function dispatchWithTimeout<T>(work: () => Promise<T>, timeoutMs: number): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -175,6 +175,7 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
       summary,
       dispatches,
       rawIssues,
+      now,
     })
   })
 
@@ -231,6 +232,7 @@ interface ClassifyTrackedParams {
   summary: ReconcileSummary
   dispatches: DispatchRequest[]
   rawIssues: RawIssue[]
+  now: Date
 }
 
 /**
@@ -295,7 +297,17 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
     return {...entry, onboarding_status: nextStatus}
   }
 
-  // Still-accessible tracked entry — apply field refresh if the probe disagrees.
+  // Still-accessible tracked entry.
+  //
+  // Periodic re-survey: onboarded entries whose `last_survey_at` is null or older than
+  // the staleness threshold become dispatch candidates. The actual dispatch may still be
+  // deferred by the per-run cap; entries that are genuinely fresh never become candidates
+  // so they don't compete for dispatch slots.
+  if (entry.onboarding_status === 'onboarded' && isSurveyStale(entry.last_survey_at, params.now)) {
+    dispatches.push({owner: entry.owner, repo: entry.name})
+  }
+
+  // Field refresh: apply probe results when they disagree with tracked fields.
   const probe = fieldProbes.get(key)
   if (probe === undefined) {
     // No probe data — preserve existing field values (do not overwrite with undefined).
@@ -312,6 +324,19 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
     has_fro_bot_workflow: probe.has_fro_bot_workflow,
     has_renovate: probe.has_renovate,
   }
+}
+
+/**
+ * Milliseconds in the staleness window. Entries whose `last_survey_at` is older than
+ * this (or null) are eligible for a re-survey dispatch.
+ */
+const SURVEY_STALENESS_MS = 30 * 24 * 60 * 60 * 1000
+
+function isSurveyStale(lastSurveyAt: string | null, now: Date): boolean {
+  if (lastSurveyAt === null) return true
+  const lastMs = Date.parse(`${lastSurveyAt}T00:00:00Z`)
+  if (!Number.isFinite(lastMs)) return true
+  return now.getTime() - lastMs >= SURVEY_STALENESS_MS
 }
 
 interface RawIssue {
@@ -420,17 +445,32 @@ const DEFAULT_WORKFLOW_FILE = 'survey-repo.yaml'
 const DEFAULT_WORKFLOW_REF = 'main'
 const DEFAULT_DISPATCH_TIMEOUT_MS = 15_000
 /**
- * Delay (ms) inserted between consecutive Survey Repo dispatches. Surveys share a single
- * Claude max20 OAuth seat via cliproxy.fro.bot and saturate upstream Anthropic rate limits
- * when dispatched concurrently (see marcusrbrown/infra#144 diagnosis). Staggering spreads
- * LLM context-window kickoff over time without exceeding the 10-minute workflow job
- * timeout for any realistic access-list size.
+ * Delay (ms) inserted between consecutive Survey Repo dispatches.
  *
- * Default: 8s between dispatches → ~2 minutes to fan out 16 surveys, well under the
- * 10-minute cap even if the access list grows to 50+ entries. Override via
- * `RECONCILE_DISPATCH_STAGGER_MS` env var or `dispatchStaggerMs` param. Tests pass 0.
+ * Surveys share a single upstream LLM seat through cliproxy.fro.bot. Concurrent kickoffs
+ * saturate upstream rate limits (see marcusrbrown/infra#144). Staggering the starts gives
+ * each survey's session breathing room to progress through its LLM calls before the next
+ * one begins.
+ *
+ * Default: 90s between dispatches. Combined with {@link DEFAULT_MAX_DISPATCHES_PER_RUN}
+ * this keeps the full fan-out inside the workflow job timeout even when the access list
+ * grows. Override via `RECONCILE_DISPATCH_STAGGER_MS` env var or `dispatchStaggerMs` param.
+ * Tests pass 0.
  */
-const DEFAULT_DISPATCH_STAGGER_MS = 8_000
+const DEFAULT_DISPATCH_STAGGER_MS = 90_000
+/**
+ * Maximum number of Survey Repo dispatches fired in a single reconcile run.
+ *
+ * Each survey run consumes upstream LLM capacity for ~5 minutes. Limiting dispatches per
+ * run keeps the scheduled job inside its timeout and bounds peak concurrent surveys to a
+ * level the single OAuth seat can sustain. Skipped candidates are dispatched on subsequent
+ * runs once the staleness gate makes them eligible again.
+ *
+ * Default: 6 dispatches. Override via `RECONCILE_MAX_DISPATCHES_PER_RUN` env var or
+ * `maxDispatchesPerRun` param. A value of 0 or negative disables the cap (dispatch all
+ * eligible candidates).
+ */
+const DEFAULT_MAX_DISPATCHES_PER_RUN = 6
 
 const PENDING_REVIEW_LABEL = 'reconcile:pending-review'
 const ROLLUP_LABEL = 'reconcile:rollup-pending-review'
@@ -486,10 +526,16 @@ export interface HandleReconcileParams {
   dispatchTimeoutMs?: number
   /**
    * Delay (ms) inserted between consecutive dispatches to avoid concurrent LLM requests
-   * against the shared Claude OAuth seat. Default 8_000 (see `DEFAULT_DISPATCH_STAGGER_MS`).
+   * against the shared upstream seat. Default {@link DEFAULT_DISPATCH_STAGGER_MS}.
    * Tests should pass 0 for speed; workflow env can override via `RECONCILE_DISPATCH_STAGGER_MS`.
    */
   dispatchStaggerMs?: number
+  /**
+   * Maximum number of dispatches fired in this run. Skipped candidates are eligible again
+   * on the next run. Default {@link DEFAULT_MAX_DISPATCHES_PER_RUN}. A value of 0 or
+   * negative disables the cap.
+   */
+  maxDispatchesPerRun?: number
   /**
    * Sleep implementation used by the dispatch loop. Test-only injection point — production
    * uses `setTimeout`-backed Promise. Tests replace with a mock to verify stagger without
@@ -508,6 +554,11 @@ export interface HandleReconcileResult {
   dispatches: number
   /** Count of dispatch failures (timed out, HTTP error, etc.). */
   dispatchesFailed: number
+  /**
+   * Count of dispatch candidates deferred to a future run because this run hit the
+   * `maxDispatchesPerRun` cap. Zero when every eligible candidate was dispatched.
+   */
+  dispatchesDeferred: number
   /** Count of successfully-created per-repo issues from reconcile's classification plan. */
   perRepoIssues: number
   /** Count of successfully-created rollup issues (from plan + self-healing). */
@@ -542,6 +593,7 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
   const now = params.now ?? new Date()
   const dispatchTimeoutMs = params.dispatchTimeoutMs ?? DEFAULT_DISPATCH_TIMEOUT_MS
   const dispatchStaggerMs = params.dispatchStaggerMs ?? loadDispatchStaggerFromEnv()
+  const maxDispatchesPerRun = params.maxDispatchesPerRun ?? loadMaxDispatchesPerRunFromEnv()
   const logger: ReconcileLogger = params.logger ?? {warn: message => process.stderr.write(`${message}\n`)}
   const operatorLogins = params.operatorLogins ?? loadOperatorLoginsFromEnv()
   const readMetadata = params.readMetadata ?? readMetadataFromDisk
@@ -653,7 +705,16 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
     committed = commitResult.committed
   }
 
-  // 9. Dispatch loop (serial, non-blocking on failure, wrapped in a per-call timeout).
+  // 9. Dispatch loop. Prioritize candidates with null `last_survey_at` first
+  //    (never surveyed), then oldest `last_survey_at` first. Cap at
+  //    `maxDispatchesPerRun` so a single run stays inside the workflow job budget and
+  //    bounds peak concurrent surveys against the shared upstream seat. Deferred
+  //    candidates become eligible again on the next run via the staleness gate.
+  const prioritizedDispatches = prioritizeDispatches(plan.dispatches, plan.nextRepos.repos)
+  const dispatchCap = maxDispatchesPerRun > 0 ? maxDispatchesPerRun : prioritizedDispatches.length
+  const selectedDispatches = prioritizedDispatches.slice(0, dispatchCap)
+  const dispatchesDeferred = prioritizedDispatches.length - selectedDispatches.length
+
   const dispatchOutcome = await runDispatches({
     staggerMs: dispatchStaggerMs,
     sleep: params.dispatchSleep,
@@ -662,7 +723,7 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
     repo,
     workflowFile,
     workflowRef,
-    dispatches: plan.dispatches,
+    dispatches: selectedDispatches,
     timeoutMs: dispatchTimeoutMs,
     logger,
   })
@@ -702,6 +763,7 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
     summary: plan.summary,
     dispatches: dispatchOutcome.succeeded,
     dispatchesFailed: dispatchOutcome.failed,
+    dispatchesDeferred,
     perRepoIssues: issueOutcome.perRepoSucceeded,
     rollupIssues: issueOutcome.rollupSucceeded + healedRollups,
     issuesFailed: issueOutcome.failed,
@@ -710,6 +772,34 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
     integrityCheck,
     committed,
   }
+}
+
+/**
+ * Order dispatch candidates by survey freshness: repos that have never been surveyed go
+ * first, then oldest `last_survey_at` first. Ties break on `owner/name` for determinism
+ * so the cap selects the same slice across reruns.
+ */
+function prioritizeDispatches(dispatches: DispatchRequest[], nextRepos: ReposFile['repos']): DispatchRequest[] {
+  const lookup = new Map<string, string | null>()
+  for (const entry of nextRepos) {
+    lookup.set(`${entry.owner}/${entry.name}`, entry.last_survey_at)
+  }
+
+  return [...dispatches].sort((left, right) => {
+    const leftKey = `${left.owner}/${left.repo}`
+    const rightKey = `${right.owner}/${right.repo}`
+    const leftAt = lookup.get(leftKey) ?? null
+    const rightAt = lookup.get(rightKey) ?? null
+
+    // Null (never surveyed) comes before any date.
+    if (leftAt === null && rightAt !== null) return -1
+    if (rightAt === null && leftAt !== null) return 1
+    if (leftAt !== null && rightAt !== null && leftAt !== rightAt) {
+      return leftAt.localeCompare(rightAt)
+    }
+    // Deterministic tiebreak.
+    return leftKey.localeCompare(rightKey)
+  })
 }
 
 /**
@@ -1041,8 +1131,8 @@ async function defaultSleep(ms: number): Promise<void> {
 
 /**
  * Parse `RECONCILE_DISPATCH_STAGGER_MS` from env. Returns the default when unset, empty,
- * or non-numeric. Negative values clamp to 0 (no stagger). Upper-bounded at 60s to prevent
- * accidental workflow-timeout triggers from bad operator config.
+ * or non-numeric. Negative values clamp to 0 (no stagger). Upper-bounded at 300s (5 min)
+ * to prevent accidental workflow-timeout triggers from bad operator config.
  */
 function loadDispatchStaggerFromEnv(): number {
   const raw = process.env.RECONCILE_DISPATCH_STAGGER_MS
@@ -1050,7 +1140,20 @@ function loadDispatchStaggerFromEnv(): number {
   const parsed = Number.parseInt(raw, 10)
   if (!Number.isFinite(parsed)) return DEFAULT_DISPATCH_STAGGER_MS
   if (parsed < 0) return 0
-  if (parsed > 60_000) return 60_000
+  if (parsed > 300_000) return 300_000
+  return parsed
+}
+
+/**
+ * Parse `RECONCILE_MAX_DISPATCHES_PER_RUN` from env. Returns the default when unset, empty,
+ * or non-numeric. A value of 0 or negative disables the cap (dispatch all eligible
+ * candidates, matching pre-cap behavior).
+ */
+function loadMaxDispatchesPerRunFromEnv(): number {
+  const raw = process.env.RECONCILE_MAX_DISPATCHES_PER_RUN
+  if (raw === undefined || raw === '') return DEFAULT_MAX_DISPATCHES_PER_RUN
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed)) return DEFAULT_MAX_DISPATCHES_PER_RUN
   return parsed
 }
 

--- a/scripts/record-survey-result.ts
+++ b/scripts/record-survey-result.ts
@@ -1,0 +1,97 @@
+import process from 'node:process'
+
+import {commitMetadata} from './commit-metadata.ts'
+import {recordSurveyResult, RepoEntryNotFoundError} from './repos-metadata.ts'
+
+/**
+ * Write the outcome of a Survey Repo run back to `metadata/repos.yaml` on the `data` branch.
+ *
+ * Survey workflows call this after the agent completes and the wiki commit step finishes.
+ * Writing `last_survey_at` + `last_survey_status` here is what lets reconcile's staleness
+ * gate (`>30d since last survey`) distinguish fresh surveys from stale ones.
+ *
+ * Inputs (env vars):
+ *   REPO_OWNER        — target repository owner (e.g. "marcusrbrown")
+ *   REPO_NAME         — target repository name (e.g. ".dotfiles")
+ *   SURVEY_STATUS     — "success" | "failure"
+ *   SURVEY_AT         — ISO 8601 timestamp; defaults to "now" if absent
+ *   GITHUB_TOKEN      — FRO_BOT_PAT (writes to `data`; classic PAT with repo scope)
+ *   GITHUB_REPOSITORY — caller-supplied "owner/name" of the control-plane repo hosting
+ *                       metadata/repos.yaml (GitHub Actions sets this automatically).
+ *
+ * Writes to: `metadata/repos.yaml` on the `data` branch via `commitMetadata`. Exits 0 on
+ * success, non-zero with a typed error on failure. When the survey target has no entry in
+ * `metadata/repos.yaml`, writes nothing and exits 0 with a warning (the entry must already
+ * exist — reconcile is the canonical writer for new entries).
+ */
+async function main(): Promise<void> {
+  const owner = requiredEnv('REPO_OWNER')
+  const name = requiredEnv('REPO_NAME')
+  const status = parseStatus(requiredEnv('SURVEY_STATUS'))
+  const at = parseAt(process.env.SURVEY_AT)
+  const [controlPlaneOwner, controlPlaneRepo] = splitControlPlane(requiredEnv('GITHUB_REPOSITORY'))
+
+  const result = await commitMetadata({
+    owner: controlPlaneOwner,
+    repo: controlPlaneRepo,
+    path: 'metadata/repos.yaml',
+    message: `chore(reconcile): record survey ${status} for ${owner}/${name}`,
+    mutator: (current: unknown) => recordSurveyResult(current, {owner, repo: name, at, status}),
+  })
+
+  if (result.committed) {
+    process.stdout.write(
+      `${JSON.stringify({committed: true, sha: result.sha, attempts: result.attempts, owner, name, status})}\n`,
+    )
+    return
+  }
+
+  // No-op commit (mutator returned the same file) — valid when status + date already match.
+  process.stdout.write(`${JSON.stringify({committed: false, attempts: result.attempts, owner, name, status})}\n`)
+}
+
+function parseStatus(raw: string): 'success' | 'failure' {
+  if (raw === 'success' || raw === 'failure') return raw
+  throw new Error(`SURVEY_STATUS must be 'success' or 'failure', got '${raw}'`)
+}
+
+function parseAt(raw: string | undefined): Date {
+  if (raw === undefined || raw === '') return new Date()
+  const parsed = new Date(raw)
+  if (Number.isNaN(parsed.getTime())) {
+    throw new TypeError(`SURVEY_AT is not a parseable date: '${raw}'`)
+  }
+  return parsed
+}
+
+function splitControlPlane(raw: string): [string, string] {
+  const [owner, repo] = raw.split('/')
+  if (owner === undefined || repo === undefined || owner === '' || repo === '') {
+    throw new Error(`GITHUB_REPOSITORY must be 'owner/name', got '${raw}'`)
+  }
+  return [owner, repo]
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]
+  if (value === undefined || value === '') {
+    throw new Error(`${name} is required`)
+  }
+  return value
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    await main()
+  } catch (error: unknown) {
+    // Surface the common "entry not found" error as a non-fatal warning — it means reconcile
+    // hasn't added the repo yet, which is legitimate when a manual survey dispatch runs
+    // against an un-onboarded repo. Exit 0 so the workflow doesn't mark the run as failed.
+    if (error instanceof RepoEntryNotFoundError) {
+      process.stderr.write(`record-survey-result: ${error.message}; skipping (non-fatal)\n`)
+      process.exit(0)
+    }
+    process.stderr.write(`record-survey-result: ${error instanceof Error ? error.message : String(error)}\n`)
+    process.exit(1)
+  }
+}

--- a/scripts/repos-metadata.test.ts
+++ b/scripts/repos-metadata.test.ts
@@ -1,7 +1,7 @@
 import type {ReposFile} from './schemas.ts'
 
 import {describe, expect, it} from 'vitest'
-import {addRepoEntry} from './repos-metadata.ts'
+import {addRepoEntry, recordSurveyResult, RepoEntryNotFoundError} from './repos-metadata.ts'
 
 const EMPTY_REPOS: ReposFile = {version: 1, repos: []}
 const NOW = new Date('2026-04-17T12:00:00Z')
@@ -158,5 +158,152 @@ describe('addRepoEntry', () => {
     expect(result.repos[0]?.name).toBe('first')
     expect(result.repos[1]?.name).toBe('second')
     expect(result.repos[2]?.name).toBe('third')
+  })
+})
+
+describe('recordSurveyResult', () => {
+  // Behavioral contract: writes ISO date + status on a matching entry
+  it('writes last_survey_at (ISO date) and last_survey_status when the entry exists', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [
+        {
+          owner: 'alice',
+          name: 'project',
+          added: '2026-04-17',
+          onboarding_status: 'onboarded',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+        },
+      ],
+    }
+
+    const result = recordSurveyResult(current, {
+      owner: 'alice',
+      repo: 'project',
+      at: new Date('2026-04-18T05:34:00Z'),
+      status: 'success',
+    })
+
+    expect(result.repos[0]?.last_survey_at).toBe('2026-04-18')
+    expect(result.repos[0]?.last_survey_status).toBe('success')
+  })
+
+  // Behavioral contract: pure — original input unchanged
+  it('does not mutate the input file', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [
+        {
+          owner: 'alice',
+          name: 'project',
+          added: '2026-04-17',
+          onboarding_status: 'onboarded',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+        },
+      ],
+    }
+
+    const snapshot = structuredClone(current)
+    recordSurveyResult(current, {
+      owner: 'alice',
+      repo: 'project',
+      at: NOW,
+      status: 'success',
+    })
+
+    expect(current).toEqual(snapshot)
+  })
+
+  // Behavioral contract: preserves sibling entries unchanged
+  it('preserves other entries verbatim while updating only the match', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [
+        {
+          owner: 'alice',
+          name: 'first',
+          added: '2026-04-01',
+          onboarding_status: 'onboarded',
+          last_survey_at: '2026-04-02',
+          last_survey_status: 'success',
+          has_fro_bot_workflow: true,
+          has_renovate: true,
+        },
+        {
+          owner: 'bob',
+          name: 'second',
+          added: '2026-04-15',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+        },
+      ],
+    }
+
+    const result = recordSurveyResult(current, {
+      owner: 'bob',
+      repo: 'second',
+      at: new Date('2026-04-18T00:00:00Z'),
+      status: 'success',
+    })
+
+    // First entry untouched
+    expect(result.repos[0]).toEqual(current.repos[0])
+    // Second entry updated
+    expect(result.repos[1]?.last_survey_at).toBe('2026-04-18')
+    expect(result.repos[1]?.last_survey_status).toBe('success')
+    // Other fields on the updated entry preserved
+    expect(result.repos[1]?.onboarding_status).toBe('pending')
+    expect(result.repos[1]?.added).toBe('2026-04-15')
+  })
+
+  // Behavioral contract: records failure outcomes too
+  it("accepts 'failure' as a valid status value", () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [
+        {
+          owner: 'alice',
+          name: 'project',
+          added: '2026-04-17',
+          onboarding_status: 'onboarded',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+        },
+      ],
+    }
+
+    const result = recordSurveyResult(current, {
+      owner: 'alice',
+      repo: 'project',
+      at: NOW,
+      status: 'failure',
+    })
+
+    expect(result.repos[0]?.last_survey_status).toBe('failure')
+  })
+
+  // Behavioral contract: typed error when the entry is missing
+  it('throws RepoEntryNotFoundError when the target repo has no entry', () => {
+    const current: ReposFile = {version: 1, repos: []}
+
+    expect(() =>
+      recordSurveyResult(current, {
+        owner: 'ghost',
+        repo: 'nowhere',
+        at: NOW,
+        status: 'success',
+      }),
+    ).toThrow(RepoEntryNotFoundError)
   })
 })

--- a/scripts/repos-metadata.ts
+++ b/scripts/repos-metadata.ts
@@ -1,14 +1,12 @@
 /**
  * Shared helpers for `metadata/repos.yaml` mutation.
  *
- * Any script that adds entries to the repos file should use `addRepoEntry` so every writer
- * produces byte-compatible entry shapes. `addRepoEntry` is for NEW entries only; it is
- * idempotent on duplicate `owner+name` and preserves the existing entry as-is (it does NOT
- * update status of existing entries — callers that need status transitions should produce
- * fresh entries inline, since a generic "update status" helper would obscure intent).
+ * Writers that add entries use `addRepoEntry`; writers that record survey outcomes use
+ * `recordSurveyResult`. Both are pure functions that never mutate inputs. `addRepoEntry`
+ * is idempotent on duplicate `owner+name` and preserves existing entries as-is.
  */
 
-import {assertReposFile, type OnboardingStatus, type ReposFile} from './schemas.ts'
+import {assertReposFile, type OnboardingStatus, type ReposFile, type SurveyStatus} from './schemas.ts'
 
 export interface AddRepoEntryInput {
   owner: string
@@ -53,5 +51,66 @@ export function addRepoEntry(current: unknown, input: AddRepoEntryInput): ReposF
         has_renovate: false,
       },
     ],
+  }
+}
+
+export interface RecordSurveyResultInput {
+  owner: string
+  repo: string
+  at: Date
+  status: SurveyStatus
+}
+
+/**
+ * Record the outcome of a Survey Repo run against an existing entry.
+ *
+ * Updates `last_survey_at` to the ISO date of `input.at` and `last_survey_status` to
+ * `input.status`. Throws `RepoEntryNotFoundError` when the entry is missing — callers must
+ * ensure the entry exists (typically via a prior reconcile run that called `addRepoEntry`).
+ *
+ * Reconcile's `>30d since last survey` staleness gate only engages when survey workflows
+ * write their outcome back here. Without this write-back, reconcile treats every repo as
+ * never-surveyed and re-dispatches the full access list every run.
+ *
+ * Pure function: never mutates `current` in place. Returns a fresh top-level object with a
+ * fresh `repos` array.
+ */
+export function recordSurveyResult(current: unknown, input: RecordSurveyResultInput): ReposFile {
+  assertReposFile(current, 'repos')
+
+  const matchIndex = current.repos.findIndex(entry => entry.owner === input.owner && entry.name === input.repo)
+  if (matchIndex === -1) {
+    throw new RepoEntryNotFoundError(input.owner, input.repo)
+  }
+
+  const match = current.repos[matchIndex]
+  if (match === undefined) {
+    throw new RepoEntryNotFoundError(input.owner, input.repo)
+  }
+
+  const updated = {
+    ...match,
+    last_survey_at: input.at.toISOString().slice(0, 10),
+    last_survey_status: input.status,
+  }
+
+  const nextRepos = [...current.repos]
+  nextRepos[matchIndex] = updated
+
+  return {
+    ...current,
+    repos: nextRepos,
+  }
+}
+
+export class RepoEntryNotFoundError extends Error {
+  readonly code = 'REPO_ENTRY_NOT_FOUND'
+
+  constructor(
+    readonly owner: string,
+    readonly repo: string,
+  ) {
+    super(`metadata/repos.yaml has no entry for ${owner}/${repo}`)
+    this.name = 'RepoEntryNotFoundError'
   }
 }


### PR DESCRIPTION
## Summary

Turn reconcile's dispatch loop from a bursty fan-out into a progressive cadence that day-over-day covers the full access list without saturating upstream LLM capacity.

Today, reconcile dispatches every allowlisted access-list entry in a single run. With the access list at 19 tracked repos and survey runs holding upstream LLM capacity for ~5 minutes each, concurrent dispatches exhaust the shared seat almost immediately (15 of 16 failed on the first real production fan-out). A longer stagger helps but isn't enough on its own — at 90s between dispatches and 16 candidates the workflow would run for ~24 minutes, outside any reasonable job timeout.

The fix composes three changes:

### 1. Staleness gate in the reconcile engine

Onboarded tracked entries become dispatch candidates only when `last_survey_at` is null (never surveyed) or older than 30 days. Entries surveyed within the last 30 days stay out of the dispatch pool entirely.

### 2. Prioritized and capped dispatch in the I/O shell

Candidates are ordered by:
1. Null `last_survey_at` first (never-surveyed repos get fresh coverage before anything else)
2. Oldest `last_survey_at` second (oldest survey gets refreshed before a more recent one)
3. Deterministic tiebreak on `owner/name` (so cap selects the same slice across reruns)

Then truncated to `maxDispatchesPerRun` (default 6). Deferred candidates reappear in the next run's pool and are dispatched then.

### 3. Stagger bumped to 90s; workflow timeout to 15 min

Each survey holds upstream capacity for ~5 min, so the stagger now exceeds each survey's startup cost window rather than fighting it. Combined with the cap of 6, a full fan-out takes 5 × 90s = 7.5 minutes, well inside the bumped 15-minute timeout.

### F3-adjacent: survey result write-back

None of the above works without the missing piece: the staleness gate only engages when survey workflows write `last_survey_at` and `last_survey_status` back to `metadata/repos.yaml` after completing. This PR adds that write-back as a new Survey Repo workflow step (`Record survey result`) calling a new `scripts/record-survey-result.ts` CLI, which uses a new pure `recordSurveyResult()` helper in `scripts/repos-metadata.ts`.

Without this, reconcile sees every repo as never-surveyed forever and re-dispatches the full access list every run — the behavior the first two production reconcile runs exhibited.

## API changes

### `scripts/reconcile-repos.ts`

- New param: `maxDispatchesPerRun?: number` (default 6; value <= 0 disables the cap).
- New env: `RECONCILE_MAX_DISPATCHES_PER_RUN`.
- Updated default: `RECONCILE_DISPATCH_STAGGER_MS` default 8_000 → 90_000; upper clamp 60_000 → 300_000.
- New result field: `dispatchesDeferred` (count of cap-deferred candidates for observability).

### `scripts/repos-metadata.ts`

- New export: `recordSurveyResult(current, {owner, repo, at, status})` — pure mutator that updates `last_survey_at` + `last_survey_status` on a matching entry, or throws `RepoEntryNotFoundError`.
- New export: `RepoEntryNotFoundError` — typed error with `code = 'REPO_ENTRY_NOT_FOUND'`.

### `scripts/record-survey-result.ts` (new)

Thin CLI wrapping `recordSurveyResult` + `commitMetadata`. Reads `REPO_OWNER`, `REPO_NAME`, `SURVEY_STATUS`, optional `SURVEY_AT`, `GITHUB_TOKEN`, `GITHUB_REPOSITORY`. On missing entry, exits 0 with a stderr warning (manual dispatches against un-onboarded repos shouldn't fail the workflow).

## Workflow changes

### `.github/workflows/reconcile-repos.yaml`

- `timeout-minutes: 10` → `15`
- `RECONCILE_DISPATCH_STAGGER_MS: '8000'` → `'90000'`
- New env: `RECONCILE_MAX_DISPATCHES_PER_RUN: '6'`

### `.github/workflows/survey-repo.yaml`

- Agent step gets `id: survey-agent` for conclusion inspection.
- New final step `Record survey result` runs regardless of whether wiki content changed, reading `steps.survey-agent.conclusion` to decide `success` vs `failure`.

## Progressive cadence in practice

Starting from the current state (19 tracked repos, all with `last_survey_at: null`):

- **Day 1**: 6 repos surveyed (the 6 never-surveyed ones selected by priority + tiebreak). 13 deferred.
- **Day 2**: 6 more repos surveyed. 7 deferred. Day 1's surveyed repos are now 1 day old — fresh, not candidates.
- **Day 3**: Remaining 7 surveyed. All 19 now covered.
- **Days 4–30**: Every repo is fresh. Dispatches per run = 0. Reconcile still runs daily for access-list + allowlist + field refresh work.
- **Day 31+**: Day 1's repos start aging out of the 30-day window, become candidates again. Cadence settles into ~6 surveys per day rotating through the list.

## Tests

- 3 new reconcile tests covering prioritization (null first, oldest first) and cap disabled
- 5 new `repos-metadata` tests covering `recordSurveyResult` purity, sibling preservation, status values, typed missing-entry error
- 2 existing reconcile tests updated with explicit non-stale `last_survey_at` so they isolate the behavior under test (previously they relied on the default null which is now a dispatch-candidate signal)
- 169/169 total pass
- `pnpm check-types`, `pnpm lint scripts`, `pnpm test` all clean

## Observability

JSON summary gets a new `dispatchesDeferred` field. Expected shape on a cap-hit run:

```json
{
  "accessListSize": 19,
  "summary": {"added": 0, "pendingReview": 0, "regained": 0, "lostAccess": 0, "refreshed": 0, "unchanged": 19},
  "dispatches": 6,
  "dispatchesFailed": 0,
  "dispatchesDeferred": 13,
  ...
}
```