### PR TITLE
feat(workflows): add wiki lint reporting workflow

### DIFF
--- a/.github/workflows/wiki-lint.yaml
+++ b/.github/workflows/wiki-lint.yaml
@@ -1,0 +1,61 @@
+---
+name: Wiki Lint
+
+on:
+  schedule:
+    - cron: '0 20 * * 0' # Every Sunday at 20:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wiki-lint
+  cancel-in-progress: false
+
+jobs:
+  wiki-lint:
+    name: Lint authoritative wiki snapshot
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: ⤵ Checkout Branch
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+
+      - name: 📦 Setup
+        uses: ./.github/actions/setup
+
+      - name: Restore wiki from data branch
+        id: restore-wiki
+        continue-on-error: true
+        run: |
+          if git ls-remote --exit-code origin data >/dev/null 2>&1; then
+            git fetch origin data
+            git restore --source FETCH_HEAD --worktree -- knowledge
+          else
+            printf '%s\n' 'cannot lint wiki snapshot: origin/data is unavailable' >&2
+            exit 1
+          fi
+
+      - name: Run wiki lint
+        if: steps.restore-wiki.outcome == 'success'
+        env:
+          WIKI_LINT_REPORT_PATH: wiki-lint-report.md
+        run: node scripts/wiki-lint.ts
+
+      - name: Report restore failure
+        if: steps.restore-wiki.outcome == 'failure'
+        env:
+          WIKI_LINT_REPORT_PATH: wiki-lint-report.md
+          WIKI_LINT_FAILURE_MESSAGE: 'cannot lint wiki snapshot: origin/data is unavailable'
+        run: node scripts/wiki-lint.ts
+
+      - name: Upload wiki lint artifact
+        if: always()
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: wiki-lint-report
+          path: wiki-lint-report.md
+          retention-days: 7

--- a/.github/workflows/wiki-lint.yaml
+++ b/.github/workflows/wiki-lint.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: ⤵ Checkout Branch
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: 📦 Setup
         uses: ./.github/actions/setup
@@ -32,7 +32,7 @@ jobs:
         continue-on-error: true
         run: |
           if git ls-remote --exit-code origin data >/dev/null 2>&1; then
-            git fetch origin data
+            git fetch --depth=1 origin data
             git restore --source FETCH_HEAD --worktree -- knowledge
           else
             printf '%s\n' 'cannot lint wiki snapshot: origin/data is unavailable' >&2
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload wiki lint artifact
         if: always()
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: wiki-lint-report
           path: wiki-lint-report.md

--- a/docs/plans/2025-04-15-001-feat-frobot-control-plane-plan.md
+++ b/docs/plans/2025-04-15-001-feat-frobot-control-plane-plan.md
@@ -72,6 +72,7 @@ This plan turns the repo into a control plane where Fro Bot is a character first
   2. The persistent compounding wiki lives under `knowledge/wiki/`
   3. `knowledge/schema.md` defines page taxonomy, frontmatter rules, naming, and cross-reference conventions
 - **Wiki uses hybrid ingest**: Survey ingest on invite acceptance, event-driven incremental ingest from meaningful interactions, and a weekly lint pass. This is the compounding mechanism for R10-R11
+- **Wiki lint v1 is detect/report only**: The weekly lint pass inspects the authoritative wiki state on `data`, classifies findings by confidence, and reports them without opening a fix branch or autonomously editing wiki content
 - **`data` branch is the autonomous write surface**: Knowledge and metadata updates land on `data`, not `main`. `main` retains `enforce_admins: true`. A scheduled weekly PR merges `data` back into `main`
 - **Data branch merge is conditional**: If the weekly `data` → `main` PR changes only `knowledge/` and `metadata/`, auto-merge is enabled. If any other path changes, the PR is labeled `needs-review` and waits for human approval
 - **Commit strategy differs by scope**: Single-file metadata updates use GitHub Contents API with retry-with-refetch through `scripts/commit-metadata.ts`. Multi-file wiki ingest uses git-based atomic commits on `data` so no partial wiki state lands across `index.md`, `log.md`, and multiple wiki pages
@@ -83,6 +84,8 @@ This plan turns the repo into a control plane where Fro Bot is a character first
 - **Social broadcast is hybrid by design**: Deterministic allowlists and cooldowns decide when a post is eligible. Once eligible, the agent generates the actual Discord embed copy or BlueSky post in persona voice
 - **Explicit secret passing replaces blanket inheritance**: Caller workflows pass only the specific secrets they need into reusable workflows
 - **Surveyed repos are untrusted input**: Survey and ingest cap source breadth, validate outputs against schema and safety rules, and isolate writes to the control-plane repo’s `data` branch
+- **Wiki lint reads `data`, not `main`**: `main` is only the promoted view of knowledge. Weekly lint must inspect the `data` snapshot that `fro-bot.yaml` restores before agent work
+- **Wiki lint findings are split by confidence**: Broken links, orphan pages, index drift, and missing required frontmatter are deterministic integrity findings. Stale claims, missing cross-references, and knowledge gaps are advisory signals until their thresholds are proven in live use
 
 ## Open Questions
 
@@ -99,10 +102,12 @@ This plan turns the repo into a control plane where Fro Bot is a character first
 
 ### Deferred to Implementation
 
-- Exact prompt wording for `INGEST_PROMPT`, `WIKI_QUERY_PROMPT`, `WIKI_LINT_PROMPT`, and `SOCIAL_POST_PROMPT`
+- Exact prompt wording for `INGEST_PROMPT`, `WIKI_QUERY_PROMPT`, and `SOCIAL_POST_PROMPT`
 - BlueSky session caching strategy beyond per-run login
 - Journal issue title/template polish once the core event loop is live
 - Fine-grained stale-claim thresholds for wiki lint after real repository activity is observed
+- Whether a later Unit 17 follow-up should escalate deterministic findings or execution failures into control-plane issues instead of keeping v1 workflow-only
+- Whether a later Unit 17 follow-up should auto-propose deterministic wiki repairs after v1 signal quality is proven
 
 ## High-Level Technical Design
 
@@ -864,50 +869,58 @@ Renovate dispatch, metadata refresh, and wiki lint. Scheduled autonomy ships onl
 
 - [ ] **Unit 17: Wiki Lint Weekly**
 
-**Goal:** Perform a weekly health check of the wiki and propose fixes through a dedicated branch.
+**Goal:** Perform a weekly detect/report health check of the authoritative wiki state on `data`.
 
 **Requirements:** R10, R11
 
-**Dependencies:** Units 6, 8, 10
+**Dependencies:** Units 5, 6, 8
 
 **Files:**
 
 - Create: `.github/workflows/wiki-lint.yaml`
 - Create: `scripts/wiki-lint.ts`
+- Create: `scripts/wiki-lint.test.ts`
 
 **Approach:**
 
 - Scheduled workflow runs Sundays at 20:00 UTC
