### PR TITLE
chore(lint): enforce strip-only TypeScript + document the trap

### DIFF
--- a/docs/solutions/runtime-errors/node-strip-only-typescript-2026-04-18.md
+++ b/docs/solutions/runtime-errors/node-strip-only-typescript-2026-04-18.md
@@ -1,0 +1,212 @@
+---
+title: Node 24 Strip-Only TypeScript Silently Accepts Then Rejects Class-Rewriting Syntax
+category: runtime-errors
+problem_type: runtime_error
+component: tooling
+root_cause: language_semantics
+resolution_type: process_improvement
+severity: high
+date: 2026-04-18
+last_updated: 2026-04-18
+module: scripts/repos-metadata.ts
+tags:
+  [
+    typescript,
+    node,
+    strip-only,
+    parameter-properties,
+    enum,
+    namespace,
+    runtime-error,
+    vitest,
+    tsc,
+    lint-rule,
+    ci-smoke-test,
+  ]
+verified: true
+---
+
+## Problem
+
+The scheduled `Poll invitations` workflow crashed at module load time with `SyntaxError [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]` after a class that used TypeScript parameter properties landed on `main`. The type checker, the test suite, and local editor tooling all reported the file as clean. Only the production workflow surfaced the failure — exactly 15 minutes after the PR merged, on the next scheduled cron.
+
+## Symptoms
+
+- Scheduled `poll-invitations.yaml` run fails with exit code 1 on its very first step:
+
+  ```
+  file:///home/runner/work/.github/.github/scripts/repos-metadata.ts:110
+    constructor(
+      readonly owner: string,
+               ^^^^^^^^^^^^^
+
+  SyntaxError [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]: TypeScript parameter property is not supported in strip-only mode
+      at parseTypeScript (node:internal/modules/typescript:68:40)
+      at processTypeScriptCode (node:internal/modules/typescript:146:42)
+      at stripTypeScriptModuleTypes (node:internal/modules/typescript:209:22)
+  ```
+
+- The error fires at _module load_, before the first line of application code runs. Import chains are affected transitively: every workflow whose entrypoint imports (directly or indirectly) the offending file fails the same way.
+- `pnpm test` — all 186 Vitest tests pass.
+- `pnpm check-types` — `tsc --noEmit` clean.
+- `pnpm lint` — no diagnostics.
+- Editor: no red squiggles.
+
+## What Didn't Work
+
+- **Trusting `pnpm test`.** Vitest runs under Vite's TypeScript transform, which is a full compiler. Parameter properties, `enum`, `namespace`, decorators, and CTS import aliases all pass through without issue. Tests that import the offending module succeed because Vite rewrites the class during transform — Node's strip-only parser never runs.
+- **Trusting `pnpm check-types`.** `tsc --noEmit` type-checks TypeScript-the-language. Parameter properties are valid TypeScript, so `tsc` says "fine." Strip-only compatibility is a _runtime execution strategy_ concern that lives entirely outside the type system.
+- **Trusting the editor.** Both VS Code and the language server evaluate TypeScript semantics, not Node's strip-only ABI.
+- **Trusting `node --check`.** `node --check path/to/file.ts` only validates shell-parseable syntax, not strip-only-compatible syntax. It returned 0 for the offending file.
+
+The failure mode is: every local guardrail passes, then the scheduled cron crashes. The feedback loop is measured in production-time, not developer-time.
+
+## Solution
+
+Two-layer guardrail: lint-time prevention plus CI smoke-test backstop.
+
+### Layer 1 — ESLint catches strip-only incompatibility before it lands
+
+The repo already consumes `@bfra.me/eslint-config`, which exposes a first-class option for this exact concern. Flip it on:
+
+```ts
+// eslint.config.ts
+import {defineConfig} from '@bfra.me/eslint-config'
+
+export default defineConfig({
+  // ...
+  typescript: {
+    tsconfigPath: './tsconfig.json',
+    // Enforce Node 24 strip-only TypeScript compatibility: rejects parameter properties,
+    // enums, namespaces, and import aliases at lint time, before they surface as
+    // ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX at runtime.
+    erasableSyntaxOnly: true,
+  },
+})
+```
+
+`eslint-plugin-erasable-syntax-only` is a devDependency of `@bfra.me/eslint-config`, not a transitive dep, so consumers that opt in must add it explicitly:
+
+```sh
+pnpm add -DE eslint-plugin-erasable-syntax-only
+```
+
+The ruleset covers:
+
+| Rule                                          | Catches                                                     |
+| --------------------------------------------- | ----------------------------------------------------------- |
+| `erasable-syntax-only/parameter-properties` | `constructor(readonly x: string)` constructor-field syntax  |
+| `erasable-syntax-only/enums`                | `enum Kind { A, B }`                                        |
+| `erasable-syntax-only/namespaces`           | `namespace X { ... }`                                       |
+| `erasable-syntax-only/import-aliases`       | `import X = require(...)` / `import X = Y.Z` aliasing forms |
+
+### Layer 2 — CI smoke test loads every production script under Node strip-only
+
+Linting catches syntactic shapes. It does not catch semantically compatible-looking code that nevertheless fails at load — decorators without the experimental flag, dynamic import trickery, newly-introduced TS features. A focused CI job closes the remaining gap by running the actual strip-only parser on every non-test module:
+
+```yaml
+# .github/workflows/main.yaml
+test-scripts-load:
+  name: Test Scripts Load
+  runs-on: ubuntu-latest
+  timeout-minutes: 10
+  steps:
+    - uses: actions/checkout@...
+    - uses: ./.github/actions/setup
+    - name: Load production scripts under Node strip-only
+      run: |
+        for f in scripts/*.ts; do
+          case "$f" in *.test.ts) continue ;; esac
+          node -e "import('./$f').then(() => {}).catch(err => { process.stderr.write('FAIL $f: ' + (err.code || err.message) + '\\n'); process.exit(1); })"
+          echo "  ok   $f"
+        done
+```
+
+Add the job name to the required status checks in `.github/settings.yml` so a regression blocks merge rather than ships.
+
+### The original code fix
+
+Replace parameter properties with explicit field declarations plus in-body assignment:
+
+```ts
+// BEFORE — rejected by strip-only
+export class RepoEntryNotFoundError extends Error {
+  readonly code = 'REPO_ENTRY_NOT_FOUND'
+
+  constructor(
+    readonly owner: string,
+    readonly repo: string,
+  ) {
+    super(`metadata/repos.yaml has no entry for ${owner}/${repo}`)
+    this.name = 'RepoEntryNotFoundError'
+  }
+}
+
+// AFTER — strip-only accepts
+export class RepoEntryNotFoundError extends Error {
+  readonly code = 'REPO_ENTRY_NOT_FOUND'
+  readonly owner: string
+  readonly repo: string
+
+  constructor(owner: string, repo: string) {
+    super(`metadata/repos.yaml has no entry for ${owner}/${repo}`)
+    this.name = 'RepoEntryNotFoundError'
+    this.owner = owner
+    this.repo = repo
+  }
+}
+```
+
+Semantics unchanged. Field declarations plus assignment are pure type erasure — strip-only accepts.
+
+## Why This Works
+
+Node 24's built-in TypeScript execution (`--experimental-strip-types`, default on in Node 24) operates in **strip-only mode**. It erases type annotations but refuses to _rewrite_ code. Any TypeScript construct that expands into different JavaScript at runtime is rejected with `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`:
+
+| Construct            | Why strip-only rejects                                                  |
+| -------------------- | ----------------------------------------------------------------------- |
+| Parameter properties | Expands into class field declarations plus constructor assignments      |
+| `enum`               | Generates an object with bidirectional key/value mapping                |
+| `namespace`          | Generates an IIFE that attaches exports to a shared object              |
+| Decorators           | Generate calls to decorator factories (unless behind experimental flag) |
+| Import aliases (TS)  | Generate CommonJS-style requires or property accesses                   |
+
+Everything else — type annotations, interfaces, type-only imports, class field declarations with type annotations, generics, `as` assertions — is pure type erasure and passes through strip-only cleanly.
+
+The trap is that:
+
+1. `tsc` accepts all of the rejected constructs as valid TypeScript.
+2. Vitest (via Vite's full compiler) silently transforms them away.
+3. Neither local tool exercises the strip-only parser.
+4. Only the actual Node invocation on a CI runner — or on the scheduled cron — fails.
+
+## Prevention
+
+1. **Opt in to `erasable-syntax-only` lint rules** for any codebase running Node strip-only TypeScript. This is the first and cheapest line of defense. The `@bfra.me/eslint-config` option is a single line; bare ESLint setups can install the plugin directly.
+
+2. **Add a CI job that imports every production entrypoint under Node.** Lint catches syntactic shapes; Node's actual parser catches everything else. Make the job a required status check so regressions block merge.
+
+3. **Reason about runtime strategy, not just TypeScript validity, when adding new language features.** If a construct generates runtime code (any class-rewriting, any enum, any namespace, any decorator), ask: "Does the target Node runtime strip or transform?" If strip-only, stick to the erasable subset.
+
+4. **Recognize the pattern from symptoms.** `SyntaxError [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]` is the canonical indicator. The stack trace will point at `node:internal/modules/typescript:*` — not your code. Cold start, no application code runs.
+
+5. **Treat subagent-generated SDK types and class shapes with the same skepticism you already apply to subagent method names.** Parameter properties are a compact class-declaration style subagents reach for naturally; they look like valid TypeScript and pass type-checking.
+
+## References
+
+### This occurrence (PR #3134)
+
+- Failed run: https://github.com/fro-bot/.github/actions/runs/24602307971/job/71942909298
+- Fix PR: https://github.com/fro-bot/.github/pull/3134
+- Guardrail PR: open follow-up to #3134
+
+### Related doc
+
+- [`docs/solutions/runtime-errors/octokit-invitation-method-names-2026-04-17.md`](./octokit-invitation-method-names-2026-04-17.md) — same category of trap: tests passed because they ran under a different runtime path than production. Different class (hallucinated method names on handwritten interfaces), same lesson (local guardrails that don't exercise the real runtime give false confidence).
+
+### External
+
+- Node 24 strip-only TypeScript docs: https://nodejs.org/api/typescript.html#type-stripping
+- `eslint-plugin-erasable-syntax-only`: https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only
+- TypeScript `--erasableSyntaxOnly` compiler option: https://www.typescriptlang.org/tsconfig#erasableSyntaxOnly
+- GitHub Node bug tracker (`ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX` class): https://github.com/nodejs/node/issues?q=ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -17,5 +17,10 @@ export default defineConfig({
   packageJson: true,
   typescript: {
     tsconfigPath: './tsconfig.json',
+    // Enforce Node 24 strip-only TypeScript compatibility: rejects parameter properties,
+    // enums, namespaces, and import aliases at lint time, before they surface as
+    // ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX at runtime. Pairs with the Test Scripts Load
+    // CI job that catches any incompatibility that slips past the linter.
+    erasableSyntaxOnly: true,
   },
 })

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@vitest/eslint-plugin": "1.6.15",
     "eslint": "10.2.0",
     "eslint-config-prettier": "10.1.1",
