### PR TITLE
fix(survey): skip deletions in porcelain + classify wiki commit failures

### DIFF
--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -137,6 +137,7 @@ jobs:
         run: echo "now=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Commit wiki ingest to data branch
+        id: wiki-commit
         if: steps.wiki-changes.outputs.changed == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.FRO_BOT_PAT }}
@@ -149,20 +150,29 @@ jobs:
 
       # Write the survey outcome back to metadata/repos.yaml on the data branch so
       # the reconcile staleness gate (30 days or more since last survey) can filter this
-      # repo out of tomorrow's candidate list. Runs regardless of whether wiki content
-      # changed — "surveyed and found nothing new" is still a completed survey.
+      # repo out of tomorrow's candidate list.
       #
-      # Status mapping for the agent step's conclusion:
-      # - 'success'   → 'success' (wiki updated or no-op; either is a completed survey)
-      # - 'failure'   → 'failure' (agent ran but raised an error, e.g. upstream rate limit)
-      # - 'cancelled' → 'failure' (cancelled surveys produce no useful output; retry next run)
-      # The outer `!cancelled()` already excludes job-level cancellation. The `!= 'skipped'`
-      # guard skips the write when an upstream step kept the agent from running at all.
+      # Status mapping:
+      # - 'success' requires BOTH the agent step AND the wiki commit step to have
+      #   succeeded (or the wiki commit to have been skipped because the agent made
+      #   no changes — that is a valid no-op survey).
+      # - Any failure upstream of metadata write — agent error, wiki commit ENOENT,
+      #   wiki commit conflict-exhaustion — records 'failure' so the reconcile
+      #   staleness gate re-dispatches the repo tomorrow instead of waiting 30 days.
+      # - 'cancelled' is excluded by the outer `!cancelled()` guard. The
+      #   `!= 'skipped'` guard on the agent step skips metadata writes entirely
+      #   when an upstream step kept the agent from running at all.
+      #
+      # A wiki-commit conclusion of 'skipped' (its step `if:` returned false because
+      # the agent made no changes) counts as success, not failure, because the agent
+      # completed cleanly.
       - name: Record survey result
         if: always() && !cancelled() && steps.survey-agent.conclusion != 'skipped'
         env:
           GITHUB_TOKEN: ${{ secrets.FRO_BOT_PAT }}
           REPO_OWNER: ${{ github.event.inputs.owner }}
           REPO_NAME: ${{ github.event.inputs.repo }}
-          SURVEY_STATUS: ${{ steps.survey-agent.conclusion == 'success' && 'success' || 'failure' }}
+          SURVEY_STATUS:
+            ${{ (steps.survey-agent.conclusion == 'success' && (steps.wiki-commit.conclusion == 'success' ||
+            steps.wiki-commit.conclusion == 'skipped')) && 'success' || 'failure' }}
         run: node scripts/record-survey-result.ts

--- a/scripts/wiki-ingest.test.ts
+++ b/scripts/wiki-ingest.test.ts
@@ -634,6 +634,57 @@ describe('parsePorcelainPaths', () => {
     // #then only the well-formed entry is kept; short garbage is ignored
     expect(paths).toEqual(['valid/path.md'])
   })