-- `wiki-lint.ts` scans `knowledge/wiki/` for broken wikilinks, stale claims, orphan pages, missing cross-references, and knowledge gaps
-- Lint findings become input to an agent maintenance prompt that proposes fixes on a `fro-bot/wiki-lint` branch
-- Resulting fixes are opened as a draft PR for review
-- Lint results are appended to `knowledge/log.md`
+- Workflow checks out the repo, runs `./.github/actions/setup`, and restores `knowledge/` from `origin/data` before linting so findings reflect the authoritative wiki snapshot rather than stale `main`
+- `wiki-lint.ts` scans `knowledge/wiki/`, `knowledge/index.md`, and schema-required frontmatter for the weekly categories already defined in `knowledge/schema.md`: broken wikilinks, orphan pages, stale claims, missing cross-references, and knowledge gaps
+- Findings are classified into deterministic integrity findings (broken links, orphan pages, index drift, missing required frontmatter) and advisory findings (stale claims, missing cross-references, knowledge gaps)
+- V1 is detect/report only: no fix branch, no draft PR, and no autonomous wiki edits triggered by lint findings
+- Every run emits a workflow summary and durable artifact report. Clean runs are successful no-ops with zero repo writes. Findings produce reports without mutating the wiki. Execution failures are reported separately from wiki findings
+- V1 reporting stops at the workflow surface: summary plus artifact only. Findings do not open or update control-plane issues unless a later follow-up explicitly adds that escalation path
+- `knowledge/log.md` logging stays explicit and low-churn in v1: only finding-bearing or failed lint runs may justify a durable log write later; clean runs do not create commits just to record that lint passed
 
 **Patterns to follow:**
 
-- Wiki maintenance flow modeled after the weekly wiki prompt pattern in `fro-bot/agent`
+- Scheduled maintenance workflow shape in `.github/workflows/reconcile-repos.yaml`
+- `data`-first wiki restore pattern already used in `.github/workflows/fro-bot.yaml`
+- Weekly lint categories and staleness threshold already defined in `knowledge/schema.md`
 
 **Test scenarios:**
 
-- Weekly lint produces a report when issues are present
-- Draft PR is created for actionable fixes
-- `knowledge/log.md` records lint operations
+- Clean fixtures produce zero findings and no repo writes
+- Broken-link, orphan-page, index-drift, and missing-frontmatter fixtures produce deterministic findings
+- Advisory checks are labeled non-blocking and remain distinct from deterministic integrity failures
+- Workflow reads the `data` snapshot rather than the checkout’s default `main` state
+- Execution failures are reported distinctly from successful runs with findings
 
 **Verification:**
 
-- Weekly workflow produces lint output
-- Draft PR is created when actionable issues exist
-- Log entries exist for lint runs
+- Weekly workflow produces a lint summary and artifact report on every run
+- Clean runs succeed without writing to `data` or `main`
+- Findings are grouped by deterministic vs advisory classification and reflect the `data` snapshot
 
 ## System-Wide Impact
 
 - **Interaction graph**: Invitation polling feeds onboarding state, survey ingest seeds the wiki, event handling queries the wiki before execution, event ingest compounds the wiki afterward, and scheduled autonomy workflows keep Renovate, metadata, and wiki hygiene current
 - **State lifecycle**: Structured metadata files are updated individually through `scripts/commit-metadata.ts`; wiki changes are written atomically through git commits on `data`; the weekly merge workflow reconciles autonomous state into `main`
-- **Knowledge lifecycle**: Knowledge now compounds instead of resetting. Unit 8 creates the initial repo pages and related topic/entity/comparison pages. Unit 10 grows them incrementally from later interactions. Unit 17 cleans drift and gaps on a schedule
+- **Knowledge lifecycle**: Knowledge now compounds instead of resetting. Unit 8 creates the initial repo pages and related topic/entity/comparison pages. Unit 10 grows them incrementally from later interactions. Unit 17 adds non-blocking weekly observability over that state so drift and gaps become visible before promotion without becoming a second mutation path
 - **Error propagation**: Failures remain isolated per workflow. Invitation polling does not block event handling. Social posting failure does not block agent output. Wiki lint failures do not block metadata refresh or Renovate dispatch. Merge failures are surfaced through journal issues instead of silently accumulating
-- **Cross-reference impact**: Because page creation spans repo, topic, entity, and comparison pages, schema enforcement in Unit 6 and linting in Unit 17 become system-level safety rails rather than optional hygiene
+- **Cross-reference impact**: Because page creation spans repo, topic, entity, and comparison pages, schema enforcement in Unit 6 and linting in Unit 17 become system-level safety rails rather than optional hygiene. Deterministic integrity findings protect the graph structure; advisory findings inform follow-up work without pretending subjectivity is a hard failure
 - **Trust boundaries**: `FRO_BOT_POLL_PAT` is exposed only to polling and survey-read workflows. `FRO_BOT_PAT` is reserved for control-plane writes and proposal flows. No workflow should combine untrusted repo content ingestion with broad write credentials to external repos
-- **End-to-end operating path**: Invite accepted → repo starred → survey dispatch → atomic wiki ingest on `data` → event handling with persona and wiki context → journal entry → optional social broadcast → weekly merge-back to `main`
+- **End-to-end operating path**: Invite accepted → repo starred → survey dispatch → atomic wiki ingest on `data` → event handling with persona and wiki context → journal entry → optional social broadcast → weekly wiki lint against `data` → weekly merge-back to `main`
 
 ## Risks & Dependencies
 
@@ -916,6 +929,10 @@ Renovate dispatch, metadata refresh, and wiki lint. Scheduled autonomy ships onl
 - **Wiki ingest atomicity**: Multi-file wiki updates could otherwise land partially and create torn state. Mitigate by using git-based atomic commits on `data` with replay-on-conflict behavior
 - **Wiki query token budget**: Aggressive wiki retrieval could bloat prompts and degrade agent performance. Mitigate with a hard 5 KB cap and type-priority ranking for returned pages
 - **Wiki content poisoning via adversarial repos**: Even capped inputs can contain malicious framing. Mitigate with schema validation, safety checks on generated patches, and explicit contradiction logging rather than blind replacement of prior knowledge
+- **Wiki lint false positives**: Heuristic checks can erode trust if they read like hard failures. Mitigate by separating deterministic integrity findings from advisory findings, labeling severity clearly, and keeping v1 non-blocking
+- **Authority skew during lint**: Linting `main` instead of `data` would report stale or wrong findings. Mitigate by making `origin/data` restore an explicit Unit 17 workflow step and verifying against that snapshot
+- **Churn from clean lint runs**: Writing a durable log entry for every clean weekly run would create meaningless commits and noisy `data` promotions. Mitigate by treating clean runs as successful no-ops and deferring durable log writes unless findings or failures justify them
+- **Implicit promotion gating**: Wiki lint could accidentally become a hidden gate on `merge-data`. Mitigate by stating explicitly that Unit 17 v1 is non-blocking and observational only
 - **API rate limits**: Invitation polling, metadata scanning, and Renovate dispatch all consume GitHub quota. Mitigate by journaling low-quota warnings, backing off non-critical work, and keeping polling cadence conservative
 - **Social channel degradation**: BlueSky or Discord may fail independently. Mitigate with per-channel retry logic, partial-failure tolerance, and journaled fallback reporting
 - **Merge drift on `data`**: If weekly merge-back fails repeatedly, autonomous state can diverge from `main`. Mitigate with stale-divergence journal alerts and a hard human review path for any PR that touches non-knowledge or non-metadata files

