### PR TITLE
fix(reconcile): rotate null-group dispatch window daily; bump cap to 12

### DIFF
--- a/.github/workflows/reconcile-repos.yaml
+++ b/.github/workflows/reconcile-repos.yaml
@@ -18,10 +18,10 @@ jobs:
     name: Reconcile metadata/repos.yaml with GitHub collaborator access
     runs-on: ubuntu-latest
     # Stagger + cap keep fan-out inside this budget even at the maximum configured
-    # dispatch count: 6 dispatches × 90s = 9 minutes of stagger, plus ≤1 minute of
-    # pre-dispatch work (access list, probes, commit). 15 minutes provides headroom
+    # dispatch count: 12 dispatches × 90s stagger = ~16.5 minutes, plus ≤1 minute of
+    # pre-dispatch work (access list, probes, commit). 25 minutes provides headroom
     # for GitHub API jitter without permitting a truly-stuck run.
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - id: get-workflow-app-token
         name: Get Workflow Access Token
@@ -47,5 +47,5 @@ jobs:
           # Cap dispatches per reconcile run. Candidates beyond the cap are eligible again
           # on the next run via the staleness gate, producing a progressive day-over-day
           # cadence instead of bursty fan-outs that exhaust upstream capacity.
-          RECONCILE_MAX_DISPATCHES_PER_RUN: '6'
+          RECONCILE_MAX_DISPATCHES_PER_RUN: '12'
         run: node scripts/reconcile-repos.ts

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -1124,7 +1124,9 @@ describe('handleReconcile (I/O shell)', () => {
         }),
       )
 
-      expect(dispatchCalls).toEqual(['r1', 'r2', 'r3'])
+      // All three repos are attempted regardless of day-rotation order; a timeout on
+      // one should not block the others from dispatching.
+      expect(dispatchCalls.slice().sort()).toEqual(['r1', 'r2', 'r3'])
       expect(result.dispatches).toBe(2)
       expect(result.dispatchesFailed).toBe(1)
     })
@@ -1285,6 +1287,49 @@ describe('handleReconcile (I/O shell)', () => {
       expect(dispatchCount.n).toBe(6)
       expect(result.dispatches).toBe(6)
       expect(result.dispatchesDeferred).toBe(0)
+    })
+
+    it('rotates the null-group selection window daily so all never-surveyed repos eventually dispatch', async () => {
+      // Four never-surveyed repos (r-a, r-b, r-c, r-d sorted alphabetically).
+      // Cap of 2. dayOrdinal(NOW=2026-04-17) = 20560; 20560 % 4 = 0 → selects [r-a, r-b].
+      // dayOrdinal(2026-04-19) = 20562; 20562 % 4 = 2 → rotates to [r-c, r-d, r-a, r-b] → selects [r-c, r-d].
+      // This proves repos that sort later don't starve when the null group exceeds the cap.
+      const repos = ['r-a', 'r-b', 'r-c', 'r-d']
+      const makeOctokit = () =>
+        mockOctokit({
+          listForAuthenticatedUser: async () => ({
+            data: repos.map(name => ({
+              owner: {login: 't'},
+              name,
+              archived: false,
+              private: false,
+              node_id: `R_${name}`,
+            })),
+          }),
+        })
+
+      const runWith = async (now: Date) => {
+        const dispatched: string[] = []
+        const createWorkflowDispatch = vi.fn(async (params: unknown) => {
+          dispatched.push((params as {inputs?: {repo: string}}).inputs?.repo ?? '?')
+        })
+        await handleReconcile(
+          baseParams({
+            userOctokit: makeOctokit(),
+            appOctokit: mockOctokit({createWorkflowDispatch}),
+            readMetadata: makeReadMetadata({allowlist: makeAllowlist(['t'])}),
+            commitMetadata: vi.fn(async () => ({committed: true, sha: 's', attempts: 1})) as never,
+            now,
+            maxDispatchesPerRun: 2,
+          }),
+        )
+        return dispatched
+      }
+
+      // Offset 0 → first slice
+      expect(await runWith(NOW)).toEqual(['r-a', 'r-b'])
+      // Offset 2 → rotated slice; r-c and r-d get their turn
+      expect(await runWith(new Date('2026-04-19T12:00:00Z'))).toEqual(['r-c', 'r-d'])
     })
   })
 

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -494,11 +494,11 @@ const DEFAULT_DISPATCH_STAGGER_MS = 90_000
  * level the single OAuth seat can sustain. Skipped candidates are dispatched on subsequent
  * runs once the staleness gate makes them eligible again.
  *
