### PR TITLE
fix(reconcile): unblock pending survey dispatch + complete Renovate probe + promote pending→onboarded

### DIFF
--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -175,8 +175,8 @@ describe('reconcileRepos', () => {
   })
 
   describe('tracked entries — still accessible', () => {
-    it('leaves a pending, still-accessible entry unchanged when no field drift', () => {
-      const entry = makeEntry({onboarding_status: 'pending', name: 'stable-repo'})
+    it('leaves a pending-review, still-accessible entry unchanged when no field drift', () => {
+      const entry = makeEntry({onboarding_status: 'pending-review', name: 'stable-repo'})
       const result = reconcileRepos(
         makeInput({
           currentRepos: {version: 1, repos: [entry]},
@@ -420,7 +420,9 @@ describe('reconcileRepos', () => {
     })
 
     it('reports all-zero counters and value-equal nextRepos when nothing changes', () => {
-      const entry = makeEntry({name: 'stable-repo', onboarding_status: 'pending'})
+      // Use pending-review: it's excluded from the dispatch gate, so this entry
+      // truly produces zero side-effects.
+      const entry = makeEntry({name: 'stable-repo', onboarding_status: 'pending-review'})
       const current: ReposFile = {version: 1, repos: [entry]}
       const result = reconcileRepos(
         makeInput({
@@ -522,6 +524,80 @@ describe('reconcileRepos', () => {
           }),
         ),
       ).toThrow(/duplicate/i)
+    })
+
+    it('dispatches pending entry with null last_survey_at (never surveyed)', () => {
+      // #given a pending entry that has never been surveyed (null survey fields)
+      const entry = makeEntry({
+        name: 'never-surveyed',
+        onboarding_status: 'pending',
+        last_survey_at: null,
+        last_survey_status: null,
+      })
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({name: 'never-surveyed'})],
+        }),
+      )
+      // #then the entry is dispatched for its initial survey
+      expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'never-surveyed'}])
+    })
+
+    it('dispatches pending entry with failure status (failed initial survey)', () => {
+      // #given a pending entry whose initial survey failed and wrote back a failure timestamp
+      const entry = makeEntry({
+        name: 'failed-initial',
+        onboarding_status: 'pending',
+        last_survey_at: '2026-04-19',
+        last_survey_status: 'failure',
+      })
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({name: 'failed-initial'})],
+        }),
+      )
+      // #then the entry is dispatched for retry (failure ≠ success, so eligible)
+      expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'failed-initial'}])
+    })
+
+    it('does not dispatch pending-review entry (requires human approval)', () => {
+      // #given a pending-review entry with null survey fields
+      const entry = makeEntry({
+        name: 'needs-approval',
+        onboarding_status: 'pending-review',
+        last_survey_at: null,
+        last_survey_status: null,
+      })
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({name: 'needs-approval'})],
+        }),
+      )
+      // #then no dispatch — pending-review entries need human promotion first
+      expect(result.dispatches).toEqual([])
+    })
+
+    it('does not dispatch pending entry with recent successful survey', () => {
+      // #given a pending entry that was surveyed successfully recently (promotion
+      // should have moved it to onboarded, but even if it didn't, the success +
+      // non-stale combination means no re-dispatch is needed)
+      const entry = makeEntry({
+        name: 'recently-succeeded',
+        onboarding_status: 'pending',
+        last_survey_at: '2026-04-16',
+        last_survey_status: 'success',
+      })
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({name: 'recently-succeeded'})],
+        }),
+      )
+      // #then no dispatch — success + within staleness window → skip
+      expect(result.dispatches).toEqual([])
     })
   })
 })