+    "eslint-plugin-erasable-syntax-only": "0.4.0",
     "eslint-plugin-node-dependencies": "2.2.0",
     "eslint-plugin-prettier": "5.5.0",
     "jiti": "2.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
     devDependencies:
       '@bfra.me/eslint-config':
         specifier: 0.51.0
-        version: 0.51.0(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(@typescript-eslint/rule-tester@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(@typescript-eslint/typescript-estree@8.58.2(typescript@6.0.2))(@typescript-eslint/utils@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(@vitest/eslint-plugin@1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)(vitest@4.1.4))(eslint-config-prettier@10.1.1(eslint@10.2.0(jiti@2.6.1)))(eslint-plugin-prettier@5.5.0(eslint-config-prettier@10.1.1(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))(prettier@3.8.1))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
+        version: 0.51.0(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(@typescript-eslint/rule-tester@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(@typescript-eslint/typescript-estree@8.58.2(typescript@6.0.2))(@typescript-eslint/utils@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(@vitest/eslint-plugin@1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)(vitest@4.1.4))(eslint-config-prettier@10.1.1(eslint@10.2.0(jiti@2.6.1)))(eslint-plugin-prettier@5.5.0(eslint-config-prettier@10.1.1(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))(prettier@3.8.1))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
       '@bfra.me/prettier-config':
         specifier: 0.16.0
         version: 0.16.0(prettier@3.8.1)
@@ -41,13 +41,16 @@ importers:
         version: 4.1.4(vitest@4.1.4)
       '@vitest/eslint-plugin':
         specifier: 1.6.15
-        version: 1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)(vitest@4.1.4)
+        version: 1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)(vitest@4.1.4)
       eslint:
         specifier: 10.2.0
         version: 10.2.0(jiti@2.6.1)
       eslint-config-prettier:
         specifier: 10.1.1
         version: 10.1.1(eslint@10.2.0(jiti@2.6.1))
+      eslint-plugin-erasable-syntax-only:
+        specifier: 0.4.0
+        version: 0.4.0(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
       eslint-plugin-node-dependencies:
         specifier: 2.2.0
         version: 2.2.0(eslint@10.2.0(jiti@2.6.1))
@@ -796,6 +799,10 @@ packages:
     resolution: {integrity: sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==}
     engines: {node: '>=18.20'}
 
+  cached-factory@0.1.0:
+    resolution: {integrity: sha512-IGOSWu+NuED5UzCRmBeqQPZ8z7SkgrD/nN67W2iY1Qv83CVhevyMexkGclJ86saXisIqxoOnbeiTWvsCHRqJBw==}
+    engines: {node: '>=18'}
+
   caniuse-lite@1.0.30001762:
     resolution: {integrity: sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==}
 
@@ -971,6 +978,14 @@ packages:
       '@typescript-eslint/typescript-estree': '*'
       '@typescript-eslint/utils': '*'
       eslint: '*'
+
+  eslint-plugin-erasable-syntax-only@0.4.0:
+    resolution: {integrity: sha512-7dx2gpfVn0FFEGukLqsF/izW4hGvSaySNOkcuSCO4q6Khh0ecOGYlRhW9hhDUtNryuKc+cXd1WFiQdpae3xzaQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      '@typescript-eslint/parser': '>=8'
+      eslint: '>=9'
+      typescript: '>=5'
 
   eslint-plugin-es-x@7.8.0:
     resolution: {integrity: sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==}
@@ -2063,7 +2078,7 @@ snapshots:
     dependencies:
       is-in-ci: 2.0.0
 
-  '@bfra.me/eslint-config@0.51.0(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(@typescript-eslint/rule-tester@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(@typescript-eslint/typescript-estree@8.58.2(typescript@6.0.2))(@typescript-eslint/utils@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(@vitest/eslint-plugin@1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)(vitest@4.1.4))(eslint-config-prettier@10.1.1(eslint@10.2.0(jiti@2.6.1)))(eslint-plugin-prettier@5.5.0(eslint-config-prettier@10.1.1(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))(prettier@3.8.1))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)':
+  '@bfra.me/eslint-config@0.51.0(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(@typescript-eslint/rule-tester@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(@typescript-eslint/typescript-estree@8.58.2(typescript@6.0.2))(@typescript-eslint/utils@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(@vitest/eslint-plugin@1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)(vitest@4.1.4))(eslint-config-prettier@10.1.1(eslint@10.2.0(jiti@2.6.1)))(eslint-plugin-prettier@5.5.0(eslint-config-prettier@10.1.1(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))(prettier@3.8.1))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
       '@bfra.me/es': 0.1.0
       '@eslint-community/eslint-plugin-eslint-comments': 4.7.1(eslint@10.2.0(jiti@2.6.1))
@@ -2083,7 +2098,7 @@ snapshots:
       eslint-plugin-regexp: 3.1.0(eslint@10.2.0(jiti@2.6.1))
       eslint-plugin-toml: 1.3.1(eslint@10.2.0(jiti@2.6.1))
       eslint-plugin-unicorn: 64.0.0(eslint@10.2.0(jiti@2.6.1))
-      eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))
+      eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))
       eslint-plugin-yml: 3.3.1(eslint@10.2.0(jiti@2.6.1))
       globals: 17.5.0
       is-in-ci: 2.0.0