- * Default: 6 dispatches. Override via `RECONCILE_MAX_DISPATCHES_PER_RUN` env var or
+ * Default: 12 dispatches. Override via `RECONCILE_MAX_DISPATCHES_PER_RUN` env var or
  * `maxDispatchesPerRun` param. A value of 0 or negative disables the cap (dispatch all
  * eligible candidates).
  */
-const DEFAULT_MAX_DISPATCHES_PER_RUN = 6
+const DEFAULT_MAX_DISPATCHES_PER_RUN = 12
 
 const PENDING_REVIEW_LABEL = 'reconcile:pending-review'
 const ROLLUP_LABEL = 'reconcile:rollup-pending-review'
@@ -741,7 +741,27 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
   //    candidates become eligible again on the next run via the staleness gate.
   const prioritizedDispatches = prioritizeDispatches(plan.dispatches, plan.nextRepos.repos)
   const dispatchCap = maxDispatchesPerRun > 0 ? maxDispatchesPerRun : prioritizedDispatches.length
-  const selectedDispatches = prioritizedDispatches.slice(0, dispatchCap)
+
+  // Rotate within the never-surveyed (null last_survey_at) leading group so that all
+  // pending repos cycle through dispatch slots across successive runs. Without rotation,
+  // repos that sort alphabetically earlier always fill the cap first, leaving later-
+  // sorting repos perpetually deferred when the cap is smaller than the null group.
+  const repoSurveyMap = new Map(plan.nextRepos.repos.map(r => [`${r.owner}/${r.name}`, r.last_survey_at]))
+  const nullGroupSize = prioritizedDispatches.filter(
+    d => (repoSurveyMap.get(`${d.owner}/${d.repo}`) ?? null) === null,
+  ).length
+  const dayOrdinal = Math.floor(now.getTime() / 86_400_000)
+  const nullOffset = nullGroupSize > 1 ? dayOrdinal % nullGroupSize : 0
+  const rotatedDispatches =
+    nullOffset > 0
+      ? [
+          ...prioritizedDispatches.slice(nullOffset, nullGroupSize),
+          ...prioritizedDispatches.slice(0, nullOffset),
+          ...prioritizedDispatches.slice(nullGroupSize),
+        ]
+      : prioritizedDispatches
+
+  const selectedDispatches = rotatedDispatches.slice(0, dispatchCap)
   const dispatchesDeferred = prioritizedDispatches.length - selectedDispatches.length
 
   const dispatchOutcome = await runDispatches({


### PR DESCRIPTION
## What

Two changes to `reconcile-repos`:

1. **Day-based rotation within the never-surveyed cohort.** The dispatch sort puts all `null last_survey_at` repos first, ordered alphabetically within that group. With a cap smaller than the null group, the same alphabetically-first repos won every run, leaving later-sorting repos perpetually deferred. Now a day-based offset (`dayOrdinal % nullGroupSize`) rotates the starting position within the null group each day, ensuring the full set cycles through over successive runs. The rotation is scoped strictly to the null group — repos with a real survey date remain after all nulls, preserving the staleness-first priority guarantee.

2. **Cap raised from 6 → 12.** Doubles the number of repos that can be surveyed per reconcile run, directly addressing the stale-coverage pattern seen in the Apr 23 run log.

## Timeout

Workflow `timeout-minutes` raised from 15 → 25 to accommodate the wider dispatch window: 11 intervals × 90s stagger = ~16.5 min, plus pre-dispatch overhead.

## Verification

- `pnpm check-types` — clean
- `pnpm test` — 245 tests passing (1 new rotation test added; 1 existing timeout test assertion relaxed to be order-independent since rotation changes which repo dispatches first)
- `pnpm lint` on changed files — clean