### PR TITLE
feat(metadata): scan fro-bot org for Renovate workflows daily

### DIFF
--- a/.github/workflows/update-metadata.yaml
+++ b/.github/workflows/update-metadata.yaml
@@ -1,0 +1,38 @@
+---
+name: Update Metadata
+
+on:
+  schedule:
+    - cron: '30 4 * * *' # Daily at 04:30 UTC (between hourly Poll Invitations and 05:17 Reconcile Repos)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: update-metadata
+  cancel-in-progress: false
+
+jobs:
+  update-metadata:
+    name: Refresh metadata/renovate.yaml from fro-bot org scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - id: get-workflow-app-token
+        name: Get Workflow Access Token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+
+      - name: ⤵ Checkout Branch
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: 📦 Setup
+        uses: ./.github/actions/setup
+
+      - name: 🔄 Update metadata
+        env:
+          GITHUB_TOKEN: ${{ steps.get-workflow-app-token.outputs.token }}
+        run: node scripts/update-metadata.ts

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -77,12 +77,12 @@ Update convention: social broadcast workflow updates this file programmatically 
 
 ## Credential expectations
 
-| File                    | Updated by                            | Credential                       |
-| ----------------------- | ------------------------------------- | -------------------------------- |
-| `allowlist.yaml`        | Human edit on `data` branch           | n/a (human commit on `data`)     |
-| `repos.yaml`            | Invitation handler, Daily reconcile   | `FRO_BOT_PAT` / app token        |
-| `renovate.yaml`         | Daily metadata workflow               | app token (`fro-bot[bot]`)       |
-| `social-cooldowns.yaml` | Social broadcast                      | `FRO_BOT_PAT`                    |
+| File                    | Updated by                          | Credential                   |
+| ----------------------- | ----------------------------------- | ---------------------------- |
+| `allowlist.yaml`        | Human edit on `data` branch         | n/a (human commit on `data`) |
+| `repos.yaml`            | Invitation handler, Daily reconcile | `FRO_BOT_PAT` / app token    |
+| `renovate.yaml`         | Daily metadata workflow             | app token (`fro-bot[bot]`)   |
+| `social-cooldowns.yaml` | Social broadcast                    | `FRO_BOT_PAT`                |
 
 PAT split summary:
 

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -49,7 +49,7 @@ For private repos in `pending-review`, the issue body omits the owner/repo name 
 
 ### `renovate.yaml`
 
-Static list of fro-bot org repositories with Renovate configs. Used by `dispatch-renovate.yaml` to determine which repos to dispatch `workflow_dispatch` events to.
+Auto-discovered list of fro-bot org repositories with Renovate workflows. Used by `dispatch-renovate.yaml` to determine which repos to dispatch `workflow_dispatch` events to.
 
 ```yaml
 repositories:
@@ -59,7 +59,7 @@ repositories:
     - tokentoilet
 ```
 
-Update convention: human-managed. Edit directly via PR — this file is not auto-managed by Fro Bot workflows.
+Update convention: the `Update Metadata` workflow (`update-metadata.yaml`) scans the fro-bot org daily for repos containing `.github/workflows/renovate.yaml` and writes the sorted list to this file on the `data` branch via `commitMetadata`. No-op when nothing changed.
 
 ### `social-cooldowns.yaml`
 
@@ -77,12 +77,12 @@ Update convention: social broadcast workflow updates this file programmatically 
 
 ## Credential expectations
 
-| File                    | Updated by                            | Credential         |
-| ----------------------- | ------------------------------------- | ------------------ |
-| `allowlist.yaml`        | Human PR                              | n/a (human commit) |
-| `repos.yaml`            | Invitation handler, Metadata workflow | `FRO_BOT_PAT`      |
-| `renovate.yaml`         | Human PR                              | n/a (human commit) |
-| `social-cooldowns.yaml` | Social broadcast                      | `FRO_BOT_PAT`      |
+| File                    | Updated by                            | Credential                       |
+| ----------------------- | ------------------------------------- | -------------------------------- |
+| `allowlist.yaml`        | Human edit on `data` branch           | n/a (human commit on `data`)     |
+| `repos.yaml`            | Invitation handler, Daily reconcile   | `FRO_BOT_PAT` / app token        |
+| `renovate.yaml`         | Daily metadata workflow               | app token (`fro-bot[bot]`)       |
+| `social-cooldowns.yaml` | Social broadcast                      | `FRO_BOT_PAT`                    |
 
 PAT split summary:
 