--- a/docs/solutions/integration-issues/wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md
+++ b/docs/solutions/integration-issues/wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md
@@ -1,0 +1,131 @@
+---
+title: Wiki Lint Must Inspect the Authoritative Data Snapshot and Report Restore Failures Separately
+category: integration-issues
+problem_type: integration_issue
+component: tooling
+root_cause: missing_workflow_step
+resolution_type: workflow_improvement
+severity: medium
+date: 2026-05-02
+last_updated: 2026-05-02
+module: .github/workflows/wiki-lint.yaml + scripts/wiki-lint.ts
+related_components:
+  - development_workflow
+tags:
+  - wiki-lint
+  - github-actions
+  - data-branch
+  - knowledge-wiki
+  - wikilinks
+  - artifacts
+  - report-only
+verified: true
+symptoms:
+  - Weekly wiki checks would be wrong if they linted the checked-out branch instead of the authoritative `data` snapshot
+  - Alias-backed wikilinks could false-positive as broken references
+  - Restore failures could end without a durable report artifact explaining why lint did not run
+  - Missing cross-reference coverage could stop at repo pages instead of the full wiki graph
+---
+
+## Problem
+
+Unit 17 originally assumed a dedicated wiki-lint branch and draft remediation PR flow. That model was wrong for this repo. The authoritative wiki lives on `data`, so a weekly lint run has to inspect the restored `origin/data` snapshot, classify findings, and report them without creating a second autonomous write path.
+
+That also meant the failure path had to be explicit. If the workflow could not restore `knowledge/` from `origin/data`, the run still needed to emit a durable report artifact instead of just failing early and leaving no explanation behind.
+
+## Symptoms
+
+- The stale Unit 17 plan targeted a dedicated proposal branch instead of the repo's `data -> main` authority model.
+- Valid alias-backed wikilinks like `[[workflow-patterns]]` could be misreported as `broken-wikilink` if lint only matched slugs.
+- A page with no wikilinks could slip through if `missing-cross-reference` only applied to repo pages.
+- Restore failure could fail the job before any markdown report artifact existed.
+
+## What Didn't Work
+
+- **Linting the checked-out tree.** `main` is not the authoritative wiki source, so linting checkout state would inspect drift instead of truth.
+- **The old draft-PR remediation model.** That would have introduced a second mutation path for `knowledge/**` instead of a detect/report-only control.
+- **Slug-only wikilink validation.** Pages can expose valid `aliases`, so looking at `page.slug` alone is incomplete.
+- **Fail-fast restore handling without a report.** A red workflow with no artifact is not enough operational evidence for weekly unattended runs.
+
+## Solution
+
+The implementation restores the authoritative snapshot, lints it, emits findings, uploads a report, and writes nothing back.
+
+`.github/workflows/wiki-lint.yaml` restores `knowledge/` from `origin/data`, runs lint only on restore success, and routes restore failure through the same reporting surface:
+
+```yaml
+- name: Restore wiki from data branch
+  id: restore-wiki
+  continue-on-error: true
+  run: |
+    if git ls-remote --exit-code origin data >/dev/null 2>&1; then
+      git fetch origin data
+      git restore --source FETCH_HEAD --worktree -- knowledge
+    else
+      printf '%s\n' 'cannot lint wiki snapshot: origin/data is unavailable' >&2
+      exit 1
+    fi
+
+- name: Run wiki lint
+  if: steps.restore-wiki.outcome == 'success'
+  env:
+    WIKI_LINT_REPORT_PATH: wiki-lint-report.md
+  run: node scripts/wiki-lint.ts
+
+- name: Report restore failure
+  if: steps.restore-wiki.outcome == 'failure'
+  env:
+    WIKI_LINT_REPORT_PATH: wiki-lint-report.md
+    WIKI_LINT_FAILURE_MESSAGE: 'cannot lint wiki snapshot: origin/data is unavailable'
+  run: node scripts/wiki-lint.ts
+```
+
+`scripts/wiki-lint.ts` implements a detect/report-only engine around `lintWikiSnapshot()`, `writeWikiLintOutputs()`, `writeWikiLintFailureOutputs()`, and `runWikiLint()`.
+
+- Deterministic findings: `broken-wikilink`, `orphan-page`, `index-drift`, `missing-frontmatter`, `invalid-frontmatter`
+- Advisory findings: `stale-claim`, `missing-cross-reference`, `knowledge-gap`
+
+The linter treats aliases as valid link targets by adding both the page slug and any frontmatter aliases into the target set, which prevents alias-backed links from false-positiving:
+
+```ts
+function collectPageTargets(pages: readonly ParsedPage[]): Set<string> {
+  const targets = new Set<string>()
+
+  for (const page of pages) {
+    targets.add(page.slug)
+
+    for (const alias of collectAliases(page.frontmatter.aliases)) {
+      targets.add(alias)
+    }
+  }
+
+  return targets
+}
+```
+
+The review fix also broadened `missing-cross-reference` across all page types while keeping `knowledge-gap` intentionally narrower and repo-specific when non-repo knowledge already exists.
+
+`scripts/wiki-lint.test.ts` now covers the current script contract: clean snapshot, alias-backed links, deterministic finding kinds, malformed frontmatter, advisory findings, non-repo `missing-cross-reference` coverage, output writing, execution-failure reporting, and disk-based runs. It also asserts that `.github/workflows/wiki-lint.yaml` includes the restore-failure reporting path.
+
+## Why This Works
+
+The fix works because it matches the repo's `data`-branch wiki source and preserves a reporting surface when restore fails.
+
+- **Authority is correct:** the workflow restores `knowledge/` from `origin/data` before linting.
+- **Signals stay distinct:** deterministic integrity defects and advisory content signals are reported separately.
+- **False positives are reduced:** alias-backed wikilinks resolve against both slugs and aliases.
+- **Page coverage is broader:** `missing-cross-reference` now applies to any page body with no wikilinks, not just repo pages.
+- **Failure is reported:** the workflow still routes restore failure through `writeWikiLintFailureOutputs()`, although the current workflow message is a fixed `origin/data is unavailable` string rather than a fully diagnosed restore error.
+
+## Prevention
+
+1. **Lint the authoritative snapshot, not checkout state.** Any future wiki health workflow should restore from `origin/data` first.
+2. **Keep the report artifact contract on script-handled paths.** Clean, findings, and `execution-failure` runs should keep producing the same markdown report surface.
+3. **Keep alias resolution and page-type coverage in tests.** If wiki schema or page types evolve, preserve regression coverage for aliases and non-repo `missing-cross-reference` behavior.
+4. **Do not smuggle remediation into v1.** Any future auto-fix or issue-escalation path should be an explicit follow-up, not a hidden side effect of linting.
+
+## Related Issues
+
+- Related issue: https://github.com/fro-bot/.github/issues/3148
+- Related learning: [`docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md`](../runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md)
+- Updated plan unit: `docs/plans/2025-04-15-001-feat-frobot-control-plane-plan.md`

