### PR TITLE
chore(reconcile): treat fro-bot and fro-bot[bot] as one identity

### DIFF
--- a/.github/workflows/reconcile-repos.yaml
+++ b/.github/workflows/reconcile-repos.yaml
@@ -52,10 +52,4 @@ jobs:
           # on the next run via the staleness gate, producing a progressive day-over-day
           # cadence instead of bursty fan-outs that exhaust upstream capacity.
           RECONCILE_MAX_DISPATCHES_PER_RUN: '6'
-          # Additional commit authors (beyond `fro-bot[bot]`) permitted on the data branch
-          # tip. Callers that write via `FRO_BOT_PAT` (record-survey-result,
-          # wiki-ingest from the Fro Bot agent) are attributed to the `fro-bot` user
-          # account. Without this allowlist, the integrity check tamper-alerts on every
-          # legitimate FRO_BOT_PAT commit.
-          RECONCILE_OPERATOR_LOGINS: fro-bot
         run: node scripts/reconcile-repos.ts

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -689,7 +689,6 @@ function baseParams(overrides: Partial<HandleReconcileParams> = {}): HandleRecon
     // Specific tests that exercise the cap override this.
     maxDispatchesPerRun: overrides.maxDispatchesPerRun ?? 0,
     dispatchSleep: overrides.dispatchSleep,
-    operatorLogins: overrides.operatorLogins ?? [],
     logger: overrides.logger ?? silentLogger(),
     workflowFile: overrides.workflowFile ?? 'survey-repo.yaml',
     workflowRef: overrides.workflowRef ?? 'main',
@@ -1519,9 +1518,13 @@ describe('handleReconcile (I/O shell)', () => {
       expect(alertCalls).toHaveLength(0)
     })
 
