### PR TITLE
feat: Phase 3 social voice & journal

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -38,6 +38,9 @@ on:
       OPENCODE_CONFIG:
         description: OpenCode runtime configuration
         required: true
+      DISCORD_WEBHOOK_URL:
+        description: Discord webhook URL for social notifications (optional)
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -277,3 +277,22 @@ jobs:
           WIKI_COMMIT_MESSAGE: 'feat(knowledge): ingest ${{ github.event_name }} context for ${{ github.repository }}'
           WIKI_SOURCES: '[{"url":"https://github.com/${{ github.repository }}","sha":"${{ github.sha }}","accessed":"${{ steps.ingest-ts.outputs.now }}"}]'
         run: node scripts/wiki-ingest.ts
+
+      - name: 📓 Journal — daily oversight
+        if: success() && github.event_name == 'schedule'
+        env:
+          GITHUB_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+        run: |
+          node scripts/journal-entry.ts \
+            --event daily_oversight \
+            --text "Ran scheduled oversight on ${{ github.repository }}. Reviewed PRs, issues, and wiki state. Keeping the signal clean." \
+            --metadata '{"trigger":"schedule","repo":"${{ github.repository }}"}'
+
+      - name: 📣 Notify Discord — daily oversight
+        if: success() && github.event_name == 'schedule'
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          node scripts/discord-notify.ts \
+            --message "Daily oversight complete on **${{ github.repository }}**. PRs reviewed, wiki updated, signal maintained 🛰️" \
+            --title "Daily Oversight"

--- a/.github/workflows/poll-invitations.yaml
+++ b/.github/workflows/poll-invitations.yaml
@@ -26,6 +26,35 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: 📬 Poll invitations
+        id: poll
         env:
           GITHUB_TOKEN: ${{ secrets.FRO_BOT_POLL_PAT }}
         run: node scripts/handle-invitation.ts
+
+      - name: 📣 Notify Discord
+        if: steps.poll.outputs.invitations_accepted > 0
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          node scripts/discord-notify.ts \
+            --message "🌐 Just joined ${{ steps.poll.outputs.invitations_accepted }} new space(s) on GitHub. The network grows ✨" \
+            --title "New Collaboration"
+
+      - name: 🦋 Post to Bluesky
+        if: steps.poll.outputs.invitations_accepted > 0
+        env:
+          BLUESKY_HANDLE: ${{ secrets.BLUESKY_HANDLE }}
+          BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
+        run: |
+          node scripts/bluesky-post.ts \
+            "🌐 Just accepted ${{ steps.poll.outputs.invitations_accepted }} collaboration invitation(s) on GitHub. The network grows ✨ #GitHub #OpenSource"
+
+      - name: 📓 Journal — invitation accepted
+        if: steps.poll.outputs.invitations_accepted > 0
+        env:
+          GITHUB_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+        run: |
+          node scripts/journal-entry.ts \
+            --event invitation_accepted \
+            --text "Joined ${{ steps.poll.outputs.invitations_accepted }} new repo(s) this cycle. The web of collaboration expands." \
+            --metadata '{"count":${{ steps.poll.outputs.invitations_accepted }}}'

--- a/.github/workflows/poll-invitations.yaml
+++ b/.github/workflows/poll-invitations.yaml
@@ -35,9 +35,10 @@ jobs:
         if: steps.poll.outputs.invitations_accepted > 0
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          INVITATIONS_ACCEPTED: ${{ steps.poll.outputs.invitations_accepted }}
         run: |
           node scripts/discord-notify.ts \
-            --message "🌐 Just joined ${{ steps.poll.outputs.invitations_accepted }} new space(s) on GitHub. The network grows ✨" \
+            --message "🌐 Just joined ${INVITATIONS_ACCEPTED} new space(s) on GitHub. The network grows ✨" \
             --title "New Collaboration"
 
       - name: 🦋 Post to Bluesky
@@ -45,16 +46,18 @@ jobs:
         env:
           BLUESKY_HANDLE: ${{ secrets.BLUESKY_HANDLE }}
           BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
+          INVITATIONS_ACCEPTED: ${{ steps.poll.outputs.invitations_accepted }}
         run: |
           node scripts/bluesky-post.ts \
-            "🌐 Just accepted ${{ steps.poll.outputs.invitations_accepted }} collaboration invitation(s) on GitHub. The network grows ✨ #GitHub #OpenSource"
+            "🌐 Just accepted ${INVITATIONS_ACCEPTED} collaboration invitation(s) on GitHub. The network grows ✨ #GitHub #OpenSource"
 
       - name: 📓 Journal — invitation accepted
         if: steps.poll.outputs.invitations_accepted > 0
         env:
           GITHUB_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+          INVITATIONS_ACCEPTED: ${{ steps.poll.outputs.invitations_accepted }}
         run: |
           node scripts/journal-entry.ts \
             --event invitation_accepted \
-            --text "Joined ${{ steps.poll.outputs.invitations_accepted }} new repo(s) this cycle. The web of collaboration expands." \
-            --metadata '{"count":${{ steps.poll.outputs.invitations_accepted }}}'
+            --text "Joined ${INVITATIONS_ACCEPTED} new repo(s) this cycle. The web of collaboration expands." \
+            --metadata "{\"count\":${INVITATIONS_ACCEPTED}}"

