### PR TITLE
feat(recovery): add reset-survey-status workflow for misclassified survey outcomes

### DIFF
--- a/.github/workflows/reset-survey-status.yaml
+++ b/.github/workflows/reset-survey-status.yaml
@@ -1,0 +1,50 @@
+---
+name: Reset Survey Status
+
+# Recovery tool: clears `last_survey_at` + `last_survey_status` to null for one or more
+# entries in `metadata/repos.yaml` on the `data` branch. Used to force reconcile to
+# re-dispatch a repo on the next cron after a misclassified survey outcome.
+#
+# Manual dispatch only. Authored by `fro-bot[bot]` via the App installation token so the
+# resulting commit on `data` passes the reconcile integrity check.
+on:
+  workflow_dispatch:
+    inputs:
+      targets:
+        description: Comma-separated `owner/name` entries to reset (e.g. `marcusrbrown/.dotfiles,marcusrbrown/.github`).
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reset-survey-status
+  cancel-in-progress: false
+
+jobs:
+  reset-survey-status:
+    name: Reset last_survey_at and last_survey_status
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - id: get-workflow-app-token
+        name: Get Workflow Access Token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+
+      - name: ⤵ Checkout Branch
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: 📦 Setup
+        uses: ./.github/actions/setup
+
+      - name: 🧹 Reset survey status
+        env:
+          GITHUB_TOKEN: ${{ steps.get-workflow-app-token.outputs.token }}
+          TARGETS: ${{ inputs.targets }}
+        run: node scripts/reset-survey-status.ts

--- a/scripts/repos-metadata.test.ts
+++ b/scripts/repos-metadata.test.ts
@@ -1,7 +1,7 @@
 import type {ReposFile} from './schemas.ts'
 
 import {describe, expect, it} from 'vitest'
-import {addRepoEntry, recordSurveyResult, RepoEntryNotFoundError} from './repos-metadata.ts'
+import {addRepoEntry, recordSurveyResult, RepoEntryNotFoundError, resetSurveyResult} from './repos-metadata.ts'
 
 const EMPTY_REPOS: ReposFile = {version: 1, repos: []}
 const NOW = new Date('2026-04-17T12:00:00Z')
@@ -305,5 +305,117 @@ describe('recordSurveyResult', () => {
         status: 'success',
       }),
     ).toThrow(RepoEntryNotFoundError)
+  })
+})
+
+describe('resetSurveyResult', () => {
+  // Behavioral contract: clear last_survey_at + last_survey_status back to null
+  it('resets last_survey_at and last_survey_status to null on the target entry', () => {
+    // #given a repo entry marked as successfully surveyed on 2026-04-19
+    const current: ReposFile = {
+      version: 1,
+      repos: [
+        {
+          owner: 'marcusrbrown',
+          name: '.dotfiles',
+          added: '2026-04-18',
+          onboarding_status: 'pending',
+          last_survey_at: '2026-04-19',
+          last_survey_status: 'success',
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+        },
+      ],
+    }
+
+    // #when the entry is reset
+    const result = resetSurveyResult(current, {owner: 'marcusrbrown', repo: '.dotfiles'})
+
+    // #then both survey fields become null; other fields are preserved exactly
+    expect(result.repos[0]).toEqual({
+      owner: 'marcusrbrown',
+      name: '.dotfiles',
+      added: '2026-04-18',
+      onboarding_status: 'pending',
+      last_survey_at: null,
+      last_survey_status: null,
+      has_fro_bot_workflow: false,
+      has_renovate: false,
+    })
+  })
+
+  // Behavioral contract: pure function — never mutates input
+  it('returns a fresh top-level object without mutating inputs', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [
+        {
+          owner: 'alice',
+          name: 'project',
+          added: '2026-04-17',
+          onboarding_status: 'onboarded',
+          last_survey_at: '2026-04-18',
+          last_survey_status: 'failure',
+          has_fro_bot_workflow: true,
+          has_renovate: true,
+        },
+      ],
+    }
+    const snapshot = structuredClone(current)
+
+    const result = resetSurveyResult(current, {owner: 'alice', repo: 'project'})
+
+    // #then the original object is untouched; the new object is a distinct reference
+    expect(current).toEqual(snapshot)
+    expect(result).not.toBe(current)
+    expect(result.repos).not.toBe(current.repos)
+  })
+
+  // Behavioral contract: leaves other entries untouched — surgical reset, not broadcast
+  it('leaves non-target entries exactly as they were', () => {
+    // #given two entries, one of which we will reset
+    const current: ReposFile = {
+      version: 1,
+      repos: [
+        {
+          owner: 'alice',
+          name: 'keep-me',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: '2026-04-18',
+          last_survey_status: 'success',
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+        },
+        {
+          owner: 'bob',
+          name: 'reset-me',
+          added: '2026-04-18',
+          onboarding_status: 'pending',
+          last_survey_at: '2026-04-19',
+          last_survey_status: 'success',
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+        },
+      ],
+    }
+
+    // #when only the second entry is reset
+    const result = resetSurveyResult(current, {owner: 'bob', repo: 'reset-me'})
+
+    // #then the first entry is preserved verbatim, the second is reset
+    expect(result.repos[0]?.last_survey_at).toBe('2026-04-18')
+    expect(result.repos[0]?.last_survey_status).toBe('success')
+    expect(result.repos[1]?.last_survey_at).toBeNull()
+    expect(result.repos[1]?.last_survey_status).toBeNull()
+  })
+
+  // Behavioral contract: typed error when the entry is missing
+  it('throws RepoEntryNotFoundError when the target repo has no entry', () => {
+    const current: ReposFile = {version: 1, repos: []}
+
+    // #when resetting a nonexistent entry
+    // #then the shared RepoEntryNotFoundError surfaces (same typed error used by recordSurveyResult)
+    expect(() => resetSurveyResult(current, {owner: 'ghost', repo: 'nowhere'})).toThrow(RepoEntryNotFoundError)
   })
 })

