### PR TITLE
fix(scripts): avoid TypeScript parameter properties (Node strip-only mode)

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -21,3 +21,4 @@ branches:
           - Renovate / Renovate
           - Review Dependencies
           - Test
+          - Test Scripts Load

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -78,6 +78,34 @@ jobs:
       - name: 🧪 Run Tests
         run: pnpm test
 
+  test-scripts-load:
+    name: Test Scripts Load
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: ⤵ Checkout Branch
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: 📦 Setup
+        uses: ./.github/actions/setup
+
+      - name: 🧪 Load production scripts under Node strip-only
+        # Node 24's strip-only TypeScript execution only erases type annotations -- it does
+        # not transform TS-specific class constructs (parameter properties, enum, namespace).
+        # Neither `tsc --noEmit` nor Vitest exercise the strip-only parser, so those runtime
+        # errors used to surface only on scheduled workflow runs. Importing each production
+        # script here catches them at merge time instead.
+        run: |
+          for f in scripts/*.ts; do
+            case "$f" in *.test.ts) continue ;; esac
+            node -e "import('./$f').then(() => {}).catch(err => { process.stderr.write('FAIL $f: ' + (err.code || err.message) + '\\n'); process.exit(1); })"
+            echo "  ok   $f"
+          done
+
   check-workflows:
     name: Check Workflows
     permissions:

--- a/scripts/repos-metadata.ts
+++ b/scripts/repos-metadata.ts
@@ -105,12 +105,16 @@ export function recordSurveyResult(current: unknown, input: RecordSurveyResultIn
 
 export class RepoEntryNotFoundError extends Error {
   readonly code = 'REPO_ENTRY_NOT_FOUND'
+  // Explicit field declarations + assignment in the constructor body, not parameter properties.
+  // Node's strip-only TypeScript mode rejects `constructor(readonly owner: string)` syntax with
+  // ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX at runtime even though tsc and Vitest both accept it.
+  readonly owner: string
+  readonly repo: string
 
-  constructor(
-    readonly owner: string,
-    readonly repo: string,
-  ) {
+  constructor(owner: string, repo: string) {
     super(`metadata/repos.yaml has no entry for ${owner}/${repo}`)
     this.name = 'RepoEntryNotFoundError'
+    this.owner = owner
+    this.repo = repo
   }
 }


### PR DESCRIPTION
Hotfix for a regression in `scripts/repos-metadata.ts` that broke the scheduled `Poll invitations` run.

```
file:///home/runner/work/.github/.github/scripts/repos-metadata.ts:110
  constructor(
    readonly owner: string,
             ^^^^^^^^^^^^^
    readonly repo: string,

SyntaxError [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]: TypeScript parameter property is not supported in strip-only mode
```

Failed run: https://github.com/fro-bot/.github/actions/runs/24602307971/job/71942909298

## Root cause

`RepoEntryNotFoundError` declared its `owner` and `repo` fields via constructor parameter properties. Node 24's strip-only TypeScript execution doesn't transform TS-specific constructs — it only erases type annotations. Parameter properties are a class-rewriting feature, so the parser rejects them at module load time with `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX` before any code runs.

The import chain is shared across the autonomous workflows:

- `poll-invitations.yaml` → `handle-invitation.ts` → `repos-metadata.ts`
- `reconcile-repos.yaml` → `reconcile-repos.ts` → `repos-metadata.ts`
- `survey-repo.yaml` (the Record survey result step) → `record-survey-result.ts` → `repos-metadata.ts`

All three would have failed with this regression the next time they ran.

## Fix

Switch to the long form: explicit `readonly` class field declarations plus assignment inside the constructor body. Semantics unchanged; strip-only accepts it cleanly.

```diff
 export class RepoEntryNotFoundError extends Error {
   readonly code = 'REPO_ENTRY_NOT_FOUND'
+  readonly owner: string
+  readonly repo: string

-  constructor(
-    readonly owner: string,
-    readonly repo: string,
-  ) {
+  constructor(owner: string, repo: string) {
     super(...)
     this.name = 'RepoEntryNotFoundError'
+    this.owner = owner
+    this.repo = repo
   }
 }
```

## CI guardrail (folded into this PR)

Adds a new `Test Scripts Load` job to `main.yaml` and marks it required in `settings.yml`. The job imports each production script under Node strip-only:

```bash
for f in scripts/*.ts; do
  case "$f" in *.test.ts) continue ;; esac
  node -e "import('./$f').then(() => {}).catch(err => { process.stderr.write('FAIL $f: ' + (err.code || err.message) + '\\n'); process.exit(1); })"
  echo "  ok   $f"
done
```

Catches parameter properties, `enum`, `namespace`, and any other strip-only-incompatible syntax at merge time instead of production runtime. Uses the existing composite setup action for caching; same timeout and permissions pattern as the other CI jobs. The `import()` calls rely on the `if (import.meta.url === ...)` main-guard every entrypoint script already has, so no side effects run — only the module graph is verified.

## Why the regression slipped through

| Check | Why it passed | Reality |
| --- | --- | --- |
| `pnpm test` (Vitest) | Vite TS transform | Supports parameter properties — never exercises strip-only parser |
| `pnpm check-types` | `tsc --noEmit` | Accepts parameter properties as valid TS; strip-only is runtime-only |
| `pnpm lint` | ESLint default | No rule configured to ban parameter properties |

The new `Test Scripts Load` job closes the first two gaps by running the actual Node strip-only parser on every production module.

## Verification

- `node -e "import('./scripts/repos-metadata.ts')"` — loads cleanly
- Loop-imported every production script under Node strip-only — all 12 load cleanly
- `pnpm test` — 186/186 passing
- `pnpm lint` — clean
- `pnpm check-types` — clean

## Further Direction (tracked, not in this PR)

- **ESLint rule**: `@typescript-eslint/parameter-properties` with `{ prefer: "class-property" }` would flag the syntax at lint time, before CI even runs. Complementary to the Node-load smoke test.
- **Compound doc**: a `docs/solutions/runtime-errors/node-strip-only-typescript-2026-04-18.md` entry listing the TS features strip-only doesn't accept (parameter properties, enum, namespace, non-experimental decorators, etc.) plus the two-layer guardrail (ESLint + CI smoke-test) this PR establishes.