--- a/docs/solutions/integration-issues/wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md
+++ b/docs/solutions/integration-issues/wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md
@@ -94,8 +94,13 @@ function collectPageTargets(pages: readonly ParsedPage[]): Set<string> {
   for (const page of pages) {
     targets.add(page.slug)
 
-    for (const alias of collectAliases(page.frontmatter.aliases)) {
-      targets.add(alias)
+    const aliases = page.frontmatter.aliases
+    if (Array.isArray(aliases)) {
+      for (const alias of aliases) {
+        if (typeof alias === 'string' && alias.trim() !== '') {
+          targets.add(alias)
+        }
+      }
     }
   }
 

--- a/scripts/wiki-lint.test.ts
+++ b/scripts/wiki-lint.test.ts
@@ -1,0 +1,576 @@
+import {mkdir, mkdtemp, readFile, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import {describe, expect, it} from 'vitest'
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const wikiLintModulePromise: Promise<{
+  lintWikiSnapshot: typeof import('./wiki-lint.js').lintWikiSnapshot
+  runWikiLint: typeof import('./wiki-lint.js').runWikiLint
+  writeWikiLintFailureOutputs: typeof import('./wiki-lint.js').writeWikiLintFailureOutputs
+  writeWikiLintOutputs: typeof import('./wiki-lint.js').writeWikiLintOutputs
+}> = import(`./wiki-lint${'.js'}`)
+const {lintWikiSnapshot, runWikiLint, writeWikiLintFailureOutputs, writeWikiLintOutputs} = await wikiLintModulePromise
+
+function buildPage(params: {
+  path: string
+  type: 'repo' | 'topic' | 'entity' | 'comparison'
+  title: string
+  updated?: string
+  tags?: string[]
+  bodyLines?: string[]
+}): [string, string] {
+  return [
+    params.path,
+    [
+      '---',
+      `type: ${params.type}`,
+      `title: ${params.title}`,
+      'created: 2026-04-16',
+      `updated: ${params.updated ?? '2026-04-16'}`,
+      ...(params.tags === undefined ? [] : [`tags: [${params.tags.join(', ')}]`]),
+      '---',
+      '',
+      ...(params.bodyLines ?? ['Body text.']),
+      '',
+    ].join('\n'),
+  ]
+}
+
+function buildIndex(lines: string[]): string {
+  return [
+    '# Wiki Index',
+    '',
+    'Master catalog of all wiki pages, organized by type.',
+    '',
+    ...lines,
+    '',
+    '---',
+    '',
+    '_Footer._',
+    '',
+  ].join('\n')
+}
+
+describe('lintWikiSnapshot', () => {
+  it('returns a clean result for a consistent wiki snapshot', () => {
+    const files = Object.fromEntries([
+      [
+        'knowledge/index.md',
+        buildIndex([
+          '## Repos',
+          '',
+          '- [[fro-bot--github]] — Fro Bot .github',
+          '',
+          '## Topics',
+          '',
+          '- [[github-actions-ci]] — GitHub Actions CI',
+          '',
+          '## Entities',
+          '',
+          '_No entity pages yet._',
+          '',
+          '## Comparisons',
+          '',
+          '_No comparison pages yet._',
+        ]),
+      ],
+      buildPage({
+        path: 'knowledge/wiki/repos/fro-bot--github.md',
+        type: 'repo',
+        title: 'Fro Bot .github',
+        tags: ['automation'],
+        bodyLines: ['See [[github-actions-ci]] for workflow conventions.'],
+      }),
+      buildPage({
+        path: 'knowledge/wiki/topics/github-actions-ci.md',
+        type: 'topic',
+        title: 'GitHub Actions CI',
+        tags: ['ci', 'automation'],
+        bodyLines: ['See [[fro-bot--github]] for control-plane workflow patterns.'],
+      }),
+    ])
+
+    const result = lintWikiSnapshot({files, now: new Date('2026-05-02T00:00:00Z')})
+
+    expect(result.ok).toBe(true)
+    expect(result.deterministicFindings).toEqual([])
+    expect(result.advisoryFindings).toEqual([])
+    expect(result.summary).toContain('Deterministic findings: 0')
+    expect(result.summary).toContain('Advisory findings: 0')
+    expect(result.report).toContain('No findings.')
+  })
+
+  it('treats alias-backed wikilinks as valid references', () => {
+    const files = Object.fromEntries([
+      [
+        'knowledge/index.md',
+        buildIndex([
+          '## Repos',
+          '',
+          '- [[fro-bot--github]] — Fro Bot .github',
+          '',
+          '## Topics',
+          '',
+          '- [[github-actions-ci]] — GitHub Actions CI',
+          '',
+          '## Entities',
+          '',
+          '_No entity pages yet._',
+          '',
+          '## Comparisons',
+          '',
+          '_No comparison pages yet._',
+        ]),
+      ],
+      buildPage({
+        path: 'knowledge/wiki/repos/fro-bot--github.md',
+        type: 'repo',
+        title: 'Fro Bot .github',
+        bodyLines: ['See [[workflow-patterns]] for reusable CI guidance.'],
+      }),
+      [
+        'knowledge/wiki/topics/github-actions-ci.md',
+        [
+          '---',
+          'type: topic',
+          'title: GitHub Actions CI',
+          'created: 2026-04-16',
+          'updated: 2026-04-16',
+          'aliases: [workflow-patterns]',
+          '---',
+          '',
+          'See [[fro-bot--github]] for the control-plane implementation.',
+          '',
+        ].join('\n'),
+      ],
+    ])
+
+    const result = lintWikiSnapshot({files, now: new Date('2026-05-02T00:00:00Z')})
+
+    expect(result.deterministicFindings).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({kind: 'broken-wikilink', target: 'workflow-patterns'})]),
+    )
+  })
+
+  it('reports broken links, orphan pages, index drift, and missing required frontmatter as deterministic findings', () => {
+    const files = Object.fromEntries([
+      [
+        'knowledge/index.md',
+        buildIndex([
+          '## Repos',
+          '',
+          '- [[fro-bot--github]] — Fro Bot .github',
+          '- [[missing-from-disk]] — Missing From Disk',
+          '',
+          '## Topics',
+          '',
+          '_No topic pages yet._',
+          '',
+          '## Entities',
+          '',
+          '_No entity pages yet._',
+          '',
+          '## Comparisons',
+          '',
+          '_No comparison pages yet._',
+        ]),
+      ],
+      [
+        'knowledge/wiki/repos/fro-bot--github.md',
+        [
+          '---',
+          'type: repo',
+          'created: 2026-04-16',
+          'updated: 2026-04-16',
+          '---',
+          '',
+          'See [[missing-topic]] for context.',
+          '',
+        ].join('\n'),
+      ],
+      buildPage({
+        path: 'knowledge/wiki/topics/github-actions-ci.md',
+        type: 'topic',
+        title: 'GitHub Actions CI',
+      }),
+    ])
+
+    const result = lintWikiSnapshot({files, now: new Date('2026-05-02T00:00:00Z')})
+
+    expect(result.ok).toBe(false)
+    expect(result.deterministicFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({kind: 'missing-frontmatter', path: 'knowledge/wiki/repos/fro-bot--github.md'}),
+        expect.objectContaining({
+          kind: 'broken-wikilink',
+          path: 'knowledge/wiki/repos/fro-bot--github.md',
+          target: 'missing-topic',
+        }),
+        expect.objectContaining({kind: 'orphan-page', path: 'knowledge/wiki/topics/github-actions-ci.md'}),
+        expect.objectContaining({kind: 'index-drift', path: 'knowledge/index.md', target: 'missing-from-disk'}),
+      ]),
+    )
+    expect(result.summary).toContain('Deterministic findings: 4')
+    expect(result.report).toContain('broken-wikilink')
+    expect(result.report).toContain('orphan-page')
+    expect(result.report).toContain('index-drift')
+    expect(result.report).toContain('missing-frontmatter')
+  })
+
+  it('reports malformed frontmatter as a deterministic finding instead of crashing the run', () => {
+    const files = Object.fromEntries([
+      [
+        'knowledge/index.md',
+        buildIndex([
+          '## Repos',
+          '',
+          '- [[fro-bot--github]] — Fro Bot .github',
+          '',
+          '## Topics',
+          '',
+          '_No topic pages yet._',
+          '',
+          '## Entities',
+          '',
+          '_No entity pages yet._',
+          '',
+          '## Comparisons',
+          '',
+          '_No comparison pages yet._',
+        ]),
+      ],
+      [
+        'knowledge/wiki/repos/fro-bot--github.md',
+        [
+          '---',
+          'type: repo',
+          'title: Fro Bot .github',
+          'created: 2026-04-16',
+          'updated: [broken',
+          '---',
+          '',
+          'Body text.',
+          '',
+        ].join('\n'),
+      ],
+    ])
+
+    const result = lintWikiSnapshot({files, now: new Date('2026-05-02T00:00:00Z')})
+
+    expect(result.ok).toBe(false)
+    expect(result.deterministicFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({kind: 'invalid-frontmatter', path: 'knowledge/wiki/repos/fro-bot--github.md'}),
+      ]),
+    )
+  })
+
+  it('labels stale claims, missing cross-references, and knowledge gaps as advisory findings', () => {
+    const files = Object.fromEntries([
+      [
+        'knowledge/index.md',
+        buildIndex([
+          '## Repos',
+          '',
+          '- [[fro-bot--github]] — Fro Bot .github',
+          '',
+          '## Topics',
+          '',
+          '- [[github-actions-ci]] — GitHub Actions CI',
+          '',
+          '## Entities',
+          '',
+          '_No entity pages yet._',
+          '',
+          '## Comparisons',
+          '',
+          '_No comparison pages yet._',
+        ]),
+      ],
+      buildPage({
+        path: 'knowledge/wiki/repos/fro-bot--github.md',
+        type: 'repo',
+        title: 'Fro Bot .github',
+        updated: '2026-01-01',
+        bodyLines: ['Workflow notes without any wikilinks or sources to related topics.'],
+      }),
+      buildPage({
+        path: 'knowledge/wiki/topics/github-actions-ci.md',
+        type: 'topic',
+        title: 'GitHub Actions CI',
+        bodyLines: ['Covers workflow pinning patterns.'],
+      }),
+    ])
+
+    const result = lintWikiSnapshot({files, now: new Date('2026-05-02T00:00:00Z')})
+
+    expect(result.ok).toBe(true)
+    expect(result.deterministicFindings).toEqual([])
+    expect(result.advisoryFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({kind: 'stale-claim', path: 'knowledge/wiki/repos/fro-bot--github.md'}),
+        expect.objectContaining({kind: 'missing-cross-reference', path: 'knowledge/wiki/repos/fro-bot--github.md'}),
+        expect.objectContaining({kind: 'missing-cross-reference', path: 'knowledge/wiki/topics/github-actions-ci.md'}),
+        expect.objectContaining({kind: 'knowledge-gap', path: 'knowledge/index.md'}),
+      ]),
+    )
+    expect(result.summary).toContain('Deterministic findings: 0')
+    expect(result.summary).toContain('Advisory findings: 4')
+    expect(result.report).toContain('non-blocking advisory')
+  })
+
+  it('labels disconnected non-repo pages as missing cross-references', () => {
+    const files = Object.fromEntries([
+      [
+        'knowledge/index.md',
+        buildIndex([
+          '## Repos',
+          '',
+          '- [[fro-bot--github]] — Fro Bot .github',
+          '',
+          '## Topics',
+          '',
+          '- [[github-actions-ci]] — GitHub Actions CI',
+          '',
+          '## Entities',
+          '',
+          '_No entity pages yet._',
+          '',
+          '## Comparisons',
+          '',
+          '_No comparison pages yet._',
+        ]),
+      ],
+      buildPage({
+        path: 'knowledge/wiki/repos/fro-bot--github.md',
+        type: 'repo',
+        title: 'Fro Bot .github',
+        bodyLines: ['See [[github-actions-ci]] for workflow conventions.'],
+      }),
+      buildPage({
+        path: 'knowledge/wiki/topics/github-actions-ci.md',
+        type: 'topic',
+        title: 'GitHub Actions CI',
+        bodyLines: ['Workflow notes without any wikilinks yet.'],
+      }),
+    ])
+
+    const result = lintWikiSnapshot({files, now: new Date('2026-05-02T00:00:00Z')})
+
+    expect(result.ok).toBe(true)
+    expect(result.advisoryFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'missing-cross-reference',
+          path: 'knowledge/wiki/topics/github-actions-ci.md',
+        }),
+      ]),
+    )
+    expect(result.advisoryFindings).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({kind: 'knowledge-gap', path: 'knowledge/index.md'})]),
+    )
+  })
+
+  it('writes the markdown artifact, workflow summary, and github outputs for findings', async () => {
+    const files = Object.fromEntries([
+      [
+        'knowledge/index.md',
+        buildIndex([
+          '## Repos',
+          '',
+          '- [[fro-bot--github]] — Fro Bot .github',
+          '',
+          '## Topics',
+          '',
+          '- [[github-actions-ci]] — GitHub Actions CI',
+          '',
+          '## Entities',
+          '',
+          '_No entity pages yet._',
+          '',
+          '## Comparisons',
+          '',
+          '_No comparison pages yet._',
+        ]),
+      ],
+      buildPage({
+        path: 'knowledge/wiki/repos/fro-bot--github.md',
+        type: 'repo',
+        title: 'Fro Bot .github',
+        updated: '2026-01-01',
+        bodyLines: ['Workflow notes without any wikilinks or sources to related topics.'],
+      }),
+      buildPage({
+        path: 'knowledge/wiki/topics/github-actions-ci.md',
+        type: 'topic',
+        title: 'GitHub Actions CI',
+        bodyLines: ['Covers workflow pinning patterns.'],
+      }),
+    ])
+    const result = lintWikiSnapshot({files, now: new Date('2026-05-02T00:00:00Z')})
+    const tempDir = await mkdtemp(join(tmpdir(), 'wiki-lint-'))
+    const reportPath = join(tempDir, 'wiki-lint-report.md')
+    const summaryPath = join(tempDir, 'step-summary.md')
+    const outputPath = join(tempDir, 'github-output.txt')
+
+    const writeResult = await writeWikiLintOutputs({
+      result,
+      reportPath,
+      githubStepSummaryPath: summaryPath,
+      githubOutputPath: outputPath,
+    })
+
+    expect(writeResult.status).toBe('findings')
+    expect(writeResult.reportPath).toBe(reportPath)
+    await expect(readFile(reportPath, 'utf8')).resolves.toContain('# Wiki Lint Report')
+    await expect(readFile(summaryPath, 'utf8')).resolves.toContain('Advisory findings: 4')
+    await expect(readFile(outputPath, 'utf8')).resolves.toContain('status=findings')
+    await expect(readFile(outputPath, 'utf8')).resolves.toContain(`report_path=${reportPath}`)
+  })
+
+  it('writes clean status outputs without changing the report shape', async () => {
+    const files = Object.fromEntries([
+      [
+        'knowledge/index.md',
+        buildIndex([
+          '## Repos',
+          '',
+          '- [[fro-bot--github]] — Fro Bot .github',
+          '',
+          '## Topics',
+          '',
+          '- [[github-actions-ci]] — GitHub Actions CI',
+          '',
+          '## Entities',
+          '',
+          '_No entity pages yet._',
+          '',
+          '## Comparisons',
+          '',
+          '_No comparison pages yet._',
+        ]),
+      ],
+      buildPage({
+        path: 'knowledge/wiki/repos/fro-bot--github.md',
+        type: 'repo',
+        title: 'Fro Bot .github',
+        tags: ['automation'],
+        bodyLines: ['See [[github-actions-ci]] for workflow conventions.'],
+      }),
+      buildPage({
+        path: 'knowledge/wiki/topics/github-actions-ci.md',
+        type: 'topic',
+        title: 'GitHub Actions CI',
+        bodyLines: ['See [[fro-bot--github]] for the control-plane implementation.'],
+      }),
+    ])
+    const result = lintWikiSnapshot({files, now: new Date('2026-05-02T00:00:00Z')})
+    const tempDir = await mkdtemp(join(tmpdir(), 'wiki-lint-clean-'))
+    const reportPath = join(tempDir, 'wiki-lint-report.md')
+    const outputPath = join(tempDir, 'github-output.txt')
+
+    const writeResult = await writeWikiLintOutputs({
+      result,
+      reportPath,
+      githubOutputPath: outputPath,
+    })
+
+    expect(writeResult.status).toBe('clean')
+    await expect(readFile(reportPath, 'utf8')).resolves.toContain('No findings.')
+    await expect(readFile(outputPath, 'utf8')).resolves.toContain('status=clean')
+  })
+
+  it('writes a distinct execution-failure artifact and status output', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'wiki-lint-failure-'))
+    const reportPath = join(tempDir, 'wiki-lint-report.md')
+    const summaryPath = join(tempDir, 'step-summary.md')
+    const outputPath = join(tempDir, 'github-output.txt')
+
+    const writeResult = await writeWikiLintFailureOutputs({
+      message: 'cannot lint wiki snapshot: origin/data is unavailable',
+      reportPath,
+      githubStepSummaryPath: summaryPath,
+      githubOutputPath: outputPath,
+    })
+
+    expect(writeResult.status).toBe('execution-failure')
+    await expect(readFile(reportPath, 'utf8')).resolves.toContain('## Execution failure')
+    await expect(readFile(summaryPath, 'utf8')).resolves.toContain('Execution failure')
+    await expect(readFile(outputPath, 'utf8')).resolves.toContain('status=execution-failure')
+  })
+
+  it('runs the full lint pipeline from disk and emits summary/report outputs', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'wiki-lint-run-'))
+    const reportPath = join(tempDir, 'wiki-lint-report.md')
+    const summaryPath = join(tempDir, 'step-summary.md')
+    const outputPath = join(tempDir, 'github-output.txt')
+    const wikiDir = join(tempDir, 'knowledge', 'wiki', 'repos')
+    await mkdir(wikiDir, {recursive: true})
+    await writeFile(
+      join(tempDir, 'knowledge', 'index.md'),
+      buildIndex([
+        '## Repos',
+        '',
+        '- [[fro-bot--github]] — Fro Bot .github',
+        '',
+        '## Topics',
+        '',
+        '_No topic pages yet._',
+        '',
+        '## Entities',
+        '',
+        '_No entity pages yet._',
+        '',
+        '## Comparisons',
+        '',
+        '_No comparison pages yet._',
+      ]),
+    )
+    await writeFile(
+      join(wikiDir, 'fro-bot--github.md'),
+      [
+        '---',
+        'type: repo',
+        'title: Fro Bot .github',
+        'created: 2026-04-16',
+        'updated: 2026-01-01',
+        '---',
+        '',
+        'Workflow notes without cross references.',
+        '',
+      ].join('\n'),
+    )
+
+    const result = await runWikiLint({
+      rootDir: tempDir,
+      reportPath,
+      githubStepSummaryPath: summaryPath,
+      githubOutputPath: outputPath,
+      now: new Date('2026-05-02T00:00:00Z'),
+    })
+
+    expect(result.status).toBe('findings')
+    expect(result.result.advisoryFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({kind: 'stale-claim'}),
+        expect.objectContaining({kind: 'missing-cross-reference'}),
+      ]),
+    )
+    await expect(readFile(summaryPath, 'utf8')).resolves.toContain('Advisory findings: 2')
+    await expect(readFile(outputPath, 'utf8')).resolves.toContain(`report_path=${reportPath}`)
+  })
+
+  it('requires the workflow to fail when the authoritative data snapshot cannot be restored', async () => {
+    const workflow = await readFile('.github/workflows/wiki-lint.yaml', 'utf8')
+
+    expect(workflow).toContain('git ls-remote --exit-code origin data')
+    expect(workflow).toContain('cannot lint wiki snapshot')
+    expect(workflow).toContain('exit 1')
+    expect(workflow).toContain('continue-on-error: true')
+    expect(workflow).toContain('WIKI_LINT_FAILURE_MESSAGE')
+    expect(workflow).toContain("steps.restore-wiki.outcome == 'failure'")
+    expect(workflow).toContain('if: always()')
+  })
+})