--- a/scripts/repos-metadata.ts
+++ b/scripts/repos-metadata.ts
@@ -2,8 +2,10 @@
  * Shared helpers for `metadata/repos.yaml` mutation.
  *
  * Writers that add entries use `addRepoEntry`; writers that record survey outcomes use
- * `recordSurveyResult`. Both are pure functions that never mutate inputs. `addRepoEntry`
- * is idempotent on duplicate `owner+name` and preserves existing entries as-is.
+ * `recordSurveyResult`; operators recovering from a misclassified survey result use
+ * `resetSurveyResult` to clear `last_survey_at`/`last_survey_status` back to null. All
+ * three are pure functions that never mutate inputs. `addRepoEntry` is idempotent on
+ * duplicate `owner+name` and preserves existing entries as-is.
  */
 
 import {assertReposFile, type OnboardingStatus, type ReposFile, type SurveyStatus} from './schemas.ts'
@@ -92,6 +94,54 @@ export function recordSurveyResult(current: unknown, input: RecordSurveyResultIn
     ...match,
     last_survey_at: input.at.toISOString().slice(0, 10),
     last_survey_status: input.status,
+  }
+
+  const nextRepos = [...current.repos]
+  nextRepos[matchIndex] = updated
+
+  return {
+    ...current,
+    repos: nextRepos,
+  }
+}
+
+export interface ResetSurveyResultInput {
+  owner: string
+  repo: string
+}
+
+/**
+ * Reset `last_survey_at` and `last_survey_status` to `null` on an existing entry.
+ *
+ * Used to recover from misclassified survey outcomes — e.g. when a wiki-commit failure
+ * was recorded as `success` under an older `SURVEY_STATUS` expression, causing the
+ * reconcile staleness gate to skip the repo for 30 days despite no wiki content landing.
+ * Clearing the fields back to `null` forces reconcile to treat the repo as never-surveyed
+ * and re-dispatch it on the next cron.
+ *
+ * Throws `RepoEntryNotFoundError` when the entry is missing — callers should enumerate
+ * known contaminated entries and fail loudly on typos.
+ *
+ * Pure function: never mutates `current` in place. Returns a fresh top-level object with
+ * a fresh `repos` array.
+ */
+export function resetSurveyResult(current: unknown, input: ResetSurveyResultInput): ReposFile {
+  assertReposFile(current, 'repos')
+
+  const matchIndex = current.repos.findIndex(entry => entry.owner === input.owner && entry.name === input.repo)
+  if (matchIndex === -1) {
+    throw new RepoEntryNotFoundError(input.owner, input.repo)
+  }
+
+  const match = current.repos[matchIndex]
+  if (match === undefined) {
+    throw new RepoEntryNotFoundError(input.owner, input.repo)
+  }
+
+  const updated = {
+    ...match,
+    last_survey_at: null,
+    last_survey_status: null,
   }
 
   const nextRepos = [...current.repos]

--- a/scripts/reset-survey-status.ts
+++ b/scripts/reset-survey-status.ts
@@ -1,0 +1,114 @@
+import process from 'node:process'
+
+import {commitMetadata} from './commit-metadata.ts'
+import {RepoEntryNotFoundError, resetSurveyResult} from './repos-metadata.ts'
+
+/**
+ * Reset `last_survey_at` and `last_survey_status` to `null` for one or more entries in
+ * `metadata/repos.yaml` on the `data` branch.
+ *
+ * Recovery tool for misclassified survey outcomes (e.g. a wiki-commit failure that was
+ * recorded as `success` under an older `SURVEY_STATUS` expression). Clearing the fields
+ * forces the reconcile staleness gate to treat affected repos as never-surveyed, so they
+ * re-dispatch on the next cron instead of waiting the default 30 days.
+ *
+ * Inputs (env vars):
+ *   TARGETS           — comma-separated list of `owner/name` entries (e.g.
+ *                       `marcusrbrown/.dotfiles,marcusrbrown/.github`). Whitespace around
+ *                       entries and repeated commas are ignored.
+ *   GITHUB_TOKEN      — App installation token with `contents:write` on the control-plane
+ *                       repo (minted via `actions/create-github-app-token`). Required so
+ *                       the commit on `data` is authored by `fro-bot[bot]` and passes the
+ *                       reconcile integrity check.
+ *   GITHUB_REPOSITORY — caller-supplied `owner/name` of the control-plane repo (GitHub
+ *                       Actions sets this automatically).
+ *
+ * One `commitMetadata` call per target. Each call independently retries on 409 conflicts,
+ * so a concurrent writer (e.g. a running survey dispatch writing `record-survey-result`)
+ * does not cause data loss. Entries missing from `metadata/repos.yaml` surface as
+ * `RepoEntryNotFoundError` and fail the run — operators should verify the target list
+ * against the current `metadata/repos.yaml` on `data` before invoking.
+ */
+async function main(): Promise<void> {
+  const targets = parseTargets(requiredEnv('TARGETS'))
+  const [controlPlaneOwner, controlPlaneRepo] = splitControlPlane(requiredEnv('GITHUB_REPOSITORY'))
+
+  const results: {
+    owner: string
+    name: string
+    committed: boolean
+    attempts: number
+    sha?: string
+  }[] = []
+
+  for (const {owner, name} of targets) {
+    const result = await commitMetadata({
+      owner: controlPlaneOwner,
+      repo: controlPlaneRepo,
+      path: 'metadata/repos.yaml',
+      message: `chore(recovery): reset survey status for ${owner}/${name}`,
+      mutator: (current: unknown) => resetSurveyResult(current, {owner, repo: name}),
+    })
+
+    results.push({
+      owner,
+      name,
+      committed: result.committed,
+      attempts: result.attempts,
+      ...(result.committed ? {sha: result.sha} : {}),
+    })
+  }
+
+  process.stdout.write(`${JSON.stringify({targets: results.length, results}, null, 2)}\n`)
+}
+
+function parseTargets(raw: string): {owner: string; name: string}[] {
+  const entries = raw
+    .split(',')
+    .map(entry => entry.trim())
+    .filter(entry => entry !== '')
+
+  if (entries.length === 0) {
+    throw new Error('TARGETS must contain at least one `owner/name` entry')
+  }
+
+  return entries.map(entry => {
+    const [owner, name] = entry.split('/')
+    if (owner === undefined || name === undefined || owner === '' || name === '') {
+      throw new Error(`TARGETS entry must be 'owner/name', got '${entry}'`)
+    }
+    return {owner, name}
+  })
+}
+
+function splitControlPlane(raw: string): [string, string] {
+  const [owner, repo] = raw.split('/')
+  if (owner === undefined || repo === undefined || owner === '' || repo === '') {
+    throw new Error(`GITHUB_REPOSITORY must be 'owner/name', got '${raw}'`)
+  }
+  return [owner, repo]
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]
+  if (value === undefined || value === '') {
+    throw new Error(`${name} is required`)
+  }
+  return value
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    await main()
+  } catch (error: unknown) {
+    // RepoEntryNotFoundError is fatal here — recovery callers should know exactly which
+    // entries they intend to reset. A typo must fail the run, not silently proceed with
+    // the remaining targets.
+    if (error instanceof RepoEntryNotFoundError) {
+      process.stderr.write(`reset-survey-status: ${error.message}\n`)
+      process.exit(1)
+    }
+    process.stderr.write(`reset-survey-status: ${error instanceof Error ? error.message : String(error)}\n`)
+    process.exit(1)
+  }
+}