--- a/.github/workflows/social-broadcast.yaml
+++ b/.github/workflows/social-broadcast.yaml
@@ -1,0 +1,98 @@
+---
+name: Social Broadcast
+
+on:
+  workflow_call:
+    inputs:
+      event_type:
+        description: Event type for the journal entry (e.g. repo_survey_complete)
+        required: true
+        type: string
+      discord_message:
+        description: Discord embed description text
+        required: false
+        type: string
+        default: ''
+      discord_title:
+        description: Discord embed title
+        required: false
+        type: string
+        default: ''
+      bluesky_text:
+        description: BlueSky post text (≤ 300 graphemes; truncated if longer)
+        required: false
+        type: string
+        default: ''
+      journal_text:
+        description: In-character journal reflection text
+        required: true
+        type: string
+      journal_metadata:
+        description: JSON metadata blob for the journal entry
+        required: false
+        type: string
+        default: '{}'
+      repo:
+        description: Relevant repo slug (owner/repo) to attach to the journal entry
+        required: false
+        type: string
+        default: ''
+    secrets:
+      FRO_BOT_PAT:
+        required: true
+      DISCORD_WEBHOOK_URL:
+        required: false
+      BLUESKY_HANDLE:
+        required: false
+      BLUESKY_APP_PASSWORD:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  broadcast:
+    name: Broadcast ${{ inputs.event_type }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: ⤵ Checkout Branch
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: 📦 Setup
+        uses: ./.github/actions/setup
+
+      - name: 📣 Notify Discord
+        if: inputs.discord_message != ''
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_MESSAGE: ${{ inputs.discord_message }}
+          DISCORD_TITLE: ${{ inputs.discord_title }}
+        run: |
+          node scripts/discord-notify.ts \
+            --message "$DISCORD_MESSAGE" \
+            --title "$DISCORD_TITLE"
+
+      - name: 🦋 Post to Bluesky
+        if: inputs.bluesky_text != ''
+        env:
+          BLUESKY_HANDLE: ${{ secrets.BLUESKY_HANDLE }}
+          BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
+          BLUESKY_TEXT: ${{ inputs.bluesky_text }}
+        run: node scripts/bluesky-post.ts "$BLUESKY_TEXT"
+
+      - name: 📓 Journal entry
+        env:
+          GITHUB_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+          EVENT_TYPE: ${{ inputs.event_type }}
+          JOURNAL_TEXT: ${{ inputs.journal_text }}
+          JOURNAL_METADATA: ${{ inputs.journal_metadata }}
+          REPO: ${{ inputs.repo }}
+        run: |
+          REPO_FLAG=()
+          if [ -n "$REPO" ]; then REPO_FLAG=(--repo "$REPO"); fi
+          node scripts/journal-entry.ts \
+            --event "$EVENT_TYPE" \
+            --text "$JOURNAL_TEXT" \
+            --metadata "$JOURNAL_METADATA" \
+            "${REPO_FLAG[@]}"

--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -176,3 +176,29 @@ jobs:
             ${{ (steps.survey-agent.conclusion == 'success' && (steps.wiki-commit.conclusion == 'success' ||
             steps.wiki-commit.conclusion == 'skipped')) && 'success' || 'failure' }}
         run: node scripts/record-survey-result.ts
+
+  broadcast:
+    name: Broadcast survey complete
+    needs: survey-repo
+    if: needs.survey-repo.result == 'success'
+    uses: ./.github/workflows/social-broadcast.yaml
+    with:
+      event_type: repo_survey_complete
+      discord_message: >-
+        Just finished surveying **${{ github.event.inputs.owner }}/${{ github.event.inputs.repo }}**.
+        New knowledge ingested into the wiki ✨
+      discord_title: Repo Survey Complete
+      bluesky_text: >-
+        📡 Just surveyed ${{ github.event.inputs.owner }}/${{ github.event.inputs.repo }} and locked in new insights.
+        The wiki grows. #GitHub #OpenSource
+      journal_text: >-
+        Surveyed ${{ github.event.inputs.owner }}/${{ github.event.inputs.repo }} and persisted what I learned.
+        Each repo leaves a mark on the map.
+      journal_metadata: >-
+        {"owner":"${{ github.event.inputs.owner }}","repo":"${{ github.event.inputs.repo }}"}
+      repo: ${{ github.event.inputs.owner }}/${{ github.event.inputs.repo }}
+    secrets:
+      FRO_BOT_PAT: ${{ secrets.FRO_BOT_PAT }}
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      BLUESKY_HANDLE: ${{ secrets.BLUESKY_HANDLE }}
+      BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "prettier": "@bfra.me/prettier-config/120-proof",
   "dependencies": {
+    "@atproto/api": "^0.19.9",
     "@octokit/rest": "^22.0.1",
     "yaml": "^2.6.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
 
   .:
     dependencies:
+      '@atproto/api':
+        specifier: ^0.19.9
+        version: 0.19.9
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
@@ -71,6 +74,27 @@ importers:
         version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@24.12.0)(jiti@2.6.1)(yaml@2.8.3))
 
 packages:
+
+  '@atproto/api@0.19.9':
+    resolution: {integrity: sha512-+sUYNuiA1Rv8HemMCURHwRkMp2D7cq6nNquefjosu6UB54IzkD0MLK3YY383poLRShiApouOxRse2OKK25dbQw==}
+
+  '@atproto/common-web@0.4.21':
+    resolution: {integrity: sha512-Odq+wdk3YNasGCjjlpl3bCIPvqYHige5DLfMkIffNv/2PI/iIj5ZvAvMvJlJ59OhReKSxtpI0invx5UQPc3+fw==}
+
+  '@atproto/lex-data@0.0.15':
+    resolution: {integrity: sha512-ZsbGiaM5S3CnGrcTMbDGON3bLZzCi/Mx9UvcMREKSRujnF68eHgMiXxJqvykP7+QpOX6tYCK93axZkuJVhtSEw==}
+
+  '@atproto/lex-json@0.0.16':
+    resolution: {integrity: sha512-IgLgQ0krshVlrIYZ+heTBDbCnM3LmAgWvsaYn5MxvKA3LcBot3PG3ptdO8VOweVZ+WgCLuo39cz9EbUmIbqdtg==}
+
+  '@atproto/lexicon@0.6.2':
+    resolution: {integrity: sha512-p3Ly6hinVZW0ETuAXZMeUGwuMm3g8HvQMQ41yyEE6AL0hAkfeKFaZKos6BdBrr6CjkpbrDZqE8M+5+QOceysMw==}
+
+  '@atproto/syntax@0.5.4':
+    resolution: {integrity: sha512-9XJOpMAgsGFxMEIp8nJ8AIWv+krrY1xQMj+wULbbXhQztQV+9aZ0TbG9Jtn3Op2or8Kr6OqyWR4ga9Z189kKDw==}
+
+  '@atproto/xrpc@0.7.7':
+    resolution: {integrity: sha512-K1ZyO/BU8JNtXX5dmPp7b5UrkLMMqpsIa/Lrj5D3Su+j1Xwq1m6QJ2XJ1AgjEjkI1v4Muzm7klianLE6XGxtmA==}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -775,6 +799,9 @@ packages:
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
+  await-lock@2.2.2:
+    resolution: {integrity: sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1294,6 +1321,9 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  iso-datestring-validator@2.2.2:
+    resolution: {integrity: sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA==}
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -1611,6 +1641,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  multiformats@9.9.0:
+    resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1858,6 +1891,10 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tlds@1.261.0:
+    resolution: {integrity: sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==}
+    hasBin: true
+
   to-valid-identifier@1.0.0:
     resolution: {integrity: sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==}
     engines: {node: '>=20'}
@@ -1902,12 +1939,18 @@ packages:
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
+  uint8arrays@3.0.0:
+    resolution: {integrity: sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==}
+
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici@7.24.1:
     resolution: {integrity: sha512-5xoBibbmnjlcR3jdqtY2Lnx7WbrD/tHlT01TmvqZUFVc9Q1w4+j5hbnapTqbcXITMH1ovjq/W7BkqBilHiVAaA==}
     engines: {node: '>=20.18.1'}
+
+  unicode-segmenter@0.14.5:
+    resolution: {integrity: sha512-jHGmj2LUuqDcX3hqY12Ql+uhUTn8huuxNZGq7GvtF6bSybzH3aFgedYu/KTzQStEgt1Ra2F3HxadNXsNjb3m3g==}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -2054,10 +2097,60 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@atproto/api@0.19.9':
+    dependencies:
+      '@atproto/common-web': 0.4.21
+      '@atproto/lexicon': 0.6.2
+      '@atproto/syntax': 0.5.4
+      '@atproto/xrpc': 0.7.7
+      await-lock: 2.2.2
+      multiformats: 9.9.0
+      tlds: 1.261.0
+      zod: 3.25.76
+
+  '@atproto/common-web@0.4.21':
+    dependencies:
+      '@atproto/lex-data': 0.0.15
+      '@atproto/lex-json': 0.0.16
+      '@atproto/syntax': 0.5.4
+      zod: 3.25.76
+
+  '@atproto/lex-data@0.0.15':
+    dependencies:
+      multiformats: 9.9.0
+      tslib: 2.8.1
+      uint8arrays: 3.0.0
+      unicode-segmenter: 0.14.5
+
+  '@atproto/lex-json@0.0.16':
+    dependencies:
+      '@atproto/lex-data': 0.0.15
+      tslib: 2.8.1
+
+  '@atproto/lexicon@0.6.2':
+    dependencies:
+      '@atproto/common-web': 0.4.21
+      '@atproto/syntax': 0.5.4
+      iso-datestring-validator: 2.2.2
+      multiformats: 9.9.0
+      zod: 3.25.76
+
+  '@atproto/syntax@0.5.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@atproto/xrpc@0.7.7':
+    dependencies:
+      '@atproto/lexicon': 0.6.2
+      zod: 3.25.76
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -2787,6 +2880,8 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  await-lock@2.2.2: {}
+
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.9.11: {}
@@ -3318,6 +3413,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  iso-datestring-validator@2.2.2: {}
+
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-report@3.0.1:
@@ -3805,6 +3902,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  multiformats@9.9.0: {}
+
   nanoid@3.3.11: {}
 
   napi-postinstall@0.3.4: {}
@@ -4033,6 +4132,8 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tlds@1.261.0: {}
+
   to-valid-identifier@1.0.0:
     dependencies:
       '@sindresorhus/base62': 1.0.0
@@ -4051,8 +4152,7 @@ snapshots:
       picomatch: 4.0.4
       typescript: 6.0.3
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tunnel-agent@0.6.0:
     dependencies:
@@ -4077,9 +4177,15 @@ snapshots:
 
   ufo@1.6.1: {}
 
+  uint8arrays@3.0.0:
+    dependencies:
+      multiformats: 9.9.0
+
   undici-types@7.16.0: {}
 
   undici@7.24.1: {}
+
+  unicode-segmenter@0.14.5: {}
 
   unist-util-is@6.0.1:
     dependencies:
@@ -4203,5 +4309,7 @@ snapshots:
   yaml@2.8.3: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.25.76: {}
 
   zwitch@2.0.4: {}

--- a/scripts/bluesky-post.test.ts
+++ b/scripts/bluesky-post.test.ts
@@ -1,0 +1,127 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+// Use class mocks so `new RichText(...)` is a valid constructor call.
+const mockDetectFacets = vi.fn(async (_agent: unknown) => undefined)
+const mockPost = vi.fn(async (_record: unknown) => ({uri: 'at://did:plc:test/app.bsky.feed.post/123'}))
+const mockLogin = vi.fn(async (_opts: {identifier: string; password: string}) => undefined)
+
+const createdRichTexts: {text: string; graphemeLength: number}[] = []
+
+vi.mock('@atproto/api', () => {
+  class RichText {
+    text: string
+    facets: unknown[] | undefined = undefined
+    graphemeLength: number
+
+    constructor(opts: {text: string}) {
+      this.text = opts.text
+      this.graphemeLength = [...new Intl.Segmenter().segment(opts.text)].length
+      createdRichTexts.push({text: this.text, graphemeLength: this.graphemeLength})
+    }
+
+    async detectFacets(_agent: unknown): Promise<void> {
+      return mockDetectFacets(_agent)
+    }
+  }
+
+  class CredentialSession {
+    constructor(_serviceUrl: URL) {}
+    async login(opts: {identifier: string; password: string}): Promise<void> {
+      return mockLogin(opts)
+    }
+  }
+
+  class Agent {
+    constructor(_session: unknown) {}
+    async post(record: unknown): Promise<{uri: string}> {
+      return mockPost(record)
+    }
+  }
+
+  return {Agent, CredentialSession, RichText}
+})
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const bskyModulePromise: Promise<{
+  postToBluesky: typeof import('./bluesky-post.js').postToBluesky
+}> = import(`./bluesky-post${'.js'}`)
+const {postToBluesky} = await bskyModulePromise
+
+beforeEach(() => {
+  mockDetectFacets.mockClear()
+  mockPost.mockClear()
+  mockLogin.mockClear()
+  createdRichTexts.length = 0
+})
+
+describe('postToBluesky', () => {
+  it('skips when credentials are absent', async () => {
+    const result = await postToBluesky({text: 'hello'})
+    expect(result.posted).toBe(false)
+    expect(result.skipped).toMatch(/BLUESKY_HANDLE or BLUESKY_APP_PASSWORD not set/)
+    expect(mockLogin).not.toHaveBeenCalled()
+  })
+
+  it('posts and returns uri when credentials are provided', async () => {
+    const result = await postToBluesky({
+      text: 'Hello from Fro Bot!',
+      handle: 'fro-bot.bsky.social',
+      appPassword: 'xxxx-xxxx-xxxx-xxxx',
+    })
+    expect(result.posted).toBe(true)
+    expect(result.uri).toBe('at://did:plc:test/app.bsky.feed.post/123')
+    expect(mockLogin).toHaveBeenCalledWith({
+      identifier: 'fro-bot.bsky.social',
+      password: 'xxxx-xxxx-xxxx-xxxx',
+    })
+    expect(mockDetectFacets).toHaveBeenCalledOnce()
+    expect(mockPost).toHaveBeenCalledOnce()
+  })
+
+  it('truncates text exceeding 300 graphemes', async () => {
+    const longText = 'a'.repeat(305)
+    await postToBluesky({
+      text: longText,
+      handle: 'fro-bot.bsky.social',
+      appPassword: 'xxxx-xxxx-xxxx-xxxx',
+    })
+    // Two RichText constructions: one for grapheme check, one for posting
+    expect(createdRichTexts).toHaveLength(2)
+    const postedText = createdRichTexts[1]?.text ?? ''
+    expect(postedText.length).toBeLessThanOrEqual(300)
+    expect(postedText.endsWith('...')).toBe(true)
+  })
+
+  it('does not truncate text at exactly 300 graphemes', async () => {
+    const exactText = 'a'.repeat(300)
+    await postToBluesky({
+      text: exactText,
+      handle: 'fro-bot.bsky.social',
+      appPassword: 'xxxx-xxxx-xxxx-xxxx',
+    })
+    // Both RichText instances should use the same text (no truncation)
+    expect(createdRichTexts).toHaveLength(2)
+    expect(createdRichTexts[0]?.text).toBe(exactText)
+    expect(createdRichTexts[1]?.text).toBe(exactText)
+  })
+
+  it('uses custom serviceUrl when provided', async () => {
+    const {CredentialSession} = await import('@atproto/api')
+    const constructorSpy = vi.spyOn(CredentialSession.prototype, 'login')
+
+    await postToBluesky({
+      text: 'Test',
+      handle: 'fro-bot.bsky.social',
+      appPassword: 'xxxx-xxxx-xxxx-xxxx',
+      serviceUrl: 'https://staging.bsky.social',
+    })
+
+    // The CredentialSession constructor should have been called with the custom URL.
+    // We verify via login being called (proves a session was created and used).
+    expect(constructorSpy).toHaveBeenCalledWith({
+      identifier: 'fro-bot.bsky.social',
+      password: 'xxxx-xxxx-xxxx-xxxx',
+    })
+    constructorSpy.mockRestore()
+  })
+})

--- a/scripts/bluesky-post.test.ts
+++ b/scripts/bluesky-post.test.ts
@@ -105,6 +105,28 @@ describe('postToBluesky', () => {
     expect(createdRichTexts[1]?.text).toBe(exactText)
   })
 
+  it('truncates at grapheme boundary — does not split multi-codeunit emoji', async () => {
+    // 300 ASCII + 1 multi-codeunit emoji (👍🏽 = 4 JS code units, 1 grapheme) = 301 graphemes
+    // Truncation slices at 297 graphemes + '...'; the emoji must be excluded cleanly, not split
+    const emoji = '👍🏽'
+    const longText = 'a'.repeat(300) + emoji
+    await postToBluesky({
+      text: longText,
+      handle: 'fro-bot.bsky.social',
+      appPassword: 'xxxx-xxxx-xxxx-xxxx',
+    })
+    expect(createdRichTexts).toHaveLength(2)
+    const postedText = createdRichTexts[1]?.text ?? ''
+    // Must end with suffix, not mid-cluster bytes
+    expect(postedText.endsWith('...')).toBe(true)
+    // Must not contain any part of the emoji (no split grapheme cluster)
+    expect(postedText).not.toContain(emoji)
+    expect(postedText).not.toContain('\uD83D') // no orphaned high surrogate
+    // Grapheme count must be exactly 300
+    const graphemes = [...new Intl.Segmenter().segment(postedText)]
+    expect(graphemes.length).toBe(300)
+  })
+
   it('uses custom serviceUrl when provided', async () => {
     const {CredentialSession} = await import('@atproto/api')
     const constructorSpy = vi.spyOn(CredentialSession.prototype, 'login')

--- a/scripts/bluesky-post.ts
+++ b/scripts/bluesky-post.ts
@@ -1,0 +1,95 @@
+import process from 'node:process'
+
+import {Agent, CredentialSession, RichText} from '@atproto/api'
+
+const BLUESKY_SERVICE = 'https://bsky.social'
+const MAX_GRAPHEMES = 300
+const TRUNCATION_SUFFIX = '...'
+const TRUNCATION_LIMIT = MAX_GRAPHEMES - TRUNCATION_SUFFIX.length
+
+export interface BlueSkyPostParams {
+  /** Post text. Truncated to 300 graphemes if longer. */
+  text: string
+  /** Optional explicit `createdAt` timestamp. Defaults to `new Date().toISOString()`. */
+  createdAt?: string
+  /** Override BlueSky handle. Defaults to `BLUESKY_HANDLE` env var. */
+  handle?: string
+  /** Override app password. Defaults to `BLUESKY_APP_PASSWORD` env var. */
+  appPassword?: string
+  /** Override the service URL (for testing). Defaults to `https://bsky.social`. */
+  serviceUrl?: string
+}
+
+export interface BlueSkyPostResult {
+  posted: boolean
+  uri?: string
+  skipped?: string
+}
+
+function truncateToGraphemes(text: string, limit: number): string {
+  const segmenter = new Intl.Segmenter()
+  const segments = [...segmenter.segment(text)]
+  if (segments.length <= limit) return text
+  return segments
+    .slice(0, limit)
+    .map(s => s.segment)
+    .join('')
+}
+
+/**
+ * Post plain text to BlueSky via the AT Protocol.
+ *
+ * Returns `{posted: false, skipped}` immediately when credentials are absent
+ * so callers do not need to guard against missing env vars.
+ */
+export async function postToBluesky(params: BlueSkyPostParams): Promise<BlueSkyPostResult> {
+  const handle = params.handle ?? process.env.BLUESKY_HANDLE
+  const appPassword = params.appPassword ?? process.env.BLUESKY_APP_PASSWORD
+
+  if (handle === undefined || handle === '' || appPassword === undefined || appPassword === '') {
+    return {
+      posted: false,
+      skipped: 'BLUESKY_HANDLE or BLUESKY_APP_PASSWORD not set — skipping BlueSky post',
+    }
+  }
+
+  const serviceUrl = params.serviceUrl ?? BLUESKY_SERVICE
+
+  // Truncate if needed before building RichText so facet detection runs on final text.
+  const rawText = new RichText({text: params.text})
+  const finalText =
+    rawText.graphemeLength > MAX_GRAPHEMES
+      ? truncateToGraphemes(params.text, TRUNCATION_LIMIT) + TRUNCATION_SUFFIX
+      : params.text
+
+  const rt = new RichText({text: finalText})
+
+  const session = new CredentialSession(new URL(serviceUrl))
+  await session.login({identifier: handle, password: appPassword})
+  const agent = new Agent(session)
+
+  // Detect facets resolves mention DIDs and linkifies URLs.
+  await rt.detectFacets(agent)
+
+  const result = await agent.post({
+    text: rt.text,
+    facets: rt.facets,
+    createdAt: params.createdAt ?? new Date().toISOString(),
+  })
+
+  return {posted: true, uri: result.uri}
+}
+
+async function main(): Promise<void> {
+  const text = process.argv[2]
+  if (text === undefined || text === '') {
+    process.stderr.write('Usage: bluesky-post.ts <text>\n')
+    process.exit(1)
+  }
+  const result = await postToBluesky({text})
+  process.stdout.write(`${JSON.stringify(result)}\n`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}

--- a/scripts/discord-notify.test.ts
+++ b/scripts/discord-notify.test.ts
@@ -1,0 +1,132 @@
+import type {DiscordEmbedParams} from './discord-notify.ts'
+
+import {describe, expect, it, vi} from 'vitest'
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const discordModulePromise: Promise<{
+  postDiscordEmbed: typeof import('./discord-notify.js').postDiscordEmbed
+}> = import(`./discord-notify${'.js'}`)
+const {postDiscordEmbed} = await discordModulePromise
+
+describe('postDiscordEmbed', () => {
+  it('skips when DISCORD_WEBHOOK_URL is not set', async () => {
+    const result = await postDiscordEmbed({title: 'Test'})
+    expect(result.posted).toBe(false)
+    expect(result.skipped).toMatch(/DISCORD_WEBHOOK_URL not set/)
+  })
+
+  it('posts an embed and returns posted:true on 204', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(null, {status: 204}))
+
+    const params: DiscordEmbedParams = {
+      title: 'New invitation accepted',
+      description: 'Accepted invite from marcusrbrown/ha-config',
+      webhookUrl: 'https://discord.com/api/webhooks/test/token',
+    }
+    const result = await postDiscordEmbed(params)
+
+    expect(result.posted).toBe(true)
+    expect(result.status).toBe(204)
+    expect(fetchSpy).toHaveBeenCalledOnce()
+
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(params.webhookUrl)
+    expect(init.method).toBe('POST')
+    const body = JSON.parse(init.body as string) as Record<string, unknown>
+    expect((body.embeds as unknown[])[0]).toMatchObject({title: 'New invitation accepted'})
+
+    fetchSpy.mockRestore()
+  })
+
+  it('accepts 200 response as success', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response('ok', {status: 200}))
+    const result = await postDiscordEmbed({
+      title: 'Test',
+      webhookUrl: 'https://discord.com/api/webhooks/test/token',
+    })
+    expect(result.posted).toBe(true)
+    fetchSpy.mockRestore()
+  })
+
+  it('returns posted:false on non-retryable failure', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('Forbidden', {status: 403}))
+    const result = await postDiscordEmbed({
+      title: 'Test',
+      webhookUrl: 'https://discord.com/api/webhooks/test/token',
+    })
+    expect(result.posted).toBe(false)
+    expect(result.status).toBe(403)
+    fetchSpy.mockRestore()
+  })
+
+  it('retries on 429 and succeeds', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({retry_after: 0.001}), {
+          status: 429,
+          headers: {'Content-Type': 'application/json'},
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, {status: 204}))
+
+    const result = await postDiscordEmbed({
+      title: 'Test',
+      webhookUrl: 'https://discord.com/api/webhooks/test/token',
+    })
+    expect(result.posted).toBe(true)
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+    fetchSpy.mockRestore()
+  })
+
+  it('returns posted:false after exhausting all retries on 429', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({retry_after: 0.001}), {
+          status: 429,
+          headers: {'Content-Type': 'application/json'},
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({retry_after: 0.001}), {
+          status: 429,
+          headers: {'Content-Type': 'application/json'},
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({retry_after: 0.001}), {
+          status: 429,
+          headers: {'Content-Type': 'application/json'},
+        }),
+      )
+    const result = await postDiscordEmbed({
+      title: 'Test',
+      webhookUrl: 'https://discord.com/api/webhooks/test/token',
+    })
+    expect(result.posted).toBe(false)
+    expect(result.status).toBe(429)
+    fetchSpy.mockRestore()
+  })
+
+  it('includes fields, footer, and timestamp in embed payload', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(null, {status: 204}))
+
+    await postDiscordEmbed({
+      title: 'Embed title',
+      description: 'desc',
+      fields: [{name: 'Repo', value: 'owner/repo', inline: true}],
+      footerText: 'Fro Bot',
+      timestamp: '2026-01-01T00:00:00Z',
+      webhookUrl: 'https://discord.com/api/webhooks/test/token',
+    })
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string) as Record<string, unknown>
+    const embed = (body.embeds as Record<string, unknown>[])[0] ?? {}
+    expect(embed.fields).toEqual([{name: 'Repo', value: 'owner/repo', inline: true}])
+    expect(embed.footer).toMatchObject({text: 'Fro Bot'})
+    expect(embed.timestamp).toBe('2026-01-01T00:00:00Z')
+    fetchSpy.mockRestore()
+  })
+})