+
+  it('skips unstaged worktree deletions (X=space, Y=D)', () => {
+    // #given a porcelain listing where an existing wiki page has been removed from the
+    // worktree (e.g. by `git restore` pulling a different branch's knowledge/ snapshot
+    // over the current checkout). Production incident: the survey-repo workflow's
+    // `Sync wiki from data branch` step removes files that exist on main but not on
+    // data, and those deletions must NOT be fed into wiki-ingest's readFile loop.
+    const stdout = [
+      ' M knowledge/wiki/repos/marcusrbrown--dotfiles.md', // agent-added content
+      ' D knowledge/wiki/entities/mise.md', // drift-induced deletion
+      '',
+    ].join('\n')
+
+    // #when porcelain lines are parsed
+    const paths = parsePorcelainPaths(stdout)
+
+    // #then the deletion is filtered out; only the present file survives
+    expect(paths).toEqual(['knowledge/wiki/repos/marcusrbrown--dotfiles.md'])
+  })
+
+  it('skips staged deletions (X=D, Y=space)', () => {
+    // #given a porcelain listing with a staged deletion alongside a normal modification
+    const stdout = ['D  knowledge/wiki/entities/old-entity.md', ' M knowledge/log.md', ''].join('\n')
+
+    // #when porcelain lines are parsed
+    const paths = parsePorcelainPaths(stdout)
+
+    // #then the staged deletion is filtered; the modification is preserved
+    expect(paths).toEqual(['knowledge/log.md'])
+  })
+
+  it('skips deletions in all dual-position variants (DD, AD, MD, RD, CD)', () => {
+    // #given porcelain lines covering every status combination where the file ends up
+    // absent from the worktree — each would crash readFile if it reached
+    // loadWorkingTreeWikiFiles.
+    const stdout = [
+      'DD knowledge/wiki/repos/both-deleted.md', // unmerged, both deleted
+      'AD knowledge/wiki/repos/added-then-deleted.md', // added in index, deleted in worktree
+      'MD knowledge/wiki/repos/modified-then-deleted.md', // modified in index, deleted in worktree
+      'RD knowledge/wiki/repos/renamed-then-deleted.md', // renamed in index, deleted in worktree
+      'CD knowledge/wiki/repos/copied-then-deleted.md', // copied in index, deleted in worktree
+      ' M knowledge/wiki/repos/kept.md', // normal unstaged modification
+      '',
+    ].join('\n')
+
+    // #when porcelain lines are parsed
+    const paths = parsePorcelainPaths(stdout)
+
+    // #then every variant with D in either position is dropped; the surviving path remains
+    expect(paths).toEqual(['knowledge/wiki/repos/kept.md'])
+  })
 })
 
 describe('commitWikiChanges (422 surfacing)', () => {

--- a/scripts/wiki-ingest.ts
+++ b/scripts/wiki-ingest.ts
@@ -723,9 +723,19 @@ async function getChangedWikiPaths(): Promise<string[]> {
  * - `M  path/to/file` — staged modification (Y = space)
  * - `A  path/to/file` — newly added (staged)
  * - `?? path/to/file` — untracked
+ * - ` D path/to/file` — worktree deletion (file gone from disk)
+ * - `D  path/to/file` — staged deletion
  *
  * Rename lines (`XY OLD -> NEW`) and submodules are out of scope — this script
  * only commits additive wiki markdown files, never renames.
+ *
+ * Deletions are filtered out. The wiki commit path's contract is additive-only,
+ * and `loadWorkingTreeWikiFiles` would crash with ENOENT trying to read a deleted
+ * path. Production incident (2026-04-19): the survey-repo workflow's
+ * `Sync wiki from data branch` step removed files that exist on main but not on
+ * data, surfacing those deletions through porcelain and crashing the ingest.
+ * Any status where X or Y is `D` signals the file is absent or being removed —
+ * skip it.
  *
  * Historical bug: a prior implementation used `line.trim()` before `line.slice(3)`,
  * which stripped the X-position space for unstaged changes and caused
@@ -734,12 +744,18 @@ async function getChangedWikiPaths(): Promise<string[]> {
  * fix: preserve the fixed 3-char prefix and only strip trailing CR for cross-platform safety.
  */
 export function parsePorcelainPaths(stdout: string): string[] {
-  return stdout
-    .split('\n')
-    .map(line => line.replace(/\r$/, ''))
-    .filter(line => line.length >= 4)
-    .map(line => line.slice(3))
-    .filter(path => path !== '')
+  return (
+    stdout
+      .split('\n')
+      .map(line => line.replace(/\r$/, ''))
+      .filter(line => line.length >= 4)
+      // Skip any status where X or Y is 'D' (deletion). The wiki commit path is
+      // additive-only; feeding deletions into `loadWorkingTreeWikiFiles` crashes
+      // with ENOENT when it tries to readFile a path no longer on disk.
+      .filter(line => !line.slice(0, 2).includes('D'))
+      .map(line => line.slice(3))
+      .filter(path => path !== '')
+  )
 }
 
 function parsePayload(raw: string): WikiIngestPayload {


### PR DESCRIPTION
Scheduled reconcile fired today and dispatched 6 surveys under the progressive pipeline (90s stagger, 6/run cap, staleness gate, survey result write-back -- all functioning as designed). All 6 survey runs failed with the same crash during the wiki commit step, yet metadata still recorded `last_survey_status: success` for each repo because the agent step itself succeeded. Without this fix, the reconcile staleness gate would treat those repos as freshly surveyed and skip them for 30 days -- silent wiki-coverage loss for a month.

## Bug A -- porcelain parser surfaced deletions that crashed readFile

Failed run excerpt:

```
Error: ENOENT: no such file or directory, open 'knowledge/wiki/entities/mise.md'
    at loadWorkingTreeWikiFiles (scripts/wiki-ingest.ts:695)
```

Root cause chain:

1. `survey-repo.yaml`'s `Sync wiki from data branch` step runs `git restore --source FETCH_HEAD --worktree -- knowledge`, which overwrites the working-tree `knowledge/` with the `data` branch's snapshot.
2. Files that exist on `main` but not on `data` (legacy wiki PRs that landed directly to `main` before the `output-mode: working-dir` agent contract) get deleted from the working tree.
3. `git status --porcelain` reports those deletions as ` D path`.
4. `parsePorcelainPaths` passed them through.
5. `loadWorkingTreeWikiFiles` called `readFile` on the absent path.
6. ENOENT crashed the step.

### Fix

Filter any porcelain line whose X or Y position is `D`. Wiki commits are additive-only by contract (renames are already out of scope per the existing comment above `parsePorcelainPaths`) -- deletions never belong in the pipeline.

```ts
.filter(line => !line.slice(0, 2).includes('D'))
```

### Tests

+3 new tests covering every deletion variant the survey workflow can produce:

- `skips unstaged worktree deletions (X=space, Y=D)` -- the exact shape of today's production failure
- `skips staged deletions (X=D, Y=space)`
- `skips deletions in all dual-position variants (DD, AD, MD, RD, CD)`

RED-GREEN-confirmed by first landing the tests on unchanged code and watching them fail before applying the filter.

## Bug B -- SURVEY_STATUS reported agent success as overall success

The `Record survey result` step was computing:

```yaml
SURVEY_STATUS: ${{ steps.survey-agent.conclusion == 'success' && 'success' || 'failure' }}
```

This ignored the wiki commit step's outcome. When the agent succeeded but the wiki commit crashed with ENOENT, metadata still recorded `success` -- silently losing wiki coverage for 30 days per affected repo.

### Fix

Give the wiki commit step `id: wiki-commit` and require BOTH the agent step AND the wiki commit step to have succeeded (or `wiki-commit` to be `skipped` because the agent made no changes -- that's a valid no-op survey) before recording success:

```yaml
SURVEY_STATUS: ${{ (steps.survey-agent.conclusion == 'success'
  && (steps.wiki-commit.conclusion == 'success'
    || steps.wiki-commit.conclusion == 'skipped'))
  && 'success' || 'failure' }}
```

After this lands, a wiki commit failure records `last_survey_status: failure` and the reconcile staleness gate re-dispatches the repo on tomorrow's cron instead of skipping it for 30 days.

## Verification

- `pnpm test`: 189/189 passing (+3 new `parsePorcelainPaths` tests)
- `pnpm lint`: clean
- `pnpm check-types`: clean
- Workflow YAML parses cleanly; `wiki-commit` step id present; `SURVEY_STATUS` expression references both step conclusions correctly

## Recovery of contaminated metadata (follow-up, not in this PR)

Today's cron wrote `last_survey_at: 2026-04-19, last_survey_status: success` to 6 entries in `metadata/repos.yaml` on `data` despite no wiki content landing. After this PR merges, those entries need a one-shot reset to `null` so tomorrow's cron re-dispatches them. Affected repos (observed so far):

- `marcusrbrown/.dotfiles`
- `marcusrbrown/.github`
- `marcusrbrown/containers`
- `marcusrbrown/copiloting`
- (2 more from the 07:00 and 07:01 UTC dispatches were still in progress at time of diagnosis; same symptoms expected)

Handling: a small follow-up script or a manual `commit-metadata.ts` call against each contaminated entry.

## Eliminate drift at its source (separate follow-up)

Longer-term, `main` and `data` diverging on wiki content is the underlying cause of the drift that triggered Bug A. Merging `main`'s wiki files into `data` as a one-time cleanup commit stops the `Sync wiki from data branch` step from generating phantom deletions. This PR does not include that cleanup -- it lives better in a separate data-state-only change.