### PR TITLE
fix(workflows): scope App token to whole installation, not calling repo

### DIFF
--- a/.github/workflows/dispatch-renovate.yaml
+++ b/.github/workflows/dispatch-renovate.yaml
@@ -25,6 +25,7 @@ jobs:
         with:
           app-id: ${{ secrets.APPLICATION_ID }}
           private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: ⤵ Checkout Branch
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/update-metadata.yaml
+++ b/.github/workflows/update-metadata.yaml
@@ -25,6 +25,7 @@ jobs:
         with:
           app-id: ${{ secrets.APPLICATION_ID }}
           private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: ⤵ Checkout Branch
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
## Summary

`actions/create-github-app-token` defaults to scoping the minted token to **only the calling repo**. Without an explicit `owner` (or `repositories`) input, `apps.listReposAccessibleToInstallation` returns just `fro-bot/.github`, and cross-repo dispatch to `fro-bot/agent` 403s with `Resource not accessible by integration`.

Adds `owner: ${{ github.repository_owner }}` to the two workflows that need installation-wide access:

- `update-metadata.yaml` — lists installation repos to find ones containing `.github/workflows/renovate.yaml`
- `dispatch-renovate.yaml` — triggers Renovate workflow runs across the fro-bot account

The other App-token workflows (`reconcile-repos`, `merge-data`, `reset-survey-status`, `manage-cache`, `manage-issues`) only operate on `fro-bot/.github`, so the calling-repo default is correct for them.

## Evidence

The 04:09 dispatch-renovate run hit this exact failure on `fro-bot/agent`:

```
POST /repos/fro-bot/agent/actions/workflows/renovate.yaml/dispatches - 403
dispatch-renovate: failed agent: Resource not accessible by integration
```

The 04:15 update-metadata run wrote `[.github]` to `data:metadata/renovate.yaml` because it could only see one repo through the same scope-limited token.

## Verification

- `pnpm test` → 273/273
- `pnpm lint` → clean
- `actionlint` → clean

After merge: dispatch `Update Metadata` to refresh `data:metadata/renovate.yaml`, then `Merge Data Branch`, then `Dispatch Renovate` to confirm cross-repo dispatch works end-to-end.
