### PR TITLE
fix(workflows): allow fro-bot-user commits on data and enable manual agent wiki ingest

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -260,7 +260,7 @@ jobs:
         if: >-
           success() &&
           steps.wiki-changes.outputs.changed == 'true' &&
-          contains(fromJSON('["issue_comment","pull_request_review_comment","discussion_comment","issues","pull_request","schedule"]'), github.event_name)
+          contains(fromJSON('["issue_comment","pull_request_review_comment","discussion_comment","issues","pull_request","schedule","workflow_dispatch"]'), github.event_name)
         id: ingest-ts
         run: echo "now=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
@@ -268,7 +268,7 @@ jobs:
         if: >-
           success() &&
           steps.wiki-changes.outputs.changed == 'true' &&
-          contains(fromJSON('["issue_comment","pull_request_review_comment","discussion_comment","issues","pull_request","schedule"]'), github.event_name)
+          contains(fromJSON('["issue_comment","pull_request_review_comment","discussion_comment","issues","pull_request","schedule","workflow_dispatch"]'), github.event_name)
         env:
           GITHUB_TOKEN: ${{ secrets.FRO_BOT_PAT }}
           WIKI_OPERATION: event

--- a/.github/workflows/reconcile-repos.yaml
+++ b/.github/workflows/reconcile-repos.yaml
@@ -52,4 +52,10 @@ jobs:
           # on the next run via the staleness gate, producing a progressive day-over-day
           # cadence instead of bursty fan-outs that exhaust upstream capacity.
           RECONCILE_MAX_DISPATCHES_PER_RUN: '6'
+          # Additional commit authors (beyond `fro-bot[bot]`) permitted on the data branch
+          # tip. Callers that write via `FRO_BOT_PAT` (record-survey-result,
+          # wiki-ingest from the Fro Bot agent) are attributed to the `fro-bot` user
+          # account. Without this allowlist, the integrity check tamper-alerts on every
+          # legitimate FRO_BOT_PAT commit.
+          RECONCILE_OPERATOR_LOGINS: fro-bot
         run: node scripts/reconcile-repos.ts


### PR DESCRIPTION
Two linked fixes that together unblock manually-dispatched Fro Bot runs from writing wiki updates to the `data` branch. Required as a prerequisite for the upcoming manual Fro Bot dispatch that will sync `main`'s wiki pages into `data` and eliminate the drift that caused today's ENOENT crashes (see PR #3144 for the underlying fix).

## Fix 1 -- data-branch integrity check rejected legitimate `fro-bot`-user commits

`scripts/reconcile-repos.ts:1044` allows only `fro-bot[bot]` plus any logins in `RECONCILE_OPERATOR_LOGINS` on the `data` branch tip commit. Callers that write via `FRO_BOT_PAT` -- `record-survey-result.ts` on every completed survey, and `wiki-ingest.ts` from the Fro Bot agent -- are attributed to the `fro-bot` user account. Without `fro-bot` in the allowlist, the integrity check tamper-alerts on every legitimate FRO_BOT_PAT commit.

This was latent since PR #3128 added the survey-result write-back step. Today's 06:53Z reconcile passed only because the tip at that moment was still yesterday's `fro-bot[bot]` commit. Subsequent `record-survey-result` commits at 07:05Z landed as the `fro-bot` user account. Tomorrow's 05:17Z reconcile would have tamper-alerted if the recovery workflow run at 13:35Z hadn't pushed HEAD back to `fro-bot[bot]`.

**Fix**: add `RECONCILE_OPERATOR_LOGINS: 'fro-bot'` to the `reconcile-repos.yaml` env block alongside the existing stagger + cap configuration.

## Fix 2 -- Fro Bot workflow's Ingest steps skipped `workflow_dispatch`

`.github/workflows/fro-bot.yaml`'s `Capture ingest timestamp` and `Ingest wiki insight changes` steps both gate on a `fromJSON` event-name allowlist that excluded `workflow_dispatch`. Manual dispatches therefore ran the agent but skipped the commit step -- any wiki changes the agent made never landed on `data`.

**Fix**: add `workflow_dispatch` to the `fromJSON` arrays in both step conditionals so on-demand agent runs can update the wiki. The existing guards (`success() && changed == 'true'`) still gate against no-op dispatches or agent failures.

## Verification

- `pnpm test`: 193/193 passing
- `pnpm lint`: clean
- `pnpm check-types`: clean
- Workflow YAML parses; `RECONCILE_OPERATOR_LOGINS` wired to the reconcile step env; both Ingest conditionals include `workflow_dispatch`

## Planned follow-up (not in this PR)

Once this merges, manually dispatch the Fro Bot agent with a wiki-sync prompt to copy `main`'s wiki pages into `data`. That commits as `fro-bot` user via `FRO_BOT_PAT`, which now passes the integrity check thanks to Fix 1, and the Ingest step now runs for workflow_dispatch events thanks to Fix 2.