### PR TITLE
docs: polish SECURITY.md and expand copilot-instructions.md architecture

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,6 +33,25 @@ If guidance conflicts, follow the order above.
 - Copilot governance hooks (`.github/hooks/`)
 - Shared repo policy/settings (`common-settings.yaml`, `.github/settings.yml`)
 - Development standards and quality gates (TypeScript/ESLint/Prettier)
+- Control-plane TypeScript (`scripts/*.ts`, executed with Node 24 native TS; no build step)
+- Metadata state (`metadata/*.yaml`, written programmatically to the `data` branch)
+- Knowledge wiki (`knowledge/{schema,index,log}.md` + `knowledge/wiki/`, Karpathy-style LLM-generated)
+- Character definition (`persona/`, injected into agent prompts)
+- Repo-scoped agent skills (`.agents/skills/`)
+- Brand assets (`assets/`, `branding/`) — downstream applied via the `apply-branding` workflow
+
+### Tests
+
+- Vitest runs tests colocated as `scripts/*.test.ts`.
+- Mocks use `vi.hoisted()` + `vi.mock()` for static `@octokit/rest` shims.
+- Prefer behavior-level assertions over implementation-coupled ones.
+
+### Autonomous Commits
+
+- Autonomous writes target the unprotected `data` branch (`main` has `enforce_admins: true`).
+- All metadata writes go through `scripts/commit-metadata.ts`.
+- `data → main` promotes via the `Merge Data Branch` workflow (Sunday 22:00 UTC).
+- Conditional auto-merge: automatic if the PR only touches `knowledge/` or `metadata/` paths; human approval required for code changes.
 
 ## Required Workflow for Every Change
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,22 +1,31 @@
 # Security Policy
 
-We appreciate your efforts to responsibly disclose vulnerabilities and help us improve the security of our project.
+We appreciate your efforts to responsibly disclose vulnerabilities and help us improve the security of this project.
 
 ## Reporting a Vulnerability
 
 To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/fro-bot/.github/security/advisories/new) tab.
 
-The team will send a response indicating the next steps in handling your report. After the initial reply to your report, the team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+We will send a response indicating the next steps in handling your report. After the initial reply we will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
 
-Report security bugs in third-party modules to the person or team maintaining the module. You can also report a vulnerability through the [npm contact form](https://www.npmjs.com/support) by selecting "I'm reporting a security vulnerability".
+Report security bugs in third-party modules to the person or team maintaining the module.
 
 ## Supported Versions
 
-The following versions of the project are currently being supported with security updates:
+This repository is a community-health and automation control plane; it is not a versioned published package. Security updates apply to the current state of `main`.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| < 1.0   | :white_check_mark: |
+| Branch | Supported          |
+| ------ | ------------------ |
+| `main` | :white_check_mark: |
+
+## Automated Security Scanning
+
+- [CodeQL](.github/workflows/codeql-analysis.yaml) — PR + weekly vulnerability analysis
+- [Dependency Review](.github/workflows/dependency-review.yaml) — blocks PRs introducing known-vulnerable packages
+- [OpenSSF Scorecard](.github/workflows/scorecard.yaml) — weekly supply-chain posture assessment
+- [Renovate](.github/workflows/renovate.yaml) — automated dependency updates including security patches
+
+Branch protection, required checks, and secret scanning are configured in [`.github/settings.yml`](.github/settings.yml) and applied via the **Update Repo Settings** workflow.
 
 ## OpenSSF Badges
 


### PR DESCRIPTION
Third and final doc-drift PR. Refreshes \`SECURITY.md\` to reflect what this repo actually is, and expands the Architecture & Key Components list in \`.github/copilot-instructions.md\` to cover the surfaces that now carry most of the repo's real behavior.

## SECURITY.md changes

- **Supported Versions**: this repo is a community-health and automation control plane, not a versioned published package. Replace the \`< 1.0\` row with a \`main\` row and a one-line explanation.
- **Reporting**: drop the npm contact-form link (this repo does not publish to npm); tighten prose.
- **New Automated Security Scanning section**: links to the CodeQL, Dependency Review, OpenSSF Scorecard, and Renovate workflows, plus the \`.github/settings.yml\` branch-protection entry point, so readers can see what's actually running.

## copilot-instructions.md changes

Architecture & Key Components previously listed only the original scaffolding (community-health files, workflows, hooks, shared settings, quality gates). Add the surfaces that now carry most of the repo's behavior:

- Control-plane TypeScript (\`scripts/*.ts\`, Node 24 native TS, no build step)
- Metadata state (\`metadata/*.yaml\`, written to the \`data\` branch)
- Knowledge wiki (\`knowledge/{schema,index,log}.md\` + \`knowledge/wiki/\`)
- Character definition (\`persona/\`, injected into agent prompts)
- Repo-scoped agent skills (\`.agents/skills/\`)
- Brand assets (\`assets/\`, \`branding/\`)

Adds two subsections:

- **Tests**: Vitest colocated as \`scripts/*.test.ts\`, \`vi.hoisted()\` + \`vi.mock()\` for \`@octokit/rest\` shims, behavior-level assertions.
- **Autonomous Commits**: \`data\`-branch write path (because \`main\` has \`enforce_admins: true\`), \`scripts/commit-metadata.ts\` as the metadata-write entry point, conditional auto-merge to \`main\`.

## Sequencing

PR 3 of 3 in the doc-drift fix sequence. Does not touch the \`.cursorrules\` references in \`.github/copilot-instructions.md\` — those are handled by #3131. Minor merge ordering may apply.

## Verification

- \`pnpm lint\` — clean
- \`pnpm check-types\` — clean
- \`pnpm test\` — 186/186 passing