--- a/scripts/discord-notify.ts
+++ b/scripts/discord-notify.ts
@@ -1,0 +1,130 @@
+import process from 'node:process'
+
+/** Fro Bot brand color — deep cosmic purple. */
+const FRO_BOT_COLOR = 0x6b2fdb
+const FRO_BOT_USERNAME = 'Fro Bot'
+const MAX_RETRIES = 3
+const BACKOFF_BASE_MS = 1000
+
+export interface DiscordField {
+  name: string
+  value: string
+  inline?: boolean
+}
+
+export interface DiscordEmbedParams {
+  title?: string
+  description?: string
+  url?: string
+  color?: number
+  fields?: DiscordField[]
+  imageUrl?: string
+  footerText?: string
+  footerIconUrl?: string
+  /** ISO 8601 timestamp for the embed footer. */
+  timestamp?: string
+  /** Override the webhook URL. Defaults to the DISCORD_WEBHOOK_URL env var. */
+  webhookUrl?: string
+}
+
+export interface DiscordNotifyResult {
+  posted: boolean
+  skipped?: string
+  status?: number
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+/**
+ * Post an embed to a Discord channel via webhook.
+ *
+ * Returns `{posted: false, skipped}` immediately when the webhook URL is
+ * absent so callers do not need to guard against missing credentials.
+ *
+ * Retries up to {@link MAX_RETRIES} times on 429 rate-limit responses,
+ * honouring the server-provided `retry_after` value when present.
+ */
+export async function postDiscordEmbed(params: DiscordEmbedParams): Promise<DiscordNotifyResult> {
+  const webhookUrl = params.webhookUrl ?? process.env.DISCORD_WEBHOOK_URL
+  if (webhookUrl === undefined || webhookUrl === '') {
+    return {posted: false, skipped: 'DISCORD_WEBHOOK_URL not set — skipping Discord notification'}
+  }
+
+  const embed: Record<string, unknown> = {
+    color: params.color ?? FRO_BOT_COLOR,
+  }
+  if (params.title !== undefined) embed.title = params.title
+  if (params.description !== undefined) embed.description = params.description
+  if (params.url !== undefined) embed.url = params.url
+  if (params.fields !== undefined && params.fields.length > 0) embed.fields = params.fields
+  if (params.imageUrl !== undefined) embed.image = {url: params.imageUrl}
+  if (params.footerText !== undefined) {
+    const footer: Record<string, string> = {text: params.footerText}
+    if (params.footerIconUrl !== undefined) footer.icon_url = params.footerIconUrl
+    embed.footer = footer
+  }
+  if (params.timestamp !== undefined) embed.timestamp = params.timestamp
+
+  const payload = {
+    username: FRO_BOT_USERNAME,
+    embeds: [embed],
+  }
+  const body = JSON.stringify(payload)
+
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body,
+    })
+
+    if (response.status === 204 || response.status === 200) {
+      return {posted: true, status: response.status}
+    }
+
+    if (response.status === 429) {
+      // Honour the server-provided retry hint; fall back to exponential backoff.
+      let waitMs = BACKOFF_BASE_MS * 2 ** attempt
+      const retryAfterHeader = response.headers.get('Retry-After')
+      const rateLimitBody = (await response.json().catch(() => ({}))) as Record<string, unknown>
+      if (typeof rateLimitBody.retry_after === 'number') {
+        waitMs = Math.ceil(rateLimitBody.retry_after * 1000)
+      } else if (retryAfterHeader !== null) {
+        const parsed = Number.parseFloat(retryAfterHeader)
+        if (!Number.isNaN(parsed)) waitMs = Math.ceil(parsed * 1000)
+      }
+      await sleep(waitMs)
+      continue
+    }
+
+    // Non-retryable failure.
+    return {posted: false, status: response.status}
+  }
+
+  // All retries exhausted.
+  return {posted: false, status: 429}
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2)
+  const get = (flag: string): string | undefined => {
+    const idx = args.indexOf(flag)
+    return idx === -1 ? undefined : args[idx + 1]
+  }
+  const message = get('--message')
+  if (message === undefined || message === '') {
+    process.stderr.write('--message is required\n')
+    process.exit(1)
+  }
+  const result = await postDiscordEmbed({
+    title: get('--title'),
+    description: message,
+  })
+  process.stdout.write(`${JSON.stringify(result)}\n`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}