--- a/scripts/wiki-lint.test.ts
+++ b/scripts/wiki-lint.test.ts
@@ -321,6 +321,46 @@ describe('lintWikiSnapshot', () => {
     expect(result.report).toContain('non-blocking advisory')
   })
 
+  it('does not label a page stale when updated is not a valid date', () => {
+    const files = Object.fromEntries([
+      [
+        'knowledge/index.md',
+        buildIndex([
+          '## Repos',
+          '',
+          '- [[fro-bot--github]] — Fro Bot .github',
+          '',
+          '## Topics',
+          '',
+          '_No topic pages yet._',
+          '',
+          '## Entities',
+          '',
+          '_No entity pages yet._',
+          '',
+          '## Comparisons',
+          '',
+          '_No comparison pages yet._',
+        ]),
+      ],
+      buildPage({
+        path: 'knowledge/wiki/repos/fro-bot--github.md',
+        type: 'repo',
+        title: 'Fro Bot .github',
+        updated: 'not-a-date',
+        bodyLines: ['See [[fro-bot--github]] for workflow conventions.'],
+      }),
+    ])
+
+    const result = lintWikiSnapshot({files, now: new Date('2026-05-02T00:00:00Z')})
+
+    expect(result.advisoryFindings).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({kind: 'stale-claim', path: 'knowledge/wiki/repos/fro-bot--github.md'}),
+      ]),
+    )
+  })
+
   it('labels disconnected non-repo pages as missing cross-references', () => {
     const files = Object.fromEntries([
       [
@@ -562,15 +602,25 @@ describe('lintWikiSnapshot', () => {
     await expect(readFile(outputPath, 'utf8')).resolves.toContain(`report_path=${reportPath}`)
   })
 
+  it('fails when knowledge/index.md is missing from disk', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'wiki-lint-missing-index-'))
+    const reportPath = join(tempDir, 'wiki-lint-report.md')
+
+    await expect(runWikiLint({rootDir: tempDir, reportPath})).rejects.toThrow(/knowledge\/index\.md/u)
+  })
+
   it('requires the workflow to fail when the authoritative data snapshot cannot be restored', async () => {
     const workflow = await readFile('.github/workflows/wiki-lint.yaml', 'utf8')
 
+    expect(workflow).toContain('fetch-depth: 1')
     expect(workflow).toContain('git ls-remote --exit-code origin data')
+    expect(workflow).toContain('git fetch --depth=1 origin data')
     expect(workflow).toContain('cannot lint wiki snapshot')
     expect(workflow).toContain('exit 1')
     expect(workflow).toContain('continue-on-error: true')
     expect(workflow).toContain('WIKI_LINT_FAILURE_MESSAGE')
     expect(workflow).toContain("steps.restore-wiki.outcome == 'failure'")
     expect(workflow).toContain('if: always()')
+    expect(workflow).toContain('actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f')
   })
 })