@@ -99,12 +99,13 @@ PAT split summary:
 | `poll-invitations.yaml` | `FRO_BOT_POLL_PAT` only                                                 |
 | `merge-data.yaml`       | `GITHUB_TOKEN` (auto-provisioned, job-scoped permissions)               |
 | `reconcile-repos.yaml`  | `FRO_BOT_POLL_PAT` + `APPLICATION_ID` + `APPLICATION_PRIVATE_KEY`       |
+| `update-metadata.yaml`  | `APPLICATION_ID` + `APPLICATION_PRIVATE_KEY`                            |
 
 ## Editing metadata files
 
-Auto-managed state files (`repos.yaml`, `social-cooldowns.yaml`) are enforced as Fro-Bot-writable-only on `main`. A CI job (`Check Wiki Authority`, backed by `scripts/check-wiki-authority.ts`) fails any PR that modifies them unless authored by `fro-bot` or `fro-bot[bot]`. This prevents `main` from drifting relative to `data`, which is the single authoritative source. Human-managed config files (`allowlist.yaml`, `renovate.yaml`) are editable via normal PRs.
+All `metadata/*.yaml` files are enforced as Fro-Bot-writable-only on `main`. A CI job (`Check Wiki Authority`, backed by `scripts/check-wiki-authority.ts`) fails any PR that modifies them unless authored by `fro-bot` or `fro-bot[bot]`. This prevents `main` from drifting relative to `data`, which is the single authoritative source for metadata state.
 