@@ -796,9 +872,11 @@ describe('handleReconcile (I/O shell)', () => {
       const commitMetadata = vi.fn(async () => ({committed: true, sha: 's', attempts: 1}))
       const createWorkflowDispatch = vi.fn(async () => undefined)
       const issuesCreate = vi.fn(async () => ({data: {number: 1}}))
+      // Use pending-review: it's excluded from the dispatch gate, so the entry
+      // truly produces zero side-effects (no dispatches, no commits).
       const existing: ReposFile = {
         version: 1,
-        repos: [makeEntry({name: 'stable-repo', onboarding_status: 'pending'})],
+        repos: [makeEntry({name: 'stable-repo', onboarding_status: 'pending-review'})],
       }
       const userOctokit = mockOctokit({
         listForAuthenticatedUser: async () => ({

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -299,11 +299,24 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
 
   // Still-accessible tracked entry.
   //
-  // Periodic re-survey: onboarded entries whose `last_survey_at` is null or has reached
-  // the staleness threshold become dispatch candidates. The actual dispatch may still be
-  // deferred by the per-run cap; entries that are genuinely fresh never become candidates
-  // so they don't compete for dispatch slots.
+  // Dispatch eligibility:
+  // - `onboarded` entries whose `last_survey_at` has reached the staleness threshold or
+  //   is null become candidates for periodic re-survey.
+  // - `pending` entries that have never been successfully surveyed are candidates for
+  //   initial bootstrapping. A `pending` repo is eligible when it has no recorded success
+  //   (`last_survey_status !== 'success'`) OR when its last survey is stale. This retries
+  //   failed/never-run initial surveys without waiting 30 days, while avoiding pointless
+  //   re-dispatch of a `pending` repo whose successful survey hasn't promoted yet.
+  //
+  // The actual dispatch may still be deferred by the per-run cap; entries that are
+  // genuinely fresh never become candidates so they don't compete for dispatch slots.
+  // `pending-review` entries are excluded — they require human approval first.
   if (entry.onboarding_status === 'onboarded' && isSurveyStale(entry.last_survey_at, params.now)) {
+    dispatches.push({owner: entry.owner, repo: entry.name})
+  } else if (
+    entry.onboarding_status === 'pending' &&
+    (entry.last_survey_status !== 'success' || isSurveyStale(entry.last_survey_at, params.now))
+  ) {
     dispatches.push({owner: entry.owner, repo: entry.name})
   }
 
@@ -1003,7 +1016,15 @@ async function probeFroBotWorkflow(userOctokit: OctokitClient, owner: string, na
   }
 }
 
-const RENOVATE_CONFIG_PATHS = ['renovate.json', '.github/renovate.json', '.renovaterc.json', '.renovaterc']
+const RENOVATE_CONFIG_PATHS = [
+  'renovate.json',
+  'renovate.json5',
+  '.github/renovate.json',
+  '.github/renovate.json5',
+  '.renovaterc.json',
+  '.renovaterc.json5',
+  '.renovaterc',
+]
 
 async function probeRenovateConfig(userOctokit: OctokitClient, owner: string, name: string): Promise<boolean> {
   for (const path of RENOVATE_CONFIG_PATHS) {

--- a/scripts/repos-metadata.test.ts
+++ b/scripts/repos-metadata.test.ts
@@ -260,8 +260,8 @@ describe('recordSurveyResult', () => {
     // Second entry updated
     expect(result.repos[1]?.last_survey_at).toBe('2026-04-18')
     expect(result.repos[1]?.last_survey_status).toBe('success')
-    // Other fields on the updated entry preserved
-    expect(result.repos[1]?.onboarding_status).toBe('pending')
+    // Pending entry promoted to onboarded on successful survey
+    expect(result.repos[1]?.onboarding_status).toBe('onboarded')
     expect(result.repos[1]?.added).toBe('2026-04-15')
   })
 
@@ -305,6 +305,92 @@ describe('recordSurveyResult', () => {
         status: 'success',
       }),
     ).toThrow(RepoEntryNotFoundError)
+  })
+
+  // Lifecycle promotion: pending → onboarded on first successful survey
+  it('promotes onboarding_status from pending to onboarded on successful survey', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [
+        {
+          owner: 'alice',
+          name: 'project',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+        },
+      ],
+    }
+
+    const result = recordSurveyResult(current, {
+      owner: 'alice',
+      repo: 'project',
+      at: new Date('2026-04-18T05:34:00Z'),
+      status: 'success',
+    })
+
+    expect(result.repos[0]?.onboarding_status).toBe('onboarded')
+    expect(result.repos[0]?.last_survey_status).toBe('success')
+  })
+
+  // Negative: failure does NOT promote pending to onboarded
+  it('preserves pending onboarding_status on failed survey', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [
+        {
+          owner: 'alice',
+          name: 'project',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+        },
+      ],
+    }
+
+    const result = recordSurveyResult(current, {
+      owner: 'alice',
+      repo: 'project',
+      at: NOW,
+      status: 'failure',
+    })
+
+    expect(result.repos[0]?.onboarding_status).toBe('pending')
+    expect(result.repos[0]?.last_survey_status).toBe('failure')
+  })
+
+  // Negative: success on already-onboarded does not change status
+  it('does not change onboarding_status when already onboarded', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [
+        {
+          owner: 'alice',
+          name: 'project',
+          added: '2026-04-17',
+          onboarding_status: 'onboarded',
+          last_survey_at: '2026-03-01',
+          last_survey_status: 'success',
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+        },
+      ],
+    }
+
+    const result = recordSurveyResult(current, {
+      owner: 'alice',
+      repo: 'project',
+      at: NOW,
+      status: 'success',
+    })
+
+    expect(result.repos[0]?.onboarding_status).toBe('onboarded')
   })
 })
 

