### PR TITLE
fix(workflows): harden data merge PR recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist
 # Test output
 coverage
 .vitest-cache
+
+# Local agent artifacts
+.context/

--- a/scripts/merge-data-pr.test.ts
+++ b/scripts/merge-data-pr.test.ts
@@ -1,4 +1,4 @@
-import type {OctokitClient} from './merge-data-pr.ts'
+import type {MergeDataPrLogger, OctokitClient} from './merge-data-pr.ts'
 import {describe, expect, it, vi} from 'vitest'
 import {mergeDataPr, MergeDataPrError} from './merge-data-pr.ts'
 
@@ -16,6 +16,15 @@ function isoDaysAgo(daysAgo: number): string {
 interface MockOverrides {
   compareCommitsWithBasehead?: (params: {owner: string; repo: string; basehead: string}) => Promise<unknown>
   listPullRequestsAssociatedWithCommit?: (params: {owner: string; repo: string; commit_sha: string}) => Promise<unknown>
+  listPullRequests?: (params: {
+    owner: string
+    repo: string
+    state: 'open' | 'closed' | 'all'
+    head?: string
+    base?: string
+    per_page?: number
+  }) => Promise<unknown>
+  getPullRequest?: (params: {owner: string; repo: string; pull_number: number}) => Promise<unknown>
   createPullRequest?: (params: {
     owner: string
     repo: string
@@ -23,6 +32,12 @@ interface MockOverrides {
     head: string
     base: string
     body: string
+  }) => Promise<unknown>
+  updateBranch?: (params: {
+    owner: string
+    repo: string
+    pull_number: number
+    expected_head_sha?: string
   }) => Promise<unknown>
   addLabels?: (params: {owner: string; repo: string; issue_number: number; labels: string[]}) => Promise<unknown>
   createIssue?: (params: {owner: string; repo: string; title: string; body: string}) => Promise<unknown>
@@ -54,11 +69,18 @@ function mockOctokit(overrides?: MockOverrides): OctokitClient {
           overrides?.listPullRequestsAssociatedWithCommit ?? (async () => ({data: []})),
       },
       pulls: {
+        list: overrides?.listPullRequests ?? (async () => ({data: []})),
+        get:
+          overrides?.getPullRequest ??
+          (async () => ({
+            data: {mergeable_state: 'clean', head: {sha: 'data-commit-sha'}},
+          })),
         create:
           overrides?.createPullRequest ??
           (async () => ({
             data: {number: 42, html_url: 'https://github.com/fro-bot/.github/pull/42'},
           })),
+        updateBranch: overrides?.updateBranch ?? (async () => ({data: {}})),
       },
       issues: {
         addLabels: overrides?.addLabels ?? (async () => ({data: {labels: [{name: 'auto-merge'}]}})),
@@ -71,6 +93,12 @@ function mockOctokit(overrides?: MockOverrides): OctokitClient {
       },
     },
   } as unknown as OctokitClient
+}
+
+function mockLogger(): MergeDataPrLogger {
+  return {
+    warn: vi.fn(),
+  }
 }
 
 describe('mergeDataPr', () => {
@@ -166,7 +194,10 @@ describe('mergeDataPr', () => {
       createIssue,
       createPullRequest: async () => {
         // #given GitHub rejects the PR with merge conflicts
-        throw Object.assign(new Error('Merge conflict'), {status: 422})
+        throw Object.assign(new Error('Merge conflict'), {
+          status: 422,
+          response: {data: {message: 'Merge conflict'}},
+        })
       },
     })
 
@@ -262,27 +293,612 @@ describe('mergeDataPr', () => {
     })
   })
 
-  it('creates a journal entry for non-conflict 422 errors with descriptive title', async () => {
-    const createIssue = vi.fn(async () => ({
-      data: {number: 88, html_url: 'https://github.com/fro-bot/.github/issues/88'},
+  it('updates a newly created PR branch when mergeable_state is behind', async () => {
+    const updateBranch = vi.fn(async () => ({data: {}}))
+    const getPullRequest = vi.fn(async () => ({
+      data: {mergeable_state: 'behind', head: {sha: 'new-pr-head-sha'}},
+    }))
+    const octokit = mockOctokit({getPullRequest, updateBranch})
+
+    const result = await mergeDataPr({octokit, now: new Date('2026-04-16T00:00:00.000Z')})
+
+    expect(result.createdPullRequest).toBe(true)
+    expect(getPullRequest).toHaveBeenCalledWith({
+      owner: 'fro-bot',
+      repo: '.github',
+      pull_number: 42,
+    })
+    expect(updateBranch).toHaveBeenCalledWith({
+      owner: 'fro-bot',
+      repo: '.github',
+      pull_number: 42,
+      expected_head_sha: 'new-pr-head-sha',
+    })
+  })
+
+  it('updates an existing PR branch when mergeable_state is behind', async () => {
+    const updateBranch = vi.fn(async () => ({data: {}}))
+    const getPullRequest = vi.fn(async () => ({
+      data: {mergeable_state: 'behind', head: {sha: 'existing-pr-head-sha'}},
     }))
     const octokit = mockOctokit({
-      createIssue,
+      listPullRequestsAssociatedWithCommit: async () => ({
+        data: [
+          {
+            number: 55,
+            html_url: 'https://github.com/fro-bot/.github/pull/55',
+            head: {ref: 'data'},
+            base: {ref: 'main'},
+          },
+        ],
+      }),
+      getPullRequest,
+      updateBranch,
+    })
+
+    const result = await mergeDataPr({octokit, now: new Date('2026-04-16T00:00:00.000Z')})
+
+    expect(result.pullRequestNumber).toBe(55)
+    expect(getPullRequest).toHaveBeenCalledWith({
+      owner: 'fro-bot',
+      repo: '.github',
+      pull_number: 55,
+    })
+    expect(updateBranch).toHaveBeenCalledWith({
+      owner: 'fro-bot',
+      repo: '.github',
+      pull_number: 55,
+      expected_head_sha: 'existing-pr-head-sha',
+    })
+  })
+
+  it('retries mergeable_state unknown until it resolves behind', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const updateBranch = vi.fn(async () => ({data: {}}))
+      const getPullRequest = vi.fn(async () => ({
+        data: {mergeable_state: 'behind', head: {sha: 'resolved-head-sha'}},
+      }))
+      getPullRequest
+        .mockResolvedValueOnce({data: {mergeable_state: 'unknown', head: {sha: 'new-pr-head-sha'}}})
+        .mockResolvedValueOnce({data: {mergeable_state: 'behind', head: {sha: 'resolved-head-sha'}}})
+      const octokit = mockOctokit({getPullRequest, updateBranch})
+
+      const resultPromise = mergeDataPr({octokit, now: new Date('2026-04-16T00:00:00.000Z')})
+
+      await vi.runAllTimersAsync()
+
+      const result = await resultPromise
+
+      expect(result.createdPullRequest).toBe(true)
+      expect(getPullRequest).toHaveBeenCalledTimes(2)
+      expect(updateBranch).toHaveBeenCalledWith({
+        owner: 'fro-bot',
+        repo: '.github',
+        pull_number: 42,
+        expected_head_sha: 'resolved-head-sha',
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('skips updateBranch after bounded unknown mergeability retries', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const logger = mockLogger()
+      const updateBranch = vi.fn(async () => ({data: {}}))
+      const getPullRequest = vi.fn(async () => ({
+        data: {mergeable_state: 'unknown', head: {sha: 'new-pr-head-sha'}},
+      }))
+      const octokit = mockOctokit({getPullRequest, updateBranch})
+
+      const resultPromise = mergeDataPr({octokit, logger, now: new Date('2026-04-16T00:00:00.000Z')})
+
+      await vi.runAllTimersAsync()
+
+      const result = await resultPromise
+
+      expect(result.createdPullRequest).toBe(true)
+      expect(getPullRequest).toHaveBeenCalledTimes(3)
+      expect(updateBranch).not.toHaveBeenCalled()
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+        'PR #42 mergeability stayed unknown after 3 checks; leaving the branch unchanged for this run.',
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('skips updateBranch when mergeability resolves to a known non-behind state', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const updateBranch = vi.fn(async () => ({data: {}}))
+      const getPullRequest = vi.fn(async () => ({
+        data: {mergeable_state: 'clean', head: {sha: 'resolved-head-sha'}},
+      }))
+      getPullRequest
+        .mockResolvedValueOnce({data: {mergeable_state: 'unknown', head: {sha: 'new-pr-head-sha'}}})
+        .mockResolvedValueOnce({data: {mergeable_state: 'clean', head: {sha: 'resolved-head-sha'}}})
+      const octokit = mockOctokit({getPullRequest, updateBranch})
+
+      const resultPromise = mergeDataPr({octokit, now: new Date('2026-04-16T00:00:00.000Z')})
+
+      await vi.runAllTimersAsync()
+
+      const result = await resultPromise
+
+      expect(result.createdPullRequest).toBe(true)
+      expect(getPullRequest).toHaveBeenCalledTimes(2)
+      expect(updateBranch).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('treats updateBranch expected_head_sha 422 as a no-op race', async () => {
+    const updateBranch = vi.fn(async () => {
+      throw Object.assign(new Error('Validation Failed'), {
+        status: 422,
+        response: {
+          data: {
+            message: 'Validation Failed',
+            errors: [{field: 'expected_head_sha', message: 'Head SHA is out of date'}],
+          },
+        },
+      })
+    })
+    const octokit = mockOctokit({
+      getPullRequest: async () => ({
+        data: {mergeable_state: 'behind', head: {sha: 'existing-pr-head-sha'}},
+      }),
+      updateBranch,
+    })
+
+    const result = await mergeDataPr({octokit, now: new Date('2026-04-16T00:00:00.000Z')})
+
+    expect(result.createdPullRequest).toBe(true)
+    expect(updateBranch).toHaveBeenCalledOnce()
+  })
+
+  it('throws a structured error when updateBranch returns a non-race 422', async () => {
+    const updateBranch = vi.fn(async () => {
+      throw Object.assign(new Error('Validation Failed'), {
+        status: 422,
+        response: {
+          data: {
+            message: 'Validation Failed',
+            errors: [{field: 'base', message: 'Branch update blocked by protection rule'}],
+          },
+        },
+      })
+    })
+    const octokit = mockOctokit({
+      getPullRequest: async () => ({
+        data: {mergeable_state: 'behind', head: {sha: 'existing-pr-head-sha'}},
+      }),
+      updateBranch,
+    })
+
+    const error = await mergeDataPr({octokit, now: new Date('2026-04-16T00:00:00.000Z')}).catch(
+      (error: unknown) => error,
+    )
+
+    expect(error).toBeInstanceOf(MergeDataPrError)
+    expect((error as MergeDataPrError).message).toContain('updating PR #42 branch')
+  })
+
+  it('warns and continues when updateBranch fails transiently', async () => {
+    const logger = mockLogger()
+    const addLabels = vi.fn(async () => ({data: {labels: [{name: 'auto-merge'}]}}))
+    const updateBranch = vi.fn(async () => {
+      throw Object.assign(new Error('Branch update failed'), {status: 503})
+    })
+    const octokit = mockOctokit({
+      addLabels,
+      getPullRequest: async () => ({
+        data: {mergeable_state: 'behind', head: {sha: 'existing-pr-head-sha'}},
+      }),
+      updateBranch,
+    })
+
+    const result = await mergeDataPr({octokit, logger, now: new Date('2026-04-16T00:00:00.000Z')})
+
+    expect(result.createdPullRequest).toBe(true)
+    expect(result.pullRequestNumber).toBe(42)
+    expect(updateBranch).toHaveBeenCalledOnce()
+    expect(addLabels).toHaveBeenCalledWith({
+      owner: 'fro-bot',
+      repo: '.github',
+      issue_number: 42,
+      labels: ['auto-merge'],
+    })
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(expect.stringContaining('updating PR #42 branch'))
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      expect.stringContaining('continuing because the PR already exists and a later run can retry the branch update'),
+    )
+  })
+
+  it('warns and continues when fetching a newly created PR fails', async () => {
+    const logger = mockLogger()
+    const addLabels = vi.fn(async () => ({data: {labels: [{name: 'auto-merge'}]}}))
+    const octokit = mockOctokit({
+      addLabels,
+      getPullRequest: async () => {
+        throw Object.assign(new Error('PR lookup failed'), {status: 503})
+      },
+    })
+
+    const result = await mergeDataPr({octokit, logger, now: new Date('2026-04-16T00:00:00.000Z')})
+
+    expect(result.createdPullRequest).toBe(true)
+    expect(result.label).toBe('auto-merge')
+    expect(result.pullRequestNumber).toBe(42)
+    expect(addLabels).toHaveBeenCalledWith({
+      owner: 'fro-bot',
+      repo: '.github',
+      issue_number: 42,
+      labels: ['auto-merge'],
+    })
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      'GitHub API error while fetching PR #42: PR lookup failed; continuing because the PR already exists and a later run can retry the branch update.',
+    )
+  })
+
+  it('warns and continues when fetching a newly created PR hits a transient transport error', async () => {
+    const logger = mockLogger()
+    const octokit = mockOctokit({
+      getPullRequest: async () => {
+        throw Object.assign(new Error('socket hang up'), {code: 'ECONNRESET'})
+      },
+    })
+
+    const result = await mergeDataPr({octokit, logger, now: new Date('2026-04-16T00:00:00.000Z')})
+
+    expect(result.createdPullRequest).toBe(true)
+    expect(result.pullRequestNumber).toBe(42)
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(expect.stringContaining('fetching PR #42'))
+  })
+
+  it('throws when mergeability probing fails permanently after an unknown retry', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const getPullRequest = vi.fn(async () => ({
+        data: {mergeable_state: 'behind', head: {sha: 'resolved-head-sha'}},
+      }))
+      getPullRequest
+        .mockResolvedValueOnce({data: {mergeable_state: 'unknown', head: {sha: 'new-pr-head-sha'}}})
+        .mockRejectedValueOnce(Object.assign(new Error('PR not found'), {status: 404}))
+      const octokit = mockOctokit({getPullRequest})
+
+      const resultPromise = mergeDataPr({octokit, now: new Date('2026-04-16T00:00:00.000Z')})
+      const errorPromise = resultPromise.catch((error: unknown) => error)
+
+      await vi.runAllTimersAsync()
+
+      const error = await errorPromise
+
+      expect(error).toBeInstanceOf(MergeDataPrError)
+      expect((error as MergeDataPrError).message).toContain('fetching PR #42')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('throws when fetching a newly created PR fails permanently', async () => {
+    const octokit = mockOctokit({
+      getPullRequest: async () => {
+        throw Object.assign(new Error('PR not found'), {status: 404})
+      },
+    })
+
+    const error = await mergeDataPr({octokit, now: new Date('2026-04-16T00:00:00.000Z')}).catch(
+      (error: unknown) => error,
+    )
+
+    expect(error).toBeInstanceOf(MergeDataPrError)
+    expect((error as MergeDataPrError).message).toContain('fetching PR #42')
+  })
+
+  it('throws when fetching an existing PR fails permanently', async () => {
+    const octokit = mockOctokit({
+      listPullRequestsAssociatedWithCommit: async () => ({
+        data: [
+          {
+            number: 55,
+            html_url: 'https://github.com/fro-bot/.github/pull/55',
+            head: {ref: 'data'},
+            base: {ref: 'main'},
+          },
+        ],
+      }),
+      getPullRequest: async () => {
+        throw Object.assign(new Error('PR not found'), {status: 404})
+      },
+    })
+
+    const error = await mergeDataPr({octokit, now: new Date('2026-04-16T00:00:00.000Z')}).catch(
+      (error: unknown) => error,
+    )
+
+    expect(error).toBeInstanceOf(MergeDataPrError)
+    expect((error as MergeDataPrError).message).toContain('fetching PR #55')
+  })
+
+  it('warns and continues when fetching an existing PR fails', async () => {
+    const logger = mockLogger()
+    const addLabels = vi.fn(async () => ({data: {labels: [{name: 'auto-merge'}]}}))
+    const octokit = mockOctokit({
+      listPullRequestsAssociatedWithCommit: async () => ({
+        data: [
+          {
+            number: 55,
+            html_url: 'https://github.com/fro-bot/.github/pull/55',
+            head: {ref: 'data'},
+            base: {ref: 'main'},
+          },
+        ],
+      }),
+      getPullRequest: async () => {
+        throw Object.assign(new Error('PR lookup failed'), {status: 503})
+      },
+      addLabels,
+    })
+
+    const result = await mergeDataPr({octokit, logger, now: new Date('2026-04-16T00:00:00.000Z')})
+
+    expect(result.createdPullRequest).toBe(true)
+    expect(result.pullRequestNumber).toBe(55)
+    expect(addLabels).toHaveBeenCalledWith({
+      owner: 'fro-bot',
+      repo: '.github',
+      issue_number: 55,
+      labels: ['auto-merge'],
+    })
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      'GitHub API error while fetching PR #55: PR lookup failed; continuing because the PR already exists and a later run can retry the branch update.',
+    )
+  })
+
+  it('reuses the existing PR when createPullRequest returns a duplicate-PR 422', async () => {
+    const addLabels = vi.fn(async () => ({data: {labels: [{name: 'auto-merge'}]}}))
+    const listPullRequests = async () => {
+      return {
+        data: [
+          {
+            number: 88,
+            html_url: 'https://github.com/fro-bot/.github/pull/88',
+            head: {ref: 'data'},
+            base: {ref: 'main'},
+          },
+        ],
+      }
+    }
+    const octokit = mockOctokit({
+      addLabels,
+      listPullRequests,
       createPullRequest: async () => {
-        // #given GitHub rejects the PR with a non-conflict 422 (e.g. duplicate PR)
-        throw Object.assign(new Error('Validation Failed: A pull request already exists'), {
+        // #given GitHub reports the PR already exists after the initial lookup missed it
+        throw Object.assign(new Error('Validation Failed'), {
           status: 422,
-          response: {data: {message: 'Validation Failed', errors: [{message: 'A pull request already exists'}]}},
+          response: {
+            data: {
+              message: 'Validation Failed',
+              errors: [{message: 'A pull request already exists for fro-bot:data.'}],
+            },
+          },
         })
       },
     })
 
-    // #when the merge PR script runs
+    // #when the merge PR script runs during that race
     const result = await mergeDataPr({octokit, now: new Date('2026-04-16T00:00:00.000Z')})
 
-    // #then it creates a journal entry (safe fallback for any 422)
+    // #then it recovers by reusing the existing PR instead of journaling a fake conflict
+    expect(result.createdPullRequest).toBe(true)
+    expect(result.pullRequestNumber).toBe(88)
+    expect(result.pullRequestUrl).toBe('https://github.com/fro-bot/.github/pull/88')
+    expect(addLabels).toHaveBeenCalledWith({
+      owner: 'fro-bot',
+      repo: '.github',
+      issue_number: 88,
+      labels: ['auto-merge'],
+    })
+  })
+
+  it('retries duplicate-PR rediscovery before failing when the PR is not listed immediately', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const listPullRequests = vi.fn(async () => ({
+        data: [
+          {
+            number: 88,
+            html_url: 'https://github.com/fro-bot/.github/pull/88',
+            head: {ref: 'data'},
+            base: {ref: 'main'},
+          },
+        ],
+      }))
+      listPullRequests.mockResolvedValueOnce({data: []}).mockResolvedValueOnce({
+        data: [
+          {
+            number: 88,
+            html_url: 'https://github.com/fro-bot/.github/pull/88',
+            head: {ref: 'data'},
+            base: {ref: 'main'},
+          },
+        ],
+      })
+      const octokit = mockOctokit({
+        listPullRequests,
+        createPullRequest: async () => {
+          throw Object.assign(new Error('Validation Failed'), {
+            status: 422,
+            response: {
+              data: {
+                message: 'Validation Failed',
+                errors: [{message: 'A pull request already exists for fro-bot:data.'}],
+              },
+            },
+          })
+        },
+      })
+
+      const resultPromise = mergeDataPr({octokit, now: new Date('2026-04-16T00:00:00.000Z')})
+
+      await vi.runAllTimersAsync()
+
+      const result = await resultPromise
+
+      expect(result.createdPullRequest).toBe(true)
+      expect(result.pullRequestNumber).toBe(88)
+      expect(listPullRequests).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('retries duplicate-PR rediscovery after a transient pull listing failure', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const listPullRequests = vi.fn(async () => ({
+        data: [
+          {
+            number: 88,
+            html_url: 'https://github.com/fro-bot/.github/pull/88',
+            head: {ref: 'data'},
+            base: {ref: 'main'},
+          },
+        ],
+      }))
+      listPullRequests
+        .mockRejectedValueOnce(Object.assign(new Error('socket hang up'), {code: 'ECONNRESET'}))
+        .mockResolvedValueOnce({
+          data: [
+            {
+              number: 88,
+              html_url: 'https://github.com/fro-bot/.github/pull/88',
+              head: {ref: 'data'},
+              base: {ref: 'main'},
+            },
+          ],
+        })
+      const octokit = mockOctokit({
+        listPullRequests,
+        createPullRequest: async () => {
+          throw Object.assign(new Error('Validation Failed'), {
+            status: 422,
+            response: {
+              data: {
+                message: 'Validation Failed',
+                errors: [{message: 'A pull request already exists for fro-bot:data.'}],
+              },
+            },
+          })
+        },
+      })
+
+      const resultPromise = mergeDataPr({octokit, now: new Date('2026-04-16T00:00:00.000Z')})
+
+      await vi.runAllTimersAsync()
+
+      const result = await resultPromise
+
+      expect(result.createdPullRequest).toBe(true)
+      expect(result.pullRequestNumber).toBe(88)
+      expect(listPullRequests).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('detects duplicate-PR 422s from the top-level message', async () => {
+    const listPullRequests = vi.fn(async () => ({
+      data: [
+        {
+          number: 88,
+          html_url: 'https://github.com/fro-bot/.github/pull/88',
+          head: {ref: 'data'},
+          base: {ref: 'main'},
+        },
+      ],
+    }))
+    const octokit = mockOctokit({
+      listPullRequests,
+      createPullRequest: async () => {
+        throw Object.assign(new Error('A pull request already exists for fro-bot:data.'), {
+          status: 422,
+          response: {
+            data: {
+              message: 'A pull request already exists for fro-bot:data.',
+              errors: [],
+            },
+          },
+        })
+      },
+    })
+
+    const result = await mergeDataPr({octokit, now: new Date('2026-04-16T00:00:00.000Z')})
+
+    expect(result.createdPullRequest).toBe(true)
+    expect(result.pullRequestNumber).toBe(88)
+  })
+
+  it('creates a journal entry when merge conflicts are reported in 422 error items', async () => {
+    const createIssue = vi.fn(async () => ({
+      data: {number: 99, html_url: 'https://github.com/fro-bot/.github/issues/99'},
+    }))
+    const octokit = mockOctokit({
+      createIssue,
+      createPullRequest: async () => {
+        throw Object.assign(new Error('Validation Failed'), {
+          status: 422,
+          response: {
+            data: {
+              message: 'Validation Failed',
+              errors: [{message: 'Merge conflict between base and head branches'}],
+            },
+          },
+        })
+      },
+    })
+
+    const result = await mergeDataPr({octokit, now: new Date('2026-04-16T00:00:00.000Z')})
+
     expect(result.createdPullRequest).toBe(false)
-    expect(result.journalIssueNumber).toBe(88)
+    expect(result.journalIssueNumber).toBe(99)
+    expect(createIssue).toHaveBeenCalledOnce()
+  })
+
+  it('throws a structured error for non-conflict 422 createPullRequest failures', async () => {
+    const octokit = mockOctokit({
+      createPullRequest: async () => {
+        throw Object.assign(new Error('Validation Failed'), {
+          status: 422,
+          response: {
+            data: {
+              message: 'Validation Failed',
+              errors: [{field: 'base', message: 'Branch update blocked by protection rule'}],
+            },
+          },
+        })
+      },
+    })
+
+    const error = await mergeDataPr({octokit, now: new Date('2026-04-16T00:00:00.000Z')}).catch(
+      (error: unknown) => error,
+    )
+
+    expect(error).toBeInstanceOf(MergeDataPrError)
+    expect((error as MergeDataPrError).message).toContain('creating data -> main pull request')
   })
 
   it('skips stale-divergence alert when an existing open alert issue matches', async () => {

--- a/scripts/merge-data-pr.ts
+++ b/scripts/merge-data-pr.ts
@@ -7,6 +7,10 @@ const DEFAULT_BASE_BRANCH = 'main'
 const DEFAULT_HEAD_BRANCH = 'data'
 const AUTO_MERGE_PATH_PREFIXES = ['knowledge/', 'metadata/'] as const
 const STALE_DIVERGENCE_MS = 14 * 24 * 60 * 60 * 1000
+const MERGEABLE_STATE_RETRY_COUNT = 2
+const MERGEABLE_STATE_RETRY_DELAY_MS = 1000
+const REDISCOVER_PULL_REQUEST_RETRY_COUNT = 1
+const REDISCOVER_PULL_REQUEST_RETRY_DELAY_MS = 1000
 
 type OctokitConstructor = new (params: {auth: string}) => OctokitClient
 type MergeLabel = 'auto-merge' | 'needs-review'
@@ -18,6 +22,7 @@ export interface MergeDataPrParams {
   headBranch?: string
   octokit?: OctokitClient
   now?: Date
+  logger?: MergeDataPrLogger
 }
 
 export interface MergeDataPrResult {
@@ -35,17 +40,37 @@ export interface MergeDataPrResult {
  */
 export type OctokitClient = Octokit
 
+export interface MergeDataPrLogger {
+  warn: (message: string) => void
+}
+
 export type MergeDataPrErrorCode = 'MISSING_TOKEN' | 'OCTOKIT_LOAD_FAILED' | 'API_ERROR'
+
+const DEFAULT_LOGGER: MergeDataPrLogger = {
+  warn(message) {
+    process.stderr.write(`merge-data-pr: ${message}\n`)
+  },
+}
 
 export class MergeDataPrError extends Error {
   readonly code: MergeDataPrErrorCode
   readonly remediation: string
+  readonly status?: number
+  readonly errorCode?: string
 
-  constructor(params: {code: MergeDataPrErrorCode; message: string; remediation: string}) {
+  constructor(params: {
+    code: MergeDataPrErrorCode
+    message: string
+    remediation: string
+    status?: number
+    errorCode?: string
+  }) {
     super(params.message)
     this.name = 'MergeDataPrError'
     this.code = params.code
     this.remediation = params.remediation
+    this.status = params.status
+    this.errorCode = params.errorCode
   }
 }
 
@@ -56,6 +81,7 @@ export async function mergeDataPr(params: MergeDataPrParams = {}): Promise<Merge
   const headBranch = params.headBranch ?? DEFAULT_HEAD_BRANCH
   const now = params.now ?? new Date()
   const octokit = params.octokit ?? (await createOctokitFromEnv())
+  const logger = params.logger ?? DEFAULT_LOGGER
 
   const comparison = await compareBranches({octokit, owner, repo, baseBranch, headBranch})
 
@@ -95,6 +121,13 @@ export async function mergeDataPr(params: MergeDataPrParams = {}): Promise<Merge
   })
 
   if (existingPullRequest !== null) {
+    await maybeUpdateBehindPullRequest({
+      octokit,
+      owner,
+      repo,
+      pullRequestNumber: existingPullRequest.number,
+      logger,
+    })
     await addLabel({octokit, owner, repo, issueNumber: existingPullRequest.number, label})
 
     return {
@@ -117,6 +150,7 @@ export async function mergeDataPr(params: MergeDataPrParams = {}): Promise<Merge
       body: createPullRequestBody({baseBranch, headBranch, changedFiles: comparison.data.files ?? []}),
     })
 
+    await maybeUpdateBehindPullRequest({octokit, owner, repo, pullRequestNumber: pullRequest.data.number, logger})
     await addLabel({octokit, owner, repo, issueNumber: pullRequest.data.number, label})
 
     return {
@@ -128,6 +162,36 @@ export async function mergeDataPr(params: MergeDataPrParams = {}): Promise<Merge
       staleAlertIssueNumber,
     }
   } catch (error: unknown) {
+    if (isAlreadyExistsPullRequestError(error)) {
+      const pullRequest = await waitForExistingPullRequestByBranch({
+        octokit,
+        owner,
+        repo,
+        headBranch,
+        baseBranch,
+      })
+
+      if (pullRequest !== null) {
+        await maybeUpdateBehindPullRequest({
+          octokit,
+          owner,
+          repo,
+          pullRequestNumber: pullRequest.number,
+          logger,
+        })
+        await addLabel({octokit, owner, repo, issueNumber: pullRequest.number, label})
+
+        return {
+          createdPullRequest: true,
+          pullRequestNumber: pullRequest.number,
+          pullRequestUrl: pullRequest.html_url,
+          label,
+          journalIssueNumber: null,
+          staleAlertIssueNumber,
+        }
+      }
+    }
+
     if (!isMergeConflictError(error)) {
       throw toMergeDataPrError(error, `creating ${headBranch} -> ${baseBranch} pull request`)
     }
@@ -150,6 +214,89 @@ export async function mergeDataPr(params: MergeDataPrParams = {}): Promise<Merge
   }
 }
 
+async function maybeUpdateBehindPullRequest(params: {
+  octokit: OctokitClient
+  owner: string
+  repo: string
+  pullRequestNumber: number
+  logger: MergeDataPrLogger
+}): Promise<void> {
+  let pullRequest
+
+  try {
+    pullRequest = await waitForKnownMergeableState(params)
+  } catch (error: unknown) {
+    if (!isRetryableGitHubApiError(error)) {
+      throw error
+    }
+
+    params.logger.warn(
+      `${formatApiWarning(error, `fetching PR #${params.pullRequestNumber}`)}; continuing because the PR already exists and a later run can retry the branch update.`,
+    )
+
+    return
+  }
+
+  if (pullRequest.data.mergeable_state === 'unknown') {
+    params.logger.warn(
+      `PR #${params.pullRequestNumber} mergeability stayed unknown after ${MERGEABLE_STATE_RETRY_COUNT + 1} checks; leaving the branch unchanged for this run.`,
+    )
+
+    return
+  }
+
+  if (pullRequest.data.mergeable_state !== 'behind') {
+    return
+  }
+
+  try {
+    await params.octokit.rest.pulls.updateBranch({
+      owner: params.owner,
+      repo: params.repo,
+      pull_number: params.pullRequestNumber,
+      expected_head_sha: pullRequest.data.head.sha,
+    })
+  } catch (error: unknown) {
+    if (isExpectedHeadShaRace(error)) {
+      return
+    }
+
+    if (isRetryableGitHubApiError(error)) {
+      params.logger.warn(
+        `${formatApiWarning(error, `updating PR #${params.pullRequestNumber} branch from ${params.repo}`)}; continuing because the PR already exists and a later run can retry the branch update.`,
+      )
+
+      return
+    }
+
+    throw toMergeDataPrError(error, `updating PR #${params.pullRequestNumber} branch from ${params.repo}`)
+  }
+}
+
+async function waitForKnownMergeableState(params: {
+  octokit: OctokitClient
+  owner: string
+  repo: string
+  pullRequestNumber: number
+}) {
+  let pullRequest = await getPullRequest(params)
+
+  for (
+    let attemptsRemaining = MERGEABLE_STATE_RETRY_COUNT;
+    pullRequest.data.mergeable_state === 'unknown';
+    attemptsRemaining--
+  ) {
+    if (attemptsRemaining === 0) {
+      return pullRequest
+    }
+
+    await delay(MERGEABLE_STATE_RETRY_DELAY_MS)
+    pullRequest = await getPullRequest(params)
+  }
+
+  return pullRequest
+}
+
 async function compareBranches(params: {
   octokit: OctokitClient
   owner: string
@@ -165,6 +312,23 @@ async function compareBranches(params: {
     })
   } catch (error: unknown) {
     throw toMergeDataPrError(error, `comparing ${params.baseBranch}...${params.headBranch}`)
+  }
+}
+
+async function getPullRequest(params: {
+  octokit: OctokitClient
+  owner: string
+  repo: string
+  pullRequestNumber: number
+}) {
+  try {
+    return await params.octokit.rest.pulls.get({
+      owner: params.owner,
+      repo: params.repo,
+      pull_number: params.pullRequestNumber,
+    })
+  } catch (error: unknown) {
+    throw toMergeDataPrError(error, `fetching PR #${params.pullRequestNumber}`)
   }
 }
 
@@ -245,6 +409,60 @@ async function findExistingPullRequest(params: {
     return pullRequest === undefined ? null : {number: pullRequest.number, html_url: pullRequest.html_url}
   } catch (error: unknown) {
     throw toMergeDataPrError(error, `discovering existing pull requests for ${params.commitSha}`)
+  }
+}
+
+async function findExistingPullRequestByBranch(params: {
+  octokit: OctokitClient
+  owner: string
+  repo: string
+  headBranch: string
+  baseBranch: string
+}): Promise<{number: number; html_url: string} | null> {
+  try {
+    const response = await params.octokit.rest.pulls.list({
+      owner: params.owner,
+      repo: params.repo,
+      state: 'open',
+      head: `${params.owner}:${params.headBranch}`,
+      base: params.baseBranch,
+      per_page: 30,
+    })
+
+    const pullRequest = response.data.find(candidate => {
+      return candidate.head?.ref === params.headBranch && candidate.base?.ref === params.baseBranch
+    })
+
+    return pullRequest === undefined ? null : {number: pullRequest.number, html_url: pullRequest.html_url}
+  } catch (error: unknown) {
+    throw toMergeDataPrError(error, `discovering existing ${params.headBranch} -> ${params.baseBranch} pull request`)
+  }
+}
+
+async function waitForExistingPullRequestByBranch(params: {
+  octokit: OctokitClient
+  owner: string
+  repo: string
+  headBranch: string
+  baseBranch: string
+}): Promise<{number: number; html_url: string} | null> {
+  let attemptsRemaining = REDISCOVER_PULL_REQUEST_RETRY_COUNT
+
+  while (true) {
+    try {
+      const pullRequest = await findExistingPullRequestByBranch(params)
+
+      if (pullRequest !== null || attemptsRemaining === 0) {
+        return pullRequest
+      }
+    } catch (error: unknown) {
+      if (!isRetryableGitHubApiError(error) || attemptsRemaining === 0) {
+        throw error
+      }
+    }
+
+    await delay(REDISCOVER_PULL_REQUEST_RETRY_DELAY_MS)
+    attemptsRemaining--
   }
 }
 
@@ -349,10 +567,116 @@ async function loadOctokitConstructor(): Promise<OctokitConstructor> {
 }
 
 function isMergeConflictError(error: unknown): boolean {
-  return isRecord(error) && typeof error.status === 'number' && error.status === 422
+  return has422Message(error, 'merge conflict')
+}
+
+function isStatus422(error: unknown): boolean {
+  return getErrorStatus(error) === 422
+}
+
+function isExpectedHeadShaRace(error: unknown): boolean {
+  if (!isStatus422(error) || !isRecord(error) || !('response' in error) || !isRecord(error.response)) {
+    return false
+  }
+
+  const data = error.response.data
+
+  if (!isRecord(data) || !('errors' in data) || !Array.isArray(data.errors)) {
+    return false
+  }
+
+  return data.errors.some(item => {
+    return (
+      isRecord(item) &&
+      item.field === 'expected_head_sha' &&
+      typeof item.message === 'string' &&
+      item.message.toLowerCase().includes('head sha')
+    )
+  })
+}
+
+function isRetryableGitHubApiError(error: unknown): boolean {
+  const status = getErrorStatus(error)
+
+  if (status === 429 || (status != null && status >= 500)) {
+    return true
+  }
+
+  const errorCode = getErrorCode(error)
+
+  if (
+    errorCode === 'ECONNRESET' ||
+    errorCode === 'ECONNREFUSED' ||
+    errorCode === 'ENOTFOUND' ||
+    errorCode === 'ETIMEDOUT'
+  ) {
+    return true
+  }
+
+  if (!(error instanceof Error)) {
+    return false
+  }
+
+  const message = error.message.toLowerCase()
+
+  return message.includes('secondary rate limit') || message.includes('timeout') || message.includes('timed out')
+}
+
+function formatApiWarning(error: unknown, action: string): string {
+  return toMergeDataPrError(error, action).message
+}
+
+function getErrorStatus(error: unknown): number | undefined {
+  return isRecord(error) && typeof error.status === 'number' ? error.status : undefined
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  if (!isRecord(error)) {
+    return undefined
+  }
+
+  if (typeof error.errorCode === 'string') {
+    return error.errorCode
+  }
+
+  return typeof error.code === 'string' ? error.code : undefined
+}
+
+function isAlreadyExistsPullRequestError(error: unknown): boolean {
+  return has422Message(error, 'a pull request already exists')
+}
+
+function has422Message(error: unknown, fragment: string): boolean {
+  if (!isStatus422(error) || !isRecord(error) || !('response' in error) || !isRecord(error.response)) {
+    return false
+  }
+
+  const data = error.response.data
+
+  if (!isRecord(data)) {
+    return false
+  }
+
+  const normalizedFragment = fragment.toLowerCase()
+
+  if (typeof data.message === 'string' && data.message.toLowerCase().includes(normalizedFragment)) {
+    return true
+  }
+
+  if (!('errors' in data) || !Array.isArray(data.errors)) {
+    return false
+  }
+
+  return data.errors.some(item => {
+    return isRecord(item) && typeof item.message === 'string' && item.message.toLowerCase().includes(normalizedFragment)
+  })
 }
 
 function toMergeDataPrError(error: unknown, action: string): MergeDataPrError {
+  if (error instanceof MergeDataPrError) {
+    return error
+  }
+
   const message = error instanceof Error ? error.message : `Unknown error while ${action}`
 
   return new MergeDataPrError({
@@ -360,11 +684,19 @@ function toMergeDataPrError(error: unknown, action: string): MergeDataPrError {
     message: `GitHub API error while ${action}: ${message}`,
     remediation:
       'Retry once. If the failure persists, inspect repository permissions, branch state, and GitHub API health.',
+    status: getErrorStatus(error),
+    errorCode: getErrorCode(error),
   })
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+async function delay(milliseconds: number): Promise<void> {
+  await new Promise<void>(resolve => {
+    setTimeout(resolve, milliseconds)
+  })
 }
 
 async function main(): Promise<void> {


### PR DESCRIPTION
## Summary
- harden `scripts/merge-data-pr.ts` so duplicate PR races are recovered via branch rediscovery instead of falling straight into failure
- treat retryable mergeability probe, branch update, and PR rediscovery failures as deferred work while still surfacing permanent failures immediately
- broaden 422 handling for duplicate-PR and merge-conflict responses, add regression coverage for the recovery paths, and ignore local `.context/` artifacts

## Testing
- pnpm check-types
- pnpm lint
- pnpm test