-For intentional manual edits to auto-managed files, land the change on `data` directly and let the existing promotion flow land it on `main`:
+For intentional manual edits to any metadata file (including `allowlist.yaml`), land the change on `data` directly and let the existing promotion flow land it on `main`:
 
 ```bash
 git worktree add ../fro-bot-.github-data data

--- a/scripts/check-wiki-authority.test.ts
+++ b/scripts/check-wiki-authority.test.ts
@@ -181,20 +181,28 @@ describe('checkWikiAuthority', () => {
       expect(result).toEqual({ok: false, blockedFiles: ['knowledge/wiki/comparisons/x-vs-y.md']})
     })
 
-    it('allows human-editable config files in metadata/', () => {
-      // #given a human author touching config metadata (not auto-managed state)
+    it('blocks metadata/allowlist.yaml for human authors (data-branch promotion required)', () => {
+      // #given a human author touching the allowlist
       // #when the guard evaluates the PR
-      // #then the edit is allowed — allowlist.yaml and renovate.yaml are human-managed
-      expect(checkWikiAuthority({author: 'marcusrbrown', files: ['metadata/allowlist.yaml']})).toEqual({ok: true})
-      expect(checkWikiAuthority({author: 'marcusrbrown', files: ['metadata/renovate.yaml']})).toEqual({ok: true})
+      // #then the edit is blocked — even human-curated allowlist edits land via data branch
+      const result = checkWikiAuthority({author: 'marcusrbrown', files: ['metadata/allowlist.yaml']})
+      expect(result).toEqual({ok: false, blockedFiles: ['metadata/allowlist.yaml']})
     })
 
-    it('allows unknown metadata/*.yaml files (guard uses explicit list)', () => {
+    it('blocks metadata/renovate.yaml for human authors (auto-managed by metadata workflow)', () => {
+      // #given a human author touching the renovate dispatch list
+      // #when the guard evaluates the PR
+      // #then the edit is blocked — renovate.yaml is rebuilt by the metadata workflow
+      const result = checkWikiAuthority({author: 'marcusrbrown', files: ['metadata/renovate.yaml']})
+      expect(result).toEqual({ok: false, blockedFiles: ['metadata/renovate.yaml']})
+    })
+
+    it('blocks hypothetical future metadata/*.yaml files (guard is path-glob, not explicit list)', () => {
       // #given a new yaml file added to metadata/ in the future
       // #when the guard evaluates the PR
-      // #then the edit is allowed — only repos.yaml and social-cooldowns.yaml are guarded
+      // #then the edit is blocked by default — new metadata files inherit the data-branch contract
       const result = checkWikiAuthority({author: 'marcusrbrown', files: ['metadata/new-thing.yaml']})
-      expect(result).toEqual({ok: true})
+      expect(result).toEqual({ok: false, blockedFiles: ['metadata/new-thing.yaml']})
     })
 
     it('blocks metadata/social-cooldowns.yaml for human authors', () => {

--- a/scripts/check-wiki-authority.ts
+++ b/scripts/check-wiki-authority.ts
@@ -17,19 +17,19 @@ const FROBOT_AUTHORS: ReadonlySet<string> = new Set(['fro-bot', 'fro-bot[bot]'])
  * - `knowledge/wiki/<subdir>/*.md` is agent-authored content — pages live in
  *   `repos/`, `topics/`, `entities/`, and `comparisons/` subdirectories per the
  *   Karpathy schema. Top-level `knowledge/wiki/README.md` is human scaffolding.
- * - `knowledge/index.md` and `knowledge/log.md` are auto-maintained catalog and journal
- * - `metadata/repos.yaml` and `metadata/social-cooldowns.yaml` are autonomous state
+ * - `knowledge/index.md` and `knowledge/log.md` are auto-maintained catalog and journal.
+ * - `metadata/*.yaml` are all auto-managed state. Manual edits to allowlist.yaml or
+ *   any other metadata YAML still land via the `data` branch and are promoted by the
+ *   `Merge Data Branch` workflow under the `fro-bot[bot]` identity.
  *
- * Human-editable config files (`metadata/allowlist.yaml`, `metadata/renovate.yaml`)
- * and docs (`knowledge/schema.md`, `knowledge/README.md`, `knowledge/wiki/README.md`,
+ * Docs (`knowledge/schema.md`, `knowledge/README.md`, `knowledge/wiki/README.md`,
  * `metadata/README.md`) are intentionally NOT covered.
  */
 const GUARDED_PATTERNS: readonly RegExp[] = [
   /^knowledge\/wiki\/[^/]+\/.+\.md$/,
   /^knowledge\/index\.md$/,
   /^knowledge\/log\.md$/,
-  /^metadata\/repos\.yaml$/,
-  /^metadata\/social-cooldowns\.yaml$/,
+  /^metadata\/[^/]+\.yaml$/,
 ]
 
 export interface GuardInput {

--- a/scripts/update-metadata.test.ts
+++ b/scripts/update-metadata.test.ts
@@ -1,0 +1,213 @@
+import type {OctokitClient} from './update-metadata.ts'
+
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+// BDD: buildRenovateFile
+// Given: a list of detected repo names
+// When: buildRenovateFile is called
+// Then: returns a RenovateFile with names sorted and deduplicated
+
+// BDD: discoverRenovateRepos
+// Given: an Octokit client and a target org
+// When: discoverRenovateRepos is called
+// Then: lists org repos (excluding archived and forks), probes each for
+//       .github/workflows/renovate.yaml, returns matching names in discovery order
+
+const {mocks, mockOctokit} = vi.hoisted(() => {
+  const mocks = {
+    listForOrg: vi.fn(),
+    getContent: vi.fn(),
+    paginate: vi.fn(),
+  }
+  return {
+    mocks,
+    mockOctokit: {
+      paginate: mocks.paginate,
+      rest: {
+        repos: {
+          listForOrg: mocks.listForOrg,
+          getContent: mocks.getContent,
+        },
+      },
+    } as unknown as OctokitClient,
+  }
+})
+
+describe('buildRenovateFile', () => {
+  it('wraps names in the renovate.yaml schema shape', async () => {
+    // #given a list of repo names
+    // #when buildRenovateFile is called
+    // #then it returns the canonical {repositories: {with-renovate: ...}} shape
+    const {buildRenovateFile} = await import('./update-metadata.ts')
+    const result = buildRenovateFile(['agent', '.github'])
+    expect(result).toEqual({repositories: {'with-renovate': ['.github', 'agent']}})
+  })
+
+  it('sorts names alphabetically using locale order', async () => {
+    // #given an unsorted list
+    // #when buildRenovateFile is called
+    // #then the output is alphabetically sorted via localeCompare
+    const {buildRenovateFile} = await import('./update-metadata.ts')
+    const result = buildRenovateFile(['tokentoilet', 'agent', '.github'])
+    expect(result.repositories['with-renovate']).toEqual(['.github', 'agent', 'tokentoilet'])
+  })
+
+  it('deduplicates duplicate repo names', async () => {
+    // #given a list with duplicates
+    // #when buildRenovateFile is called
+    // #then the duplicates are collapsed to a single entry
+    const {buildRenovateFile} = await import('./update-metadata.ts')
+    const result = buildRenovateFile(['agent', 'agent', '.github'])
+    expect(result.repositories['with-renovate']).toEqual(['.github', 'agent'])
+  })
+
+  it('returns empty list shape for empty input', async () => {
+    // #given an empty input list
+    // #when buildRenovateFile is called
+    // #then the schema is preserved with an empty array
+    const {buildRenovateFile} = await import('./update-metadata.ts')
+    const result = buildRenovateFile([])
+    expect(result).toEqual({repositories: {'with-renovate': []}})
+  })
+})
+
+describe('discoverRenovateRepos', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns repos containing .github/workflows/renovate.yaml in discovery order', async () => {
+    // #given an org with three repos and two of them have a Renovate workflow
+    // #when discoverRenovateRepos is called
+    // #then it returns matching names in the order paginate yielded them (sort happens in buildRenovateFile)
+    const {discoverRenovateRepos} = await import('./update-metadata.ts')
+    mocks.paginate.mockResolvedValueOnce([
+      {name: 'agent', archived: false, fork: false},
+      {name: '.github', archived: false, fork: false},
+      {name: 'tokentoilet', archived: false, fork: false},
+    ])
+    // probe order matches input order; resolve = present (200), reject 404 = absent
+    mocks.getContent.mockResolvedValueOnce({status: 200})
+    mocks.getContent.mockResolvedValueOnce({status: 200})
+    mocks.getContent.mockRejectedValueOnce(Object.assign(new Error('Not Found'), {status: 404}))
+
+    const result = await discoverRenovateRepos(mockOctokit, 'fro-bot')
+    expect(result).toEqual(['agent', '.github'])
+  })
+
+  it('calls paginate with listForOrg and the correct org/type/per_page options', async () => {
+    // #given a target org
+    // #when discoverRenovateRepos is called
+    // #then paginate receives the listForOrg method plus org/type/per_page=100 so private+public+forks are enumerated
+    const {discoverRenovateRepos} = await import('./update-metadata.ts')
+    mocks.paginate.mockResolvedValueOnce([])
+
+    await discoverRenovateRepos(mockOctokit, 'other-org')
+    expect(mocks.paginate).toHaveBeenCalledTimes(1)
+    expect(mocks.paginate).toHaveBeenCalledWith(mocks.listForOrg, {
+      org: 'other-org',
+      type: 'all',
+      per_page: 100,
+    })
+  })
+
+  it('skips archived repos (no probe call for them)', async () => {
+    // #given an archived repo in the org listing
+    // #when discoverRenovateRepos is called
+    // #then no probe is issued for the archived repo and it is excluded from output
+    const {discoverRenovateRepos} = await import('./update-metadata.ts')
+    mocks.paginate.mockResolvedValueOnce([
+      {name: 'archived-repo', archived: true, fork: false},
+      {name: 'agent', archived: false, fork: false},
+    ])
+    mocks.getContent.mockResolvedValueOnce({status: 200})
+
+    const result = await discoverRenovateRepos(mockOctokit, 'fro-bot')
+    expect(result).toEqual(['agent'])
+    expect(mocks.getContent).toHaveBeenCalledTimes(1)
+    expect(mocks.getContent).toHaveBeenCalledWith(expect.objectContaining({repo: 'agent'}))
+  })
+
+  it('skips forks (no probe call for them)', async () => {
+    // #given a forked repo in the org listing
+    // #when discoverRenovateRepos is called
+    // #then no probe is issued for the fork and it is excluded from output
+    const {discoverRenovateRepos} = await import('./update-metadata.ts')
+    mocks.paginate.mockResolvedValueOnce([
+      {name: 'forked-repo', archived: false, fork: true},
+      {name: 'agent', archived: false, fork: false},
+    ])
+    mocks.getContent.mockResolvedValueOnce({status: 200})
+
+    const result = await discoverRenovateRepos(mockOctokit, 'fro-bot')
+    expect(result).toEqual(['agent'])
+    expect(mocks.getContent).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats 404 from probe as missing-config (not an error)', async () => {
+    // #given a repo whose probe returns 404
+    // #when discoverRenovateRepos is called
+    // #then the repo is omitted from the result without throwing
+    const {discoverRenovateRepos} = await import('./update-metadata.ts')
+    mocks.paginate.mockResolvedValueOnce([{name: 'no-renovate', archived: false, fork: false}])
+    mocks.getContent.mockRejectedValueOnce(Object.assign(new Error('Not Found'), {status: 404}))
+
+    const result = await discoverRenovateRepos(mockOctokit, 'fro-bot')
+    expect(result).toEqual([])
+  })
+
+  it('rethrows non-404 errors with repo context so the offending repo is identifiable', async () => {
+    // #given a repo whose probe returns 500
+    // #when discoverRenovateRepos is called
+    // #then the error wraps the original with org/repo and status context, and exposes the original via cause
+    const {discoverRenovateRepos} = await import('./update-metadata.ts')
+    mocks.paginate.mockResolvedValueOnce([{name: 'broken-repo', archived: false, fork: false}])
+    const original = Object.assign(new Error('Server Error'), {status: 500})
+    mocks.getContent.mockRejectedValueOnce(original)
+
+    await expect(discoverRenovateRepos(mockOctokit, 'fro-bot')).rejects.toThrow(/fro-bot\/broken-repo.*status=500/)
+    // Re-run to inspect the cause chain (the previous expect consumed the rejection).
+    mocks.paginate.mockResolvedValueOnce([{name: 'broken-repo', archived: false, fork: false}])
+    mocks.getContent.mockRejectedValueOnce(original)
+    await expect(discoverRenovateRepos(mockOctokit, 'fro-bot')).rejects.toMatchObject({cause: original})
+  })
+
+  it('propagates paginate rejections without probing any repos', async () => {
+    // #given the org listing call itself fails
+    // #when discoverRenovateRepos is called
+    // #then the error propagates and no per-repo probes happen
+    const {discoverRenovateRepos} = await import('./update-metadata.ts')
+    mocks.paginate.mockRejectedValueOnce(new Error('API down'))
+
+    await expect(discoverRenovateRepos(mockOctokit, 'fro-bot')).rejects.toThrow('API down')
+    expect(mocks.getContent).not.toHaveBeenCalled()
+  })
+
+  it('returns an empty array when org has no repos', async () => {
+    // #given an empty org listing
+    // #when discoverRenovateRepos is called
+    // #then it returns []
+    const {discoverRenovateRepos} = await import('./update-metadata.ts')
+    mocks.paginate.mockResolvedValueOnce([])
+
+    const result = await discoverRenovateRepos(mockOctokit, 'fro-bot')
+    expect(result).toEqual([])
+    expect(mocks.getContent).not.toHaveBeenCalled()
+  })
+
+  it('probes the canonical workflow path (.github/workflows/renovate.yaml)', async () => {
+    // #given a single repo
+    // #when discoverRenovateRepos is called
+    // #then it probes exactly the canonical path under the correct owner/repo
+    const {discoverRenovateRepos} = await import('./update-metadata.ts')
+    mocks.paginate.mockResolvedValueOnce([{name: 'agent', archived: false, fork: false}])
+    mocks.getContent.mockResolvedValueOnce({status: 200})
+
+    await discoverRenovateRepos(mockOctokit, 'fro-bot')
+    expect(mocks.getContent).toHaveBeenCalledWith({
+      owner: 'fro-bot',
+      repo: 'agent',
+      path: '.github/workflows/renovate.yaml',
+    })
+  })
+})