-    it('passes when data branch tip is authored by an operator login in RECONCILE_OPERATOR_LOGINS', async () => {
+    it('passes when data branch tip is authored by fro-bot user (PAT writes)', async () => {
+      // Fro Bot writes that go through FRO_BOT_PAT (survey-repo record-survey-result,
+      // fro-bot agent wiki-ingest) are attributed to the `fro-bot` user account. The
+      // integrity check accepts it alongside `fro-bot[bot]` because both identities
+      // belong to the same autonomous operator.
       const getBranch = vi.fn(async () => ({
-        data: {name: 'data', commit: {sha: 'op-sha', author: {login: 'marcusrbrown'}}},
+        data: {name: 'data', commit: {sha: 'pat-sha', author: {login: 'fro-bot'}}},
       }))
       const commitMetadata = vi.fn(async () => ({committed: true, sha: 's', attempts: 1}))
       const userOctokit = mockOctokit({
@@ -1536,7 +1539,6 @@ describe('handleReconcile (I/O shell)', () => {
           appOctokit: mockOctokit({getBranch}),
           readMetadata: makeReadMetadata({allowlist: makeAllowlist(['t'])}),
           commitMetadata: commitMetadata as never,
-          operatorLogins: ['marcusrbrown'],
         }),
       )
 
@@ -1622,7 +1624,6 @@ describe('handleReconcile (I/O shell)', () => {
           readMetadata: makeReadMetadata({allowlist: makeAllowlist(['t'])}),
           commitMetadata: commitMetadata as never,
           bootstrapDataBranch: bootstrap as never,
-          operatorLogins: [], // no operators — would normally reject 'human-merger'
         }),
       )
 

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -490,7 +490,11 @@ const DEFAULT_MAX_DISPATCHES_PER_RUN = 6
 const PENDING_REVIEW_LABEL = 'reconcile:pending-review'
 const ROLLUP_LABEL = 'reconcile:rollup-pending-review'
 const INTEGRITY_ALERT_LABEL = 'reconcile:integrity-alert'
-const EXPECTED_APP_AUTHOR = 'fro-bot[bot]'
+// Fro Bot is one entity with two GitHub identities: the user account `fro-bot`
+// (FRO_BOT_PAT writes) and the app installation `fro-bot[bot]` (App-token writes).
+// Both have identical access to this repo and represent the same autonomous operator,
+// so the integrity check accepts either as legitimate.
+const EXPECTED_AUTHORS = new Set<string>(['fro-bot', 'fro-bot[bot]'])
 
 const NODE_ID_MARKER_PATTERN = /<!-- reconcile:subject:node_id=([\w-]+) -->/
 const ROLLUP_OWNER_MARKER_PATTERN = /<!-- reconcile:subject:rollup-owner=([\w-]+) -->/
@@ -557,8 +561,6 @@ export interface HandleReconcileParams {
    * real-time waits.
    */
   dispatchSleep?: (ms: number) => Promise<void>
-  /** Extra authors allowed on the data branch tip commit (beyond `fro-bot[bot]`). */
-  operatorLogins?: string[]
   logger?: ReconcileLogger
 }
 
@@ -610,7 +612,6 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
   const dispatchStaggerMs = params.dispatchStaggerMs ?? loadDispatchStaggerFromEnv()
   const maxDispatchesPerRun = params.maxDispatchesPerRun ?? loadMaxDispatchesPerRunFromEnv()
   const logger: ReconcileLogger = params.logger ?? {warn: message => process.stderr.write(`${message}\n`)}
-  const operatorLogins = params.operatorLogins ?? loadOperatorLoginsFromEnv()
   const readMetadata = params.readMetadata ?? readMetadataFromDisk
   const commitMetadataImpl = params.commitMetadata ?? defaultCommitMetadata
   const bootstrap = params.bootstrapDataBranch ?? defaultBootstrapDataBranch
@@ -655,7 +656,7 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
     if (justBootstrapped) {
       integrityCheck = 'skipped-just-bootstrapped'
     } else {
-      const integrity = await verifyDataBranchIntegrity({appOctokit, owner, repo, operatorLogins})
+      const integrity = await verifyDataBranchIntegrity({appOctokit, owner, repo})
       if (!integrity.ok) {
         await fileIntegrityAlert({
           appOctokit,
@@ -669,7 +670,7 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
           code: 'DATA_BRANCH_TAMPER',
           message: `Unexpected author on data branch tip commit: ${integrity.authorLogin ?? 'unknown'} (sha: ${integrity.sha})`,
           remediation:
-            'Investigate who has contents:write on this repo. If legitimate, add the login to RECONCILE_OPERATOR_LOGINS and rerun.',
+            'Only `fro-bot` (PAT) and `fro-bot[bot]` (App) are allowed to write to `data`. Investigate who else has contents:write on this repo.',
         })
       }
       integrityCheck = integrity.status
@@ -688,7 +689,7 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
         // also re-verifies, catching any tamper that lands during the retry loop. Skipped
         // on bootstrap runs for the same reason as the initial check.
         if (!justBootstrapped) {
-          const retryIntegrity = await verifyDataBranchIntegrity({appOctokit, owner, repo, operatorLogins})
+          const retryIntegrity = await verifyDataBranchIntegrity({appOctokit, owner, repo})
           if (!retryIntegrity.ok) {
             await fileIntegrityAlert({
               appOctokit,
@@ -702,7 +703,7 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
               code: 'DATA_BRANCH_TAMPER',
               message: `Unexpected author on data branch tip commit during commit retry: ${retryIntegrity.authorLogin ?? 'unknown'} (sha: ${retryIntegrity.sha})`,
               remediation:
-                'Investigate who has contents:write on this repo. If legitimate, add the login to RECONCILE_OPERATOR_LOGINS and rerun.',
+                'Only `fro-bot` (PAT) and `fro-bot[bot]` (App) are allowed to write to `data`. Investigate who else has contents:write on this repo.',
             })
           }
         }
@@ -1031,7 +1032,6 @@ async function verifyDataBranchIntegrity(params: {
   appOctokit: OctokitClient
   owner: string
   repo: string
-  operatorLogins: string[]
 }): Promise<IntegrityCheckOkResult | IntegrityCheckFailResult> {
   try {
     const response = await params.appOctokit.rest.repos.getBranch({
@@ -1041,8 +1041,7 @@ async function verifyDataBranchIntegrity(params: {
     })
     const commit = response.data.commit as {sha: string; author?: {login?: string} | null}
     const authorLogin = typeof commit.author?.login === 'string' ? commit.author.login : null
-    const allowed = new Set<string>([EXPECTED_APP_AUTHOR, ...params.operatorLogins])
-    if (authorLogin !== null && allowed.has(authorLogin)) {
+    if (authorLogin !== null && EXPECTED_AUTHORS.has(authorLogin)) {
       return {ok: true, status: 'ok'}
     }
     return {ok: false, authorLogin, sha: commit.sha}
@@ -1072,11 +1071,11 @@ async function fileIntegrityAlert(params: {
         '',
         `- Tip SHA: \`${params.sha}\``,
         `- Author login: \`${params.authorLogin ?? 'unknown'}\``,
-        `- Expected: \`${EXPECTED_APP_AUTHOR}\` or an operator login in \`RECONCILE_OPERATOR_LOGINS\``,
+        '- Expected: `fro-bot` (PAT writes) or `fro-bot[bot]` (App writes). Both belong to the Fro Bot account.',
         '',
         'Next steps:',
-        '- If this is a legitimate operator commit, add the login to `RECONCILE_OPERATOR_LOGINS` and rerun.',
-        '- If unauthorized, investigate who has `contents:write` on this repository.',
+        '- Investigate who else has `contents:write` on this repository.',
+        '- If the commit is a legitimate one-off operator action, rewrite the branch tip as `fro-bot`/`fro-bot[bot]` before rerunning.',
       ].join('\n'),
       labels: [INTEGRITY_ALERT_LABEL],
     })
@@ -1469,15 +1468,6 @@ async function selfHealRollups(params: {
  */
 async function callIssuesCreate(octokit: OctokitClient, payload: IssuePayload): Promise<void> {
   await octokit.rest.issues.create(payload as unknown as Parameters<OctokitClient['rest']['issues']['create']>[0])
-}
-
-function loadOperatorLoginsFromEnv(): string[] {
-  const raw = process.env.RECONCILE_OPERATOR_LOGINS
-  if (raw === undefined || raw === '') return []
-  return raw
-    .split(',')
-    .map(s => s.trim())
-    .filter(s => s.length > 0)
 }
 
 async function createOctokitFromEnv(envVar: 'FRO_BOT_POLL_PAT' | 'GITHUB_TOKEN'): Promise<OctokitClient> {


### PR DESCRIPTION
Fro Bot is one entity with two GitHub identities:

- `fro-bot` -- the user account authenticated via `FRO_BOT_PAT`
- `fro-bot[bot]` -- the App installation on the same user account

Both have identical access to this repo and represent the same autonomous operator. The integrity check on the `data` branch tip was treating them as separate, forcing an ever-growing operator-allowlist mechanism that artificially distinguished identities that are the same entity. Cleaning that up.

## What changed

| File                                      | Change                                                                                        |
| ----------------------------------------- | --------------------------------------------------------------------------------------------- |
| `scripts/reconcile-repos.ts`                | `EXPECTED_APP_AUTHOR` -> `EXPECTED_AUTHORS = {fro-bot, fro-bot[bot]}`. Delete `operatorLogins` param, `loadOperatorLoginsFromEnv`, allowlist plumbing in `verifyDataBranchIntegrity` + retry mutator. Remediation messages simplified. |
| `.github/workflows/reconcile-repos.yaml`    | Remove `RECONCILE_OPERATOR_LOGINS: fro-bot` env var + comment block.                              |
| `scripts/reconcile-repos.test.ts`           | Drop `operatorLogins` from the `baseParams` helper. Replace the `'marcusrbrown' via operator allowlist'` test with `'fro-bot user via PAT writes'`. Remove the bootstrap test's now-redundant `operatorLogins: []` assertion. |

## Why

The previous shape was actively harmful: every new writer pattern (survey result write-back via FRO_BOT_PAT, wiki ingest via agent) forced either a workflow env change to widen the allowlist or another App-token migration. Both are identity theater; Fro Bot is Fro Bot regardless of how the commit gets signed.

After this lands: adding `fro-bot` to the allowlist when a new workflow step uses FRO_BOT_PAT is no longer a class of config change we need to remember. The check stays (it caught a bad manual push earlier today -- that's a genuine tamper event). It just answers one question now: was the tip commit authored by Fro Bot (either identity)? Yes -> proceed. No -> alert.

## Verification

- `pnpm lint`: clean
- `pnpm check-types`: clean
- `pnpm test`: 193/193 passing
- No residual references to `RECONCILE_OPERATOR_LOGINS`, `operatorLogins`, `EXPECTED_APP_AUTHOR`, or `loadOperatorLoginsFromEnv` outside of historical prose (compound doc + changelog-style entries).

## Followups (not in this PR)

1. `docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md` (PR #3147, still open) has prose about `RECONCILE_OPERATOR_LOGINS` as a prevention rule. After this lands I'll add a small amendment to that doc noting the allowlist mechanism was removed the next day.
2. The remaining cosmetic wiki drift on `data` (`marcusrbrown--ha-config.md` and `home-assistant.md` each miss one or two `related:` frontmatter entries present on `main`) heals organically on the next Fro Bot agent survey of those repos -- not urgent.