@@ -2092,7 +2107,7 @@ snapshots:
       sort-package-json: 3.6.1
       typescript-eslint: 8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
     optionalDependencies:
-      '@vitest/eslint-plugin': 1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)(vitest@4.1.4)
+      '@vitest/eslint-plugin': 1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)(vitest@4.1.4)
       eslint-config-prettier: 10.1.1(eslint@10.2.0(jiti@2.6.1))
       eslint-plugin-prettier: 5.5.0(eslint-config-prettier@10.1.1(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))(prettier@3.8.1)
     transitivePeerDependencies:
@@ -2447,6 +2462,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/scope-manager': 8.58.1
+      '@typescript-eslint/type-utils': 8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/visitor-keys': 8.58.1
+      eslint: 10.2.0(jiti@2.6.1)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.2)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@typescript-eslint/parser@8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.58.1
@@ -2672,13 +2704,13 @@ snapshots:
       tinyrainbow: 3.1.0
       vitest: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@24.12.0)(jiti@2.6.1)(yaml@2.8.3))
 
-  '@vitest/eslint-plugin@1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)(vitest@4.1.4)':
+  '@vitest/eslint-plugin@1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)(vitest@4.1.4)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.58.2
       '@typescript-eslint/utils': 8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
       eslint: 10.2.0(jiti@2.6.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
       typescript: 6.0.2
       vitest: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@24.12.0)(jiti@2.6.1)(yaml@2.8.3))
     transitivePeerDependencies:
