### PR TITLE
fix(metadata): list repos via App installation, not org endpoint

### DIFF
--- a/scripts/update-metadata.test.ts
+++ b/scripts/update-metadata.test.ts
@@ -8,14 +8,15 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 // Then: returns a RenovateFile with names sorted and deduplicated
 
 // BDD: discoverRenovateRepos
-// Given: an Octokit client and a target org
+// Given: an Octokit client and a target owner
 // When: discoverRenovateRepos is called
-// Then: lists org repos (excluding archived and forks), probes each for
-//       .github/workflows/renovate.yaml, returns matching names in discovery order
+// Then: lists installation-accessible repos, filters to owner (excluding archived
+//       and forks), probes each for .github/workflows/renovate.yaml, returns
+//       matching names in discovery order
 
 const {mocks, mockOctokit} = vi.hoisted(() => {
   const mocks = {
-    listForOrg: vi.fn(),
+    listReposAccessibleToInstallation: vi.fn(),
     getContent: vi.fn(),
     paginate: vi.fn(),
   }
@@ -24,14 +25,27 @@ const {mocks, mockOctokit} = vi.hoisted(() => {
     mockOctokit: {
       paginate: mocks.paginate,
       rest: {
+        apps: {
+          listReposAccessibleToInstallation: mocks.listReposAccessibleToInstallation,
+        },
         repos: {
-          listForOrg: mocks.listForOrg,
           getContent: mocks.getContent,
         },
       },
     } as unknown as OctokitClient,
   }
 })
+
+// Test fixture builder so each repo carries the realistic owner/archived/fork shape
+// returned by `apps.listReposAccessibleToInstallation`.
+function repo(name: string, opts?: {owner?: string; archived?: boolean; fork?: boolean}) {
+  return {
+    name,
+    archived: opts?.archived ?? false,
+    fork: opts?.fork ?? false,
+    owner: {login: opts?.owner ?? 'fro-bot'},
+  }
+}
 
 describe('buildRenovateFile', () => {
   it('wraps names in the renovate.yaml schema shape', async () => {
@@ -77,16 +91,12 @@ describe('discoverRenovateRepos', () => {
   })
 
   it('returns repos containing .github/workflows/renovate.yaml in discovery order', async () => {
-    // #given an org with three repos and two of them have a Renovate workflow
-    // #when discoverRenovateRepos is called
-    // #then it returns matching names in the order paginate yielded them (sort happens in buildRenovateFile)
+    // #given the installation lists three fro-bot repos and two have a Renovate workflow
+    // #when discoverRenovateRepos is called for fro-bot
+    // #then it returns matching names in pagination order (sort happens in buildRenovateFile)
     const {discoverRenovateRepos} = await import('./update-metadata.ts')
-    mocks.paginate.mockResolvedValueOnce([
-      {name: 'agent', archived: false, fork: false},
-      {name: '.github', archived: false, fork: false},
-      {name: 'tokentoilet', archived: false, fork: false},
-    ])
-    // probe order matches input order; resolve = present (200), reject 404 = absent
+    mocks.paginate.mockResolvedValueOnce([repo('agent'), repo('.github'), repo('tokentoilet')])
+    // probe order matches input order; resolve = present, reject 404 = absent
     mocks.getContent.mockResolvedValueOnce({status: 200})
     mocks.getContent.mockResolvedValueOnce({status: 200})
     mocks.getContent.mockRejectedValueOnce(Object.assign(new Error('Not Found'), {status: 404}))
@@ -95,31 +105,43 @@ describe('discoverRenovateRepos', () => {
     expect(result).toEqual(['agent', '.github'])
   })
 
-  it('calls paginate with listForOrg and the correct org/type/per_page options', async () => {
-    // #given a target org
+  it('calls paginate against listReposAccessibleToInstallation with per_page=100', async () => {
+    // #given a target owner
     // #when discoverRenovateRepos is called
-    // #then paginate receives the listForOrg method plus org/type/per_page=100 so private+public+forks are enumerated
+    // #then paginate uses the App installation listing endpoint (works for users and orgs)
     const {discoverRenovateRepos} = await import('./update-metadata.ts')
     mocks.paginate.mockResolvedValueOnce([])
 
-    await discoverRenovateRepos(mockOctokit, 'other-org')
+    await discoverRenovateRepos(mockOctokit, 'fro-bot')
     expect(mocks.paginate).toHaveBeenCalledTimes(1)
-    expect(mocks.paginate).toHaveBeenCalledWith(mocks.listForOrg, {
-      org: 'other-org',
-      type: 'all',
-      per_page: 100,
-    })
+    expect(mocks.paginate).toHaveBeenCalledWith(mocks.listReposAccessibleToInstallation, {per_page: 100})
+  })
+
+  it('filters out repos owned by accounts other than the target owner', async () => {
+    // #given the installation lists repos under multiple owners
+    // #when discoverRenovateRepos is called for fro-bot
+    // #then repos owned by anyone other than fro-bot are skipped (no probe call)
+    const {discoverRenovateRepos} = await import('./update-metadata.ts')
+    mocks.paginate.mockResolvedValueOnce([
+      repo('agent', {owner: 'fro-bot'}),
+      repo('config', {owner: 'marcusrbrown'}),
+      repo('.github', {owner: 'fro-bot'}),
+    ])
+    mocks.getContent.mockResolvedValueOnce({status: 200})
+    mocks.getContent.mockResolvedValueOnce({status: 200})
+
+    const result = await discoverRenovateRepos(mockOctokit, 'fro-bot')
+    expect(result).toEqual(['agent', '.github'])
+    expect(mocks.getContent).toHaveBeenCalledTimes(2)
+    expect(mocks.getContent).not.toHaveBeenCalledWith(expect.objectContaining({repo: 'config'}))
   })
 
   it('skips archived repos (no probe call for them)', async () => {
-    // #given an archived repo in the org listing
+    // #given an archived repo in the listing
     // #when discoverRenovateRepos is called
     // #then no probe is issued for the archived repo and it is excluded from output
     const {discoverRenovateRepos} = await import('./update-metadata.ts')
-    mocks.paginate.mockResolvedValueOnce([
-      {name: 'archived-repo', archived: true, fork: false},
-      {name: 'agent', archived: false, fork: false},
-    ])
+    mocks.paginate.mockResolvedValueOnce([repo('archived-repo', {archived: true}), repo('agent')])
     mocks.getContent.mockResolvedValueOnce({status: 200})
 
     const result = await discoverRenovateRepos(mockOctokit, 'fro-bot')
@@ -129,14 +151,11 @@ describe('discoverRenovateRepos', () => {
   })
 
   it('skips forks (no probe call for them)', async () => {
-    // #given a forked repo in the org listing
+    // #given a forked repo in the listing
     // #when discoverRenovateRepos is called
     // #then no probe is issued for the fork and it is excluded from output
     const {discoverRenovateRepos} = await import('./update-metadata.ts')
-    mocks.paginate.mockResolvedValueOnce([
-      {name: 'forked-repo', archived: false, fork: true},
-      {name: 'agent', archived: false, fork: false},
-    ])
+    mocks.paginate.mockResolvedValueOnce([repo('forked-repo', {fork: true}), repo('agent')])
     mocks.getContent.mockResolvedValueOnce({status: 200})
 
     const result = await discoverRenovateRepos(mockOctokit, 'fro-bot')
@@ -149,7 +168,7 @@ describe('discoverRenovateRepos', () => {
     // #when discoverRenovateRepos is called
     // #then the repo is omitted from the result without throwing
     const {discoverRenovateRepos} = await import('./update-metadata.ts')
-    mocks.paginate.mockResolvedValueOnce([{name: 'no-renovate', archived: false, fork: false}])
+    mocks.paginate.mockResolvedValueOnce([repo('no-renovate')])
     mocks.getContent.mockRejectedValueOnce(Object.assign(new Error('Not Found'), {status: 404}))
 
     const result = await discoverRenovateRepos(mockOctokit, 'fro-bot')
@@ -159,21 +178,21 @@ describe('discoverRenovateRepos', () => {
   it('rethrows non-404 errors with repo context so the offending repo is identifiable', async () => {
     // #given a repo whose probe returns 500
     // #when discoverRenovateRepos is called
-    // #then the error wraps the original with org/repo and status context, and exposes the original via cause
+    // #then the error wraps the original with owner/repo and status context, and exposes the original via cause
     const {discoverRenovateRepos} = await import('./update-metadata.ts')
-    mocks.paginate.mockResolvedValueOnce([{name: 'broken-repo', archived: false, fork: false}])
+    mocks.paginate.mockResolvedValueOnce([repo('broken-repo')])
     const original = Object.assign(new Error('Server Error'), {status: 500})
     mocks.getContent.mockRejectedValueOnce(original)
 
     await expect(discoverRenovateRepos(mockOctokit, 'fro-bot')).rejects.toThrow(/fro-bot\/broken-repo.*status=500/)
     // Re-run to inspect the cause chain (the previous expect consumed the rejection).
-    mocks.paginate.mockResolvedValueOnce([{name: 'broken-repo', archived: false, fork: false}])
+    mocks.paginate.mockResolvedValueOnce([repo('broken-repo')])
     mocks.getContent.mockRejectedValueOnce(original)
     await expect(discoverRenovateRepos(mockOctokit, 'fro-bot')).rejects.toMatchObject({cause: original})
   })
 
   it('propagates paginate rejections without probing any repos', async () => {
-    // #given the org listing call itself fails
+    // #given the installation listing call itself fails
     // #when discoverRenovateRepos is called
     // #then the error propagates and no per-repo probes happen
     const {discoverRenovateRepos} = await import('./update-metadata.ts')
@@ -183,8 +202,8 @@ describe('discoverRenovateRepos', () => {
     expect(mocks.getContent).not.toHaveBeenCalled()
   })
 
-  it('returns an empty array when org has no repos', async () => {
-    // #given an empty org listing
+  it('returns an empty array when the installation has no repos', async () => {
+    // #given an empty installation listing
     // #when discoverRenovateRepos is called
     // #then it returns []
     const {discoverRenovateRepos} = await import('./update-metadata.ts')
@@ -200,7 +219,7 @@ describe('discoverRenovateRepos', () => {
     // #when discoverRenovateRepos is called
     // #then it probes exactly the canonical path under the correct owner/repo
     const {discoverRenovateRepos} = await import('./update-metadata.ts')
-    mocks.paginate.mockResolvedValueOnce([{name: 'agent', archived: false, fork: false}])
+    mocks.paginate.mockResolvedValueOnce([repo('agent')])
     mocks.getContent.mockResolvedValueOnce({status: 200})
 
     await discoverRenovateRepos(mockOctokit, 'fro-bot')

--- a/scripts/update-metadata.ts
+++ b/scripts/update-metadata.ts
@@ -1,15 +1,21 @@
 /**
- * Metadata refresh for the fro-bot org.
+ * Metadata refresh for the fro-bot account.
  *
- * Scans the fro-bot org for repositories containing `.github/workflows/renovate.yaml`
- * and writes the sorted list to `metadata/renovate.yaml` on the `data` branch.
- * Mirrors the bfra-me/.github update-metadata pattern.
+ * Scans the repositories accessible to the Fro Bot GitHub App installation,
+ * filters to those owned by the configured account containing
+ * `.github/workflows/renovate.yaml`, and writes the sorted list to
+ * `metadata/renovate.yaml` on the `data` branch. Mirrors the bfra-me/.github
+ * update-metadata pattern.
  *
  * Architecture:
  *   - buildRenovateFile(names): pure shape builder — sole owner of sort + dedupe.
- *   - discoverRenovateRepos(octokit, org): async I/O — list org repos, probe each.
- *     Returns repos in discovery order; canonicalization happens in buildRenovateFile.
+ *   - discoverRenovateRepos(octokit, owner): async I/O — list installation repos
+ *     filtered to the target owner, probe each. Returns repos in discovery order;
+ *     canonicalization happens in buildRenovateFile.
  *   - main(): thin shell — token, octokit, discover, commitMetadata.
+ *
+ * Uses `apps.listReposAccessibleToInstallation` so the call works whether the
+ * Fro Bot account is a User (current) or an Organization (future migration).
  */
 
 import type {Octokit, RestEndpointMethodTypes} from '@octokit/rest'
@@ -21,12 +27,13 @@ import {commitMetadata} from './commit-metadata.ts'
 
 export type OctokitClient = Octokit
 
-const DEFAULT_ORG = 'fro-bot'
+const DEFAULT_OWNER = 'fro-bot'
 const RENOVATE_WORKFLOW_PATH = '.github/workflows/renovate.yaml'
 const RENOVATE_METADATA_PATH = 'metadata/renovate.yaml'
 
 // Derived from the real Octokit response so SDK drift becomes a compile error.
-type OrgRepoListing = RestEndpointMethodTypes['repos']['listForOrg']['response']['data'][number]
+type InstallationRepo =
+  RestEndpointMethodTypes['apps']['listReposAccessibleToInstallation']['response']['data']['repositories'][number]
 
 // ─── Pure engine ────────────────────────────────────────────────────────────
 
@@ -43,18 +50,18 @@ export function buildRenovateFile(repoNames: string[]): RenovateFile {
 // ─── Async discovery engine ─────────────────────────────────────────────────
 
 /**
- * Discover org repos that contain a Renovate workflow at the canonical path.
- * Skips archived repos and forks (neither should be receiving Renovate dispatches).
- * 404 from the probe means "no Renovate workflow"; non-404 errors propagate with
- * repo context so failures point at the offending repo.
+ * Discover repos under `owner` that contain a Renovate workflow at the canonical path.
+ * Lists repos via the App installation's accessible-repositories endpoint, filters to
+ * the target owner, then skips archived repos and forks (neither should be receiving
+ * Renovate dispatches). 404 from the probe means "no Renovate workflow"; non-404
+ * errors propagate with repo context so failures point at the offending repo.
  */
-export async function discoverRenovateRepos(octokit: OctokitClient, org: string): Promise<string[]> {
-  const repos: OrgRepoListing[] = await octokit.paginate(octokit.rest.repos.listForOrg, {
-    org,
-    type: 'all',
+export async function discoverRenovateRepos(octokit: OctokitClient, owner: string): Promise<string[]> {
+  const allRepos: InstallationRepo[] = await octokit.paginate(octokit.rest.apps.listReposAccessibleToInstallation, {
     per_page: 100,
   })
 
+  const repos = allRepos.filter(r => r.owner.login === owner)
   const found: string[] = []
 
   for (const repo of repos) {
@@ -62,14 +69,14 @@ export async function discoverRenovateRepos(octokit: OctokitClient, org: string)
 
     try {
       await octokit.rest.repos.getContent({
-        owner: org,
+        owner,
         repo: repo.name,
         path: RENOVATE_WORKFLOW_PATH,
       })
       found.push(repo.name)
     } catch (error: unknown) {
       if (isNotFoundError(error)) continue
-      throw new Error(`update-metadata: probe failed for ${org}/${repo.name} (${formatErrorStatus(error)})`, {
+      throw new Error(`update-metadata: probe failed for ${owner}/${repo.name} (${formatErrorStatus(error)})`, {
         cause: error,
       })
     }
@@ -105,14 +112,14 @@ async function main(): Promise<void> {
   if (token === undefined || token === '') throw new Error('GITHUB_TOKEN is required')
 
   const octokit = new Octokit({auth: token})
-  const org = process.env.UPDATE_METADATA_ORG ?? DEFAULT_ORG
+  const owner = process.env.UPDATE_METADATA_OWNER ?? DEFAULT_OWNER
 
-  const detected = await discoverRenovateRepos(octokit, org)
+  const detected = await discoverRenovateRepos(octokit, owner)
   const next = buildRenovateFile(detected)
 
   const result = await commitMetadata({
     path: RENOVATE_METADATA_PATH,
-    message: `chore(metadata): refresh renovate.yaml from ${org} org scan`,
+    message: `chore(metadata): refresh renovate.yaml from ${owner} account scan`,
     octokit,
     async mutator() {
       return next
@@ -120,7 +127,7 @@ async function main(): Promise<void> {
   })
 
   const summary = {
-    org,
+    owner,
     detected: detected.length,
     committed: result.committed,
     attempts: result.attempts,


### PR DESCRIPTION
## Summary

The first run of the daily Update Metadata workflow failed with `Not Found` on `repos.listForOrg`. Root cause: `fro-bot` is a User account, not an Organization, so the org-listing endpoint 404s.

Switch to `apps.listReposAccessibleToInstallation`, which is the canonical endpoint for App installation tokens — works for users and orgs, and is naturally scoped to repos the App can access. Filter the result by `owner.login` so we only consider repos under the configured account.

## Changes

- `scripts/update-metadata.ts`:
  - Replaced `repos.listForOrg` with `apps.listReposAccessibleToInstallation`
  - Renamed parameter and env var: `org` → `owner`, `UPDATE_METADATA_ORG` → `UPDATE_METADATA_OWNER`
  - `InstallationRepo` type derived from the new endpoint's response so SDK drift remains a compile error
- `scripts/update-metadata.test.ts`:
  - Mock now wires `mocks.apps.listReposAccessibleToInstallation`
  - Test fixture builder includes `owner.login` (matches real response shape)
  - New test: `'filters out repos owned by accounts other than the target owner'`

## Verification

- `pnpm test` → 273/273 (one new test)
- `pnpm check-types` → clean
- `pnpm lint` → clean
- Strip-only smoke test → clean

The first failed run is documented at https://github.com/fro-bot/.github/actions/runs/25044993892.
