### PR TITLE
ci(workflows): reduce default token permissions

### DIFF
--- a/.github/workflows/manage-cache.yaml
+++ b/.github/workflows/manage-cache.yaml
@@ -12,7 +12,8 @@ on:
         description: The ref where cache entries should be deleted
         type: string
 
-permissions: {}
+permissions:
+  contents: read
 
 env:
   REF: >-
@@ -26,8 +27,6 @@ env:
 jobs:
   cleanup-cache:
     name: Cleanup cache
-    permissions:
-      actions: write
     runs-on: ubuntu-latest
     steps:
       - if: env.REF != ''
@@ -51,8 +50,6 @@ jobs:
   setup-cache:
     if: github.event_name != 'pull_request'
     name: Setup cache
-    permissions:
-      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: ⤵ Checkout Branch

--- a/.github/workflows/merge-data.yaml
+++ b/.github/workflows/merge-data.yaml
@@ -12,10 +12,6 @@ permissions:
 jobs:
   merge-data:
     name: Merge data into main
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/reconcile-repos.yaml
+++ b/.github/workflows/reconcile-repos.yaml
@@ -16,10 +16,6 @@ concurrency:
 jobs:
   reconcile-repos:
     name: Reconcile metadata/repos.yaml with GitHub collaborator access
-    permissions:
-      contents: write
-      actions: write
-      issues: write
     runs-on: ubuntu-latest
     # Stagger + cap keep fan-out inside this budget even at the maximum configured
     # dispatch count: 6 dispatches × 90s = 9 minutes of stagger, plus ≤1 minute of

--- a/.github/workflows/reset-survey-status.yaml
+++ b/.github/workflows/reset-survey-status.yaml
@@ -25,8 +25,6 @@ concurrency:
 jobs:
   reset-survey-status:
     name: Reset last_survey_at and last_survey_status
-    permissions:
-      contents: write
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -14,7 +14,7 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: survey-repo-${{ github.event.inputs.owner }}-${{ github.event.inputs.repo }}


### PR DESCRIPTION
- set top-level permissions to `contents: read` in manage-cache
- remove redundant job-level permissions in merge-data, reconcile-repos, and reset-survey-status
- downgrade survey-repo default `contents` permission from write to read
- preserve existing workflow behavior while tightening least-privilege defaults