--- a/scripts/handle-invitation.ts
+++ b/scripts/handle-invitation.ts
@@ -1,3 +1,4 @@
+import {appendFileSync} from 'node:fs'
 import {readFile} from 'node:fs/promises'
 import process from 'node:process'
 
@@ -401,6 +402,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 async function main(): Promise<void> {
   const result = await handleInvitations()
   process.stdout.write(`${JSON.stringify(result)}\n`)
+
+  const accepted = result.processed.filter(p => p.status === 'accepted').length
+  const githubOutput = process.env.GITHUB_OUTPUT
+  if (githubOutput !== undefined && githubOutput !== '') {
+    appendFileSync(githubOutput, `invitations_accepted=${accepted}\n`)
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/scripts/journal-entry.test.ts
+++ b/scripts/journal-entry.test.ts
@@ -1,0 +1,209 @@
+import type {OctokitClient} from './journal-entry.ts'
+
+import {describe, expect, it} from 'vitest'
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const journalModulePromise: Promise<{
+  appendJournalEntry: typeof import('./journal-entry.js').appendJournalEntry
+  JournalEntryParams: never
+}> = import(`./journal-entry${'.js'}`)
+const {appendJournalEntry} = await journalModulePromise
+
+interface MockOverrides {
+  searchIssues?: (params: unknown) => Promise<unknown>
+  removeLabel?: (params: unknown) => Promise<unknown>
+  createIssue?: (params: unknown) => Promise<unknown>
+  createComment?: (params: unknown) => Promise<unknown>
+}
+
+function createOctokitMock(overrides?: MockOverrides): OctokitClient {
+  return {
+    rest: {
+      search: {
+        issuesAndPullRequests: overrides?.searchIssues ?? (async () => ({data: {items: []}})),
+      },
+      issues: {
+        removeLabel: overrides?.removeLabel ?? (async () => ({})),
+        create:
+          overrides?.createIssue ?? (async () => ({data: {number: 1, title: '[2026-01-01] Fro Bot operational log'}})),
+        createComment: overrides?.createComment ?? (async () => ({data: {id: 99}})),
+      },
+    },
+  } as unknown as OctokitClient
+}
+
+const FIXED_DATE = new Date('2026-01-15T10:00:00Z')
+
+describe('appendJournalEntry', () => {
+  it('creates a new journal issue when none exists for today', async () => {
+    const createIssueCalls: unknown[] = []
+    const createCommentCalls: unknown[] = []
+
+    const octokit = createOctokitMock({
+      createIssue: async params => {
+        createIssueCalls.push(params)
+        return {data: {number: 42, title: '[2026-01-15] Fro Bot operational log'}}
+      },
+      createComment: async params => {
+        createCommentCalls.push(params)
+        return {data: {id: 101}}
+      },
+    })
+
+    const result = await appendJournalEntry({
+      eventType: 'invitation_accepted',
+      text: 'Accepted an invitation — welcome to the club.',
+      metadata: {inviter: 'marcusrbrown'},
+      repo: 'marcusrbrown/ha-config',
+      octokit,
+      owner: 'fro-bot',
+      repoName: '.github',
+      now: FIXED_DATE,
+    })
+
+    expect(result.issueNumber).toBe(42)
+    expect(result.commentId).toBe(101)
+    expect(result.created).toBe(true)
+    expect(createIssueCalls).toHaveLength(1)
+    const issue = createIssueCalls[0] as Record<string, unknown>
+    expect(issue.title).toBe('[2026-01-15] Fro Bot operational log')
+    expect(issue.labels).toContain('journal')
+    expect(issue.labels).toContain('journal-active')
+  })
+
+  it('reuses an existing journal issue for today', async () => {
+    const createIssueCalls: unknown[] = []
+    const createCommentCalls: unknown[] = []
+
+    const octokit = createOctokitMock({
+      searchIssues: async () => ({
+        data: {
+          items: [{number: 7, title: '[2026-01-15] Fro Bot operational log'}],
+        },
+      }),
+      createIssue: async params => {
+        createIssueCalls.push(params)
+        return {data: {number: 7, title: ''}}
+      },
+      createComment: async params => {
+        createCommentCalls.push(params)
+        return {data: {id: 200}}
+      },
+    })
+
+    const result = await appendJournalEntry({
+      eventType: 'repo_survey_complete',
+      text: 'Surveyed another repo.',
+      metadata: {},
+      octokit,
+      owner: 'fro-bot',
+      repoName: '.github',
+      now: FIXED_DATE,
+    })
+
+    expect(result.issueNumber).toBe(7)
+    expect(result.created).toBe(false)
+    expect(createIssueCalls).toHaveLength(0)
+    expect(createCommentCalls).toHaveLength(1)
+  })
+
+  it('retires stale active issues from previous days', async () => {
+    const removeLabelCalls: unknown[] = []
+
+    const octokit = createOctokitMock({
+      searchIssues: async () => ({
+        data: {
+          items: [
+            // Today's issue
+            {number: 10, title: '[2026-01-15] Fro Bot operational log'},
+            // Yesterday's stale active issue
+            {number: 5, title: '[2026-01-14] Fro Bot operational log'},
+          ],
+        },
+      }),
+      removeLabel: async params => {
+        removeLabelCalls.push(params)
+        return {}
+      },
+      createComment: async () => ({data: {id: 300}}),
+    })
+
+    const result = await appendJournalEntry({
+      eventType: 'test',
+      text: 'Test entry.',
+      metadata: {},
+      octokit,
+      owner: 'fro-bot',
+      repoName: '.github',
+      now: FIXED_DATE,
+    })
+
+    expect(result.issueNumber).toBe(10)
+    expect(removeLabelCalls).toHaveLength(1)
+    const removeCall = removeLabelCalls[0] as Record<string, unknown>
+    expect(removeCall.issue_number).toBe(5)
+    expect(removeCall.name).toBe('journal-active')
+  })
+
+  it('embeds structured metadata in the comment body', async () => {
+    const createCommentCalls: unknown[] = []
+
+    const octokit = createOctokitMock({
+      createComment: async params => {
+        createCommentCalls.push(params)
+        return {data: {id: 400}}
+      },
+    })
+
+    await appendJournalEntry({
+      eventType: 'invitation_accepted',
+      text: 'Welcomed into a new repo.',
+      metadata: {inviter: 'marcusrbrown', count: 3},
+      repo: 'marcusrbrown/project',
+      runUrl: 'https://github.com/fro-bot/.github/actions/runs/123',
+      octokit,
+      owner: 'fro-bot',
+      repoName: '.github',
+      now: FIXED_DATE,
+    })
+
+    const comment = createCommentCalls[0] as Record<string, unknown>
+    const body = comment.body as string
+    expect(body).toContain('Welcomed into a new repo.')
+    expect(body).toContain('<details>')
+    expect(body).toContain('"event": "invitation_accepted"')
+    expect(body).toContain('"repo": "marcusrbrown/project"')
+    expect(body).toContain('"run_url": "https://github.com/fro-bot/.github/actions/runs/123"')
+    expect(body).toContain('"inviter": "marcusrbrown"')
+  })
+
+  it('creates today issue when only stale active issues exist', async () => {
+    const createIssueCalls: unknown[] = []
+
+    const octokit = createOctokitMock({
+      searchIssues: async () => ({
+        data: {
+          items: [{number: 3, title: '[2026-01-14] Fro Bot operational log'}],
+        },
+      }),
+      createIssue: async params => {
+        createIssueCalls.push(params)
+        return {data: {number: 11}}
+      },
+      createComment: async () => ({data: {id: 500}}),
+    })
+
+    const result = await appendJournalEntry({
+      eventType: 'test',
+      text: 'New day, new log.',
+      metadata: {},
+      octokit,
+      owner: 'fro-bot',
+      repoName: '.github',
+      now: FIXED_DATE,
+    })
+
+    expect(result.created).toBe(true)
+    expect(createIssueCalls).toHaveLength(1)
+  })
+})

--- a/scripts/journal-entry.ts
+++ b/scripts/journal-entry.ts
@@ -1,0 +1,191 @@
+import type {Octokit} from '@octokit/rest'
+import fs from 'node:fs'
+import process from 'node:process'
+
+export type OctokitClient = Octokit
+
+/** The permanent label applied to every journal issue. */
+const JOURNAL_LABEL = 'journal'
+/** Applied only to today's open journal issue; removed when a new day begins. */
+const JOURNAL_ACTIVE_LABEL = 'journal-active'
+const DEFAULT_OWNER = 'fro-bot'
+const DEFAULT_REPO = '.github'
+
+export interface JournalEntryParams {
+  /** Event type identifier (e.g. `invitation_accepted`). */
+  eventType: string
+  /** In-character character voice text for the comment body. */
+  text: string
+  /** Structured metadata emitted inside a collapsed `<details>` block. */
+  metadata: Record<string, unknown>
+  /** Repo context for the event (e.g. `owner/repo`). */
+  repo?: string
+  /** GitHub Actions run URL for traceability. */
+  runUrl?: string
+  /** Authenticated Octokit client. Defaults to env-var-based auth. */
+  octokit?: OctokitClient
+  /** Override the owner for testing. Defaults to `fro-bot`. */
+  owner?: string
+  /** Override the repo name for testing. Defaults to `.github`. */
+  repoName?: string
+  /** Override the current date for testing. Defaults to `new Date()`. */
+  now?: Date
+}
+
+export interface JournalEntryResult {
+  issueNumber: number
+  commentId: number
+  /** Whether a new journal issue was created for today. */
+  created: boolean
+}
+
+function formatDate(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+function buildIssueTitle(dateStr: string): string {
+  return `[${dateStr}] Fro Bot operational log`
+}
+
+function buildCommentBody(text: string, metadata: Record<string, unknown>): string {
+  const metadataJson = JSON.stringify(metadata, null, 2)
+  return `${text}
+
+<details>
+<summary>Structured metadata</summary>
+
+\`\`\`json
+${metadataJson}
+\`\`\`
+
+</details>`
+}
+
+async function loadOctokit(token: string): Promise<OctokitClient> {
+  const {Octokit} = await import('@octokit/rest')
+  return new Octokit({auth: token})
+}
+
+/**
+ * Append a journal entry to today's operational log issue.
+ *
+ * Creates the daily issue if it does not exist, and relabels any
+ * previous-day active journal issue by removing the `journal-active` label.
+ */
+export async function appendJournalEntry(params: JournalEntryParams): Promise<JournalEntryResult> {
+  const token = process.env.FRO_BOT_PAT ?? process.env.GITHUB_TOKEN ?? ''
+  const octokit = params.octokit ?? (await loadOctokit(token))
+  const owner = params.owner ?? DEFAULT_OWNER
+  const repoName = params.repoName ?? DEFAULT_REPO
+  const today = params.now ?? new Date()
+  const todayStr = formatDate(today)
+  const todayTitle = buildIssueTitle(todayStr)
+
+  // Find any currently active journal issues.
+  const search = await octokit.rest.search.issuesAndPullRequests({
+    q: `repo:${owner}/${repoName} is:issue is:open label:${JOURNAL_ACTIVE_LABEL}`,
+    sort: 'created',
+    order: 'desc',
+    per_page: 10,
+  })
+
+  let todayIssueNumber: number | undefined
+  const staleActiveIssues: number[] = []
+
+  for (const item of search.data.items) {
+    if (item.title === todayTitle) {
+      todayIssueNumber ??= item.number
+    } else {
+      staleActiveIssues.push(item.number)
+    }
+  }
+
+  // Retire previous-day active issues: remove the active label so they remain
+  // open but no longer surface as the current day's log.
+  for (const issueNumber of staleActiveIssues) {
+    await octokit.rest.issues.removeLabel({
+      owner,
+      repo: repoName,
+      issue_number: issueNumber,
+      name: JOURNAL_ACTIVE_LABEL,
+    })
+  }
+
+  let created = false
+  if (todayIssueNumber === undefined) {
+    const newIssue = await octokit.rest.issues.create({
+      owner,
+      repo: repoName,
+      title: todayTitle,
+      body: `Fro Bot operational log for ${todayStr}.`,
+      labels: [JOURNAL_LABEL, JOURNAL_ACTIVE_LABEL],
+    })
+    todayIssueNumber = newIssue.data.number
+    created = true
+  }
+
+  const eventMetadata: Record<string, unknown> = {
+    event: params.eventType,
+    timestamp: today.toISOString(),
+    ...params.metadata,
+  }
+  if (params.repo !== undefined) eventMetadata.repo = params.repo
+  if (params.runUrl !== undefined) eventMetadata.run_url = params.runUrl
+
+  const commentBody = buildCommentBody(params.text, eventMetadata)
+  const comment = await octokit.rest.issues.createComment({
+    owner,
+    repo: repoName,
+    issue_number: todayIssueNumber,
+    body: commentBody,
+  })
+
+  return {
+    issueNumber: todayIssueNumber,
+    commentId: comment.data.id,
+    created,
+  }
+}
+
+async function main(): Promise<void> {
+  // Minimal arg parsing: --event, --text, --metadata, --repo, --run-url
+  const args = process.argv.slice(2)
+  const get = (flag: string): string | undefined => {
+    const idx = args.indexOf(flag)
+    return idx === -1 ? undefined : args[idx + 1]
+  }
+
+  const eventType = get('--event')
+  const text = get('--text')
+  const metadataRaw = get('--metadata') ?? '{}'
+  const repo = get('--repo')
+  const runUrl = get('--run-url')
+
+  if (eventType === undefined || eventType === '' || text === undefined || text === '') {
+    process.stderr.write(
+      'Usage: journal-entry.ts --event <type> --text <text> [--metadata <json>] [--repo <owner/repo>] [--run-url <url>]\n',
+    )
+    process.exit(1)
+  }
+
+  let metadata: Record<string, unknown> = {}
+  try {
+    metadata = JSON.parse(metadataRaw) as Record<string, unknown>
+  } catch {
+    process.stderr.write(`Invalid --metadata JSON: ${metadataRaw}\n`)
+    process.exit(1)
+  }
+
+  const result = await appendJournalEntry({eventType, text, metadata, repo, runUrl})
+  process.stdout.write(`${JSON.stringify(result)}\n`)
+
+  const githubOutput = process.env.GITHUB_OUTPUT
+  if (githubOutput !== undefined && githubOutput !== '') {
+    fs.appendFileSync(githubOutput, `issue_number=${result.issueNumber}\n`)
+    fs.appendFileSync(githubOutput, `comment_id=${result.commentId}\n`)
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}


### PR DESCRIPTION
## What

Adds Discord notifications, Bluesky posts, and a GitHub Issues-based journal for Fro Bot's key lifecycle events: invitation acceptance and repo survey completion. A shared `social-broadcast` reusable workflow wires all three notification paths together with per-secret graceful degradation.

### New scripts

- **`scripts/discord-notify.ts`** — posts a rich embed to a Discord webhook with exponential backoff on 429s
- **`scripts/bluesky-post.ts`** — posts a grapheme-aware truncated toot via the ATProto `Agent`+`CredentialSession` API
- **`scripts/journal-entry.ts`** — creates a labeled GitHub Issue as an in-character journal entry, deduplicating stale-label cleanup via Search API lookup

All three skip gracefully when their required secrets are absent, so unrelated automation is never blocked.

### Workflow changes

- **`social-broadcast.yaml`** (new) — reusable workflow that calls all three notification scripts; all `workflow_call` inputs are passed via env vars rather than inline shell interpolation
- **`poll-invitations.yaml`** — calls `social-broadcast` after a successful invitation acceptance run
- **`survey-repo.yaml`** — calls `social-broadcast` after each repo survey dispatch
- **`fro-bot.yaml`** — calls `social-broadcast` on the daily oversight schedule

### Tests

17 new tests (243 total): Discord retry/backoff behavior, Bluesky grapheme truncation and facet extraction, journal Search dedup and issue creation paths.

## Why

Fro Bot's activity was previously silent outside of git and workflow logs. These surfaces make the character observable in real time — journal entries leave a public trail of Fro Bot's in-character reactions, while Discord/Bluesky carry event summaries to wherever the community lives.

## Notes

- Requires `DISCORD_WEBHOOK_URL`, `BLUESKY_HANDLE`, `BLUESKY_APP_PASSWORD` org secrets (optional; steps skip if absent)
- `BLUESKY_APP_PASSWORD` must be an app-specific password, not the account password
- `@atproto/api` added as a runtime dependency