--- a/scripts/repos-metadata.ts
+++ b/scripts/repos-metadata.ts
@@ -90,8 +90,17 @@ export function recordSurveyResult(current: unknown, input: RecordSurveyResultIn
     throw new RepoEntryNotFoundError(input.owner, input.repo)
   }
 
+  // Promote pending → onboarded on first successful survey. This closes the
+  // bootstrapping lifecycle: pending (added) → onboarded (first success) →
+  // staleness-gated re-surveys. Without this promotion, pending repos would
+  // never reach onboarded status and the staleness gate on the onboarded path
+  // would never apply.
+  const nextStatus =
+    input.status === 'success' && match.onboarding_status === 'pending' ? 'onboarded' : match.onboarding_status
+
   const updated = {
     ...match,
+    onboarding_status: nextStatus,
     last_survey_at: input.at.toISOString().slice(0, 10),
     last_survey_status: input.status,
   }


### PR DESCRIPTION
Three bugs found from analyzing the first clean Reconcile Repos scheduled run.

## Bug 1: Pending repos never re-dispatched after rate-limit failures

The dispatch gate (`classifyTracked` line 306) only fired for `'onboarded'` entries:

```typescript
if (entry.onboarding_status === 'onboarded' && isSurveyStale(...))
```

All 17 repos are `pending` with `last_survey_at: null` — their initial surveys all rate-limited on 2026-04-18, the recovery workflow reset their survey fields to null, but `onboarding_status` stayed `pending` (correctly — status governs trust, not survey eligibility). No code path re-dispatched them.

**Fix:** Expand the gate to include `pending` entries where `last_survey_status !== 'success'` OR the survey is stale. `pending-review` remains excluded (requires human approval). This gives the progressive pipeline its bootstrapping behavior back while not changing trust semantics.

## Bug 2: Renovate config probe missing .json5 paths

`RENOVATE_CONFIG_PATHS` only covered `.json` and `.renovaterc` variants. All repos using `.github/renovate.json5` (confirmed: 6 of 17) reported `has_renovate: false`.

**Fix:** Add `renovate.json5`, `.github/renovate.json5`, and `.renovaterc.json5` per official Renovate documentation.

## Bug 3: `recordSurveyResult` never promoted pending → onboarded

The intended lifecycle is `pending → (first successful survey) → onboarded → (staleness-gated re-surveys)`. But `recordSurveyResult` only wrote `last_survey_at` and `last_survey_status` — it never changed `onboarding_status`. Without this promotion, pending repos would never reach `onboarded` and the staleness-gate path would never apply.

**Fix:** Promote `onboarding_status` from `pending` to `onboarded` when `status === 'success'`. Failure leaves status as `pending` (correct — retry until first success).

## Changes

| File | Change |
|------|--------|
| `scripts/reconcile-repos.ts` | Expand dispatch gate for `pending` entries; add `.json5` Renovate probe paths |
| `scripts/repos-metadata.ts` | Promote `pending → onboarded` on successful survey |
| `scripts/reconcile-repos.test.ts` | 4 new dispatch-gate tests + 4 existing tests updated for new semantics |
| `scripts/repos-metadata.test.ts` | 3 new promotion tests + 1 existing test updated |

## Verification

- 226/226 tests passing (was 219; +7 new)
- Lint and type-check clean
- All production scripts load under Node strip-only
- Oracle verified both fix approaches before implementation

## Expected behavior after merge

Tomorrow's 05:17Z reconcile cron will:
- Dispatch up to 6 pending repos (null `last_survey_at` = eligible, cap enforced)
- Successful surveys write back `onboarded` status via `recordSurveyResult`
- Renovate probe correctly detects `.github/renovate.json5` configs
- Subsequent runs only re-dispatch onboarded repos past the 30-day staleness window