--- a/scripts/update-metadata.ts
+++ b/scripts/update-metadata.ts
@@ -1,0 +1,133 @@
+/**
+ * Metadata refresh for the fro-bot org.
+ *
+ * Scans the fro-bot org for repositories containing `.github/workflows/renovate.yaml`
+ * and writes the sorted list to `metadata/renovate.yaml` on the `data` branch.
+ * Mirrors the bfra-me/.github update-metadata pattern.
+ *
+ * Architecture:
+ *   - buildRenovateFile(names): pure shape builder — sole owner of sort + dedupe.
+ *   - discoverRenovateRepos(octokit, org): async I/O — list org repos, probe each.
+ *     Returns repos in discovery order; canonicalization happens in buildRenovateFile.
+ *   - main(): thin shell — token, octokit, discover, commitMetadata.
+ */
+
+import type {Octokit, RestEndpointMethodTypes} from '@octokit/rest'
+import type {RenovateFile} from './schemas.ts'
+
+import process from 'node:process'
+
+import {commitMetadata} from './commit-metadata.ts'
+
+export type OctokitClient = Octokit
+
+const DEFAULT_ORG = 'fro-bot'
+const RENOVATE_WORKFLOW_PATH = '.github/workflows/renovate.yaml'
+const RENOVATE_METADATA_PATH = 'metadata/renovate.yaml'
+
+// Derived from the real Octokit response so SDK drift becomes a compile error.
+type OrgRepoListing = RestEndpointMethodTypes['repos']['listForOrg']['response']['data'][number]
+
+// ─── Pure engine ────────────────────────────────────────────────────────────
+
+/**
+ * Wrap a list of repo names in the canonical `metadata/renovate.yaml` schema.
+ * Sorts alphabetically and deduplicates so the file shape is stable.
+ */
+export function buildRenovateFile(repoNames: string[]): RenovateFile {
+  const unique = [...new Set(repoNames)]
+  unique.sort((a, b) => a.localeCompare(b))
+  return {repositories: {'with-renovate': unique}}
+}
+
+// ─── Async discovery engine ─────────────────────────────────────────────────
+
+/**
+ * Discover org repos that contain a Renovate workflow at the canonical path.
+ * Skips archived repos and forks (neither should be receiving Renovate dispatches).
+ * 404 from the probe means "no Renovate workflow"; non-404 errors propagate with
+ * repo context so failures point at the offending repo.
+ */
+export async function discoverRenovateRepos(octokit: OctokitClient, org: string): Promise<string[]> {
+  const repos: OrgRepoListing[] = await octokit.paginate(octokit.rest.repos.listForOrg, {
+    org,
+    type: 'all',
+    per_page: 100,
+  })
+
+  const found: string[] = []
+
+  for (const repo of repos) {
+    if (repo.archived || repo.fork) continue
+
+    try {
+      await octokit.rest.repos.getContent({
+        owner: org,
+        repo: repo.name,
+        path: RENOVATE_WORKFLOW_PATH,
+      })
+      found.push(repo.name)
+    } catch (error: unknown) {
+      if (isNotFoundError(error)) continue
+      throw new Error(`update-metadata: probe failed for ${org}/${repo.name} (${formatErrorStatus(error)})`, {
+        cause: error,
+      })
+    }
+  }
+
+  return found
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function hasNumericStatus(error: unknown): error is {status: number} {
+  if (typeof error !== 'object' || error === null) return false
+  const status = (error as {status?: unknown}).status
+  return typeof status === 'number'
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return hasNumericStatus(error) && error.status === 404
+}
+
+function formatErrorStatus(error: unknown): string {
+  if (hasNumericStatus(error)) return `status=${error.status}`
+  if (error instanceof Error) return error.message
+  return 'unknown error'
+}
+
+// ─── CLI entrypoint ─────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const {Octokit} = await import('@octokit/rest')
+
+  const token = process.env.GITHUB_TOKEN
+  if (token === undefined || token === '') throw new Error('GITHUB_TOKEN is required')
+
+  const octokit = new Octokit({auth: token})
+  const org = process.env.UPDATE_METADATA_ORG ?? DEFAULT_ORG
+
+  const detected = await discoverRenovateRepos(octokit, org)
+  const next = buildRenovateFile(detected)
+
+  const result = await commitMetadata({
+    path: RENOVATE_METADATA_PATH,
+    message: `chore(metadata): refresh renovate.yaml from ${org} org scan`,
+    octokit,
+    async mutator() {
+      return next
+    },
+  })
+
+  const summary = {
+    org,
+    detected: detected.length,
+    committed: result.committed,
+    attempts: result.attempts,
+  }
+  process.stdout.write(`${JSON.stringify(summary)}\n`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}


### PR DESCRIPTION
## Summary

Adds an `Update Metadata` workflow that auto-populates `metadata/renovate.yaml` from a daily scan of the `fro-bot` org. The dispatch pipeline now has a real source of truth instead of a hand-edited seed list.

- **04:30 UTC daily**: scan fro-bot org → list repos containing `.github/workflows/renovate.yaml` → write sorted list to `metadata/renovate.yaml` on `data`
- **Every 4 hours**: existing Dispatch Renovate reads that file and dispatches Renovate to idle repos
- **Weekly**: Merge Data Branch promotes `data` → `main` for production consumption

## Architecture

| Layer       | Function                                                                                                                                                                                                            |
| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Pure engine | `buildRenovateFile(names)`: sort + dedupe + wrap in canonical schema                                                                                                                                                  |
| Async I/O   | `discoverRenovateRepos(octokit, org)`: paginate `listForOrg`, skip archived/forks, probe canonical path. 404 = absent. Non-404 errors wrap with `org/repo` and HTTP status context (preserves original via `cause`).      |
| CLI shell   | Reads `GITHUB_TOKEN`, instantiates Octokit, calls discover + buildRenovateFile, then `commitMetadata` to `data` branch                                                                                                  |

Type-safe Octokit listing via `RestEndpointMethodTypes['repos']['listForOrg']['response']['data'][number]` — SDK drift becomes a compile error.

## Wiki authority guard

Restores blanket `^metadata/[^/]+\.yaml$` protection. The previous PR incorrectly relaxed this to allow human edits to `renovate.yaml` and `allowlist.yaml`; both are auto-managed (or land via the `data` branch promotion flow). Manual metadata edits go through `data` and surface on `main` via the existing Merge Data Branch workflow.

## Latency note

The dispatch pipeline reads `metadata/renovate.yaml` from `main`, and the daily refresh writes to `data`. Updates surface on `main` via the weekly Merge Data Branch cron. This matches the existing `metadata/repos.yaml` lifecycle and is acceptable for Renovate (not time-critical). If shorter latency is needed later, increase `merge-data.yaml` cadence.

## Tests

12 new tests covering schema shape, sort/dedupe, archived/fork skip, 404-as-missing, paginate options, paginate-rejection propagation, contextual error rethrow with `cause`, and canonical probe path. 272/272 total.

## Verification

- `pnpm test` → 272/272
- `pnpm check-types` → clean
- `pnpm lint` (scoped) → clean
- Strip-only smoke test → clean