--- a/scripts/wiki-lint.ts
+++ b/scripts/wiki-lint.ts
@@ -1,0 +1,446 @@
+import {appendFile, readdir, readFile, writeFile} from 'node:fs/promises'
+import {join} from 'node:path'
+import process from 'node:process'
+
+import {parse} from 'yaml'
+
+const WIKILINK_PATTERN = /\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/gu
+const PAGE_PATH_PATTERN = /^knowledge\/wiki\/[^/]+\/.+\.md$/u
+const REQUIRED_FRONTMATTER_FIELDS = ['type', 'title', 'created', 'updated'] as const
+const STALE_DAYS = 90
+
+export type WikiLintFindingKind =
+  | 'broken-wikilink'
+  | 'orphan-page'
+  | 'index-drift'
+  | 'missing-frontmatter'
+  | 'invalid-frontmatter'
+  | 'stale-claim'
+  | 'missing-cross-reference'
+  | 'knowledge-gap'
+
+export interface WikiLintFinding {
+  readonly kind: WikiLintFindingKind
+  readonly path: string
+  readonly message: string
+  readonly target?: string
+}
+
+export interface WikiLintResult {
+  readonly ok: boolean
+  readonly deterministicFindings: readonly WikiLintFinding[]
+  readonly advisoryFindings: readonly WikiLintFinding[]
+  readonly summary: string
+  readonly report: string
+}
+
+export interface LintWikiSnapshotParams {
+  readonly files: Record<string, string>
+  readonly now?: Date
+}
+
+export interface WriteWikiLintOutputsParams {
+  readonly result: WikiLintResult
+  readonly reportPath: string
+  readonly githubStepSummaryPath?: string
+  readonly githubOutputPath?: string
+}
+
+export interface WriteWikiLintOutputsResult {
+  readonly status: 'clean' | 'findings'
+  readonly reportPath: string
+}
+
+export interface WriteWikiLintFailureOutputsParams {
+  readonly message: string
+  readonly reportPath: string
+  readonly githubStepSummaryPath?: string
+  readonly githubOutputPath?: string
+}
+
+export interface WriteWikiLintFailureOutputsResult {
+  readonly status: 'execution-failure'
+  readonly reportPath: string
+}
+
+export interface RunWikiLintParams {
+  readonly rootDir?: string
+  readonly reportPath: string
+  readonly githubStepSummaryPath?: string
+  readonly githubOutputPath?: string
+  readonly now?: Date
+}
+
+export interface RunWikiLintResult extends WriteWikiLintOutputsResult {
+  readonly result: WikiLintResult
+}
+
+interface ParsedPage {
+  readonly path: string
+  readonly slug: string
+  readonly content: string
+  readonly body: string
+  readonly frontmatter: Record<string, unknown>
+  readonly frontmatterError?: string
+}
+
+export function lintWikiSnapshot(params: LintWikiSnapshotParams): WikiLintResult {
+  const now = params.now ?? new Date()
+  const pages = collectPages(params.files)
+  const pageTargets = collectPageTargets(pages)
+  const indexedSlugs = collectIndexedSlugs(params.files['knowledge/index.md'] ?? '')
+  const hasNonRepoKnowledge = pages.some(
+    page =>
+      page.frontmatter.type === 'topic' || page.frontmatter.type === 'entity' || page.frontmatter.type === 'comparison',
+  )
+
+  const deterministicFindings: WikiLintFinding[] = []
+  const advisoryFindings: WikiLintFinding[] = []
+
+  for (const page of pages) {
+    const missingFields = REQUIRED_FRONTMATTER_FIELDS.filter(field => !hasNonEmptyString(page.frontmatter[field]))
+    if (page.frontmatterError !== undefined) {
+      deterministicFindings.push({
+        kind: 'invalid-frontmatter',
+        path: page.path,
+        message: page.frontmatterError,
+      })
+      continue
+    }
+
+    if (missingFields.length > 0) {
+      deterministicFindings.push({
+        kind: 'missing-frontmatter',
+        path: page.path,
+        message: `Missing required frontmatter: ${missingFields.join(', ')}`,
+      })
+    }
+
+    for (const target of collectWikilinks(page.body)) {
+      if (!pageTargets.has(target)) {
+        deterministicFindings.push({
+          kind: 'broken-wikilink',
+          path: page.path,
+          target,
+          message: `Broken wikilink to [[${target}]]`,
+        })
+      }
+    }
+
+    if (!indexedSlugs.has(page.slug)) {
+      deterministicFindings.push({
+        kind: 'orphan-page',
+        path: page.path,
+        message: `Page ${page.slug} exists on disk but is missing from knowledge/index.md`,
+      })
+    }
+
+    if (isStale(page.frontmatter.updated, now)) {
+      advisoryFindings.push({
+        kind: 'stale-claim',
+        path: page.path,
+        message: `Page has not been updated in ${STALE_DAYS}+ days`,
+      })
+    }
+
+    if (!page.body.includes('[[')) {
+      advisoryFindings.push({
+        kind: 'missing-cross-reference',
+        path: page.path,
+        message: 'Page has no wikilinks to related knowledge',
+      })
+
+      if (page.frontmatter.type === 'repo' && hasNonRepoKnowledge) {
+        advisoryFindings.push({
+          kind: 'knowledge-gap',
+          path: 'knowledge/index.md',
+          message: `Repo page ${page.slug} is not connected to existing non-repo knowledge`,
+        })
+      }
+    }
+  }
+
+  for (const indexedSlug of indexedSlugs) {
+    if (pageTargets.has(indexedSlug)) {
+      continue
+    }
+
+    deterministicFindings.push({
+      kind: 'index-drift',
+      path: 'knowledge/index.md',
+      target: indexedSlug,
+      message: `Index references [[${indexedSlug}]] but no page exists on disk`,
+    })
+  }
+
+  const summary = [
+    '# Wiki lint summary',
+    '',
+    `Deterministic findings: ${deterministicFindings.length}`,
+    `Advisory findings: ${advisoryFindings.length}`,
+  ].join('\n')
+
+  const reportSections = [
+    '# Wiki Lint Report',
+    '',
+    renderSection('Deterministic findings', deterministicFindings),
+    '',
+    '## Advisory findings',
+    '',
+    '_These are non-blocking advisory signals._',
+    '',
+    ...renderFindingLines(advisoryFindings),
+  ]
+
+  const report = reportSections.join('\n')
+
+  return {
+    ok: deterministicFindings.length === 0,
+    deterministicFindings,
+    advisoryFindings,
+    summary,
+    report,
+  }
+}
+
+export async function writeWikiLintOutputs(params: WriteWikiLintOutputsParams): Promise<WriteWikiLintOutputsResult> {
+  const status =
+    params.result.deterministicFindings.length === 0 && params.result.advisoryFindings.length === 0
+      ? 'clean'
+      : 'findings'
+
+  await writeFile(params.reportPath, `${params.result.report}\n`, 'utf8')
+
+  if (params.githubStepSummaryPath !== undefined && params.githubStepSummaryPath !== '') {
+    await appendFile(params.githubStepSummaryPath, `${params.result.summary}\n`, 'utf8')
+  }
+
+  if (params.githubOutputPath !== undefined && params.githubOutputPath !== '') {
+    const lines = [`status=${status}`, `report_path=${params.reportPath}`]
+    await appendFile(params.githubOutputPath, `${lines.join('\n')}\n`, 'utf8')
+  }
+
+  return {status, reportPath: params.reportPath}
+}
+
+export async function writeWikiLintFailureOutputs(
+  params: WriteWikiLintFailureOutputsParams,
+): Promise<WriteWikiLintFailureOutputsResult> {
+  const summary = ['# Wiki lint summary', '', 'Execution failure', '', params.message].join('\n')
+  const report = ['# Wiki Lint Report', '', '## Execution failure', '', params.message].join('\n')
+
+  await writeFile(params.reportPath, `${report}\n`, 'utf8')
+
+  if (params.githubStepSummaryPath !== undefined && params.githubStepSummaryPath !== '') {
+    await appendFile(params.githubStepSummaryPath, `${summary}\n`, 'utf8')
+  }
+
+  if (params.githubOutputPath !== undefined && params.githubOutputPath !== '') {
+    const lines = ['status=execution-failure', `report_path=${params.reportPath}`]
+    await appendFile(params.githubOutputPath, `${lines.join('\n')}\n`, 'utf8')
+  }
+
+  return {status: 'execution-failure', reportPath: params.reportPath}
+}
+
+export async function runWikiLint(params: RunWikiLintParams): Promise<RunWikiLintResult> {
+  const rootDir = params.rootDir ?? process.cwd()
+  const files = await loadWikiFilesFromDisk(rootDir)
+  const result = lintWikiSnapshot({files, now: params.now})
+  const outputs = await writeWikiLintOutputs({
+    result,
+    reportPath: params.reportPath,
+    githubStepSummaryPath: params.githubStepSummaryPath,
+    githubOutputPath: params.githubOutputPath,
+  })
+
+  return {...outputs, result}
+}
+
+function renderSection(title: string, findings: readonly WikiLintFinding[]): string {
+  return [`## ${title}`, '', ...renderFindingLines(findings)].join('\n')
+}
+
+function renderFindingLines(findings: readonly WikiLintFinding[]): string[] {
+  if (findings.length === 0) {
+    return ['No findings.']
+  }
+
+  return findings.map(
+    finding =>
+      `- \`${finding.kind}\` | ${finding.path}${finding.target === undefined ? '' : ` | target=${finding.target}`} | ${finding.message}`,
+  )
+}
+
+async function loadWikiFilesFromDisk(rootDir: string): Promise<Record<string, string>> {
+  const files: Record<string, string> = {}
+  const indexPath = join(rootDir, 'knowledge', 'index.md')
+  files['knowledge/index.md'] = await readFile(indexPath, 'utf8')
+
+  for (const directory of ['repos', 'topics', 'entities', 'comparisons']) {
+    const directoryPath = join(rootDir, 'knowledge', 'wiki', directory)
+    let entries
+
+    try {
+      entries = await readdir(directoryPath, {withFileTypes: true})
+    } catch (error: unknown) {
+      if (isErrorWithCode(error, 'ENOENT')) {
+        continue
+      }
+      throw error
+    }
+
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.md')) {
+        continue
+      }
+
+      const relativePath = `knowledge/wiki/${directory}/${entry.name}`
+      files[relativePath] = await readFile(join(directoryPath, entry.name), 'utf8')
+    }
+  }
+
+  return files
+}
+
+function collectPages(files: Record<string, string>): ParsedPage[] {
+  return Object.entries(files)
+    .filter(([path]) => PAGE_PATH_PATTERN.test(path))
+    .map(([path, content]) => {
+      const {frontmatter, body, error} = splitFrontmatter(content)
+      const pathParts = path.split('/')
+      // eslint-disable-next-line unicorn/prefer-at -- false-positive here; tsconfig/lsp intermittently flags .at()
+      const fileName = pathParts[pathParts.length - 1]
+      return {
+        path,
+        slug: (fileName ?? path).replace(/\.md$/u, ''),
+        content,
+        body,
+        frontmatter,
+        frontmatterError: error,
+      }
+    })
+}
+
+function collectIndexedSlugs(indexContent: string): Set<string> {
+  return new Set(collectWikilinks(indexContent))
+}
+
+function collectPageTargets(pages: readonly ParsedPage[]): Set<string> {
+  const targets = new Set<string>()
+
+  for (const page of pages) {
+    targets.add(page.slug)
+
+    const aliases = page.frontmatter.aliases
+    if (Array.isArray(aliases)) {
+      for (const alias of aliases) {
+        if (typeof alias === 'string' && alias.trim() !== '') {
+          targets.add(alias)
+        }
+      }
+    }
+  }
+
+  return targets
+}
+
+function collectWikilinks(content: string): string[] {
+  const matches = content.matchAll(WIKILINK_PATTERN)
+  return Array.from(matches, match => match[1]).filter((value): value is string => value !== undefined && value !== '')
+}
+
+function splitFrontmatter(content: string): {frontmatter: Record<string, unknown>; body: string; error?: string} {
+  const match = /^---\n([\s\S]+?)\n---\n?/u.exec(content)
+  if (match === null) {
+    return {frontmatter: {}, body: content.trim()}
+  }
+
+  const frontmatterText = match[1]
+  if (frontmatterText === undefined) {
+    return {frontmatter: {}, body: content.trim()}
+  }
+
+  let parsed: unknown
+  try {
+    parsed = parse(frontmatterText)
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Unknown YAML parse error'
+    return {
+      frontmatter: {},
+      body: content.slice(match[0].length).trim(),
+      error: `Invalid YAML frontmatter: ${message}`,
+    }
+  }
+
+  return {
+    frontmatter: isRecord(parsed) ? parsed : {},
+    body: content.slice(match[0].length).trim(),
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isErrorWithCode(error: unknown, code: string): boolean {
+  return isRecord(error) && typeof error.code === 'string' && error.code === code
+}
+
+function hasNonEmptyString(value: unknown): boolean {
+  return typeof value === 'string' && value.trim() !== ''
+}
+
+function isStale(updated: unknown, now: Date): boolean {
+  if (!hasNonEmptyString(updated)) {
+    return false
+  }
+
+  const updatedDate = new Date(`${String(updated)}T00:00:00Z`)
+  if (Number.isNaN(updatedDate.getTime())) {
+    return false
+  }
+
+  const ageMs = now.getTime() - updatedDate.getTime()
+  return ageMs >= STALE_DAYS * 24 * 60 * 60 * 1000
+}
+
+async function main(): Promise<void> {
+  const reportPath = process.env.WIKI_LINT_REPORT_PATH ?? 'wiki-lint-report.md'
+  const failureMessage = process.env.WIKI_LINT_FAILURE_MESSAGE
+
+  if (failureMessage !== undefined && failureMessage !== '') {
+    await writeWikiLintFailureOutputs({
+      message: failureMessage,
+      reportPath,
+      githubStepSummaryPath: process.env.GITHUB_STEP_SUMMARY,
+      githubOutputPath: process.env.GITHUB_OUTPUT,
+    })
+    process.stderr.write(`wiki-lint: ${failureMessage}\n`)
+    process.exit(1)
+  }
+
+  try {
+    const result = await runWikiLint({
+      reportPath,
+      githubStepSummaryPath: process.env.GITHUB_STEP_SUMMARY,
+      githubOutputPath: process.env.GITHUB_OUTPUT,
+    })
+
+    process.stdout.write(`${JSON.stringify(result.result)}\n`)
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Unknown wiki lint execution failure'
+    await writeWikiLintFailureOutputs({
+      message,
+      reportPath,
+      githubStepSummaryPath: process.env.GITHUB_STEP_SUMMARY,
+      githubOutputPath: process.env.GITHUB_OUTPUT,
+    })
+    process.stderr.write(`wiki-lint: ${message}\n`)
+    process.exit(1)
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}


### PR DESCRIPTION
## Summary
- add Unit 17 wiki lint v1 as a detect/report-only weekly workflow that restores the authoritative `data` snapshot before linting
- implement `scripts/wiki-lint.ts` with deterministic and advisory findings, alias-aware wikilink validation, and restore-failure reporting outputs
- document the authoritative-snapshot/reporting pattern in `docs/solutions/integration-issues/wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md`

## Verification
- pnpm bootstrap
- pnpm check-types
- pnpm lint
- pnpm test