### PR TITLE
feat(ci): add Check Wiki Authority guard for data-branch authority

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -14,6 +14,7 @@ branches:
         contexts:
           - Analyze (typescript)
           - Check Types
+          - Check Wiki Authority
           - Check Workflows
           - CodeQL
           - Fro Bot

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -123,3 +123,27 @@ jobs:
 
       - name: ✅ Validate Workflows
         uses: rhysd/actionlint@e7d448ef7507c20fc4c88a95d0c448b848cd6127 # v1.7.8
+
+  check-wiki-authority:
+    name: Check Wiki Authority
+    # Only pull_request events carry a PR author to evaluate against the guard.
+    # Post-merge push runs on `main` are already past the gate.
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: ⤵ Checkout Branch
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: 📦 Setup
+        uses: ./.github/actions/setup
+
+      - name: 🛡 Enforce Wiki Authority
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/check-wiki-authority.ts

--- a/docs/plans/2026-04-19-001-feat-wiki-authority-ci-guard-plan.md
+++ b/docs/plans/2026-04-19-001-feat-wiki-authority-ci-guard-plan.md
@@ -1,0 +1,243 @@
+---
+title: 'feat: Wiki authority CI guard'
+type: feat
+status: active
+date: 2026-04-19
+---
+
+# feat: Wiki authority CI guard
+
+## Overview
+
+Add a CI guard that fails pull requests touching auto-managed `knowledge/` and `metadata/` files unless authored by Fro Bot (either identity). This closes the divergence loop that caused today's wiki drift incident: legacy human PRs landing directly on `main` produced content that `data`'s snapshot lacked, which then crashed downstream survey runs under `git restore`.
+
+The guard structurally enforces the single authority rule established earlier today: `data` is the only writable source for autonomously-managed state; `main` receives those files only via the `data → main` promotion PR opened by `merge-data.yaml`. Operators with intentional one-off edits commit to `data` and let the existing promotion flow land them on `main`.
+
+## Problem Frame
+
+Today's reconcile cron produced six failed survey runs traced to a structural drift between `main` and `data`. Root-cause analysis (see `docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md`) identified that `main` accumulated 22 wiki pages and their catalog/log entries directly — none went through `data` first — because prior agent versions and legacy human PRs had write paths that bypassed the intended `data`-branch-first model.
+
+The immediate symptom was patched in `PR #3144` by filtering porcelain deletions in `scripts/wiki-ingest.ts`. The deeper cause — that `main` can accept wiki/metadata edits outside the promotion flow — remains. Oracle's architectural audit called out this as the highest-leverage structural change needed to prevent recurrence.
+
+## Requirements Trace
+
+- **R1.** Block PRs targeting `main` that modify `knowledge/wiki/**`, `knowledge/index.md`, `knowledge/log.md`, or `metadata/*.yaml` when authored by any identity other than `fro-bot` or `fro-bot[bot]`.
+- **R2.** Allow the `data → main` promotion PR opened by `merge-data.yaml` to pass (authored by `fro-bot[bot]`).
+- **R3.** Allow human-authored edits to human-maintained docs inside the same directories (`knowledge/schema.md`, `knowledge/README.md`, `knowledge/wiki/README.md`, `metadata/README.md`).
+- **R4.** Fail closed with a clear, actionable error message naming the blocked files and pointing the PR author to the `data` branch workflow.
+- **R5.** Enforce via required status check on `main` branch protection.
+- **R6.** Run with zero new dependencies; stay consistent with existing `scripts/*.ts` + Vitest pattern.
+
+## Scope Boundaries
+
+- Does not guard `knowledge/schema.md`, `knowledge/README.md`, `knowledge/wiki/README.md`, or `metadata/README.md`. Those are intentionally human-editable documentation.
+- Does not guard arbitrary files outside `knowledge/` and `metadata/`. The rest of the repo uses normal code-review.
+- Does not add a label-based override mechanism. Oracle's Section 4 prescription is that `data` itself is the operator path; adding a bypass label would dilute the policy.
+- Does not retroactively audit existing commits on `main`. The guard applies to future PRs only.
+- Does not block direct pushes to `main` — branch protection already requires PRs, so the guard on the PR surface is sufficient.
+
+### Deferred to Separate Tasks
+
+- Monitoring the first time a real human PR hits the guard, to decide whether a documented override is worth adding later: handled via a smart note after the guard ships. Not infrastructure work.
+- Broader Oracle Section 4 items (survey-outcome classification as tested script, push protection in `common-settings.yaml`): separate plans.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `.github/workflows/main.yaml` — existing CI job pattern (Lint, Check Types, Test, Test Scripts Load, Check Workflows). Each job uses `./.github/actions/setup`, runs on `pull_request` + `push` to `main`, `timeout-minutes: 10`, explicit `permissions`.
+- `.github/settings.yml` — required-status-check registry under `branches.main.protection.required_status_checks.contexts`. Changes apply via the `Update Repo Settings` workflow after merge.
+- `scripts/wiki-slug.ts` — precedent for a small pure function + CLI wrapper pattern. Takes CLI args, emits stdout, exits non-zero on error.
+- `scripts/record-survey-result.ts` — precedent for a CLI that reads env + GitHub context and calls a tested helper.
+- `scripts/reconcile-repos.ts` — precedent for fail-closed error shapes (`ReconcileError` with `code` + `remediation`) and for tight unit-test coverage over pure decision functions.
+- `.github/workflows/merge-data.yaml` — authors the promotion PR as `fro-bot[bot]` (App installation token via `actions/create-github-app-token`). This is the legitimate actor the guard must allow.
+- `scripts/reconcile-repos.ts:493` — the identity-equivalence set `EXPECTED_AUTHORS = {'fro-bot', 'fro-bot[bot]'}`. The new guard reuses the same semantics (two identities, one operator).
+
+### Institutional Learnings
+
+- `docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md` — captures the trap that motivates this plan. Prevention rule 4 explicitly names "eliminate drift sources rather than papering over them with filters" as the architectural move; this guard is that move for the `main ↔ data` drift surface.
+
+### External References
+
+Not required. This is a well-patterned CI guard, and the codebase has two direct precedents for tested pure-function + thin-CLI scripts.
+
+## Key Technical Decisions
+
+- **Guard lives in `scripts/` as a tested pure function + thin CLI wrapper.** Matches `scripts/wiki-slug.ts` and `scripts/record-survey-result.ts`. Pure function takes `{author, files}` and returns `{ok} | {ok: false, blockedFiles}`. CLI reads `GITHUB_EVENT_PATH` + `gh pr diff --name-only` for the actual PR context. Unit tests cover the pure function; CLI is pattern-matched against existing scripts.
+
+- **Path rules are declarative and enumerated, not directory-wide.** Protect `knowledge/wiki/**`, `knowledge/index.md`, `knowledge/log.md`, and `metadata/*.yaml` exactly. `knowledge/schema.md`, `knowledge/README.md`, `knowledge/wiki/README.md`, and `metadata/README.md` stay human-editable. Avoids the "over-guard makes docs changes painful, under-guard leaves loopholes" failure modes.
+
+- **Identity equivalence mirrors reconcile.** Allow `fro-bot` and `fro-bot[bot]` via an explicit set. Reuses the same pattern `scripts/reconcile-repos.ts` adopted earlier today. No operator allowlist env var — that mechanism was just removed for being identity theater; don't reintroduce it here.
+
+- **Mixed PRs fail.** If a human PR touches any guarded file plus any unguarded file, the guard fails. Splitting the PR (human part stays, guarded edits move to `data`) is the correct resolution; a partial-accept path would erode the policy.
+
+- **No override label.** The `data` branch is the operator path. If a true emergency arrives, admin can temporarily remove the required check from `settings.yml` (reversible in one PR). Avoiding the override keeps the policy crisp.
+
+- **Mounted in `main.yaml`, not a dedicated workflow file.** Matches the existing cluster of CI jobs. New workflow file would add surface without benefit.
+
+- **Runs on `pull_request` only.** The existing `main.yaml` triggers include `push: [main]`; the new job will gate itself with `if: github.event_name == 'pull_request'` so it only evaluates against PR context, not post-merge pushes.
+
+- **Pure function design is case-sensitive and prefix-normalized.** GitHub's filesystem is case-sensitive; guard matches exact casing. Paths from `gh pr diff --name-only` arrive repo-relative without leading `./`, matching the regex shapes.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Which files in `metadata/` and `knowledge/` are guarded?** Enumerated in Key Technical Decisions: `knowledge/wiki/**`, `knowledge/index.md`, `knowledge/log.md`, `metadata/*.yaml`. Human docs (README, schema) explicitly outside the guard.
+- **Which identities can write to guarded files via PR?** `fro-bot` and `fro-bot[bot]`. The reconcile integrity check already models these as one operator; the guard reuses the same model.
+- **Where does the guard execute?** New CI job `check-wiki-authority` inside `.github/workflows/main.yaml`, following existing job patterns.
+- **Is there an override?** No. The `data` branch is the operator path; removing the required check temporarily is the break-glass option.
+
+### Deferred to Implementation
+
+- **Exact failure message copy.** The guard's error output goes into the CI log and becomes the first thing the PR author sees. Final wording will be tuned during Unit 1 to match repo voice (direct, factual, short). The substance — which files are blocked, who is authorized, and how to resubmit via `data` — is locked by the plan.
+
+## Implementation Units
+
+- [ ] **Unit 1: Pure guard function + CLI script**
+
+**Goal:** Implement the wiki-authority decision function and a thin CLI that wires it to PR event context.
+
+**Requirements:** R1, R2, R3, R4, R6
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `scripts/check-wiki-authority.ts`
+- Test: `scripts/check-wiki-authority.test.ts`
+
+**Approach:**
+- Export a pure `checkWikiAuthority(input: {author: string; files: string[]}): GuardResult` where `GuardResult` is `{ok: true} | {ok: false; blockedFiles: string[]}`.
+- Maintain an internal `FROBOT_AUTHORS = new Set<string>(['fro-bot', 'fro-bot[bot]'])` mirroring `scripts/reconcile-repos.ts`.
+- Maintain an internal `GUARDED_PATTERNS: RegExp[]` covering the four rules: `^knowledge/wiki/.+\.md$`, `^knowledge/index\.md$`, `^knowledge/log\.md$`, `^metadata/[^/]+\.yaml$`.
+- CLI wrapper at the bottom of the file: when invoked as a script (check `import.meta.url` against `process.argv[1]`), read PR context from `GITHUB_EVENT_PATH` (pull_request event payload), fetch changed files via `gh pr diff --name-only <pr-number>` or read from the event payload if present, call the pure function, emit a formatted failure message to stderr and exit 1 on block, or exit 0 with a brief success message on allow.
+- Errors read by the pure function are typed; errors in the CLI layer (missing env, gh failure) exit with a distinct non-zero status and explicit message so workflow debugging is obvious.
+
+**Execution note:** Test-first. Write the test file listing all scenarios (see below), confirm RED, then implement the pure function until GREEN. CLI wrapper is pattern-matched against `scripts/record-survey-result.ts` and smoke-tested manually in Unit 2.
+
+**Patterns to follow:**
+- `scripts/wiki-slug.ts` — pure function + CLI wrapper shape.
+- `scripts/record-survey-result.ts` — env-driven CLI reading GitHub context.
+- `scripts/reconcile-repos.ts` — identity-equivalence set + structured error messaging (just the message shape; this script doesn't need a full `ReconcileError` class).
+- `scripts/reconcile-repos.test.ts` — Vitest conventions for pure decision functions with comprehensive scenario tables.
+
+**Test scenarios:**
+- Happy path: author `fro-bot[bot]`, files `['metadata/repos.yaml']` → `{ok: true}`.
+- Happy path: author `fro-bot`, files `['knowledge/wiki/topics/home-assistant.md']` → `{ok: true}`.
+- Happy path: author `fro-bot[bot]`, files `['knowledge/wiki/repos/marcusrbrown--x.md', 'metadata/allowlist.yaml', 'knowledge/index.md', 'knowledge/log.md']` (mixed guarded) → `{ok: true}`.
+- Happy path: author `marcusrbrown`, files `['README.md', 'src/foo.ts']` → `{ok: true}` (no guarded paths touched).
+- Happy path: author `marcusrbrown`, files `[]` → `{ok: true}` (vacuous).
+- Happy path: author `marcusrbrown`, files `['knowledge/schema.md']` → `{ok: true}` (schema intentionally unguarded).
+- Happy path: author `marcusrbrown`, files `['knowledge/README.md']` → `{ok: true}`.
+- Happy path: author `marcusrbrown`, files `['knowledge/wiki/README.md']` → `{ok: true}`.
+- Happy path: author `marcusrbrown`, files `['metadata/README.md']` → `{ok: true}`.
+- Error path: author `marcusrbrown`, files `['metadata/repos.yaml']` → `{ok: false, blockedFiles: ['metadata/repos.yaml']}`.
+- Error path: author `marcusrbrown`, files `['knowledge/wiki/topics/home-assistant.md']` → blocked.
+- Error path: author `marcusrbrown`, files `['knowledge/index.md']` → blocked.
+- Error path: author `marcusrbrown`, files `['knowledge/log.md']` → blocked.
+- Error path: author `marcusrbrown`, files `['src/foo.ts', 'metadata/repos.yaml']` → blocked, only the guarded file in `blockedFiles`.
+- Error path: author `marcusrbrown`, files `['metadata/repos.yaml', 'knowledge/wiki/repos/x.md', 'knowledge/index.md', 'knowledge/log.md']` → blocked, all four in `blockedFiles` preserving input order.
+- Error path: author `github-actions[bot]`, files `['metadata/repos.yaml']` → blocked (not an allowed identity).
+- Error path: author `dependabot[bot]`, files `['metadata/repos.yaml']` → blocked.
+- Edge case: author `marcusrbrown`, files `['knowledge/wiki/comparisons/x-vs-y.md']` → blocked (nested wiki glob).
+- Edge case: author `marcusrbrown`, files `['metadata/new-thing.yaml']` (hypothetical future file) → blocked (glob covers any `*.yaml` under `metadata/`).
+- Edge case: author `marcusrbrown`, files `['metadata/subdir/x.yaml']` (hypothetical nested) → not blocked by current glob (glob is single-segment). Document this in the test as the current intended behavior; if nested metadata appears later, revisit.
+- Edge case: author `marcusrbrown`, files `['metadata/repos.yml']` (wrong extension) → not blocked. Only `.yaml` is guarded.
+
+**Verification:**
+- `pnpm test` passes with the new test file contributing clean scenarios.
+- `pnpm lint` and `pnpm check-types` clean on the new file.
+- Smoke-test the CLI locally by invoking it with a synthetic `GITHUB_EVENT_PATH` JSON and observing exit status + message.
+
+- [ ] **Unit 2: Wire guard into CI + required status check**
+
+**Goal:** Add the `check-wiki-authority` job to `main.yaml` and register it in `settings.yml` so branch protection enforces it.
+
+**Requirements:** R5
+
+**Dependencies:** Unit 1 merged (the script must exist before the workflow invokes it).
+
+**Files:**
+- Modify: `.github/workflows/main.yaml`
+- Modify: `.github/settings.yml`
+
+**Approach:**
+- Add a new job `check-wiki-authority` to `main.yaml` following the existing job layout (explicit `permissions`, `runs-on: ubuntu-latest`, `timeout-minutes: 10`, checkout with `ref: ${{ github.head_ref }}`, `./.github/actions/setup`).
+- Gate with `if: github.event_name == 'pull_request'` so it runs only on PR events, not on post-merge `push: [main]` runs.
+- Invoke via `run: node scripts/check-wiki-authority.ts`. Pass `GITHUB_TOKEN` from the default `${{ github.token }}` for `gh` CLI auth; the job only needs read access to PR metadata and diff, so `permissions: pull-requests: read, contents: read` is sufficient.
+- In `settings.yml`, insert `Check Wiki Authority` into the alphabetically-ordered `branches.main.protection.required_status_checks.contexts` list.
+
+**Patterns to follow:**
+- `.github/workflows/main.yaml` jobs `Test Scripts Load` and `Check Workflows` — same shape.
+- `.github/settings.yml` existing contexts list — keep alphabetical.
+
+**Test scenarios:**
+
+Test expectation: none — this unit is YAML config with no behavioral logic to unit-test. Verification happens via the workflow's actual run on Unit 2's own PR (the guard must pass on a PR authored by the user that changes only workflow/settings files, which are not guarded).
+
+**Verification:**
+- `actionlint` (via `Check Workflows` job) passes on the modified `main.yaml`.
+- On the Unit 2 PR itself, the new `check-wiki-authority` job runs, evaluates `{author: <user>, files: ['.github/workflows/main.yaml', '.github/settings.yml']}`, and passes (neither file is guarded).
+- After merge, `Update Repo Settings` workflow applies the new required check to branch protection. A subsequent test PR touching `metadata/repos.yaml` under a non-Fro-Bot author must fail the check and block merge.
+
+- [ ] **Unit 3: Document operator workflow**
+
+**Goal:** Document the policy so future operators know the correct workflow for one-off wiki or metadata edits.
+
+**Requirements:** R4 (discoverable remediation)
+
+**Dependencies:** None (can land in parallel with Unit 1).
+
+**Files:**
+- Modify: `metadata/README.md`
+- Modify: `knowledge/schema.md`
+
+**Approach:**
+- Add a short section to `metadata/README.md` (after the existing schema sections) titled "Editing metadata files" that explains: `metadata/*.yaml` are auto-managed; edits must land via `data` branch; open the `data` worktree, commit, push, and let `merge-data.yaml` promote; README files are fine to edit on a normal human PR.
+- Add the mirroring guidance to `knowledge/schema.md` — a short "Editing the wiki" subsection that describes the same workflow for `knowledge/wiki/**`, `knowledge/index.md`, `knowledge/log.md`.
+- Both sections point to the CI guard as the enforcement mechanism, reference the guard script path, and note that the guard respects the two Fro Bot identities.
+- No plan references, no session framing; write as operator-facing docs.
+
+**Patterns to follow:**
+- `metadata/README.md` existing voice (terse, factual, operator-focused).
+- `knowledge/schema.md` existing voice (Karpathy-style conventions doc).
+
+**Test scenarios:**
+
+Test expectation: none — documentation change with no behavior to test.
+
+**Verification:**
+- `pnpm lint` clean (markdownlint rules applied via ESLint).
+- Reading each updated section cold, an operator can correctly answer: "how do I edit `metadata/repos.yaml` as a human?"
+
+## System-Wide Impact
+
+- **Interaction graph:** The guard interposes between PRs and `main`. Existing CI jobs (Lint, Check Types, Test, Test Scripts Load, Check Workflows) are untouched. `merge-data.yaml` PR passes the guard via `fro-bot[bot]` identity; no workflow change needed.
+- **Error propagation:** CI failure with exit 1 and a stderr message pointing at the correct workflow. Branch protection turns that into a "this check failed" state on the PR. No silent failures.
+- **State lifecycle risks:** None. The guard evaluates PR metadata per run, no persistent state.
+- **API surface parity:** `scripts/check-wiki-authority.ts` mirrors the identity-equivalence set from `scripts/reconcile-repos.ts`. If the operator identity model ever expands (unlikely), both files need to change together. Surface this in Unit 1's implementation comment so a future editor notices.
+- **Integration coverage:** Unit-test coverage over the pure function is sufficient. CLI wrapper is smoke-tested on Unit 2's own PR via the real event path.
+- **Unchanged invariants:** `data` branch remains unprotected (autonomous writers unchanged). `merge-data.yaml` flow unchanged. `reconcile-repos.yaml` integrity check unchanged. Human PRs touching code in `src/`, `scripts/`, workflows, or docs outside the guarded paths continue to work as today.
+
+## Risks & Dependencies
+
+| Risk                                                                                                                        | Mitigation                                                                                                                                                                                                                                  |
+| --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Guard false-positives a legitimate operator edit                                                                            | Fail message tells the operator exactly how to resubmit via `data`. Worst case: a single extra round-trip. No data loss; the edit still lands, just through the intended channel.                                                           |
+| Guard false-negatives a malformed path match (e.g., `./knowledge/wiki/x.md` with leading `./`)                              | Pure function tests pin the expected input shape to repo-relative paths without leading `./`. `gh pr diff --name-only` emits that shape. CLI layer could normalize defensively if a real mismatch appears — added as a deferred follow-up. |
+| `merge-data.yaml` author identity drifts (e.g., GitHub renames bot suffix)                                                  | Identity set is centralized in one helper; changing it is a one-file change. Existing `scripts/reconcile-repos.ts` uses the same set, so drift affects both symmetrically.                                                                  |
+| Required status check misconfigured in `settings.yml` and blocks merges before Unit 2's own PR lands                        | Add the context to `settings.yml` in Unit 2's PR only after the job itself is defined in the same PR. The new context applies only to PRs opened after the `Update Repo Settings` run. Unit 2's own PR is merged under the old rule set.    |
+| A future metadata subdirectory (e.g., `metadata/archive/`) escapes the single-segment glob                                  | Documented in test scenarios as current intended behavior. If nested metadata is added, revise the glob in one line and update the test.                                                                                                    |
+| Human operator accidentally creates a `.yml` (not `.yaml`) file in `metadata/` and it bypasses the guard                    | Documented in tests as current behavior. Lint or schema tooling can be layered later to enforce the canonical `.yaml` extension, tracked as a separate concern.                                                                             |
+
+## Documentation / Operational Notes
+
+- `metadata/README.md` and `knowledge/schema.md` carry the operator workflow (Unit 3).
+- The `docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md` compound doc already notes "eliminate drift sources" as the architectural move; a short amendment after this plan lands can reference the guard as the concrete realization. Tracked as a follow-up, not part of this plan.
+- Operational note for the first real human PR that hits the guard: monitor the fail message for clarity and adjust copy if needed. No pre-emptive tuning — wait for real feedback.
+
+## Sources & References
+
+- Related code: `scripts/reconcile-repos.ts` (`EXPECTED_AUTHORS` set), `scripts/wiki-slug.ts` (CLI pattern), `scripts/record-survey-result.ts` (CLI with env context), `.github/workflows/main.yaml` (job layout), `.github/workflows/merge-data.yaml` (promotion PR flow).
+- Related PRs: `#3144` (porcelain deletion filter — patched the symptom), `#3149` (identity collapse — normalized the two Fro Bot identities), `#3147` (compound doc prevention rule 4 names this exact structural move).
+- Architectural context: this plan executes Oracle's Section 4 recommendation from the 2026-04-19 control-plane audit — "Make `data` the only writable authority for `knowledge/**` and `metadata/**`. Add a guard in PR CI that fails non-promotion PRs touching those paths."

--- a/knowledge/schema.md
+++ b/knowledge/schema.md
@@ -84,3 +84,22 @@ Operations: `ingest`, `query`, `lint`, `manual-edit`.
 - **Weekly lint**: scans for broken wikilinks, orphan pages, stale claims, missing cross-references, and knowledge gaps.
 - **Ingest validation**: every ingest operation validates output against this schema before committing.
 - **Index consistency**: `index.md` MUST list every page in `wiki/`. Orphan pages (in wiki but not index) are flagged by lint.
+
+## Editing the wiki
+
+The `knowledge/wiki/<subdir>/*.md` pages, `knowledge/index.md`, and `knowledge/log.md` are enforced as Fro-Bot-writable-only on `main`. A CI job (`Check Wiki Authority`, backed by `scripts/check-wiki-authority.ts`) fails any PR that modifies them unless authored by `fro-bot` or `fro-bot[bot]`. This keeps `main` aligned with `data`, which is the authoritative wiki source.
+
+For intentional manual edits (correcting a factual error the agent hasn't caught, for example), land the change on `data` and let the existing promotion flow land it on `main`:
+
+```bash
+git worktree add ../fro-bot-.github-data data
+cd ../fro-bot-.github-data
+# edit the wiki page or append a manual-edit log entry
+git add knowledge/...
+git commit -m "docs(knowledge): <what changed and why>"
+git push origin data
+```
+
+The `Merge Data Branch` workflow promotes `data → main` on a weekly schedule (or run it immediately via `gh workflow run merge-data.yaml`). The promotion PR is authored by `fro-bot[bot]`, which passes the guard.
+
+This file (`knowledge/schema.md`) and `knowledge/README.md` / `knowledge/wiki/README.md` remain editable through normal PRs to `main` — the guard targets only the agent-authored content tree, not conventions or scaffolding docs.

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -16,7 +16,7 @@ approved_inviters:
     role: string
 ```
 
-Update convention: human-maintained. Changes go through PRs to `main`.
+Update convention: human-maintained; edits land via the `data` branch (see [Editing metadata files](#editing-metadata-files) below).
 
 ### `repos.yaml`
 
@@ -102,10 +102,29 @@ PAT split summary:
 | `merge-data.yaml`       | `GITHUB_TOKEN` (auto-provisioned, job-scoped permissions)               |
 | `reconcile-repos.yaml`  | `FRO_BOT_POLL_PAT` + `APPLICATION_ID` + `APPLICATION_PRIVATE_KEY`       |
 
+## Editing metadata files
+
+The `metadata/*.yaml` files are enforced as Fro-Bot-writable-only on `main`. A CI job (`Check Wiki Authority`, backed by `scripts/check-wiki-authority.ts`) fails any PR that modifies them unless authored by `fro-bot` or `fro-bot[bot]`. This prevents `main` from drifting relative to `data`, which is the single authoritative source.
+
+For intentional manual edits (e.g., adding an entry to `allowlist.yaml`), land the change on `data` directly and let the existing promotion flow land it on `main`:
+
+```bash
+git worktree add ../fro-bot-.github-data data
+cd ../fro-bot-.github-data
+# edit the file
+git add metadata/<file>.yaml
+git commit -m "chore(metadata): <what changed and why>"
+git push origin data
+```
+
+The `Merge Data Branch` workflow runs on a schedule (weekly) and opens a `data → main` promotion PR authored by `fro-bot[bot]`, which is allowed through the guard. For faster turnaround, trigger it manually via `gh workflow run merge-data.yaml`.
+
+`metadata/README.md` (this file) and other human documentation remain editable through normal PRs to `main` — the guard targets only `metadata/*.yaml`.
+
 ## Commit conventions
 
 - All programmatic metadata writes must go through `scripts/commit-metadata.ts` and target the `data` branch.
-- Manual edits go through normal PR review to `main`.
+- Manual edits to `metadata/*.yaml` also target `data` and are promoted via the `Merge Data Branch` workflow — see above.
 - Metadata files are initialized in-repo first; automation updates existing files only.
 
 ## Metrics note

--- a/scripts/check-wiki-authority.test.ts
+++ b/scripts/check-wiki-authority.test.ts
@@ -1,0 +1,258 @@
+import {describe, expect, it} from 'vitest'
+
+import {checkWikiAuthority, formatBlockMessage} from './check-wiki-authority.ts'
+
+describe('checkWikiAuthority', () => {
+  describe('author is an allowed Fro Bot identity', () => {
+    it('allows fro-bot[bot] editing a guarded metadata yaml', () => {
+      // #given the App installation author touching metadata/repos.yaml
+      // #when the guard evaluates the PR
+      // #then the edit is allowed (fro-bot[bot] is the promotion-PR identity)
+      const result = checkWikiAuthority({author: 'fro-bot[bot]', files: ['metadata/repos.yaml']})
+      expect(result).toEqual({ok: true})
+    })
+
+    it('allows fro-bot user editing a guarded wiki page', () => {
+      // #given the user-token author (FRO_BOT_PAT writes) touching a wiki page
+      // #when the guard evaluates the PR
+      // #then the edit is allowed (fro-bot and fro-bot[bot] are one operator)
+      const result = checkWikiAuthority({
+        author: 'fro-bot',
+        files: ['knowledge/wiki/topics/home-assistant.md'],
+      })
+      expect(result).toEqual({ok: true})
+    })
+
+    it('allows fro-bot[bot] editing multiple guarded paths in one PR', () => {
+      // #given a promotion-style PR touching wiki, index, log, and metadata together
+      // #when the guard evaluates the PR
+      // #then every guarded path is allowed under the Fro Bot identity
+      const result = checkWikiAuthority({
+        author: 'fro-bot[bot]',
+        files: [
+          'knowledge/wiki/repos/marcusrbrown--x.md',
+          'metadata/allowlist.yaml',
+          'knowledge/index.md',
+          'knowledge/log.md',
+        ],
+      })
+      expect(result).toEqual({ok: true})
+    })
+  })
+
+  describe('author is not Fro Bot; only unguarded files touched', () => {
+    it('allows arbitrary source-file edits', () => {
+      // #given a human PR touching only application code and top-level docs
+      // #when the guard evaluates the PR
+      // #then the edit is allowed (no guarded paths present)
+      const result = checkWikiAuthority({author: 'marcusrbrown', files: ['README.md', 'src/foo.ts']})
+      expect(result).toEqual({ok: true})
+    })
+
+    it('allows an empty file list (vacuous case)', () => {
+      // #given a PR whose file list is empty (edge case)
+      // #when the guard evaluates the PR
+      // #then the guard does not fire (nothing to check)
+      const result = checkWikiAuthority({author: 'marcusrbrown', files: []})
+      expect(result).toEqual({ok: true})
+    })
+
+    it('allows editing knowledge/schema.md (human-editable conventions doc)', () => {
+      // #given the Karpathy-style conventions doc edited by a human
+      // #when the guard evaluates the PR
+      // #then the edit is allowed (schema is intentionally outside the guard)
+      const result = checkWikiAuthority({author: 'marcusrbrown', files: ['knowledge/schema.md']})
+      expect(result).toEqual({ok: true})
+    })
+
+    it('allows editing knowledge/README.md', () => {
+      // #given a human edit to the knowledge directory's README
+      // #when the guard evaluates the PR
+      // #then the edit is allowed (READMEs are human-editable)
+      const result = checkWikiAuthority({author: 'marcusrbrown', files: ['knowledge/README.md']})
+      expect(result).toEqual({ok: true})
+    })
+
+    it('allows editing knowledge/wiki/README.md', () => {
+      // #given a human edit to the wiki directory's README
+      // #when the guard evaluates the PR
+      // #then the edit is allowed (README is outside the auto-managed wiki content)
+      const result = checkWikiAuthority({author: 'marcusrbrown', files: ['knowledge/wiki/README.md']})
+      expect(result).toEqual({ok: true})
+    })
+
+    it('allows editing metadata/README.md', () => {
+      // #given a human edit to the metadata directory's README
+      // #when the guard evaluates the PR
+      // #then the edit is allowed (only *.yaml files in metadata/ are guarded)
+      const result = checkWikiAuthority({author: 'marcusrbrown', files: ['metadata/README.md']})
+      expect(result).toEqual({ok: true})
+    })
+  })
+
+  describe('author is not Fro Bot; guarded files touched', () => {
+    it('blocks a human PR editing metadata/repos.yaml', () => {
+      // #given a human author touching an auto-managed metadata yaml
+      // #when the guard evaluates the PR
+      // #then the edit is blocked and the file is listed
+      const result = checkWikiAuthority({author: 'marcusrbrown', files: ['metadata/repos.yaml']})
+      expect(result).toEqual({ok: false, blockedFiles: ['metadata/repos.yaml']})
+    })
+
+    it('blocks a human PR editing a knowledge/wiki page', () => {
+      // #given a human author touching an auto-managed wiki page
+      // #when the guard evaluates the PR
+      // #then the edit is blocked
+      const result = checkWikiAuthority({
+        author: 'marcusrbrown',
+        files: ['knowledge/wiki/topics/home-assistant.md'],
+      })
+      expect(result).toEqual({ok: false, blockedFiles: ['knowledge/wiki/topics/home-assistant.md']})
+    })
+
+    it('blocks a human PR editing knowledge/index.md', () => {
+      // #given a human author touching the wiki catalog
+      // #when the guard evaluates the PR
+      // #then the edit is blocked
+      const result = checkWikiAuthority({author: 'marcusrbrown', files: ['knowledge/index.md']})
+      expect(result).toEqual({ok: false, blockedFiles: ['knowledge/index.md']})
+    })
+
+    it('blocks a human PR editing knowledge/log.md', () => {
+      // #given a human author touching the append-only wiki log
+      // #when the guard evaluates the PR
+      // #then the edit is blocked
+      const result = checkWikiAuthority({author: 'marcusrbrown', files: ['knowledge/log.md']})
+      expect(result).toEqual({ok: false, blockedFiles: ['knowledge/log.md']})
+    })
+
+    it('lists only the guarded files when mixed with unguarded files', () => {
+      // #given a human author touching both code and a single guarded yaml
+      // #when the guard evaluates the PR
+      // #then blockedFiles contains only the guarded file, not the code file
+      const result = checkWikiAuthority({
+        author: 'marcusrbrown',
+        files: ['src/foo.ts', 'metadata/repos.yaml'],
+      })
+      expect(result).toEqual({ok: false, blockedFiles: ['metadata/repos.yaml']})
+    })
+
+    it('preserves input order when multiple guarded files are blocked', () => {
+      // #given a human author touching every guarded surface at once
+      // #when the guard evaluates the PR
+      // #then blockedFiles lists every guarded path in the original order
+      const files = ['metadata/repos.yaml', 'knowledge/wiki/repos/x.md', 'knowledge/index.md', 'knowledge/log.md']
+      const result = checkWikiAuthority({author: 'marcusrbrown', files})
+      expect(result).toEqual({ok: false, blockedFiles: files})
+    })
+
+    it('blocks github-actions[bot] (not a Fro Bot identity)', () => {
+      // #given the default GITHUB_TOKEN identity touching a guarded file
+      // #when the guard evaluates the PR
+      // #then the edit is blocked — only fro-bot and fro-bot[bot] are authorized
+      const result = checkWikiAuthority({
+        author: 'github-actions[bot]',
+        files: ['metadata/repos.yaml'],
+      })
+      expect(result).toEqual({ok: false, blockedFiles: ['metadata/repos.yaml']})
+    })
+
+    it('blocks dependabot[bot] (defensive, should never touch guarded files)', () => {
+      // #given a random bot identity touching a guarded file
+      // #when the guard evaluates the PR
+      // #then the edit is blocked — the guard fails closed on unknown identities
+      const result = checkWikiAuthority({
+        author: 'dependabot[bot]',
+        files: ['metadata/repos.yaml'],
+      })
+      expect(result).toEqual({ok: false, blockedFiles: ['metadata/repos.yaml']})
+    })
+  })
+
+  describe('path-matching edge cases', () => {
+    it('blocks nested wiki subdirectories via the wiki glob', () => {
+      // #given a deep nested wiki path
+      // #when the guard evaluates the PR
+      // #then the knowledge/wiki/** glob matches at any depth
+      const result = checkWikiAuthority({
+        author: 'marcusrbrown',
+        files: ['knowledge/wiki/comparisons/x-vs-y.md'],
+      })
+      expect(result).toEqual({ok: false, blockedFiles: ['knowledge/wiki/comparisons/x-vs-y.md']})
+    })
+
+    it('blocks hypothetical future metadata/*.yaml files', () => {
+      // #given a new yaml file that could be added to metadata/ in future
+      // #when the guard evaluates the PR
+      // #then the single-segment glob covers it without needing a guard update
+      const result = checkWikiAuthority({author: 'marcusrbrown', files: ['metadata/new-thing.yaml']})
+      expect(result).toEqual({ok: false, blockedFiles: ['metadata/new-thing.yaml']})
+    })
+
+    it('does not block metadata/<subdir>/*.yaml (single-segment glob by design)', () => {
+      // #given a hypothetical nested metadata file
+      // #when the guard evaluates the PR
+      // #then the edit is NOT blocked — if nested metadata is added later, the glob is revisited
+      const result = checkWikiAuthority({author: 'marcusrbrown', files: ['metadata/subdir/x.yaml']})
+      expect(result).toEqual({ok: true})
+    })
+
+    it('does not block metadata/*.yml (wrong extension)', () => {
+      // #given a yaml file with the non-canonical .yml extension
+      // #when the guard evaluates the PR
+      // #then the edit is NOT blocked — the repo convention is *.yaml, and guard matches that literally
+      const result = checkWikiAuthority({author: 'marcusrbrown', files: ['metadata/repos.yml']})
+      expect(result).toEqual({ok: true})
+    })
+
+    it('does not block files named like the guarded ones but outside the guarded prefix', () => {
+      // #given files with guard-lookalike names at other locations
+      // #when the guard evaluates the PR
+      // #then the edit is NOT blocked — anchored regexes only match the canonical prefixes
+      const result = checkWikiAuthority({
+        author: 'marcusrbrown',
+        files: ['docs/knowledge/index.md', 'backup/metadata/repos.yaml', 'src/knowledge/wiki/x.md'],
+      })
+      expect(result).toEqual({ok: true})
+    })
+  })
+})
+
+describe('formatBlockMessage', () => {
+  it('names every blocked file in the message', () => {
+    // #given a result blocking two guarded files
+    // #when the failure message is formatted
+    // #then each blocked path appears in the output
+    const msg = formatBlockMessage({
+      ok: false,
+      blockedFiles: ['metadata/repos.yaml', 'knowledge/wiki/topics/home-assistant.md'],
+    })
+    expect(msg).toContain('metadata/repos.yaml')
+    expect(msg).toContain('knowledge/wiki/topics/home-assistant.md')
+  })
+
+  it('names the data branch as the resubmission path', () => {
+    // #given any block result
+    // #when the failure message is formatted
+    // #then the message instructs the PR author to land edits via `data`
+    const msg = formatBlockMessage({ok: false, blockedFiles: ['metadata/repos.yaml']})
+    expect(msg.toLowerCase()).toContain('data branch')
+  })
+
+  it('names both Fro Bot identities as the authorized writers', () => {
+    // #given any block result
+    // #when the failure message is formatted
+    // #then both `fro-bot` and `fro-bot[bot]` appear so the reader sees the equivalence
+    const msg = formatBlockMessage({ok: false, blockedFiles: ['metadata/repos.yaml']})
+    expect(msg).toContain('fro-bot')
+    expect(msg).toContain('fro-bot[bot]')
+  })
+
+  it('produces non-empty output', () => {
+    // #given a minimal block result
+    // #when the failure message is formatted
+    // #then the output is a non-trivial string the CI log can surface
+    const msg = formatBlockMessage({ok: false, blockedFiles: ['metadata/repos.yaml']})
+    expect(msg.length).toBeGreaterThan(50)
+  })
+})

--- a/scripts/check-wiki-authority.ts
+++ b/scripts/check-wiki-authority.ts
@@ -1,0 +1,146 @@
+import {execFileSync} from 'node:child_process'
+import {readFile} from 'node:fs/promises'
+import process from 'node:process'
+
+/**
+ * Fro Bot identities permitted to commit autonomously-managed files on `main`.
+ *
+ * Kept symmetric with `EXPECTED_AUTHORS` in `scripts/reconcile-repos.ts` so the two
+ * enforcement points (pre-commit integrity check on `data` and pre-merge PR guard on
+ * `main`) share one operator model. If this set ever changes, change both files.
+ */
+const FROBOT_AUTHORS: ReadonlySet<string> = new Set(['fro-bot', 'fro-bot[bot]'])
+
+/**
+ * Anchored patterns for files whose only legitimate writer is Fro Bot.
+ *
+ * - `knowledge/wiki/<subdir>/*.md` is agent-authored content — pages live in
+ *   `repos/`, `topics/`, `entities/`, and `comparisons/` subdirectories per the
+ *   Karpathy schema. Top-level `knowledge/wiki/README.md` is human scaffolding.
+ * - `knowledge/index.md` and `knowledge/log.md` are auto-maintained catalog and journal
+ * - `metadata/*.yaml` are autonomous state files (repos.yaml, allowlist.yaml, etc.)
+ *
+ * Human-editable siblings (`knowledge/schema.md`, `knowledge/README.md`,
+ * `knowledge/wiki/README.md`, `metadata/README.md`) are intentionally NOT covered —
+ * they carry conventions and docs that humans should own.
+ */
+const GUARDED_PATTERNS: readonly RegExp[] = [
+  /^knowledge\/wiki\/[^/]+\/.+\.md$/,
+  /^knowledge\/index\.md$/,
+  /^knowledge\/log\.md$/,
+  /^metadata\/[^/]+\.yaml$/,
+]
+
+export interface GuardInput {
+  readonly author: string
+  readonly files: readonly string[]
+}
+
+export type GuardResult = {readonly ok: true} | {readonly ok: false; readonly blockedFiles: readonly string[]}
+
+/**
+ * Pure decision function: should this PR be allowed to touch autonomously-managed files?
+ *
+ * Rules:
+ * - If the author is a Fro Bot identity, always allow. Fro Bot is the legitimate writer.
+ * - Otherwise, reject if any changed file matches a guarded pattern. The PR must split
+ *   its guarded edits onto the `data` branch and let the promotion flow land them.
+ *
+ * Returns `{ok: true}` on allow, `{ok: false, blockedFiles}` listing the offending paths
+ * in input order. Mixed PRs (some guarded, some not) still fail; splitting the PR is the
+ * intended resolution.
+ */
+export function checkWikiAuthority(input: GuardInput): GuardResult {
+  if (FROBOT_AUTHORS.has(input.author)) {
+    return {ok: true}
+  }
+  const blockedFiles = input.files.filter(f => GUARDED_PATTERNS.some(p => p.test(f)))
+  if (blockedFiles.length === 0) {
+    return {ok: true}
+  }
+  return {ok: false, blockedFiles}
+}
+
+/**
+ * Render the failure message the CI job surfaces when a PR hits the guard.
+ *
+ * Content contract (enforced by tests):
+ * - lists every blocked file
+ * - names the `data` branch as the resubmission path
+ * - names both `fro-bot` and `fro-bot[bot]` so the reader sees the identity equivalence
+ */
+export function formatBlockMessage(result: {readonly ok: false; readonly blockedFiles: readonly string[]}): string {
+  const lines = [
+    'Cannot merge: this PR modifies files that are auto-managed by Fro Bot workflows.',
+    '',
+    'Blocked files:',
+    ...result.blockedFiles.map(f => `  - ${f}`),
+    '',
+    'These paths are writable only by `fro-bot` (PAT writes) or `fro-bot[bot]` (App writes)',
+    'via the `data` branch. Authorized manual edits land like this:',
+    '',
+    '  1. Check out `data` in a worktree (`git worktree add ../worktree-data data`)',
+    '  2. Make the edit there',
+    '  3. Push `data` to origin',
+    '  4. The Merge Data Branch workflow opens a promotion PR from `data` → `main`',
+    '',
+    'See metadata/README.md and knowledge/schema.md for the operator workflow.',
+  ]
+  return lines.join('\n')
+}
+
+interface PullRequestEventPayload {
+  readonly pull_request?: {
+    readonly number?: number
+    readonly user?: {readonly login?: string} | null
+  }
+}
+
+async function readPullRequestContext(eventPath: string): Promise<{prNumber: number; author: string}> {
+  const raw = await readFile(eventPath, 'utf8')
+  const parsed = JSON.parse(raw) as PullRequestEventPayload
+  const prNumber = parsed.pull_request?.number
+  const author = parsed.pull_request?.user?.login
+  if (typeof prNumber !== 'number' || typeof author !== 'string' || author === '') {
+    throw new Error(
+      `check-wiki-authority: event payload missing pull_request.number or pull_request.user.login (path=${eventPath})`,
+    )
+  }
+  return {prNumber, author}
+}
+
+function fetchChangedFiles(prNumber: number): string[] {
+  // `gh pr view` with --json files returns paginated results. For PRs under GitHub's
+  // default per-file soft limit this single-page view is sufficient; if it ever proves
+  // insufficient, swap to `gh api --paginate /repos/{owner}/{repo}/pulls/{n}/files`.
+  const stdout = execFileSync('gh', ['pr', 'view', String(prNumber), '--json', 'files', '--jq', '.files[].path'], {
+    encoding: 'utf8',
+  })
+  return stdout.split('\n').filter(line => line.length > 0)
+}
+
+async function main(): Promise<void> {
+  const eventPath = process.env.GITHUB_EVENT_PATH
+  if (eventPath === undefined || eventPath === '') {
+    process.stderr.write(
+      'check-wiki-authority: GITHUB_EVENT_PATH not set. This script must run inside a GitHub Actions pull_request event.\n',
+    )
+    process.exit(1)
+  }
+
+  const {prNumber, author} = await readPullRequestContext(eventPath)
+  const files = fetchChangedFiles(prNumber)
+  const result = checkWikiAuthority({author, files})
+
+  if (result.ok) {
+    process.stdout.write(`check-wiki-authority: ok (author=${author}, files_checked=${files.length})\n`)
+    return
+  }
+
+  process.stderr.write(`${formatBlockMessage(result)}\n`)
+  process.exit(1)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}


### PR DESCRIPTION
Enforces the single-writer rule for autonomously-managed files on `main`: only `fro-bot` and `fro-bot[bot]` can land edits to `metadata/*.yaml`, `knowledge/wiki/<subdir>/*.md`, `knowledge/index.md`, and `knowledge/log.md`. Every other author's PR is blocked with a message pointing at the `data`-branch workflow.

Closes the structural drift loop that caused earlier incident traffic — `main` had accumulated wiki content that `data` never saw, so the `Sync wiki from data branch` step in downstream surveys produced phantom deletions that crashed `wiki-ingest`. Filtering deletions in `scripts/wiki-ingest.ts` patched the symptom; this guard removes the source.

## What's in the change

| File                                     | Change                                                                        |
| ---------------------------------------- | ----------------------------------------------------------------------------- |
| `scripts/check-wiki-authority.ts`          | Pure `checkWikiAuthority({author, files})` decision function + CLI wrapper      |
| `scripts/check-wiki-authority.test.ts`     | 26 unit tests covering happy paths, error paths, and path-boundary edge cases |
| `.github/workflows/main.yaml`              | New `check-wiki-authority` job, PR-only, minimum-privilege permissions          |
| `.github/settings.yml`                     | Registers `Check Wiki Authority` as required status check                     |
| `metadata/README.md`                       | New `Editing metadata files` section with the worktree-to-promotion workflow    |
| `knowledge/schema.md`                      | Mirroring `Editing the wiki` section for knowledge edits                        |
| `docs/plans/...-wiki-authority-ci-guard-plan.md` | Plan doc (written earlier this session)                                       |

## Guard contract

- **Authors allowed:** `fro-bot` (PAT writes), `fro-bot[bot]` (App writes). Same identity set as `scripts/reconcile-repos.ts` so the pre-commit integrity check and pre-merge PR guard agree on who Fro Bot is.
- **Paths guarded:**
  - `knowledge/wiki/<subdir>/*.md` (subdir-required — `knowledge/wiki/README.md` stays human-editable)
  - `knowledge/index.md`, `knowledge/log.md`
  - `metadata/*.yaml` (single-segment glob — nested metadata not yet in use)
- **Paths intentionally unguarded:** `knowledge/schema.md`, `knowledge/README.md`, `knowledge/wiki/README.md`, `metadata/README.md`. These are human-owned docs.
- **Mixed PRs:** if a non-Fro-Bot PR touches any guarded file alongside other files, the PR fails — split is the correct resolution.
- **No override label.** If a true emergency arrives, admin can temporarily remove the check from `settings.yml` (reversible in one PR). Keeping the policy binary keeps it honest.

## Verification

- `pnpm lint` / `pnpm check-types` / `pnpm test` — all clean
- 26 new tests + 193 existing = 219/219 passing
- All 14 production scripts load cleanly under Node strip-only (the `Test Scripts Load` job exercises this on every PR)
- This PR itself is the first real validation of the guard: author = `marcusrbrown`, files span workflows/settings/docs/scripts/plan — none of those match the guarded patterns, so the `Check Wiki Authority` job passes.

## Operator workflow for manual edits

The new sections in `metadata/README.md` and `knowledge/schema.md` document the path end-to-end: worktree on `data`, edit, push, let the `Merge Data Branch` workflow promote. The merge-data PR is authored by `fro-bot[bot]` which passes the guard.

## Related

- PR #3144 (porcelain deletion filter — patched the symptom this PR addresses structurally)
- PR #3149 (identity collapse — established the `fro-bot` ≡ `fro-bot[bot]` model this guard reuses)
- `docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md` (compound doc prevention rule 4 names this exact structural move)