@@ -2774,6 +2806,8 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
   builtin-modules@5.0.0: {}
+
+  cached-factory@0.1.0: {}
 
   caniuse-lite@1.0.30001762: {}
 
@@ -2904,6 +2938,16 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.58.2(typescript@6.0.2)
       '@typescript-eslint/utils': 8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
       eslint: 10.2.0(jiti@2.6.1)
+
+  eslint-plugin-erasable-syntax-only@0.4.0(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2):
+    dependencies:
+      '@typescript-eslint/parser': 8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
+      cached-factory: 0.1.0
+      eslint: 10.2.0(jiti@2.6.1)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-es-x@7.8.0(eslint@10.2.0(jiti@2.6.1)):
     dependencies:
@@ -3071,11 +3115,11 @@ snapshots:
       semver: 7.7.4
       strip-indent: 4.1.1
 
-  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1)):
+  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1)):
     dependencies:
       eslint: 10.2.0(jiti@2.6.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
 
   eslint-plugin-yml@3.3.1(eslint@10.2.0(jiti@2.6.1)):
     dependencies:


### PR DESCRIPTION
Two complementary guardrails against the class of bug fixed in #3134, plus a compound doc capturing the full trap.

## Why

`#3134` fixed a scheduled-workflow regression caused by TypeScript parameter properties — a construct Node 24's strip-only TypeScript execution rejects at module load, but that `tsc --noEmit` and Vitest both accept without complaint. The failure only surfaced 15 minutes after merge, on the next cron run. This PR closes the feedback-loop gap so the next contributor who reaches for parameter properties, `enum`, or `namespace` finds out at lint time instead of production time.

## What changes

### Layer 1 — ESLint rule

Opt in to `@bfra.me/eslint-config`'s existing first-class support:

```ts
// eslint.config.ts
typescript: {
  tsconfigPath: './tsconfig.json',
  erasableSyntaxOnly: true,
},
```

Enables `eslint-plugin-erasable-syntax-only`, which provides four rules covering the complete strip-only-rejected set:

| Rule | Catches |
| --- | --- |
| `erasable-syntax-only/parameter-properties` | `constructor(readonly x: string)` |
| `erasable-syntax-only/enums` | `enum Kind { A, B }` |
| `erasable-syntax-only/namespaces` | `namespace X { ... }` |
| `erasable-syntax-only/import-aliases` | `import X = require(...)` / `import X = Y.Z` |

The plugin is a devDependency of `@bfra.me/eslint-config` (not transitive), so consumers opting in must install it. `pnpm add -DE eslint-plugin-erasable-syntax-only` is the only `package.json` / `pnpm-lock.yaml` change here.

### Layer 2 — CI smoke test (already merged in #3134)

The `Test Scripts Load` job that landed with #3134 imports every production script under the actual Node strip-only parser. Lint catches syntactic shapes; CI imports catch anything new that lint doesn't yet know about. Two independent layers, one purpose.

### Compound doc

`docs/solutions/runtime-errors/node-strip-only-typescript-2026-04-18.md` captures:

- Full trap description (what strip-only accepts vs rejects, with the complete rejected-construct table)
- Why `pnpm test`, `pnpm check-types`, and the editor all miss the issue
- Both guardrail layers (lint + CI smoke-test), with ready-to-copy config
- The code-level fix pattern (parameter properties → field declarations + assignment)
- Five prevention rules
- Cross-link to the companion doc (`octokit-invitation-method-names-2026-04-17.md`) — same trap shape, different class

## Verification

- `pnpm lint` — clean on existing codebase (no false positives from the new rules)
- `pnpm check-types` — clean
- `pnpm test` — 186/186 passing
- **Regression check** — a temporary file with a parameter property, enum, and namespace triggered four diagnostics as expected:

  ```
  error  This parameter property will not be allowed under TypeScript's --erasableSyntaxOnly    erasable-syntax-only/parameter-properties
  error  This parameter property will not be allowed under TypeScript's --erasableSyntaxOnly    erasable-syntax-only/parameter-properties
  error  This enum will not be allowed under TypeScript's --erasableSyntaxOnly                  erasable-syntax-only/enums
  error  This namespace will not be allowed under TypeScript's --erasableSyntaxOnly             erasable-syntax-only/namespaces
  ```

## Further Direction (tracked, not in this PR)

- **`@typescript-eslint/parameter-properties` upstream consideration.** We chose the `erasable-syntax-only` plugin over the narrower `@typescript-eslint/parameter-properties` rule because it covers the entire strip-only trap surface in one option, not just one construct. No action needed.
- **Other trap families.** The pattern "local guardrails accept what production rejects" applies beyond strip-only TS. Future compound docs in `docs/solutions/runtime-errors/` should use the same two-layer framing: what lint can catch at diff time vs what needs a CI smoke test that actually exercises the production runtime.