### PR DESCRIPTION
Recovery mechanism for the 6 contaminated entries from today's reconcile cron. After PR #3144 fixed the wiki-commit failure classification going forward, existing entries in `metadata/repos.yaml` on `data` still carry stale `last_survey_at: 2026-04-19, last_survey_status: success` from surveys whose wiki commits actually crashed on ENOENT. Without intervention, the reconcile staleness gate treats those repos as freshly surveyed and skips them for 30 days despite no wiki content having landed.

## What this PR adds

### Mutator + tests

`resetSurveyResult(current, {owner, repo})` in `scripts/repos-metadata.ts`. Pure function that clears `last_survey_at` and `last_survey_status` back to `null` on the target entry, throws `RepoEntryNotFoundError` on missing entries. Follows the same shape as the existing `recordSurveyResult` mutator.

+4 tests covering:

- Reset shape: survey fields → null, other fields preserved verbatim
- Purity: input never mutated, new object is a distinct reference
- Sibling preservation: non-target entries untouched
- Missing entry: throws `RepoEntryNotFoundError` (typo protection for operators)

### CLI

`scripts/reset-survey-status.ts` reads a `TARGETS` env var with a comma-separated list of `owner/name` entries and calls `commitMetadata` once per entry. Any `RepoEntryNotFoundError` exits non-zero -- recovery callers should know exactly which entries they intend to reset, so a typo must fail the run rather than silently skip.

One commit per target means concurrent writers (e.g. a survey-result write from an in-flight dispatch) don't cause data loss via the existing `commitMetadata` 409-retry path.

### Workflow

`.github/workflows/reset-survey-status.yaml` manual-dispatch only, takes a `targets` input, mints an App installation token via `actions/create-github-app-token`. Commits are authored by `fro-bot[bot]` so the reconcile integrity check on the next cron doesn't false-positive. Pattern matches the existing `reconcile-repos.yaml` token flow.

- 5-minute timeout
- `contents: write` permission scoped to this job
- Serialized via `concurrency: reset-survey-status` so parallel dispatches can't race

## Verification

- `pnpm test`: 193/193 (+4 new `resetSurveyResult` tests)
- `pnpm lint`: clean
- `pnpm check-types`: clean
- Node strip-only load: OK for the new CLI (via the `Test Scripts Load` CI job added in PR #3134)
- Workflow YAML parses; `targets` input present; App-token + `TARGETS` wiring matches `reconcile-repos.yaml`

## How to use after merge

```bash
gh workflow run reset-survey-status.yaml \
  -R fro-bot/.github \
  -f targets=marcusrbrown/.dotfiles,marcusrbrown/.github,marcusrbrown/containers,marcusrbrown/copiloting,marcusrbrown/esphome.life,marcusrbrown/extend-vscode
```

That's the 6 entries from today's cron with `last_survey_at: 2026-04-19, last_survey_status: success` that never had their wiki content committed. After the workflow completes, the next reconcile cron will re-dispatch them under the now-correct wiki-commit classification.

## Further direction (tracked, not in this PR)

- **Data-branch wiki sync.** The underlying drift that caused today's ENOENT (files on `main` but not on `data`) still exists. A separate follow-up to merge `main`'s wiki content into `data` eliminates the source of drift-induced deletions. Not part of this PR since it's a data-state change, not a code change.