### PR TITLE
feat(schemas): add discovery_channel and next_survey_eligible_at to RepoEntry

### DIFF
--- a/docs/brainstorms/2026-05-04-survey-cadence-and-multi-channel-discovery-requirements.md
+++ b/docs/brainstorms/2026-05-04-survey-cadence-and-multi-channel-discovery-requirements.md
@@ -1,0 +1,131 @@
+---
+title: Survey cadence + multi-channel discovery
+type: feat
+status: draft
+date: 2026-05-04
+---
+
+## Problem
+
+The wiki has gone dark for stretches and the access surface no longer matches where Fro Bot actually operates.
+
+**Cadence problem.** Reconcile uses a single 30-day staleness threshold per entry. When most repos get surveyed in the same short window, they all become re-eligible in the same short window 30 days later. Between those windows, no surveys fire. Operationally this looks like "Fro Bot stopped working" even when reconcile reports `success`. The current data confirms this: 18 of 21 onboarded repos were last surveyed 2026-04-27, the latest cron at 2026-05-04 dispatched zero, and the next dispatch wave isn't expected until 2026-05-27.
+
+**Reach problem.** Fro Bot's tracked-repo list only covers user-account collaborator invitations. Two real access channels are missing:
+
+- **Owned org.** `fro-bot/agent`, `fro-bot/systematic`, `fro-bot/.github`, `fro-bot/fro-bot.github.io` — the control plane and the agent itself are not in the wiki.
+- **Cross-org contribution.** Repos like `bfra-me/.github` and `bfra-me/renovate-action` already invoke `fro-bot/agent` via `.github/workflows/fro-bot.yaml`. Fro Bot is operating in those repos as a service but has no presence in the wiki.
+
+These are one initiative, not two. Fixing cadence without expanding reach leaves the wiki small. Expanding reach without fixing cadence makes the herd worse. Both must move together.
+
+## Goals
+
+- Surveys fire on most days instead of in herds. Weekly wiki growth becomes visible week over week.
+- Fro Bot's own org repos appear in the wiki under the same lifecycle as collaborator repos.
+- Operator-allowlisted cross-org repos appear in the wiki under the same lifecycle.
+- Every entry in the tracked list records which discovery channel surfaced it, so reports and per-channel tuning are possible.
+
+## Non-Goals
+
+- **Self-survey of `fro-bot/.github`.** Discovery skips this repo. Possibly revisited as a separate question after the rest stabilizes.
+- **Per-page-type stale thresholds.** Cadence is per-repo only. Page-type intervals (repos vs topics vs entities) belong to the wiki-lint follow-on plan if they ever become a thing.
+- **Auto-removal beyond the existing `lost-access` flow.** A contrib repo whose `fro-bot.yaml` disappears does not auto-leave the list. Operators remove entries explicitly.
+- **Changes to the `data → main` promotion model.** Branch protection, merge-data cadence, and the wiki authority guard are unchanged.
+- **Real-time activity signals.** Cadence is time-based with jitter. No new telemetry pipeline. Activity-driven freshening is a future plan if needed.
+- **Discovery outside the explicit allowlist.** No probing of random orgs Fro Bot was once installed in. Contributor probes only run against orgs/repos the operator has named.
+
+## Users and Stakeholders
+
+- **Operator (Marcus).** Wants the wiki to grow continuously and to see Fro Bot present where it is being used. Explicitly opts repos in via metadata edits.
+- **Fro Bot agent.** Reads the wiki for cross-repo context during PR review, issue triage, and scheduled oversight. Better coverage and freshness directly improve the agent's usefulness.
+- **Future readers (humans + agents).** Treat the wiki as the canonical narrative of what Fro Bot has touched. The doc must reflect actual reach.
+
+## Success Criteria
+
+| # | Criterion | Verification |
+| --- | --- | --- |
+| SC1 | Two weeks after rollout, scheduled reconcile runs dispatch surveys on most days, with no five-day-or-longer zero-dispatch gap unrelated to upstream rate limits. | Daily reconcile JSON output shows non-zero dispatches on a clear majority of days. |
+| SC2 | Wiki pages exist for all non-archived repos in the `fro-bot` org except `fro-bot/.github`. | `knowledge/wiki/repos/` listing includes `fro-bot--agent.md`, `fro-bot--systematic.md`, `fro-bot--fro-bot.github.io.md`. |
+| SC3 | Wiki pages exist for every operator-allowlisted cross-org repo whose access probe succeeded. | `knowledge/wiki/repos/` listing matches the allowlisted set; mismatches surface as `lost-access` entries. |
+| SC4 | Each entry in `metadata/repos.yaml` records its discovery channel. Reports and reconcile JSON output can break activity down by channel. | Every entry has a `discovery_channel` (or equivalent) field; reconcile output reports per-channel counts. |
+
+## Functional Requirements
+
+### Discovery
+
+- **R1.** Reconcile gains three discovery channels into a single `metadata/repos.yaml` list:
+  - **Channel `collab`** — current behavior. Collaborator invitations on user accounts (handled by `poll-invitations.yaml` + `handle-invitation.ts`) seed entries with channel `collab`.
+  - **Channel `owned`** — fro-bot's own org. Reconcile enumerates non-archived non-fork repos under the `fro-bot` org via `apps.listReposAccessibleToInstallation` (or equivalent installation-scoped enumeration), skipping `fro-bot/.github`. New repos appear as `pending` entries with channel `owned`.
+  - **Channel `contrib`** — cross-org. `metadata/allowlist.yaml` gains an opt-in section for contrib access. Reconcile probes each named org / repo and accepts entries whose access check succeeds and whose `fro-bot.yaml` (or operator-named signal file) is present. New entries appear as `pending` with channel `contrib`.
+
+- **R2.** Every entry in `metadata/repos.yaml` records its discovery channel as a typed field. Reconcile preserves the channel across status transitions; the channel never changes after first write.
+
+- **R3.** Discovery skips `fro-bot/.github` unconditionally. The skip is an explicit constant, not a probe outcome.
+
+### Cadence
+
+- **R4.** Each entry stores a `next_survey_eligible_at` timestamp computed at survey time as `last_survey_at + base_interval + jitter`, where:
+  - `base_interval` is per-channel and operator-tunable (initial values: `owned = 14d`, `contrib = 21d`, `collab = 30d`; tuneable via constants).
+  - `jitter` is a small bounded random value (e.g. `±0..3 days`) drawn at survey-completion time, deterministic per `(repo, last_survey_at)` so re-running reconcile against the same snapshot yields identical decisions.
+
+- **R5.** Reconcile dispatches a repo when `now >= next_survey_eligible_at` (with appropriate handling for null = never surveyed and malformed-date = treat as eligible). Existing dispatch caps, stagger, and prioritization (`null first → oldest next_survey_eligible_at next`) continue to apply.
+
+- **R6.** A repo's `next_survey_eligible_at` is set during the survey-result write-back path (`recordSurveyResult` / `survey-repo.yaml`), not at dispatch time. A failed survey resets it to the same `last_survey_at + base_interval + jitter` formula but starting from "now" so retries don't pile up immediately.
+
+### Allowlist surface for contrib
+
+- **R7.** `metadata/allowlist.yaml` gains a new section that supports both:
+  - **Org-level opt-in:** `approved_contrib_orgs` — list of org logins. Reconcile enumerates repos in each org and probes for the `fro-bot.yaml` signal file.
+  - **Repo-level opt-in:** `approved_contrib_repos` — list of fully qualified `org/repo` strings. Reconcile probes the named repo directly without enumeration.
+
+- **R8.** A contrib probe failure (App not installed, signal file missing, repo archived/private without access) does not error the reconcile run. The repo is omitted from the tracked list with a structured log line.
+
+### Backwards compatibility
+
+- **R9.** Existing `metadata/repos.yaml` entries are migrated forward on first reconcile run after rollout: missing `discovery_channel` defaults to `collab`, missing `next_survey_eligible_at` defaults to `last_survey_at + 30d + jitter` (for `onboarded`) or `null` (for `pending`). Migration is a single pure mapping, not a data backfill workflow.
+
+- **R10.** The single 30-day `SURVEY_STALENESS_MS` constant is replaced by per-channel intervals plus the per-entry `next_survey_eligible_at`. The shape of the JSON reconcile output preserves existing keys (`dispatches`, `dispatchesDeferred`, `unchanged`, etc.) and adds per-channel breakdowns.
+
+### Observability
+
+- **R11.** Reconcile JSON output includes per-channel counters (`{collab: {tracked, dispatched, deferred, lostAccess}, owned: {...}, contrib: {...}}`) so daily reports and operator review can attribute activity to channels.
+
+- **R12.** A repo's first survey under the `owned` or `contrib` channel logs an explicit "first survey for new channel entry" line so the operator can verify rollout is working without diffing files.
+
+## Constraints
+
+- **C1.** `metadata/*.yaml` writes must continue to land on `data` and promote via `merge-data`. The wiki authority guard (`scripts/check-wiki-authority.ts`) must continue to enforce Fro Bot identity for all guarded paths.
+- **C2.** All scripts remain TypeScript under `scripts/`, executable with Node v24 native TS.
+- **C3.** Cross-org probes must use the App installation token scoped via `owner: ${{ github.repository_owner }}` (or equivalent multi-org input) — the existing trap from PR #3201 must not regress.
+- **C4.** Anthropic seat budget is the binding capacity constraint, not GitHub API quota. Per-channel intervals must be chosen so the steady-state daily dispatch volume stays inside the cliproxy.fro.bot tolerance proven by the existing 90-second stagger + 12-cap workflow.
+- **C5.** Discovery probes must not make API calls during every reconcile run that scale with org size beyond what the existing daily reconcile already does. Cross-org enumeration runs at most once per reconcile pass per org.
+- **C6.** Tests must cover the new staleness-gate, channel routing, jitter determinism, and migration mapping before any production pipeline change lands.
+
+## Open Questions
+
+Resolved during this brainstorm:
+
+- **Discovery model.** Three channels into one tracked list. Resolved.
+- **Cadence shape.** Per-repo `next_survey_eligible_at` with per-channel base interval and small jitter. Resolved.
+- **Contrib trust boundary.** Operator-curated allowlist (`approved_contrib_orgs` + `approved_contrib_repos`) with auto-discovery probe. Resolved.
+- **Self-survey of `fro-bot/.github`.** Out of scope. Skip in discovery. Resolved.
+- **Per-page-type thresholds.** Out of scope. Resolved.
+
+Deferred to planning:
+
+- Exact starting values for `base_interval` per channel and jitter window. Initial recommendation: `owned = 14d`, `contrib = 21d`, `collab = 30d`, jitter = `±0..3d`. Planning may revise based on capacity math.
+- Whether `discovery_channel` is stored as a string field or an enum. (Schema-level concern.)
+- Whether the contrib probe requires `.github/workflows/fro-bot.yaml` specifically or accepts any signal file pattern. Initial recommendation: require `fro-bot.yaml` to keep the trust signal explicit.
+- Whether the survey-result write-back path computes jitter from a deterministic seed (`hash(repo, last_survey_at)`) or pulls from a non-deterministic RNG. Determinism wins for test stability; planning resolves the seed source.
+- Migration ordering: does the first reconcile after rollout dispatch every newly-eligible repo at once (producing a new herd), or is rollout staggered? Initial recommendation: cap the first run via the existing per-run dispatch cap so the new model self-staggers.
+
+## References
+
+- `docs/plans/2026-04-17-001-feat-repo-reconciliation-plan.md` — current reconcile architecture (decision engine + thin I/O shell).
+- `docs/brainstorms/2026-04-17-repo-reconciliation-requirements.md` — origin requirements for the daily reconcile pass.
+- `docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md` — the prior silent-failure pattern (relevant: success status while no work is dispatched is the same shape as the current cadence outage).
+- `scripts/reconcile-repos.ts` — `SURVEY_STALENESS_MS`, `isSurveyStale`, dispatch cap, stagger, and per-channel JSON output keys live here.
+- `scripts/handle-invitation.ts` — current `collab` channel entry point.
+- `scripts/repos-metadata.ts` — `recordSurveyResult` is where `next_survey_eligible_at` will be written.
+- `scripts/update-metadata.ts` — existing `apps.listReposAccessibleToInstallation` pattern for the `owned` channel.
+- `metadata/allowlist.yaml` — operator surface for `approved_contrib_orgs` / `approved_contrib_repos`.

--- a/docs/plans/2026-05-02-001-feat-wiki-lint-followups-plan.md
+++ b/docs/plans/2026-05-02-001-feat-wiki-lint-followups-plan.md
@@ -1,0 +1,315 @@
+---
+title: feat: Add post-v1 wiki-lint escalation and repair flows
+type: feat
+status: active
+date: 2026-05-02
+deepened: 2026-05-02
+---
+
+## Overview
+
+Extend `wiki-lint` beyond v1's detect/report-only baseline without breaking the repo's `data`-branch authority model. This follow-on plan focuses on the immediate foundation work that is implementable now: a stable machine-readable lint artifact plus a durable issue lifecycle for deterministic findings and execution failures. It also records the explicit triggers for the later deferred features, stale-claim threshold tuning and repair proposals, without pretending those phases are ready to execute yet.
+
+## Problem Frame
+
+`wiki-lint` v1 intentionally stopped at authoritative-snapshot restore, finding classification, workflow summary output, and markdown artifact upload. That solved the core control-plane gap, but it left the deferred post-v1 work untouched: weekly runs still require humans to inspect artifacts manually, advisory stale-claim thresholds are still a single global constant, and there is no explicit path for safe deterministic repairs after signal quality is proven.
+
+The follow-on work must not reintroduce the stale Unit 17 model that treated lint as a second autonomous write path. The authoritative wiki still lives on `data`, `scripts/wiki-lint.ts` still needs to stay detect/report focused, and any later mutation must be explicit, rerun against the latest `origin/data` snapshot, and flow back through the existing `data -> main` promotion path. That makes the immediate post-v1 work narrower than the full deferred roadmap: first make lint machine-consumable and operator-visible, then use live evidence to decide whether threshold tuning or repair automation deserves its own follow-on plan.
+
+## Requirements Trace
+
+### Immediate foundation
+
+- R1. Preserve `origin/data` as the authoritative wiki source for every post-v1 `wiki-lint` path.
+- R2. Keep `scripts/wiki-lint.ts` focused on detection and report generation rather than hidden GitHub or wiki mutation side effects.
+- R3. Add a stable machine-readable artifact that downstream automation can consume without scraping markdown.
+- R4. Escalate deterministic findings and execution failures into durable control-plane issues with dedupe, reopen, update, and close-on-clear behavior.
+- R6. Keep detection, issue escalation, and wiki repair as explicit phases with separate status accounting; no silent green runs when a required follow-on step fails.
+
+### Future-gated follow-ons
+
+- R5. Capture enough weekly freshness telemetry to justify a later page-type stale-policy plan instead of hard-coding new thresholds now.
+- R7. Restrict automated repair proposals to an explicit allowlist of unambiguous finding kinds and route any resulting wiki writes through the `data` branch under Fro Bot identity.
+
+## Scope Boundaries
+
+- Advisory findings remain artifact-only; this plan does not add issue escalation or semantic auto-fixes for `stale-claim`, `missing-cross-reference`, or `knowledge-gap`.
+- `scripts/wiki-lint.ts` does not become a GitHub Issues client or a wiki mutation entrypoint.
+- This plan does not change the weekly `data -> main` promotion model, branch protections, or `scripts/check-wiki-authority.ts` guardrails.
+
+### Deferred to Separate Tasks
+
+- Stale-claim threshold tuning after durable observation storage and six weekly runs exist.
+- Repair proposal automation after issue-sync is stable enough to justify a separate follow-on plan.
+- Richer semantic lint heuristics beyond the current deterministic/advisory finding set.
+- Broader auto-repair beyond catalog drift (`index-drift`, `orphan-page`) once real production data proves other findings are both low-noise and unambiguous to heal.
+- Long-term retention policy changes for any new `wiki-lint` issues if the initial lifecycle proves too noisy.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `.github/workflows/wiki-lint.yaml` restores `knowledge/` from `origin/data`, runs `node scripts/wiki-lint.ts`, and always uploads a markdown report artifact.
+- `scripts/wiki-lint.ts` currently owns the pure lint engine, markdown report generation, step-summary output, and execution-failure reporting.
+- `scripts/wiki-lint.test.ts` already covers the authoritative-snapshot contract, output writing, alias-backed links, and workflow-shape assertions.
+- `scripts/reconcile-repos.ts` is the strongest local pattern for hidden issue markers, explicit issue labels, reopen/update/close lifecycle, and "try every issue op, but keep failures visible" behavior.
+- `scripts/wiki-ingest.ts` and `scripts/rebuild-wiki-index.ts` are the sanctioned building blocks for `data`-branch wiki writes and deterministic catalog repair.
+- `.github/workflows/manage-issues.yaml` shows the repo's existing automation around old report issues, but it is intentionally broader and less precise than the close-on-clear lifecycle needed here.
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md` establishes the v1 contract: authoritative `data` snapshot, separate failure reporting, and no hidden remediation inside lint.
+- `docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md` shows why aggregate workflow status must include every required downstream step and why recovery tooling must match production shape, not just happy-path tests.
+- `docs/solutions/integration-issues/merge-data-pr-github-422-race-recovery-2026-05-02.md` reinforces bounded retries, transient-vs-permanent GitHub failure classification, and durable operator-facing surfaces.
+- `docs/solutions/workflow-issues/github-actions-step-output-interpolation-2026-04-21.md` is the workflow-shell pattern to follow when new steps pass structured data around.
+
+## Key Technical Decisions
+
+- **Versioned JSON artifact alongside markdown report**: downstream issue sync and repair workflows will consume a stable JSON contract rather than parsing the markdown report.
+- **The JSON artifact is a fail-closed control-plane contract**: it must include schema version, fingerprint version, scan completeness, authoritative snapshot SHA when available, run metadata, and repair eligibility so downstream jobs can reject incomplete or unknown payloads instead of inferring behavior from ad hoc fields.
+- **One issue per stable finding fingerprint or failure class**: deterministic findings will dedupe on fingerprint (`kind + path + target?`), execution failures on a smaller failure-class key. This avoids one-issue-per-run churn while preserving close-on-clear behavior in the immediate plan.
+- **Issue sync is a separate workflow job, not a side effect inside lint**: detection remains pure, while escalation runs in a distinct job with App-token auth and its own failure accounting.
+- **Close-on-clear only happens after a complete authoritative scan**: issue-sync may close or reconcile finding issues only when the JSON artifact represents a completed authoritative scan (`clean` or `findings`), never on `execution-failure`.
+- **Freshness telemetry must outlive a single artifact retention window**: Unit 1's JSON contract has to emit per-page freshness data now so a later stale-threshold plan can rely on observed data instead of retrofitting the schema after the fact.
+- **Future repair automation should use `workflow_call` for automatic handoff**: if a later repair plan is approved, the automatic path should stay in the same run graph with `workflow_call`, while `workflow_dispatch` remains the manual operator entrypoint.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Issue grouping model**: use per-fingerprint issues for deterministic findings and per-failure-class issues for execution failures rather than a weekly rollup issue.
+- **Execution-failure granularity**: split at least into `snapshot-restore`, `lint-execution`, and `repair-proposal` classes so recurrence and closure are specific.
+- **Repairable finding scope**: first repair phase is limited to `index-drift` and `orphan-page`; `broken-wikilink`, `missing-frontmatter`, and `invalid-frontmatter` remain issue-only.
+- **Staleness source of truth**: continue using frontmatter `updated`; do not introduce git-history heuristics in this follow-on plan.
+- **Repair rollout control**: use a repo variable gate (for example, `WIKI_LINT_AUTO_REPAIR`) so the repair workflow can exist before automatic dispatch is enabled.
+
+### Deferred to Implementation
+
+- Exact page-type stale thresholds once at least six weekly JSON artifacts exist to justify non-global values.
+- Exact label strings and issue body wording, as long as the lifecycle contract and hidden marker strategy remain intact.
+- Which durable store should back the later stale-threshold observation window if weekly artifact retention remains shorter than the required six-run sample.
+- Whether a future repair commit path should append a `knowledge/log.md` entry through a small extracted helper in `scripts/wiki-ingest.ts` or leave auditability to issues + workflow artifacts; that remains a follow-on decision.
+
+## Output Structure
+
+```text
+.github/
+  workflows/
+    wiki-lint.yaml                # modified: lint + issue sync
+    settings.yml                  # modified: repo-local wiki-lint labels if new labels are introduced
+scripts/
+  wiki-lint.ts                    # modified: JSON artifact, finding fingerprints, richer status contract
+  wiki-lint.test.ts               # modified: output contract, threshold policy, workflow assertions
+  wiki-lint-issues.ts             # new: issue lifecycle sync for deterministic findings / execution failures
+  wiki-lint-issues.test.ts        # new: issue dedupe, reopen, close-on-clear, failure handling
+```
+
+## High-Level Technical Design
+
+> _This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce._
+
+```mermaid
+flowchart TB
+    A[wiki-lint.yaml restores origin/data snapshot] --> B[scripts/wiki-lint.ts]
+    B --> C[wiki-lint-report.md]
+    B --> D[wiki-lint-report.json]
+    D --> E[scripts/wiki-lint-issues.ts]
+    E --> F[Open / update / reopen / close wiki-lint issues]
+    F --> G[Future follow-on plans consume the same JSON contract]
+```
+
+## Phased Delivery
+
+### Phase 1
+
+- Ship the machine-readable artifact and durable issue lifecycle first.
+- Let the workflow operate for multiple weekly cycles so future planning can use real issue churn and freshness data instead of guesses.
+
+### Phase 2
+
+- If freshness telemetry is still useful after six weekly runs and a durable observation store exists, create a separate stale-threshold plan using the data from Phase 1.
+
+### Phase 3
+
+- If issue-sync stays clean and low-noise across multiple scheduled runs, create a separate repair-plan that uses `workflow_call` for automatic handoff and keeps manual `workflow_dispatch` as the operator fallback.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add versioned `wiki-lint` JSON output and finding fingerprints**
+
+**Goal:** Extend `wiki-lint`'s artifact contract so downstream automation can consume structured status, snapshot metadata, and stable finding fingerprints without scraping markdown.
+
+**Requirements:** R1, R2, R3, R6
+
+**Dependencies:** None
+
+**Files:**
+
+- Modify: `scripts/wiki-lint.ts`
+- Modify: `scripts/wiki-lint.test.ts`
+- Modify: `.github/workflows/wiki-lint.yaml`
+
+**Approach:**
+
+- Add a versioned JSON artifact written on every path that currently produces a markdown report: `clean`, `findings`, and `execution-failure`.
+- Include enough machine-readable metadata for downstream consumers to reason about recurrence and authority: schema version, fingerprint version, scan completeness, lint status, `origin/data` snapshot SHA when available, generated timestamp, deterministic/advisory findings, execution-failure class, repair eligibility, stable finding fingerprints, and per-page freshness telemetry sufficient for later threshold analysis.
+- Preserve the existing markdown report contract and step summary output rather than replacing them.
+- Update the workflow to upload both artifacts and to pass snapshot metadata through environment variables instead of shell interpolation.
+- Make downstream consumers fail closed on unknown schema/fingerprint versions or incomplete scans.
+
+**Execution note:** Start with failing tests for the JSON artifact contract and workflow artifact upload across clean, findings, and execution-failure paths.
+
+**Patterns to follow:**
+
+- `scripts/wiki-lint.ts` output helpers and status contract
+- `docs/solutions/workflow-issues/github-actions-step-output-interpolation-2026-04-21.md`
+
+**Test scenarios:**
+
+- Happy path: a clean snapshot writes matching markdown + JSON artifacts with `status: clean` and zero findings.
+- Happy path: a deterministic finding writes a fingerprint that is stable across repeated runs of the same snapshot.
+- Happy path: the JSON artifact includes per-page freshness telemetry even when a page is not currently stale.
+- Edge case: a consumer-facing JSON payload with an unknown schema or fingerprint version is treated as unusable rather than partially processed.
+- Error path: restore or execution failure writes `status: execution-failure` with a classified failure type and still produces both artifacts.
+- Integration: workflow-shape assertions prove both artifacts are uploaded and available to downstream jobs on every path.
+
+**Verification:**
+
+- The workflow produces a markdown report and a versioned JSON artifact for `clean`, `findings`, and `execution-failure` runs.
+- Re-running the linter against the same snapshot produces identical fingerprints for unchanged findings.
+- The JSON artifact contains enough freshness telemetry to support a later stale-threshold plan without changing the schema first.
+
+---
+
+- [ ] **Unit 2: Add durable issue lifecycle for deterministic findings and execution failures**
+
+**Goal:** Turn `wiki-lint` findings into durable operator-facing issues that dedupe, reopen, update, and close automatically instead of forcing humans to poll artifacts manually.
+
+**Requirements:** R3, R4, R6
+
+**Dependencies:** Unit 1
+
+**Files:**
+
+- Create: `scripts/wiki-lint-issues.ts`
+- Create: `scripts/wiki-lint-issues.test.ts`
+- Modify: `.github/workflows/wiki-lint.yaml`
+- Modify: `.github/settings.yml`
+
+**Approach:**
+
+- Add a second job to `wiki-lint.yaml` that always runs after lint, downloads the JSON artifact, and reconciles open `wiki-lint` issues under an App token.
+- Use hidden markers and stable fingerprints in issue bodies so the script can find, reopen, update, and close the correct issues without title matching.
+- Create issues only for deterministic findings and execution failures; advisory findings remain artifact-only.
+- Attempt every needed issue operation in a single run, but make the job fail if any required issue operation fails so the workflow cannot report green while escalation is broken.
+- Skip close-on-clear reconciliation for deterministic finding issues whenever the JSON artifact says the authoritative scan was incomplete or ended in `execution-failure`.
+- Emit machine-readable lifecycle counters (`opened`, `updated`, `reopened`, `closed`, `failed`) so rollout decisions can rely on evidence instead of eyeballing issue state.
+
+**Execution note:** Start with failing lifecycle tests for "same finding updates existing issue", "cleared finding closes issue", and "closed issue reopens on recurrence" before wiring GitHub I/O.
+
+**Patterns to follow:**
+
+- `scripts/reconcile-repos.ts` issue markers, labels, and close-on-clear behavior
+- `scripts/journal-entry.ts` for compact GitHub issue client usage
+
+**Test scenarios:**
+
+- Happy path: a new deterministic finding opens one labeled issue with its fingerprint marker.
+- Happy path: the same fingerprint on a later run updates or comments on the existing open issue instead of opening a duplicate.
+- Edge case: a previously closed issue with the same fingerprint reopens when the finding recurs.
+- Edge case: a clean run closes any previously open issue whose fingerprint is absent from the current JSON artifact.
+- Edge case: an `execution-failure` artifact still opens or updates the correct failure-class issue but does not close existing deterministic-finding issues.
+- Error path: a failed issue create/update/close makes the issue-sync job fail after recording which operations were attempted.
+- Integration: a workflow-level assertion proves the issue-sync job runs even on `status: clean`, so close-on-clear is not skipped.
+- Integration: the workflow summary or outputs expose the lifecycle counters needed for rollout decisions.
+
+**Verification:**
+
+- One repeated deterministic finding or execution failure churns a single durable issue instead of one issue per run.
+- A clean authoritative snapshot closes the corresponding open issue on the next run.
+- The workflow is red when issue sync is required and fails.
+- Operators can verify issue-sync health from explicit counters instead of manual repo inspection.
+
+## Follow-on Triggers
+
+### Future Plan A: Stale-Threshold Tuning
+
+Create a separate follow-on plan for R5 only when both of these are true:
+
+- six scheduled `wiki-lint` runs have produced Unit 1 freshness telemetry
+- the repo has a durable observation store that survives longer than the current artifact retention window
+
+The later plan should stay advisory-only, keep freshness based on frontmatter `updated`, and introduce a dedicated `scripts/wiki-lint-policy.ts` + `scripts/wiki-lint-policy.test.ts` pair only if the observed data justifies page-type-specific thresholds.
+
+### Future Plan B: Repair Proposal Automation
+
+Create a separate follow-on plan for R7 only when all of these are true:
+
+- issue-sync from Unit 2 has stayed stable across at least three consecutive scheduled runs
+- explicit lifecycle counters show zero duplicate issues, zero missed close-on-clear events on complete scans, and zero unclassified execution failures
+- a human operator approves enabling repair planning
+
+That later plan should:
+
+- use `workflow_call` for the automatic path from `wiki-lint.yaml`
+- keep `workflow_dispatch` as the manual operator entrypoint
+- make the repair workflow emit the same versioned artifact/status shape so `repair-proposal` failures participate in the same durable issue lifecycle
+- limit the first repair allowlist to deterministic catalog drift only
+
+## System-Wide Impact
+
+- **Interaction graph:** `wiki-lint.yaml` becomes a two-stage control that restores `origin/data`, emits structured artifacts, and syncs issues. Future stale-policy and repair plans consume the same artifact contract rather than adding hidden branches now.
+- **Error propagation:** lint engine failures stay inside `scripts/wiki-lint.ts`; issue-sync failures become a separate job failure so required downstream work cannot disappear behind a green lint job.
+- **State lifecycle risks:** stable finding fingerprints and close-on-clear logic prevent issue duplication, but only when scan completeness is explicit and respected.
+- **Run overlap risks:** issue sync and repair must key their work to one authoritative artifact/snapshot at a time so overlapping weekly or manual runs do not reopen/close thrash or create duplicate repair proposals.
+- **API surface parity:** markdown report output remains intact while the JSON artifact adds a second, machine-readable surface; downstream automation must consume JSON rather than scraping markdown.
+- **Integration coverage:** workflow assertions need to cover artifact upload, issue-sync job execution on `clean` and `execution-failure`, and counter publication; pure unit tests alone will not prove the full control-plane contract.
+- **Unchanged invariants:** `scripts/wiki-lint.ts` still does not mutate wiki content or call GitHub Issues directly, advisory findings remain artifact-only, and `main` remains protected from direct autonomous wiki writes.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| Stable finding fingerprints are too coarse or too noisy, causing issue churn | Include fingerprint regression tests in Unit 1 and lifecycle tests in Unit 2 before enabling issue sync |
+| Workflow status regresses into another silent-failure class | Treat issue sync and repair proposal as separate required jobs with explicit red-state behavior when they fail |
+| Incomplete scans close live finding issues incorrectly | Allow close-on-clear only for complete authoritative scans; `execution-failure` runs update failure issues only |
+| Repair writes mutate stale state or paper over unrepairable findings | Re-run lint against the latest `origin/data` snapshot immediately before repair and limit the first allowlist to index rebuild cases |
+| Threshold tuning overfits sparse weekly data or lacks durable evidence | Keep threshold tuning out of this plan until six scheduled runs plus durable observation storage exist |
+| New repo-local labels drift from repo settings | Manage `wiki-lint` labels in `.github/settings.yml`, not the org-wide `common-settings.yaml` contract |
+| Overlapping manual and scheduled runs race on issue or repair state | Use workflow concurrency plus snapshot-aware no-op behavior for superseded artifacts before issue sync or repair writes |
+
+## Documentation / Operational Notes
+
+- Update the `wiki-lint` learning doc after Units 1 and 2 land so the documented contract includes JSON output and issue escalation.
+- Document any new labels and operator expectations in the workflow README surface if the issue-sync job adds a new recurring operational surface.
+
+### Rollout Criteria
+
+- Treat issue-sync as stable enough for later follow-on planning only after three consecutive scheduled runs show zero duplicate issues, zero missed close-on-clear cases on complete scans, and zero unclassified execution failures.
+
+### Rollback / Containment
+
+- Immediate containment for noisy issue-sync behavior is to disable or bypass the issue-sync job, leaving `wiki-lint` artifact-only.
+- If issue-sync misbehaves, close or relabel noisy issues with an operator note rather than leaving the repo in a flood state.
+- If a future repair plan is approved and later misbehaves, contain it by reverting the repair commit on `data`, closing any resulting promotion PR, and verifying that no additional repair runs remain in flight.
+
+### Live Verification
+
+- Verify on first deploy that every run still uploads both artifacts and reports an unambiguous aggregate status.
+- Verify on the first recurring deterministic finding that the same issue is updated rather than duplicated.
+- Verify on the first clean run after an open finding that close-on-clear happens only when the scan was complete.
+- Verify that workflow summaries or outputs expose the lifecycle counters needed for rollout decisions.
+
+### Failure Policy
+
+- One transient weekly red run is acceptable if rerun evidence proves the downstream dependency failure was temporary.
+- Do not start later stale-threshold or repair planning while issue-sync still shows transient or permanent failure churn.
+
+## Sources & References
+
+- Prior control-plane plan: `docs/plans/2025-04-15-001-feat-frobot-control-plane-plan.md`
+- Related learning: `docs/solutions/integration-issues/wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md`
+- Related learning: `docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md`
+- Related learning: `docs/solutions/integration-issues/merge-data-pr-github-422-race-recovery-2026-05-02.md`
+- Related code: `.github/workflows/wiki-lint.yaml`, `scripts/wiki-lint.ts`, `scripts/wiki-ingest.ts`, `scripts/rebuild-wiki-index.ts`, `scripts/reconcile-repos.ts`
+- Related issue: `#3148`

--- a/docs/plans/2026-05-05-001-feat-survey-cadence-and-multi-channel-discovery-plan.md
+++ b/docs/plans/2026-05-05-001-feat-survey-cadence-and-multi-channel-discovery-plan.md
@@ -1,0 +1,492 @@
+---
+title: 'feat: Survey cadence + multi-channel discovery'
+type: feat
+status: active
+date: 2026-05-05
+origin: docs/brainstorms/2026-05-04-survey-cadence-and-multi-channel-discovery-requirements.md
+deepened: 2026-05-05
+---
+
+## Overview
+
+Extend the daily reconcile pipeline with three discovery channels (`collab`, `owned`, `contrib`) feeding a single `metadata/repos.yaml` list, and replace the single 30-day staleness threshold with a per-repo `next_survey_eligible_at` field computed from a per-channel base interval plus deterministic jitter.
+
+The cadence change reduces consecutive-zero-survey-day stretches via jitter and per-channel intervals. It does NOT eliminate the underlying structural pattern: at the current scale (~17-27 repos × 30-day cycle), the 12-dispatch cap drains eligible candidates in 2-3 days and then leaves ~22-25 days of silence per cycle. Jitter spreads those active days from 2-3 to ~5-6 — partial improvement, not a fix. The real architectural answer for "wiki diffs every week" is a per-day quota model (always dispatch the N oldest-eligible repos regardless of staleness threshold) which is deliberately deferred to a future plan; this plan ships the smaller change first.
+
+The discovery expansion brings Fro Bot's own org repos and operator-allowlisted cross-org repos into the same lifecycle as collaborator invitations. Both changes ship together because each one in isolation makes the other's problem worse: fixing cadence without expanding reach leaves the wiki small; expanding reach without fixing cadence amplifies the cluster width on cycle days.
+
+## Problem Frame
+
+The reconcile cron has been reporting `success` while dispatching zero surveys for several days running. The proximate cause was a clustering event: 18 of 21 onboarded repos were last surveyed on 2026-04-27 (followed by a recovery wipe that left 17/17 entries with `last_survey_at: null` on the `data` branch as of plan-write time). The single 30-day threshold makes any cluster-of-N repos all simultaneously ineligible for ~28 days after they survey, then dispatches them again in a 2-3-day burst (12-cap drain), then idles for ~28 days. Per-channel intervals + jitter widen the burst window from 2-3 days to 5-6 and slow re-clustering, but the population-vs-cycle ratio (N=17, cycle=30d) means most days will still be zero-dispatch days even at steady state. This plan accepts that limitation and ships the partial fix; a future plan addresses the structural answer (a per-day quota that always dispatches the oldest-eligible regardless of threshold).
+
+In parallel, Fro Bot's tracked-repo list misses two real access channels:
+
+- **Owned org**: `fro-bot/agent`, `fro-bot/systematic`, `fro-bot/fro-bot.github.io` — the agent itself and the GH Pages presence are not in the wiki. (`fro-bot/.github` is excluded by design — see Scope Boundaries.)
+- **Cross-org contribution**: repos like `bfra-me/.github` and `bfra-me/renovate-action` already invoke `fro-bot/agent` via `.github/workflows/fro-bot.yaml`. Fro Bot operates in those repos as a service but has no presence in the wiki.
+
+The origin document treats these as one initiative. The plan does too. (See origin: `docs/brainstorms/2026-05-04-survey-cadence-and-multi-channel-discovery-requirements.md`.)
+
+## Requirements Trace
+
+- **R1, R2, R3** — Three discovery channels into one `metadata/repos.yaml`; every entry records its discovery channel; `fro-bot/.github` skipped unconditionally. Implemented across Units 1, 2, 3.
+- **R4, R5, R6** — Per-repo `next_survey_eligible_at` with per-channel base interval and deterministic jitter; reconcile dispatches when `now >= next_survey_eligible_at`; eligibility set during survey-result write-back. Implemented in Units 1, 2, 4.
+- **R7, R8** — `metadata/allowlist.yaml` gains `approved_contrib_orgs` + `approved_contrib_repos`; contrib probe failures don't error the run. Implemented in Unit 3. Honors **C3** (App token scoped via `owner: ${{ github.repository_owner }}`) and **C5** (cross-org enumeration runs at most once per allowlisted org per reconcile pass).
+- **R9, R10** — Existing entries migrated forward via additive defaults on first run; reconcile JSON output preserves keys and adds per-channel breakdowns. Implemented in Units 1, 5.
+- **R11, R12** — Per-channel counters in JSON output; first-survey-of-channel log line. Implemented in Unit 5.
+- **SC1** — Surveys fire on most days AND wiki content actually changes most weeks. Two-part verification: (a) daily reconcile JSON output shows non-zero dispatches on a clear majority of days over a 14-day window, (b) `git log --oneline --since='7 days ago' -- knowledge/wiki/` shows non-zero diffs on at least 4 of the last 7 days during steady state. Dispatch frequency alone is a proxy — the silent-failure mode the plan addresses is "reconcile reports success while no real work happens", and surveys-without-wiki-diffs is the same shape. Verifying both prevents shipping green on a metric while the actual problem (wiki silence) persists.
+- **SC2** — Wiki includes `fro-bot/agent`, `fro-bot/systematic`, `fro-bot/fro-bot.github.io`. Verified via `knowledge/wiki/repos/` listing two weeks after rollout.
+- **SC3** — Wiki includes operator-allowlisted cross-org repos. Verified the same way.
+- **SC4** — Per-channel attribution. Verified by inspecting any post-rollout `metadata/repos.yaml` and reconcile JSON output.
+
+## Scope Boundaries
+
+- **No self-survey of `fro-bot/.github`.** Discovery skips this repo via an explicit constant.
+- **No per-page-type stale thresholds.** Cadence is per-repo only.
+- **No auto-removal beyond the existing `lost-access` flow.** Operators remove contrib entries by deleting allowlist lines; reconcile flips status to `lost-access` on the next pass when a probe fails.
+- **No changes to the `data → main` promotion model.** The wiki authority guard (`scripts/check-wiki-authority.ts`) remains untouched.
+- **No real-time activity signals.** Cadence is purely time-based with deterministic jitter.
+- **No discovery outside the explicit allowlist.** Contributor probes only run against orgs/repos the operator has named.
+
+### Deferred to Separate Tasks
+
+- **Per-day quota model for true continuous wiki growth.** SC1's "non-zero wiki diffs on at least 4 of the last 7 days" target is achievable with this plan only if the channel-cycle math cooperates. At N=17 collab repos × 30d cycle, structurally there are still ~22 zero-dispatch days per cycle. The architectural answer is a per-day quota: dispatch the N oldest-eligible repos every day regardless of staleness threshold. This plan deliberately does NOT ship that change — it's a separate plan once the cadence work proves the threshold model's limits in production. Trigger for that plan: 30 days of operation under this plan show consecutive-zero-day stretches >7 days even with jitter applied.
+- **Compound learnings after rollout.** Three institutional gaps surfaced in research that are worth `ce:compound`-ing once the work ships and bites in production: (1) App installation token + `owner: github.repository_owner` cross-org scoping, (2) additive YAML mutator purity for schema migrations, (3) Anthropic seat capacity / dispatch staggering observability. These are documentation work, not implementation work.
+- **Tunable per-channel intervals via env vars.** This plan ships hardcoded constants (`OWNED_INTERVAL_DAYS = 14`, `CONTRIB_INTERVAL_DAYS = 21`, `COLLAB_INTERVAL_DAYS = 30`, `JITTER_MAX_DAYS = 3`). Promotion to env-var override is a small follow-up after observing real cadence.
+- **Recovery script for misclassified `next_survey_eligible_at` values.** `scripts/reset-survey-status.ts` already exists and clears `last_survey_at` + `last_survey_status` to null, which is sufficient to force re-dispatch. Adding a parallel `reset-eligibility.ts` is a follow-up if the new field develops its own corruption pattern.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/reconcile-repos.ts` — Pure decision engine + I/O shell. Pattern: `reconcileRepos(input) → ReconcileResult` with a thin async shell. New cadence logic lives in this file. Mutator closure (`commitMetadataImpl` callback) re-runs `reconcileRepos` on each 409 retry.
+- `scripts/repos-metadata.ts` — Pure mutators (`addRepoEntry`, `recordSurveyResult`, `resetSurveyResult`). New cadence helper for computing `next_survey_eligible_at` lives here. Existing `recordSurveyResult` already does pending → onboarded promotion on first success — extend that path to set the new field.
+- `scripts/schemas.ts` — String-literal union pattern (`OnboardingStatus`, `SurveyStatus`). Add `DiscoveryChannel = 'collab' | 'owned' | 'contrib'` and extend `RepoEntry`. Strip-only TS forbids enums.
+- `scripts/update-metadata.ts` — Existing `apps.listReposAccessibleToInstallation` pattern. The owned-channel and contrib-channel discovery paths mirror this exactly: same `paginate`, same per-repo content probe, same `as RestEndpointMethodTypes[...]` typing to keep SDK drift a compile error.
+- `scripts/handle-invitation.ts` — Current `collab` channel entry point. Calls `addRepoEntry` with default `'pending'` status. Migration must preserve this path: when invitations land, the new entry must carry `discovery_channel: 'collab'`.
+- `metadata/allowlist.yaml` — Currently `version: 1` + `approved_inviters[]`. Gains `approved_contrib_orgs[]` and `approved_contrib_repos[]`.
+- `.github/workflows/reconcile-repos.yaml` — Mints App token via `actions/create-github-app-token` but does NOT currently set `owner: ${{ github.repository_owner }}` (unlike `update-metadata.yaml`, which does). PR #3201 added that input to `update-metadata.yaml`/`dispatch-renovate.yaml` but did not extend it to `reconcile-repos.yaml`. **Unit 3 must add `owner: ${{ github.repository_owner }}` to the App-token step before cross-org probes will work** — without it, the minted token is scoped to the workflow repo only and cross-org `apps.listReposAccessibleToInstallation` calls return an empty (or wrong-scope) list. See Unit 3 prerequisite.
+
+### Institutional Learnings
+
+- `docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md` — The 30-day staleness gate's silent-failure mode (misclassified `success` skipped a repo for 30 days). The cadence change _moves_ the failure surface to `next_survey_eligible_at`, not eliminates it. Mitigation: failed surveys still set the new field, but starting from "now", so a misclassified success at most defers re-survey by `base_interval + jitter` (max 33 days for collab), the same as today's worst case. No new blast radius.
+- `docs/solutions/runtime-errors/octokit-invitation-method-names-2026-04-17.md` — Use `RestEndpointMethodTypes[...]` types from `@octokit/rest` to derive types instead of handwriting. Already the pattern in `update-metadata.ts`. New code follows it.
+- `docs/solutions/runtime-errors/node-strip-only-typescript-2026-04-18.md` — No enums, no parameter properties. `DiscoveryChannel` is a string-literal union. Channel intervals live as plain object literals with `as const`.
+- `docs/solutions/integration-issues/wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md` — Don't introduce a second mutation path for autonomous-write surfaces. Per-channel observability counters are report-only in the JSON output; they never feed back into a mutation.
+
+### Slack Context
+
+Not gathered. No Slack tools in this session. Ask if organizational context would help before implementation.
+
+## Key Technical Decisions
+
+- **Per-channel base intervals**: `owned = 14d`, `contrib = 21d`, `collab = 30d`. The hierarchy reflects what each channel narratively represents to Fro Bot:
+  - **Owned (14d, fastest)** — fro-bot org repos are Fro Bot's own substrate (the agent itself, systematic, the GH Pages site). Wiki entries here are the agent's _self-knowledge_. When the substrate changes, the agent's understanding of itself should refresh quickly. Tightest cadence because Fro Bot has the highest stake in keeping its self-model accurate.
+  - **Contrib (21d, middle)** — cross-org repos where Fro Bot operates as a service. Wiki narrative is "where Fro Bot is actively present in the world." External presence should refresh faster than passive context but slower than the agent's substrate, because the agent's authority over external repos is bounded.
+  - **Collab (30d, slowest)** — Marcus's other repos. Wiki narrative is biographical context — "what does the operator work on." Slowest cadence because biographical context moves slowly and existing staleness on this channel was already tolerated in v0.
+
+  The capacity math (5/14 + 5/21 + 17/30 ≈ 1.2 surveys/day average across 27 tracked repos) shows the hierarchy fits well inside the proven 12-cap + 90s-stagger envelope. The hierarchy comes first; capacity confirms it's affordable. Hardcoded as constants for v1; env-var override is a small follow-up if observation suggests tuning.
+
+- **Jitter window**: `±0..3 days` (i.e. `+0..3d` past the base interval — never negative; we don't want surveys earlier than the channel cadence claims). Bounded random ensures repos never land on the exact same eligibility date twice in a row, which is what causes the herd in the first place.
+
+- **Deterministic jitter seed**: `hash(owner + name + survey_date_string)` where `survey_date_string` is the YYYY-MM-DD UTC slice that just got recorded as `last_survey_at` for this survey. Concretely: `crypto.createHash('sha256').update(`${owner}/${name}@${survey_date_string}`).digest()` → first 4 bytes as big-endian uint32 → modulo 4 (0..3 days). **Critical**: the seed is the YYYY-MM-DD UTC date string, never a `Date` object and never a local time. This guarantees that 409-retry mutator re-runs across UTC midnight produce the same jitter value (the `last_survey_at` slice is timezone-stable; raw `Date.now()` is not). For Unit 4 migration, the seed is the existing `last_survey_at` (already a YYYY-MM-DD string). For Unit 2 `recordSurveyResult`, compute `last_survey_at` first (via `input.at.toISOString().slice(0, 10)`), THEN use that string as the seed — not `input.at` directly. Determinism wins over true randomness because (a) test fixtures pin against stable values, (b) migration backfill produces stable values without persisting a separate seed, (c) 409-retry idempotency is preserved. The 4-bucket jitter is naturally collision-prone (~25% per pair by construction) — that's arithmetic, not a bug. The `recordSurveyResult` reseed-on-each-survey means the value evolves naturally without a stored RNG state.
+
+- **Migration is additive-only and runs inside the existing reconcile flow**: First post-rollout reconcile sees entries missing `discovery_channel` (defaults to `'collab'` — the existing channel) and missing `next_survey_eligible_at` (computed from `last_survey_at + 30d + jitter` for entries with a real `last_survey_at`, null for entries that have never been surveyed). The mutation happens in `reconcileRepos`'s tracked-pass, returning fresh entries with the new fields. No standalone migration script. The 12-dispatch cap absorbs any "newly eligible all at once" rush naturally.
+
+- **Discovery channel is sticky in autonomous code paths.** Reconcile never auto-rewrites `discovery_channel` once it's set. If a repo somehow becomes eligible for two channels (e.g. a contrib repo whose owner is later allowlisted as a `collab` inviter, or a contrib repo that gets transferred to fro-bot's own org), the autonomous path leaves the channel alone and the cadence stays on the original channel's interval. **Operator escape hatch**: to re-classify, the operator edits `metadata/repos.yaml` directly on the `data` branch and lets reconcile pick it up on next pass. Documented in `metadata/README.md` so this isn't folklore. The race window between contrib enumeration and a fresh collab invitation is acceptable as-is — the cadence asymmetry it can produce (21d vs 30d on a misclassified repo) is small and operator-correctable.
+
+- **Owned channel discovery uses `apps.listReposAccessibleToInstallation` filtered to the configured owner. NO `fro-bot.yaml` probe.** Same call already used by `update-metadata.ts`. Skips `fro-bot/.github` via an explicit constant. Skips archived repos (no point surveying frozen state). Forks are also skipped — the wiki narrative is about original repos. Trust signal for owned is "the App is installed in fro-bot's own org" — we don't need a workflow file to confirm what we already control. This is intentional asymmetry with contrib (which DOES require `fro-bot.yaml` content verification): owned trusts org membership, contrib requires explicit invocation. `fro-bot/fro-bot.github.io` (a GH Pages site without `fro-bot.yaml`) gets surveyed as a result; that's the intended behavior.
+
+- **Contrib channel discovery is two-mode**:
+  - `approved_contrib_orgs: [bfra-me]` — list installation repos under each org, then probe each for `.github/workflows/fro-bot.yaml`. Repos that lack the signal file are omitted with a structured log line.
+  - `approved_contrib_repos: [bfra-me/.github, foo/bar]` — probe each named repo directly. Same probe, no enumeration. Useful for repos in orgs that aren't fully opted-in.
+
+- **Probe is restricted to `.github/workflows/fro-bot.yaml`.** Keeps the trust signal tight: a repo using fro-bot via a different workflow filename doesn't count. Operators can always add the repo to `approved_contrib_repos` if they want it surveyed regardless.
+
+- **Probe verifies file content, not just presence.** Mere existence of `fro-bot/workflows/fro-bot.yaml` is forge-able by anyone with push access in an `approved_contrib_orgs` org. Unit 3's probe MUST `repos.getContent` the file and confirm at least one of: `uses: fro-bot/agent@`, `uses: fro-bot/.github/.github/workflows/`, or a `secrets:` block referencing `FRO_BOT_PAT`/`OPENCODE_AUTH_JSON`. An empty or no-fro-bot-reference file is treated as "no signal" (same as missing). The check is a substring scan over the decoded content; not parsing YAML, just verifying the workflow actually wires up to fro-bot. This shifts the trust signal from "someone created a file" to "someone wired up the agent" — non-trivially harder to forge by accident or for bait.
+
+- **Channel interval lookup is a `satisfies`-typed object literal.** Plain `Record<DiscoveryChannel, number>` constant — no enum, no class. Strip-only-safe, easy to extend, easy to test.
+
+- **Logger gets a new `info` level for the first-survey-of-channel telemetry**. Existing `ReconcileLogger` only has `warn`. R12 wants an explicit "first survey for new channel entry" log line; that's an info-level signal, not a warning.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q1: Base intervals + jitter window.** Resolved: `owned = 14d`, `contrib = 21d`, `collab = 30d`, jitter `+0..3d`. Steady-state arithmetic shows ~1.2 surveys/day average at current scale.
+- **Q2: `discovery_channel` field type.** Resolved: string-literal union (matches `OnboardingStatus`, `SurveyStatus`; strip-only TS forbids enums).
+- **Q3: Contrib probe path.** Resolved: require `.github/workflows/fro-bot.yaml` specifically.
+- **Q4: Jitter seed source.** Resolved: deterministic SHA-256 of `${owner}/${name}@${last_survey_at}`.
+- **Q5: Migration ordering.** Resolved: self-stagger via the existing 12-cap; additive mutation inside `reconcileRepos`'s tracked-pass; no standalone migration script.
+
+### Deferred to Implementation
+
+- **Exact log message wording for first-survey-of-channel.** Not architecturally significant. The implementer picks something clear.
+- **Whether owned-channel discovery should also update `has_fro_bot_workflow` / `has_renovate` field probes for newly-discovered repos.** Today's code does this for tracked entries; it's not obviously different for newcomers. Defer to implementation; the answer will be obvious once the code is in front of someone.
+- **Whether contrib repo enumeration counts archived/fork repos as "lost-access" or just omits them.** Probably omit (no entry was ever created), but the exact branch in `classifyTracked` is easier to settle while writing the test.
+- **Whether to surface `dispatchesDeferred` per channel** or keep it as a global counter. The brainstorm asks for per-channel breakdowns; this specific deferred-vs-actual split adds noise. Decide while wiring the JSON output.
+
+## High-Level Technical Design
+
+> _This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce._
+
+The data-flow change is small and surgical:
+
+```text
+                          ┌───────────────────────────────┐
+                          │  metadata/repos.yaml (data)   │
+                          │                               │
+                          │  RepoEntry (extended):        │
+                          │   + discovery_channel         │
+                          │   + next_survey_eligible_at   │
+                          └───────────────┬───────────────┘
+                                          │
+                                          │ assertReposFile + migrateOnRead
+                                          ▼
+  Shell-side discovery (Unit 3 I/O):
+
+    ┌─ collab fetch ──┐  ┌─ owned fetch ──────┐  ┌─ contrib fetch ──────┐
+    │ user PAT        │  │ App token          │  │ App token            │
+    │ /user/repos     │  │ apps.listReposAcc.ToInst.│ apps.listReposAcc.ToInst.│
+    │ (existing)      │  │ filter fro-bot,    │  │ filter approved orgs │
+    │                 │  │ skip .github+arch+fork │  │ + repos              │
+    │                 │  │                    │  │ + verify fro-bot.yaml│
+    │                 │  │                    │  │   content            │
+    └────────┬────────┘  └─────────┬──────────┘  └──────────┬───────────┘
+             │                     │                        │
+             ▼                     ▼                        ▼
+        merge with dedup precedence: collab > owned > contrib
+        produces: accessList + accessChannelByKey: Map<key, channel>
+                            │
+                            ▼
+            ┌──────────── reconcileRepos (pure engine) ────────────┐
+            │                                                      │
+            │  Tracked-pass:                                       │
+            │   ┌─ classifyTracked ─────────────────────────────┐  │
+            │   │  migrateRepoEntry first (Unit 4)              │  │
+            │   │  then isEligible(entry, now)                  │  │
+            │   │  uses entry.next_survey_eligible_at           │  │
+            │   └────────────────────────────────────────────────┘  │
+            │                                                      │
+            │  Newcomer-pass (single pass over accessList):        │
+            │   look up channel from accessChannelByKey            │
+            │   addRepoEntry({..., discovery_channel: channel})    │
+            │   collab newcomers: allowlist gate (existing)        │
+            │   owned/contrib newcomers: skip allowlist gate       │
+            │                                                      │
+            │  Per-channel summary counters                        │
+            └──────────────────────────────────────────────────────┘
+                                          │
+                                          ▼
+            ┌─ recordSurveyResult (mutator) ─────────────────────────┐
+            │  on success: last_survey_at = now                      │
+            │              last_survey_status = 'success'            │
+            │              next_survey_eligible_at = ──────────────┐ │
+            │                computeNextEligible(                  │ │
+            │                  channel, now, owner, repo)          │ │
+            │  on failure: same formula but seed from "now" not    │ │
+            │              previous last_survey_at                  │ │
+            └──────────────────────────────────────────────────────┘
+```
+
+The pure engine boundary stays clean. New I/O (owned + contrib enumeration) lives in the shell; new pure logic (channel classification, eligibility check, migration mapping) lives in the engine and `repos-metadata.ts`.
+
+## Implementation Units
+
+- [x] **Unit 1: Schema migration — `discovery_channel` + `next_survey_eligible_at`**
+
+**Goal:** Extend `RepoEntry` with the two new fields (optional during the rollout window) and the `DiscoveryChannel` union. Add runtime guards that accept legacy entries missing the new fields. Migrate `metadata/repos.yaml` on `main` with deterministic jitter so eligibility-day distribution stays inside the 12-dispatch cap. No reconcile behavior change yet — migration consumers and writers come in Unit 4. This unit lands cleanly and unblocks everything else without breaking the `data` branch.
+
+**Requirements:** R1, R2, R4, R9.
+
+**Dependencies:** None.
+
+**Files:**
+
+- Modify: `scripts/schemas.ts` — add `DiscoveryChannel`, extend `RepoEntry` with the two new fields as **optional** (`discovery_channel?: DiscoveryChannel`, `next_survey_eligible_at?: string | null`), update `isRepoEntry`/`assertRepoEntry` to accept missing values. Unit 4 tightens to required after data-branch migration.
+- Modify: `scripts/repos-metadata.ts` — extend `addRepoEntry`'s literal to write `discovery_channel` (defaulting from a new optional `discovery_channel?: DiscoveryChannel` field on `AddRepoEntryInput`, falling back to `'collab'`) and `next_survey_eligible_at: null`. New entries always carry both fields.
+- Modify: `scripts/handle-invitation.ts` — pass `discovery_channel: 'collab'` to the existing `addRepoEntry` call so the collab path explicitly tags its newcomers.
+- Modify: `metadata/repos.yaml` — one-time content migration. Each entry with a non-null `last_survey_at` gets `next_survey_eligible_at = last_survey_at + 30d + jitter(owner, name, last_survey_at)` where `jitter` is `sha256(${owner}/${name}@${last_survey_at}).readUInt32BE(0) % 4` (0–3 days). All entries get `discovery_channel: collab`. Avoids cap-12 starvation that a flat +30d migration would create.
+- Modify: `scripts/schemas.test.ts` — extend tests for new fields + channel guard. Includes a "legacy entry missing both fields is accepted" test that pins the loose-then-tight contract.
+- Modify: `scripts/repos-metadata.test.ts` — extend `addRepoEntry` tests for the new field default and the optional channel input.
+- Modify: `scripts/handle-invitation.test.ts` — round-trip via `assertReposFile` to verify the mutator output carries `discovery_channel: 'collab'`.
+- Modify: `metadata/README.md` — schema documentation update; documents the loose-then-tight rollout.
+
+**Approach:**
+
+- Add `export type DiscoveryChannel = 'collab' | 'owned' | 'contrib'`.
+- Extend `RepoEntry` with `discovery_channel?: DiscoveryChannel` and `next_survey_eligible_at?: string | null` — both **optional during rollout**. JSDoc on each field calls out the loose-then-tight pattern: legacy entries without channel default to `'collab'`; missing eligible-at is treated as immediately eligible.
+- Add `isDiscoveryChannel(value: unknown): value is DiscoveryChannel` helper following the existing `isOnboardingStatus` pattern.
+- Update `isRepoEntry` and `assertRepoEntry` to accept `undefined` for both new fields. `null` for `discovery_channel` still rejects (only `undefined` or one of the three literals).
+- Migrate `metadata/repos.yaml` on `main` with jitter so the 18 entries spread across multiple eligibility days (max same-day eligibility ≤ cap of 12).
+- `addRepoEntry` always emits both fields with defaults so new entries are never legacy-shaped. Migration applies only to entries that pre-date Unit 1.
+- Schema doc in `metadata/README.md` adds the two new fields, explains channel semantics + when each fires, documents the loose-then-tight rollout.
+
+**Why optional, not required:** Tight required schema would break the `data` branch on first autonomous write. `data` retains 17 legacy entries with no new fields; `handle-invitation` / `reconcile` / survey scripts call `assertReposFile` inside their commit mutators, so a tight schema fails the mutator and crashes the run. Optional fields let Unit 1 land cleanly while Unit 4 lands the data-branch migration via `migrateRepoEntry`. Unit 4 then tightens to required as part of its same-PR scope.
+
+**Why jitter on the migration:** A flat `+30d` migration produces 13 entries with `next_survey_eligible_at: 2026-05-27` against a per-run cap of 12. The `oldestFirst` tiebreak is alphabetical, deterministically excluding the 13th repo every cycle — permanent starvation. Deterministic 0–3 day jitter spreads the eligibility set across 7 days, max same-day is 6, well under the cap.
+
+**Patterns to follow:**
+
+- `OnboardingStatus` + `isOnboardingStatus` + `assertRepoEntry` shape in `scripts/schemas.ts`.
+
+**Test scenarios:**
+
+- Happy path: a `RepoEntry` fixture with `discovery_channel: 'owned'` + `next_survey_eligible_at: '2026-05-15'` passes both guards.
+- Happy path: every literal value in `DiscoveryChannel` is accepted by `isDiscoveryChannel`.
+- Happy path: legacy entry with neither `discovery_channel` nor `next_survey_eligible_at` passes both guards (loose-then-tight contract).
+- Edge case: `next_survey_eligible_at: null` is accepted (never-surveyed entries).
+- Error path: `discovery_channel: 'unknown'` fails `assertRepoEntry` with path `repos.repos[N].discovery_channel`.
+- Error path: `next_survey_eligible_at` as a number fails `assertRepoEntry`.
+- Error path: `discovery_channel` as `null` fails `assertRepoEntry` (only `undefined` or one of the three literals).
+- Mutator output: `addRepoEntry` always produces an entry with both fields populated; `handle-invitation.test.ts` round-trips via `assertReposFile` to pin the contract.
+
+**Verification:**
+
+- `pnpm check-types` clean.
+- `pnpm test` clean (new tests + all existing schema tests still pass).
+- `pnpm lint` clean.
+- `metadata/README.md` reflects the new fields + describes the loose-then-tight rollout.
+- `metadata/repos.yaml` jittered eligibility distribution: max same-day ≤ 6 (verified at migration time), well under the 12-dispatch cap.
+
+**Note on `ReconcileSummary.migrated`:** The original plan added a `migrated: number` counter to `ReconcileSummary` in this unit. It was removed during ce:review (5-reviewer agreement: the field is dead state without Unit 4's `migrateRepoEntry` producer, and the unguarded counter would cause silent no-op classification when the producer arrives). The counter ships with Unit 4, atomically with its writer.
+
+---
+
+- [ ] **Unit 2: Cadence engine — eligibility check + jitter helper**
+
+**Goal:** Replace `isSurveyStale` with `isEligibleForSurvey` that consults `next_survey_eligible_at`. Add `computeNextEligibleAt` helper to `repos-metadata.ts`. Wire `recordSurveyResult` to set the new field on every survey outcome. This unit makes the cadence model real for entries that already have the new field; Unit 4's migration handles the legacy path.
+
+**Requirements:** R4, R5, R6.
+
+**Dependencies:** Unit 1 (schema).
+
+**Files:**
+
+- Modify: `scripts/reconcile-repos.ts` — replace `isSurveyStale` callers with `isEligibleForSurvey`. Keep the old export name aliased for backwards compatibility within this unit so tests don't break before Unit 4. Add `CHANNEL_INTERVAL_DAYS` constant.
+- Modify: `scripts/repos-metadata.ts` — add `computeNextEligibleAt(input)` and wire `recordSurveyResult` to set `next_survey_eligible_at` on both success and failure paths.
+- Modify: `scripts/repos-metadata.test.ts` — extend `recordSurveyResult` tests; add `computeNextEligibleAt` tests.
+- Modify: `scripts/reconcile-repos.test.ts` — extend tests for eligibility behavior using the new field.
+
+**Approach:**
+
+- New constant: `CHANNEL_INTERVAL_DAYS = {collab: 30, owned: 14, contrib: 21} as const satisfies Record<DiscoveryChannel, number>`. Plus `JITTER_MAX_DAYS = 3`.
+- New helper in `repos-metadata.ts`: `computeNextEligibleAt({owner, repo, channel, baseDate})` returns ISO date string `baseDate + interval[channel] + jitter(owner, repo, baseDate)` days.
+- Jitter implementation: derive `survey_date_string = baseDate.toISOString().slice(0, 10)` first, then `crypto.createHash('sha256').update(`${owner}/${name}@${survey_date_string}`).digest()` → read first 4 bytes as big-endian uint32 → `% (JITTER_MAX_DAYS + 1)` → days. The intermediate `survey_date_string` variable is required — do NOT pass `baseDate` (a Date object) into the hash. Two `recordSurveyResult` calls with `baseDate` values 1ms apart but on opposite sides of UTC midnight must produce the same jitter value when the resulting `last_survey_at` is the same; only different YYYY-MM-DD slices may produce different values.
+- `recordSurveyResult` wires `next_survey_eligible_at = computeNextEligibleAt({owner, repo, channel: entry.discovery_channel, baseDate: input.at})` on both success and failure.
+- Reconcile's eligibility check becomes `isEligibleForSurvey(entry, now)` returning `true` when `next_survey_eligible_at` is null OR `now >= parse(next_survey_eligible_at)`. Malformed dates treated as eligible (don't lose coverage on corruption).
+- Keep `SURVEY_STALENESS_MS` exported until Unit 4 migrates the legacy path; no callers should remain after that unit.
+
+**Patterns to follow:**
+
+- `isSurveyStale` in `scripts/reconcile-repos.ts` for the boundary-test pinning style.
+- `recordSurveyResult` in `scripts/repos-metadata.ts` for the pending → onboarded promotion pattern (extend it; don't replace).
+
+**Test scenarios:**
+
+- Happy path: `computeNextEligibleAt` for `collab` channel + `2026-05-01` base + repo `marcusrbrown/foo` → ISO date 30..33 days later.
+- Happy path: `computeNextEligibleAt` is deterministic — same `(owner, repo, baseDate)` yields the same output across calls.
+- Edge case (midnight stability): `computeNextEligibleAt` for `(owner, repo, baseDate=2026-05-04T23:59:59.999Z)` and `(owner, repo, baseDate=2026-05-05T00:00:00.001Z)` produce DIFFERENT outputs (different YYYY-MM-DD slice → different seed); but `computeNextEligibleAt` for `(owner, repo, baseDate=2026-05-05T00:00:00.001Z)` called twice 50ms apart produces the SAME output (same slice → same seed). Pins the seed-from-string contract.
+- Happy path: different `(owner, repo)` pairs at the same `baseDate` produce different jitter values (sample size: 5 distinct repo pairs, expect at least 2 distinct jitter outputs).
+- Edge case: `computeNextEligibleAt` for `owned` channel uses 14d base + jitter range.
+- Edge case: `isEligibleForSurvey` returns `true` when `next_survey_eligible_at` is null.
+- Edge case: `isEligibleForSurvey` returns `true` when `now` equals `next_survey_eligible_at` (inclusive boundary).
+- Edge case: `isEligibleForSurvey` returns `false` when `now` is one day before `next_survey_eligible_at`.
+- Edge case: `isEligibleForSurvey` returns `true` for a malformed `next_survey_eligible_at` string.
+- Happy path: `recordSurveyResult` on a `'success'` outcome sets `next_survey_eligible_at` to a date `interval[channel] + jitter` days after `input.at`.
+- Happy path: `recordSurveyResult` on a `'failure'` outcome sets `next_survey_eligible_at` using the same formula but with the failure date as the seed.
+- Happy path: `recordSurveyResult` preserves the existing `pending → onboarded` promotion on first success.
+- Error path: `recordSurveyResult` still throws `RepoEntryNotFoundError` when the entry is missing.
+
+**Verification:**
+
+- `pnpm check-types` clean.
+- `pnpm test` clean.
+- Existing reconcile tests still pass (the boundary test pinning may shift to use the new field once a fixture is updated).
+
+---
+
+- [ ] **Unit 3: Allowlist surface for contrib + I/O shell discovery passes**
+
+**Goal:** Extend `metadata/allowlist.yaml` schema with `approved_contrib_orgs` + `approved_contrib_repos`. Add owned-channel and contrib-channel discovery passes to the reconcile I/O shell. Both passes feed into the existing `accessList` and flow through `reconcileRepos` unchanged.
+
+**Requirements:** R1, R3, R7, R8, C3, C5.
+
+**Dependencies:** Unit 1.
+
+**Files:**
+
+- Modify: `scripts/schemas.ts` — extend `AllowlistFile` with the two new arrays. Update guards.
+- Modify: `scripts/schemas.test.ts` — schema tests for the new fields.
+- Modify: `metadata/allowlist.yaml` — seed with `approved_contrib_orgs: []` + `approved_contrib_repos: []` (empty arrays for v1; operators populate as they want).
+- Modify: `.github/workflows/reconcile-repos.yaml` — **prerequisite**: add `owner: ${{ github.repository_owner }}` to the `actions/create-github-app-token` step. Without this, cross-org probes return empty/wrong-scope results. Mirrors the PR #3201 fix already applied to `update-metadata.yaml` and `dispatch-renovate.yaml`.
+- Modify: `scripts/reconcile-repos.ts` — add `fetchOwnedRepos(appOctokit, owner)` and `fetchContribRepos(appOctokit, allowlist)` functions in the shell; merge their outputs into `accessList` before calling `reconcileRepos`; tag each entry with its channel via a new `accessChannelByKey: Map<string, DiscoveryChannel>` input. **Dedup precedence in the merge:** when the same `owner/name` appears in both the user-PAT collab list and an owned/contrib probe result, the collab entry wins (`collab > owned > contrib`, first-write-wins) so `validateAccessList` doesn't throw on overlap.
+- Modify: `scripts/reconcile-repos.test.ts` — extend tests for owned + contrib classification using the new channel map.
+- Modify: `metadata/README.md` — document the new allowlist sections.
+
+**Approach:**
+
+- `AllowlistFile` gets two new optional-ish (i.e. `string[]`, default `[]` in YAML) fields. Guards accept missing fields as empty arrays for backward compatibility on existing allowlist files.
+- New shell helpers mirror `update-metadata.ts`: paginate via `apps.listReposAccessibleToInstallation`, filter to target owner(s), probe `.github/workflows/fro-bot.yaml` via `repos.getContent`. **Error classification matters here**: 404 means "no signal file" (omit silently); 403 means "App not installed in that org / no access" (omit + structured warn log distinguishing it from no-signal); 5xx means "transient" (omit + warn). Treating 403 as 404 silently masks misinstallation, which is the silent-failure mode `docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md` warns about. Skip `fro-bot/.github` constant for the owned pass.
+- Each discovered repo becomes an `AccessListEntry`. The shell builds a parallel `accessChannelByKey: Map<string, DiscoveryChannel>` recording which channel each entry came from. The map gets passed into `reconcileRepos` as a new input field.
+- `reconcileRepos` uses the channel map only for newcomer entries (Pass 2): when adding a new entry via `addRepoEntry`, it includes `discovery_channel` from the map (defaulting to `'collab'` when missing — preserves existing behavior). Tracked entries already carry their channel from previous runs.
+- For owned + contrib newcomers, skip the `pending-review` allowlist check that exists for `collab`. Owned repos are always trusted (we own them); contrib repos are explicitly named in the allowlist so they're already approved.
+- Cap on cross-org enumeration: at most one `paginate` call per org per reconcile run (C5). The contrib-orgs path enumerates once per allowlisted org; contrib-repos path is direct probes.
+
+**Patterns to follow:**
+
+- `discoverRenovateRepos` in `scripts/update-metadata.ts` for the App-token paginate + filter pattern.
+- `probeFroBotWorkflow` in `scripts/reconcile-repos.ts` for the existing fro-bot.yaml content probe.
+
+**Test scenarios:**
+
+- Happy path: allowlist with `approved_contrib_orgs: ['bfra-me']` + 2 repos under bfra-me with fro-bot.yaml + 1 without → 2 entries added with `discovery_channel: 'contrib'`, the third silently omitted.
+- Happy path: allowlist with `approved_contrib_repos: ['some-org/foo']` + foo has fro-bot.yaml → 1 entry added with `discovery_channel: 'contrib'`.
+- Happy path: owned-channel discovery returns 4 fro-bot org repos (`agent`, `systematic`, `fro-bot.github.io`, `.github`) → 3 entries added with `discovery_channel: 'owned'` (`fro-bot/.github` skipped by the explicit constant; `fro-bot.yaml` probe is NOT performed for owned).
+- Edge case: `fro-bot/.github` is in the App's accessible-repos list → skipped, no entry added.
+- Edge case: owned org has 1 archived repo → skipped silently.
+- Edge case: owned org has 1 forked repo → skipped silently.
+- Edge case: existing `metadata/allowlist.yaml` without `approved_contrib_orgs` field still parses (backward-compat default to empty).
+- Error path: contrib probe returns 500 → entry omitted, structured warn log with status code fires, reconcile run continues.
+- Error path: contrib probe returns 403 → entry omitted, structured warn log distinguishing "App not installed in org" from "no signal file", reconcile run continues. (404 = no signal; 403 = access denied; do NOT collapse them.)
+- Error path: contrib org enumeration fails (e.g. installation revoked) → run continues, the org's repos are absent, structured warn log fires.
+- Edge case (forge resistance): allowlist with `approved_contrib_orgs: ['some-org']` + a some-org repo containing an empty `.github/workflows/fro-bot.yaml` → entry is NOT added (content verification rejects empty/no-fro-bot-reference files).
+- Edge case (forge resistance): same setup with a `fro-bot.yaml` that contains only an unrelated workflow (e.g. just `name: foo` + a generic step) → entry is NOT added.
+- Edge case (dedup precedence): a repo discovered via both contrib probe AND collab access list → produces exactly one accessList entry tagged `collab` (collab > owned > contrib precedence). `validateAccessList` does not throw.
+- Integration: a tracked entry with `discovery_channel: 'contrib'` whose `fro-bot.yaml` was deleted → next reconcile flips it to `lost-access` via the existing pass-1 path (no new code needed, just verify the existing flow works for the new channel).
+
+**Verification:**
+
+- `pnpm check-types` clean.
+- `pnpm test` clean.
+- A dry-run-style integration test asserts the new field appears in `metadata/repos.yaml` for owned + contrib newcomers.
+
+---
+
+- [ ] **Unit 4: Migration + cleanup of `SURVEY_STALENESS_MS`**
+
+**Goal:** Make the migration of legacy entries automatic on first post-rollout reconcile run. Remove the `SURVEY_STALENESS_MS` constant and `isSurveyStale` legacy export now that all callers are migrated. This is the unit that "flips the switch" for cadence — after this lands, `next_survey_eligible_at` is the only source of truth.
+
+**Requirements:** R9, R10.
+
+**Dependencies:** Units 1, 2.
+
+**Files:**
+
+- Modify: `scripts/reconcile-repos.ts` — add `migrateRepoEntry(entry, now)` helper called inside the tracked-pass `classifyTracked` for entries missing the new fields. Remove `SURVEY_STALENESS_MS`, `isSurveyStale`. Update all eligibility checks to use the Unit 2 helpers.
+- Modify: `scripts/reconcile-repos.test.ts` — add migration tests; remove tests for `isSurveyStale`.
+
+**Approach:**
+
+- `migrateRepoEntry`: when `entry.discovery_channel` is missing, default to `'collab'`. When `entry.next_survey_eligible_at` is missing, compute it from `last_survey_at` if non-null (treating the missing field's interval as `collab`'s 30 days, seeded by the existing `last_survey_at` string for jitter determinism), else `null`. Returns a fresh entry with both fields populated. Idempotent on already-migrated entries (returns by reference, no allocation).
+- `classifyTracked` calls `migrateRepoEntry` first thing. When the migration produces a fresh entry, increment `summary.migrated` (NOT `summary.refreshed`) so operators can distinguish one-time migration commits from steady-state field-probe drift. `refreshed` continues to mean "field probe vs entry mismatch" only.
+- After this unit, the only callers of `isEligibleForSurvey` are inside `classifyTracked`. The legacy `isSurveyStale` test cases delete; the new ones cover the migrated boundary.
+- The first post-rollout reconcile run produces a single commit migrating every tracked entry. Extend `formatCommitMessage` to include `+{migrated} migrated` only when the count is non-zero, preserving the existing format for steady-state runs.
+
+**Patterns to follow:**
+
+- The `isNoOp` zero-change optimization pattern for keeping `currentRepos` reference identity when no migration is needed.
+- The mutator-closure 409 retry safety in `commitMetadataImpl` — `migrateRepoEntry` must be pure (and is, since it's just default-filling).
+
+**Test scenarios:**
+
+- Happy path: a legacy entry without `discovery_channel` and without `next_survey_eligible_at` but with `last_survey_at: '2026-04-27'` and `onboarding_status: 'onboarded'` → migrated to `discovery_channel: 'collab'` + `next_survey_eligible_at: '2026-05-27' + jitter (0..3 days)`.
+- Happy path: a legacy entry with `last_survey_at: null` → migrated to `discovery_channel: 'collab'` + `next_survey_eligible_at: null`.
+- Happy path: an already-migrated entry passes through unchanged (referential equality preserved).
+- Edge case: a legacy entry with `last_survey_at: 'not-a-date'` → migrated to `next_survey_eligible_at: null` (treat malformed as never-surveyed).
+- Integration: full reconcile run on a fixture where all 18 entries are legacy → produces a single commit with `summary.migrated === 18` and a commit message containing `+18 migrated` (NOT in the `refreshed` slot); subsequent run on the migrated state is a no-op for migration (`summary.migrated === 0`) and the commit message omits the `+0 migrated` suffix.
+- Edge case: post-migration, an entry that was last surveyed >30d ago becomes immediately eligible — verify the dispatch loop picks it up but the 12-cap absorbs the rest.
+
+**Execution note:** Confirm Unit 2's existing tests for `recordSurveyResult` still pass, then delete the `SURVEY_STALENESS_MS` boundary tests in `reconcile-repos.test.ts` after replacing them with the equivalent `next_survey_eligible_at` boundary tests.
+
+**Verification:**
+
+- `pnpm check-types` clean.
+- `pnpm test` clean.
+- `grep` for `SURVEY_STALENESS_MS` and `isSurveyStale` in `scripts/` returns zero matches outside of the deleted-tests history.
+- A manual run of `node scripts/reconcile-repos.ts` against a checkout with the live legacy `metadata/repos.yaml` produces the expected migration commit.
+
+---
+
+- [ ] **Unit 5: Per-channel observability**
+
+**Goal:** Extend the reconcile JSON output with per-channel counters and add an info-level log line on first survey for new-channel entries. Operator can now answer "how much did each channel contribute today?" by reading the JSON output alone.
+
+**Requirements:** R11, R12.
+
+**Dependencies:** Units 1, 3.
+
+**Files:**
+
+- Modify: `scripts/reconcile-repos.ts` — extend `ReconcileSummary` with per-channel breakdowns; extend `HandleReconcileResult` accordingly; add `info` to `ReconcileLogger`; add the "first survey for new channel entry" log line at dispatch time.
+- Modify: `scripts/reconcile-repos.test.ts` — assertions on the new counters and log line.
+- Modify: `scripts/repos-metadata.test.ts` and any other test files that mock `ReconcileLogger` — add `info: vi.fn()` to mock objects so the new field is satisfied.
+
+**Approach:**
+
+- New shape: `summary.byChannel: Record<DiscoveryChannel, {tracked, dispatched, deferred, lostAccess}>` exactly per R11. Keeps existing top-level counters (`added`, `pendingReview`, `refreshed`, `migrated`, etc.) unchanged for backward compat — those stay global because their semantics don't break down cleanly per channel and R11 doesn't request it.
+- `ReconcileLogger` gets `info: (message: string) => void`. Default impl writes to stdout (existing `process.stderr.write` style for warn).
+- The dispatch loop iterates `selectedDispatches`; before calling `dispatchWithTimeout`, it checks the entry's `discovery_channel` and `last_survey_at`. If `last_survey_at === null` (never surveyed) AND channel is `'owned'` or `'contrib'`, log an info line: `reconcile: first survey for new <channel> entry: <owner>/<repo>`.
+- JSON output extended with `byChannel`. The `formatCommitMessage` is unchanged (still the high-level summary).
+
+**Patterns to follow:**
+
+- Existing `ReconcileSummary` shape and `summary.<field> += 1` accumulation.
+- Existing `logger.warn(...)` call sites for the structured log style.
+
+**Test scenarios:**
+
+- Happy path: a reconcile run with 2 collab dispatches + 1 owned dispatch + 1 contrib dispatch → `byChannel.collab.dispatched === 2`, `byChannel.owned.dispatched === 1`, `byChannel.contrib.dispatched === 1`.
+- Happy path: tracked counts are populated even on no-op runs (e.g. `byChannel.collab.tracked === 18` for the current snapshot).
+- Happy path: a first-time owned-channel survey logs `reconcile: first survey for new owned entry: fro-bot/agent` exactly once.
+- Happy path: a first-time contrib-channel survey logs the analogous line for `'contrib'`.
+- Edge case: a re-survey of an already-surveyed owned entry does NOT log the first-survey line.
+- Edge case: a collab-channel first-survey does NOT log the first-survey line (only owned + contrib are flagged because the milestone matters less for the historical channel).
+- Integration: the JSON written to stdout in `main()` includes `byChannel` for all three channels even when one channel has zero entries.
+
+**Verification:**
+
+- `pnpm check-types` clean.
+- `pnpm test` clean.
+- A manual `node scripts/reconcile-repos.ts | jq .summary.byChannel` shows the three-channel breakdown.
+
+## System-Wide Impact
+
+- **Interaction graph:** Reconcile and `recordSurveyResult` (in `survey-repo.yaml`) are the two writers of `next_survey_eligible_at`. Both go through `commitMetadata` against `data`. The wiki authority guard (`scripts/check-wiki-authority.ts`) keeps blocking unauthorized writers — no change. Downstream readers (just reconcile itself, today) all use the new helpers.
+- **Error propagation:** Owned + contrib probe failures are non-blocking (R8): logged via `logger.warn`, the run continues, the affected repo is omitted from the access list. This matches the existing field-probe failure handling. Allowlist parse failures still throw `ReconcileError` since they indicate a malformed config.
+- **State lifecycle risks:** The migration commit is a single additive write. It runs inside the existing mutator-closure flow, so 409 retries re-migrate cleanly. A misbehaving migration (e.g. losing `last_survey_at` for some entries) would surface as an immediate re-dispatch storm because they'd look never-surveyed; the 12-cap absorbs it but Unit 4's tests should pin this boundary explicitly.
+- **API surface parity:** No change. Reconcile JSON output is a strict superset (R10).
+- **Integration coverage:** The owned + contrib paths cross the App-token boundary that PR #3201 established. Tests should mock `apps.listReposAccessibleToInstallation` against representative responses (3 repos, mixed archived/fork, mixed signal-file presence) — not just synthetic happy-path fixtures.
+- **Unchanged invariants:** `enforce_admins: true` on `main` still blocks autonomous commits — all metadata writes still land on `data` and promote via merge-data. `EXPECTED_AUTHORS = {fro-bot, fro-bot[bot]}` still gates the integrity check. The 12-dispatch cap and 90-second stagger still apply uniformly across channels (no per-channel cap split). The conditional auto-merge semantics (`knowledge/` + `metadata/`-only PRs auto-merge; code paths require approval) still apply since the schema migration touches metadata only.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| Migration commit lands during a reconcile race and gets the wrong shape on legacy entries. | Mutator closure re-runs `reconcileRepos` on each 409 retry (existing pattern); `migrateRepoEntry` is pure and idempotent. Test scenario "already-migrated entry passes through unchanged" pins this. |
+| First post-rollout reconcile dispatches a herd because every legacy entry's migrated `next_survey_eligible_at` lands in the past or null. | The 12-dispatch cap absorbs the immediate rush. After drain, surveyed entries cluster within a (~2-day drain + 0..3d jitter) ≈ 5-day band per channel. Steady-state daily dispatch is bounded by channel-cycle pigeonholing (e.g. 17 collab repos / 30..33d → up to 5 surveys on collision days, well inside the cap). The 4-bucket jitter window (0..3d) doesn't fully decorrelate at this population size — the cap is doing real work, not jitter alone. **Open decision**: widen `JITTER_MAX_DAYS` to 7 (8 buckets) for better steady-state spread, or accept that the cap is the primary de-herding mechanism. Defer to implementation; pick once we observe the actual post-migration distribution. |
+| Owned-channel discovery picks up a fro-bot repo that shouldn't be surveyed (e.g. a private experimentation repo). | The `fro-bot/.github` skip is the only hardcoded exclusion. Other repos in fro-bot are presumed legitimate; if a future repo needs to be excluded, it's a one-line constant addition. Documented as a deferred consideration. |
+| Contrib probe runs on every reconcile run and adds latency proportional to org size. | C5 caps at one `paginate` call per allowlisted org per run. At today's scale (1 org, ~10 repos) the cost is negligible; the cap exists as a future guardrail. |
+| `apps.listReposAccessibleToInstallation` returns an empty list when the App installation token is mis-scoped (PR #3201's trap). | The existing `reconcile-repos.yaml` mints the token with `owner: ${{ github.repository_owner }}` already. C3 documents this as a constraint. Unit 3's test mocks an empty response and verifies the run continues without crashing — it just produces no owned/contrib newcomers. |
+| Jitter seed collision: two repos accidentally producing the same eligibility date. | Acceptable. The jitter window is 4 distinct values (0..3 days) so collisions are expected by design. The point of jitter is to reduce simultaneity, not eliminate it. The 12-cap and stagger handle the residual concurrency. |
+| Removing `isSurveyStale` breaks downstream code we forgot about. | `grep` audit in Unit 4's verification step. Repo is small enough that this is high-confidence. |
+
+## Documentation / Operational Notes
+
+- **`metadata/README.md`** documents both the schema additions (Unit 1) and the new allowlist sections (Unit 3). Single PR, single doc update. Spell out the trust path explicitly: "modifications to `approved_contrib_orgs` and `approved_contrib_repos` follow the same trust path as `approved_inviters` — PR from operator owner, main CI required. The conditional auto-merge rule for metadata-only PRs has an exception for `metadata/allowlist.yaml`: allowlist changes are operator-owned policy, not bot-owned state, and require human approval before promoting to `main`."
+
+- **Auto-merge exception for `metadata/allowlist.yaml`.** The conditional auto-merge rule (per `.github/copilot-instructions.md`) auto-merges PRs touching only `knowledge/` or `metadata/` paths. That rule was written assuming `metadata/` = bot-owned state (e.g. `repos.yaml`). The allowlist is operator-owned policy: adding an org grants survey reach. Auto-merging an allowlist edit without operator review is a privilege-escalation path. The plan's rollout includes either (a) updating `merge-data-pr.ts` and any auto-merge labelers to exclude allowlist changes from auto-merge, or (b) splitting allowlist into a different protected path entirely. Decide which during Unit 3.
+
+- **Cross-org App installation prerequisite.** Adding an org to `approved_contrib_orgs` requires the Fro Bot App to be installed on that org first; adding a repo to `approved_contrib_repos` requires installation in that owner's account. Without installation, probes return 404/403 and the entry is silently omitted (per Unit 3 error classification). Document this as the operator's preflight when adding entries.
+
+- **Contrib drop alarm.** When a contrib repo previously present transitions to omitted (workflow file removed, App uninstalled, signal verification failed), reconcile should surface this as more than a warn-level log line — the entry is leaving the wiki's lifecycle and the operator should know. Track as a Unit 5 stretch goal: a `contribDrops` counter in JSON output that operators can monitor against zero. If non-zero, file a single integrity-style issue per run with the dropped set so it isn't lost in noise.
+- **`docs/solutions/`** — three candidate compound docs identified in research (App-token cross-org scoping, additive YAML migration, Anthropic seat capacity). Not in scope for this plan; if implementation surfaces a sharp learning, fold it in via a follow-up `ce:compound` PR.
+- **No workflow changes needed.** `reconcile-repos.yaml` already mints the App token correctly (PR #3201) and runs daily. The new code paths run inside the existing job.
+- **Rollout watch**: after Unit 4 lands, the first daily reconcile run produces a one-time migration commit. Operator should verify the resulting `metadata/repos.yaml` on `data` shows `discovery_channel: 'collab'` + `next_survey_eligible_at` populated for all 18 onboarded entries before letting the next merge-data cron promote it.
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-05-04-survey-cadence-and-multi-channel-discovery-requirements.md`
+- Related plans: `docs/plans/2026-04-17-001-feat-repo-reconciliation-plan.md` (existing reconcile architecture), `docs/plans/2025-04-15-001-feat-frobot-control-plane-plan.md` (Phase 4 closeout — this plan extends Unit 16's territory).
+- Related learnings: `docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md`, `docs/solutions/runtime-errors/octokit-invitation-method-names-2026-04-17.md`, `docs/solutions/runtime-errors/node-strip-only-typescript-2026-04-18.md`, `docs/solutions/integration-issues/wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md`.
+- Related code: `scripts/reconcile-repos.ts`, `scripts/repos-metadata.ts`, `scripts/schemas.ts`, `scripts/update-metadata.ts`, `scripts/handle-invitation.ts`, `metadata/allowlist.yaml`, `.github/workflows/reconcile-repos.yaml`, `.github/workflows/survey-repo.yaml`.
+- Related PRs: PR #3201 (`owner: ${{ github.repository_owner }}` App-token scoping), PR #3196/#3198 (`update-metadata` pattern for App-token cross-account discovery).

--- a/docs/plans/2026-05-05-001-feat-survey-cadence-and-multi-channel-discovery-plan.md
+++ b/docs/plans/2026-05-05-001-feat-survey-cadence-and-multi-channel-discovery-plan.md
@@ -194,9 +194,9 @@ The pure engine boundary stays clean. New I/O (owned + contrib enumeration) live
 
 - [x] **Unit 1: Schema migration — `discovery_channel` + `next_survey_eligible_at`**
 
-**Goal:** Extend `RepoEntry` with the two new fields (optional during the rollout window) and the `DiscoveryChannel` union. Add runtime guards that accept legacy entries missing the new fields. Migrate `metadata/repos.yaml` on `main` with deterministic jitter so eligibility-day distribution stays inside the 12-dispatch cap. No reconcile behavior change yet — migration consumers and writers come in Unit 4. This unit lands cleanly and unblocks everything else without breaking the `data` branch.
+**Goal:** Extend `RepoEntry` with the two new fields (optional during the rollout window) and the `DiscoveryChannel` union. Add runtime guards that accept legacy entries missing the new fields. No reconcile behavior change yet — migration consumers, writers, and the data-branch backfill come in Unit 4. This unit lands cleanly and unblocks everything else without breaking the `data` branch.
 
-**Requirements:** R1, R2, R4, R9.
+**Requirements:** R1, R2 (partial — schema only; data backfill in Unit 4).
 
 **Dependencies:** None.
 
@@ -205,7 +205,6 @@ The pure engine boundary stays clean. New I/O (owned + contrib enumeration) live
 - Modify: `scripts/schemas.ts` — add `DiscoveryChannel`, extend `RepoEntry` with the two new fields as **optional** (`discovery_channel?: DiscoveryChannel`, `next_survey_eligible_at?: string | null`), update `isRepoEntry`/`assertRepoEntry` to accept missing values. Unit 4 tightens to required after data-branch migration.
 - Modify: `scripts/repos-metadata.ts` — extend `addRepoEntry`'s literal to write `discovery_channel` (defaulting from a new optional `discovery_channel?: DiscoveryChannel` field on `AddRepoEntryInput`, falling back to `'collab'`) and `next_survey_eligible_at: null`. New entries always carry both fields.
 - Modify: `scripts/handle-invitation.ts` — pass `discovery_channel: 'collab'` to the existing `addRepoEntry` call so the collab path explicitly tags its newcomers.
-- Modify: `metadata/repos.yaml` — one-time content migration. Each entry with a non-null `last_survey_at` gets `next_survey_eligible_at = last_survey_at + 30d + jitter(owner, name, last_survey_at)` where `jitter` is `sha256(${owner}/${name}@${last_survey_at}).readUInt32BE(0) % 4` (0–3 days). All entries get `discovery_channel: collab`. Avoids cap-12 starvation that a flat +30d migration would create.
 - Modify: `scripts/schemas.test.ts` — extend tests for new fields + channel guard. Includes a "legacy entry missing both fields is accepted" test that pins the loose-then-tight contract.
 - Modify: `scripts/repos-metadata.test.ts` — extend `addRepoEntry` tests for the new field default and the optional channel input.
 - Modify: `scripts/handle-invitation.test.ts` — round-trip via `assertReposFile` to verify the mutator output carries `discovery_channel: 'collab'`.
@@ -217,13 +216,12 @@ The pure engine boundary stays clean. New I/O (owned + contrib enumeration) live
 - Extend `RepoEntry` with `discovery_channel?: DiscoveryChannel` and `next_survey_eligible_at?: string | null` — both **optional during rollout**. JSDoc on each field calls out the loose-then-tight pattern: legacy entries without channel default to `'collab'`; missing eligible-at is treated as immediately eligible.
 - Add `isDiscoveryChannel(value: unknown): value is DiscoveryChannel` helper following the existing `isOnboardingStatus` pattern.
 - Update `isRepoEntry` and `assertRepoEntry` to accept `undefined` for both new fields. `null` for `discovery_channel` still rejects (only `undefined` or one of the three literals).
-- Migrate `metadata/repos.yaml` on `main` with jitter so the 18 entries spread across multiple eligibility days (max same-day eligibility ≤ cap of 12).
-- `addRepoEntry` always emits both fields with defaults so new entries are never legacy-shaped. Migration applies only to entries that pre-date Unit 1.
+- `addRepoEntry` always emits both fields with defaults so new entries are never legacy-shaped. Backfill of pre-existing entries is Unit 4's responsibility — it runs `migrateRepoEntry` via the autonomous `data`-branch path under `fro-bot[bot]` identity, satisfying the wiki authority guard.
 - Schema doc in `metadata/README.md` adds the two new fields, explains channel semantics + when each fires, documents the loose-then-tight rollout.
 
-**Why optional, not required:** Tight required schema would break the `data` branch on first autonomous write. `data` retains 17 legacy entries with no new fields; `handle-invitation` / `reconcile` / survey scripts call `assertReposFile` inside their commit mutators, so a tight schema fails the mutator and crashes the run. Optional fields let Unit 1 land cleanly while Unit 4 lands the data-branch migration via `migrateRepoEntry`. Unit 4 then tightens to required as part of its same-PR scope.
+**Why no `metadata/repos.yaml` change in this PR:** `metadata/*.yaml` is auto-managed and protected by the `Check Wiki Authority` CI guard — only PRs opened by `fro-bot` / `fro-bot[bot]` can land changes to those files. The legitimate path is `data`-branch writes by an autonomous workflow, then promotion via the weekly merge-data PR. Unit 4's `migrateRepoEntry` is the autonomous workflow that does this; it computes the same `last_survey_at + 30d + jitter` formula on the `data` branch and lets the merge-data cron promote the result to `main`. Doing the migration manually in Unit 1's PR would either fail the guard or require disabling it — both wrong.
 
-**Why jitter on the migration:** A flat `+30d` migration produces 13 entries with `next_survey_eligible_at: 2026-05-27` against a per-run cap of 12. The `oldestFirst` tiebreak is alphabetical, deterministically excluding the 13th repo every cycle — permanent starvation. Deterministic 0–3 day jitter spreads the eligibility set across 7 days, max same-day is 6, well under the cap.
+**Why optional, not required:** Tight required schema would break the `data` branch on first autonomous write. `data` retains 17 legacy entries with no new fields; `handle-invitation` / `reconcile` / survey scripts call `assertReposFile` inside their commit mutators, so a tight schema fails the mutator and crashes the run. Optional fields let Unit 1 land cleanly while Unit 4 lands the data-branch migration via `migrateRepoEntry`. Unit 4 then tightens to required as part of its same-PR scope.
 
 **Patterns to follow:**
 
@@ -246,9 +244,10 @@ The pure engine boundary stays clean. New I/O (owned + contrib enumeration) live
 - `pnpm test` clean (new tests + all existing schema tests still pass).
 - `pnpm lint` clean.
 - `metadata/README.md` reflects the new fields + describes the loose-then-tight rollout.
-- `metadata/repos.yaml` jittered eligibility distribution: max same-day ≤ 6 (verified at migration time), well under the 12-dispatch cap.
 
 **Note on `ReconcileSummary.migrated`:** The original plan added a `migrated: number` counter to `ReconcileSummary` in this unit. It was removed during ce:review (5-reviewer agreement: the field is dead state without Unit 4's `migrateRepoEntry` producer, and the unguarded counter would cause silent no-op classification when the producer arrives). The counter ships with Unit 4, atomically with its writer.
+
+**Note on jitter:** Earlier drafts of this unit migrated `metadata/repos.yaml` directly with a deterministic 0–3 day jitter to avoid cap-12 starvation on 2026-05-27. The migration was removed from this unit (see "Why no `metadata/repos.yaml` change in this PR" above); the same jitter formula moves to Unit 4's `migrateRepoEntry`, which produces the same end state via the autonomous `data`-branch path.
 
 ---
 

--- a/docs/solutions/best-practices/loose-then-tight-schema-migration-pattern-2026-05-05.md
+++ b/docs/solutions/best-practices/loose-then-tight-schema-migration-pattern-2026-05-05.md
@@ -1,0 +1,193 @@
+---
+title: Loose-then-tight schema migration pattern
+category: best-practices
+problem_type: best_practice
+module: scripts/schemas.ts
+component: development_workflow
+severity: medium
+tags:
+  - schema-migration
+  - rollout
+  - autonomous-workflows
+  - validation
+  - data-branch
+  - backwards-compatibility
+applies_when:
+  - producer and consumer of a schema ship in different prs
+  - schema validation runs at runtime on live data
+  - autonomous or scheduled writers read production state during rollout
+  - data migration must lag schema landing safely
+created: 2026-05-05
+last_updated: 2026-05-05
+verified: true
+---
+
+## Context
+
+This came up during ce:review of fro-bot/.github Unit 1 of the survey cadence + multi-channel discovery feature.
+
+Unit 1 was supposed to be "pure types + guards + docs; no behavior change," with the actual data migration deferred to Unit 4. The trap: tightening the schema in Unit 1 would have passed CI, but it would have broken every live autonomous workflow as soon as they read legacy data from the unprotected `data` branch. Those workflows call `assertReposFile` inside commit-mutator closures, so they validate live data on every run.
+
+Three reviewers converged on the same risk:
+
+- the api-contract reviewer flagged it as a P0,
+- the adversarial reviewer corroborated it as a P1,
+- and the failure chain was concrete: failed reconcile → failed merge-data → regressed main → cascade.
+
+## Guidance
+
+Make new schema fields optional during the rollout window when the producer ships in a separate PR from the consumer; tighten them back to required once both producer and data are caught up.
+
+When to go loose:
+
+- schema validation happens at runtime, not just build/deploy time
+- the producer lands in a different PR than the schema
+- live data exists in branches/databases that won't be migrated atomically
+- autonomous or scheduled workflows would crash on first run after the schema lands
+
+Loose-phase shape:
+
+```ts
+export interface RepoEntry {
+  // ... existing required fields
+  /**
+   * Optional during the rollout window: legacy entries without a channel are treated
+   * as `'collab'` by default. The cadence migration path will tighten this to required
+   * after `data` is migrated.
+   */
+  discovery_channel?: DiscoveryChannel
+  next_survey_eligible_at?: string | null
+}
+```
+
+Runtime guards must accept both new and legacy shapes — see the full Before/After examples below.
+
+Producers must always emit defaults. New entries created during the loose phase should never be legacy-shaped. `addRepoEntry` and similar writers should write the default values (`'collab'`, `null`) so only pre-existing rows remain legacy.
+
+A note on the tri-state for `next_survey_eligible_at`: during the loose phase the field can be `string` (set), `null` (explicitly cleared by the producer for not-yet-surveyed entries), or `undefined` (legacy rows that predate the field). `null` and `undefined` are treated the same by consumers, but the producer always writes explicit `null` so new rows never look legacy-shaped. After tightening, only `string | null` remains; the `undefined` branch goes away.
+
+Tight phase:
+
+- ship the migration function atomically with the schema-tightening edit
+- run the producer once to back-fill any remaining legacy entries on the writer-owned branch
+- remove the `?` and the `=== undefined` branches from both the type and the guard
+
+Do not leave fields optional forever. The looseness is a temporary rollout tactic, not the final contract.
+
+## Why This Matters
+
+In autonomous-workflow systems, schema validation runs continuously on production data. A schema/data mismatch is not a CI issue — it is a live production outage.
+
+Without this pattern:
+
+- the tight schema lands on `main`
+- CI passes
+- the first scheduled cron run reads live legacy data
+- `assertX` throws inside the mutator
+- the run fails before it can commit
+- the next cron tick fails the same way
+- dependent workflows stall too
+
+Recovery is bad either way:
+
+- roll back, which is slow and blocks unrelated work
+- or hotfix the schema to make fields optional after the fact, which is just the loose phase under duress
+
+The cost of doing it right is two `?` characters and a JSDoc note. The cost of getting it wrong is a production outage in the control plane.
+
+## When to Apply
+
+Use this pattern when all of these are true:
+
+1. You are adding required fields to a schema validated at runtime
+2. The schema and producer ship in separate PRs
+3. Live data exists on a branch/store that will not be migrated in the schema PR window
+4. Autonomous workflows read that live data and validate it against the schema
+
+If the producer and schema land in the same PR and the data is migrated atomically, tight from day one is fine.
+
+## Examples
+
+**Before: tight from day one — broken**
+
+```ts
+// scripts/schemas.ts
+export interface RepoEntry {
+  owner: string
+  // ... existing fields
+  discovery_channel: DiscoveryChannel
+  next_survey_eligible_at: string | null
+}
+
+function isRepoEntry(value: unknown): value is RepoEntry {
+  return (
+    isRecord(value) &&
+    // ... existing checks
+    isDiscoveryChannel(value.discovery_channel) &&
+    (value.next_survey_eligible_at === null || typeof value.next_survey_eligible_at === 'string')
+  )
+}
+```
+
+**After: loose during rollout — survives mixed-shape data**
+
+```ts
+// scripts/schemas.ts
+export interface RepoEntry {
+  owner: string
+  // ... existing fields
+  /**
+   * Optional during the rollout window: legacy entries without a channel are treated as
+   * `'collab'` by default. The cadence migration path will tighten this to required.
+   */
+  discovery_channel?: DiscoveryChannel
+  next_survey_eligible_at?: string | null
+}
+
+function isRepoEntry(value: unknown): value is RepoEntry {
+  return (
+    isRecord(value) &&
+    // ... existing checks
+    (value.discovery_channel === undefined || isDiscoveryChannel(value.discovery_channel)) &&
+    (value.next_survey_eligible_at === undefined ||
+      value.next_survey_eligible_at === null ||
+      typeof value.next_survey_eligible_at === 'string')
+  )
+}
+```
+
+**Producer always emits the new fields**
+
+```ts
+// scripts/repos-metadata.ts
+export function addRepoEntry(input: AddRepoEntryInput): ReposFile {
+  return {
+    ...input.reposFile,
+    repos: [
+      ...input.reposFile.repos,
+      {
+        // ... existing required fields
+        discovery_channel: input.discovery_channel ?? 'collab',
+        next_survey_eligible_at: null,
+      },
+    ],
+  }
+}
+```
+
+**Tight phase: drop the `?` and `=== undefined` branches**
+
+```ts
+// After migrator has run, in the same PR that ships migrateRepoEntry:
+export interface RepoEntry {
+  // ... existing fields
+  discovery_channel: DiscoveryChannel
+  next_survey_eligible_at: string | null
+}
+```
+
+## Related Documentation
+
+- `docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md` — moderate overlap. Same family: contract enforcement on autonomous-workflow data. The silent-failure doc covers what happens when validation rejects live data; this doc covers how to avoid that rejection during a rollout window.
+- `docs/solutions/integration-issues/wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md` — moderate overlap. Both touch the `data` vs `main` branch authority concept. Wiki-lint reads from `data` as the authoritative snapshot; this pattern keeps `data`-resident legacy entries readable while `main` evolves.
+- `docs/solutions/integration-issues/merge-data-pr-github-422-race-recovery-2026-05-02.md` — low overlap. Both involve staged rollout with delayed consistency, but different failure modes.

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -20,7 +20,7 @@ Update convention: human-maintained; edits land via the `data` branch (see [Edit
 
 ### `repos.yaml`
 
-Collaborator repositories where Fro Bot is active.
+Repositories where Fro Bot is active. Surfaced through three discovery channels: collaborator invitations on user accounts, fro-bot's own org, and operator-allowlisted cross-org repos.
 
 ```yaml
 version: 1
@@ -33,6 +33,8 @@ repos:
     last_survey_status: success | failure | null
     has_fro_bot_workflow: boolean
     has_renovate: boolean
+    discovery_channel: collab | owned | contrib
+    next_survey_eligible_at: ISO date | null
 ```
 
 Update convention: invitation handler, metadata workflow, and daily reconcile update this file programmatically on the `data` branch.
@@ -46,6 +48,16 @@ Onboarding status values:
 - `pending-review` — repo was discovered via collaborator access from an owner not listed in `allowlist.yaml`. A GitHub issue labeled `reconcile:pending-review` tracks each one; the entry stays in this state until an operator promotes it (approve and change status to `pending`) or removes it.
 
 For private repos in `pending-review`, the issue body omits the owner/repo name and identifies the subject via its GitHub `node_id`. Public-repo `pending-review` issues include the full `owner/repo`. The control-plane repo is public, so issue bodies never leak private repo names.
+
+Discovery channel values:
+
+- `collab` — repo surfaced via a collaborator invitation accepted by `poll-invitations.yaml`. Default channel for newcomers when none is specified.
+- `owned` — repo surfaced via fro-bot's own org enumeration (`apps.listReposAccessibleToInstallation`). Skips `fro-bot/.github` unconditionally.
+- `contrib` — repo surfaced via the operator-curated allowlist in `allowlist.yaml` (`approved_contrib_orgs` / `approved_contrib_repos`), with a successful probe for `.github/workflows/fro-bot.yaml` proving fro-bot is invoked there.
+
+The channel is sticky after first write — neither reconcile nor any other writer auto-rewrites it. Operators re-classify by editing `metadata/repos.yaml` on the `data` branch directly.
+
+`next_survey_eligible_at` is the ISO date at which an entry becomes eligible for re-survey, computed at survey-completion time as `last_survey_at + base_interval[channel] + jitter(owner, name, last_survey_at)`. `null` means never-surveyed (treat as immediately eligible).
 
 ### `renovate.yaml`
 

--- a/scripts/handle-invitation.test.ts
+++ b/scripts/handle-invitation.test.ts
@@ -1,6 +1,11 @@
+import type {CommitMetadataParams, CommitMetadataResult} from './commit-metadata.ts'
 import type {OctokitClient} from './handle-invitation.ts'
+
 import {describe, expect, it, vi} from 'vitest'
 import {handleInvitations, InvitationHandlingError} from './handle-invitation.ts'
+import {assertReposFile} from './schemas.ts'
+
+type CommitMetadataMock = (params: CommitMetadataParams) => Promise<CommitMetadataResult>
 
 function mockOctokit(overrides?: {
   listInvitationsForAuthenticatedUser?: () => Promise<{
@@ -76,7 +81,11 @@ describe('handleInvitations', () => {
     const acceptInvitation = vi.fn(async () => undefined)
     const starRepoForAuthenticatedUser = vi.fn(async () => undefined)
     const createWorkflowDispatch = vi.fn(async () => undefined)
-    const commitMetadata = vi.fn(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
+    const commitMetadata = vi.fn<CommitMetadataMock>(async () => ({
+      committed: true,
+      sha: 'commit-sha',
+      attempts: 1,
+    }))
     const octokit = mockOctokit({
       listInvitationsForAuthenticatedUser: async () => ({
         data: [
@@ -137,6 +146,18 @@ describe('handleInvitations', () => {
       inputs: {owner: 'fro-bot', repo: 'hello-world'},
     })
     expect(commitMetadata).toHaveBeenCalledOnce()
+
+    // #and the mutator persists discovery_channel: 'collab' so the entry surfaces
+    // through the collab channel in reconcile reports
+    const commitCall = commitMetadata.mock.calls[0]?.[0]
+    const mutator = commitCall?.mutator
+    expect(typeof mutator).toBe('function')
+    if (typeof mutator === 'function') {
+      const newReposFile = mutator({version: 1, repos: []})
+      assertReposFile(newReposFile)
+      expect(newReposFile.repos[0]?.discovery_channel).toBe('collab')
+      expect(newReposFile.repos[0]?.next_survey_eligible_at).toBeNull()
+    }
   })
 
   it('skips invitations from unapproved inviters', async () => {

--- a/scripts/handle-invitation.ts
+++ b/scripts/handle-invitation.ts
@@ -207,7 +207,8 @@ async function processInvitation(params: {
       octokit: params.octokit,
       path: params.reposPath,
       message: `chore(metadata): add ${repoOwner}/${repoName} from invitation polling`,
-      mutator: current => addRepoEntry(current, {owner: repoOwner, repo: repoName, now: params.now}),
+      mutator: current =>
+        addRepoEntry(current, {owner: repoOwner, repo: repoName, now: params.now, discovery_channel: 'collab'}),
     })
     await params.octokit.rest.actions.createWorkflowDispatch({
       owner: params.owner,

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -51,6 +51,8 @@ function makeEntry(overrides: Partial<RepoEntry> = {}): RepoEntry {
     last_survey_status: null,
     has_fro_bot_workflow: false,
     has_renovate: false,
+    discovery_channel: 'collab',
+    next_survey_eligible_at: null,
     ...overrides,
   }
 }
@@ -1172,6 +1174,8 @@ describe('handleReconcile (I/O shell)', () => {
                   last_survey_status: 'success',
                   has_fro_bot_workflow: false,
                   has_renovate: false,
+                  discovery_channel: 'collab',
+                  next_survey_eligible_at: null,
                 },
               ],
             },
@@ -1222,6 +1226,8 @@ describe('handleReconcile (I/O shell)', () => {
                   last_survey_status: 'success',
                   has_fro_bot_workflow: false,
                   has_renovate: false,
+                  discovery_channel: 'collab',
+                  next_survey_eligible_at: null,
                 },
                 {
                   owner: 't',
@@ -1232,6 +1238,8 @@ describe('handleReconcile (I/O shell)', () => {
                   last_survey_status: 'success',
                   has_fro_bot_workflow: false,
                   has_renovate: false,
+                  discovery_channel: 'collab',
+                  next_survey_eligible_at: null,
                 },
                 {
                   owner: 't',
@@ -1242,6 +1250,8 @@ describe('handleReconcile (I/O shell)', () => {
                   last_survey_status: 'success',
                   has_fro_bot_workflow: false,
                   has_renovate: false,
+                  discovery_channel: 'collab',
+                  next_survey_eligible_at: null,
                 },
               ],
             },

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -123,6 +123,10 @@ export interface ReconcileSummary {
   pendingReview: number
   regained: number
   lostAccess: number
+  /**
+   * Number of entries whose probed fields (`has_fro_bot_workflow`, `has_renovate`) drifted
+   * from the live signal and were rewritten this run. Steady-state field-probe drift only.
+   */
   refreshed: number
   unchanged: number
 }

--- a/scripts/repos-metadata.test.ts
+++ b/scripts/repos-metadata.test.ts
@@ -26,7 +26,43 @@ describe('addRepoEntry', () => {
       last_survey_status: null,
       has_fro_bot_workflow: false,
       has_renovate: false,
+      discovery_channel: 'collab',
+      next_survey_eligible_at: null,
     })
+  })
+
+  // Cadence-and-discovery: defaults discovery_channel to 'collab' when not specified
+  it("defaults discovery_channel to 'collab' when not specified", () => {
+    const result = addRepoEntry(EMPTY_REPOS, {owner: 'alice', repo: 'project', now: NOW})
+    expect(result.repos[0]?.discovery_channel).toBe('collab')
+  })
+
+  // Cadence-and-discovery: defaults next_survey_eligible_at to null (never-surveyed = immediately eligible)
+  it('defaults next_survey_eligible_at to null', () => {
+    const result = addRepoEntry(EMPTY_REPOS, {owner: 'alice', repo: 'project', now: NOW})
+    expect(result.repos[0]?.next_survey_eligible_at).toBeNull()
+  })
+
+  // Cadence-and-discovery: accepts and persists owned channel for fro-bot org repos
+  it("accepts 'owned' discovery_channel for fro-bot org repos", () => {
+    const result = addRepoEntry(EMPTY_REPOS, {
+      owner: 'fro-bot',
+      repo: 'agent',
+      now: NOW,
+      discovery_channel: 'owned',
+    })
+    expect(result.repos[0]?.discovery_channel).toBe('owned')
+  })
+
+  // Cadence-and-discovery: accepts and persists contrib channel for cross-org repos
+  it("accepts 'contrib' discovery_channel for cross-org repos", () => {
+    const result = addRepoEntry(EMPTY_REPOS, {
+      owner: 'bfra-me',
+      repo: '.github',
+      now: NOW,
+      discovery_channel: 'contrib',
+    })
+    expect(result.repos[0]?.discovery_channel).toBe('contrib')
   })
 
   // Extended behavior: accepts pending-review status
@@ -67,6 +103,8 @@ describe('addRepoEntry', () => {
           last_survey_status: 'success',
           has_fro_bot_workflow: true,
           has_renovate: true,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
         },
       ],
     }
@@ -88,6 +126,8 @@ describe('addRepoEntry', () => {
           last_survey_status: null,
           has_fro_bot_workflow: false,
           has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
         },
       ],
     }
@@ -140,6 +180,8 @@ describe('addRepoEntry', () => {
           last_survey_status: null,
           has_fro_bot_workflow: false,
           has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
         },
         {
           owner: 'bob',
@@ -150,6 +192,8 @@ describe('addRepoEntry', () => {
           last_survey_status: null,
           has_fro_bot_workflow: false,
           has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
         },
       ],
     }
@@ -176,6 +220,8 @@ describe('recordSurveyResult', () => {
           last_survey_status: null,
           has_fro_bot_workflow: false,
           has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
         },
       ],
     }
@@ -205,6 +251,8 @@ describe('recordSurveyResult', () => {
           last_survey_status: null,
           has_fro_bot_workflow: false,
           has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
         },
       ],
     }
@@ -234,6 +282,8 @@ describe('recordSurveyResult', () => {
           last_survey_status: 'success',
           has_fro_bot_workflow: true,
           has_renovate: true,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
         },
         {
           owner: 'bob',
@@ -244,6 +294,8 @@ describe('recordSurveyResult', () => {
           last_survey_status: null,
           has_fro_bot_workflow: false,
           has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
         },
       ],
     }
@@ -279,6 +331,8 @@ describe('recordSurveyResult', () => {
           last_survey_status: null,
           has_fro_bot_workflow: false,
           has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
         },
       ],
     }
@@ -321,6 +375,8 @@ describe('recordSurveyResult', () => {
           last_survey_status: null,
           has_fro_bot_workflow: false,
           has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
         },
       ],
     }
@@ -350,6 +406,8 @@ describe('recordSurveyResult', () => {
           last_survey_status: null,
           has_fro_bot_workflow: false,
           has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
         },
       ],
     }
@@ -379,6 +437,8 @@ describe('recordSurveyResult', () => {
           last_survey_status: 'success',
           has_fro_bot_workflow: false,
           has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
         },
       ],
     }
@@ -410,6 +470,8 @@ describe('resetSurveyResult', () => {
           last_survey_status: 'success',
           has_fro_bot_workflow: false,
           has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
         },
       ],
     }
@@ -427,6 +489,8 @@ describe('resetSurveyResult', () => {
       last_survey_status: null,
       has_fro_bot_workflow: false,
       has_renovate: false,
+      discovery_channel: 'collab',
+      next_survey_eligible_at: null,
     })
   })
 
@@ -444,6 +508,8 @@ describe('resetSurveyResult', () => {
           last_survey_status: 'failure',
           has_fro_bot_workflow: true,
           has_renovate: true,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
         },
       ],
     }
@@ -472,6 +538,8 @@ describe('resetSurveyResult', () => {
           last_survey_status: 'success',
           has_fro_bot_workflow: false,
           has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
         },
         {
           owner: 'bob',
@@ -482,6 +550,8 @@ describe('resetSurveyResult', () => {
           last_survey_status: 'success',
           has_fro_bot_workflow: false,
           has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
         },
       ],
     }

--- a/scripts/repos-metadata.ts
+++ b/scripts/repos-metadata.ts
@@ -8,7 +8,13 @@
  * duplicate `owner+name` and preserves existing entries as-is.
  */
 
-import {assertReposFile, type OnboardingStatus, type ReposFile, type SurveyStatus} from './schemas.ts'
+import {
+  assertReposFile,
+  type DiscoveryChannel,
+  type OnboardingStatus,
+  type ReposFile,
+  type SurveyStatus,
+} from './schemas.ts'
 
 export interface AddRepoEntryInput {
   owner: string
@@ -20,6 +26,16 @@ export interface AddRepoEntryInput {
    * not in `metadata/allowlist.yaml`.
    */
   onboarding_status?: OnboardingStatus
+  /**
+   * Which discovery channel surfaced this newcomer. Defaults to `'collab'` to match the
+   * original invitation-acceptance path. Reconcile passes `'owned'` for fro-bot org repos
+   * discovered via the App's installation enumeration, and `'contrib'` for repos surfaced
+   * through `metadata/allowlist.yaml`'s `approved_contrib_*` lists.
+   *
+   * Sticky after first write — neither reconcile nor any other writer auto-rewrites this
+   * field. Operators re-classify by editing `metadata/repos.yaml` on the `data` branch.
+   */
+  discovery_channel?: DiscoveryChannel
 }
 
 /**
@@ -51,6 +67,8 @@ export function addRepoEntry(current: unknown, input: AddRepoEntryInput): ReposF
         last_survey_status: null,
         has_fro_bot_workflow: false,
         has_renovate: false,
+        discovery_channel: input.discovery_channel ?? 'collab',
+        next_survey_eligible_at: null,
       },
     ],
   }

--- a/scripts/schemas.test.ts
+++ b/scripts/schemas.test.ts
@@ -8,6 +8,7 @@ import {
   assertReposFile,
   assertSocialCooldownsFile,
   isAllowlistFile,
+  isDiscoveryChannel,
   isRenovateFile,
   isReposFile,
   isSocialCooldownsFile,
@@ -94,6 +95,8 @@ describe('schemas — rejection cases', () => {
           last_survey_status: null,
           has_fro_bot_workflow: false,
           has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
         },
       ],
     }
@@ -115,6 +118,8 @@ describe('schemas — rejection cases', () => {
           last_survey_status: null,
           has_fro_bot_workflow: false,
           has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
         },
       ],
     }
@@ -135,6 +140,8 @@ describe('schemas — rejection cases', () => {
           last_survey_status: null,
           has_fro_bot_workflow: false,
           has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
         },
       ],
     }
@@ -155,12 +162,165 @@ describe('schemas — rejection cases', () => {
           last_survey_status: null,
           has_fro_bot_workflow: false,
           has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
         },
       ],
     }
     expect(isReposFile(bad)).toBe(false)
     const error = catchSchemaError(() => assertReposFile(bad))
     expect(error.path).toContain('onboarding_status')
+  })
+
+  it('accepts owned discovery_channel + populated next_survey_eligible_at', () => {
+    const ok = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'agent',
+          added: '2026-05-05',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'owned',
+          next_survey_eligible_at: '2026-05-19',
+        },
+      ],
+    }
+    expect(isReposFile(ok)).toBe(true)
+    expect(() => assertReposFile(ok)).not.toThrow()
+  })
+
+  it('accepts contrib discovery_channel', () => {
+    const ok = {
+      version: 1,
+      repos: [
+        {
+          owner: 'bfra-me',
+          name: '.github',
+          added: '2026-05-05',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: true,
+          has_renovate: true,
+          discovery_channel: 'contrib',
+          next_survey_eligible_at: null,
+        },
+      ],
+    }
+    expect(isReposFile(ok)).toBe(true)
+    expect(() => assertReposFile(ok)).not.toThrow()
+  })
+
+  it('rejects unknown discovery_channel value', () => {
+    const bad = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'partner',
+          next_survey_eligible_at: null,
+        },
+      ],
+    }
+    expect(isReposFile(bad)).toBe(false)
+    const error = catchSchemaError(() => assertReposFile(bad))
+    expect(error.path).toContain('discovery_channel')
+  })
+
+  it('rejects null discovery_channel', () => {
+    const bad = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: null,
+          next_survey_eligible_at: null,
+        },
+      ],
+    }
+    expect(isReposFile(bad)).toBe(false)
+    const error = catchSchemaError(() => assertReposFile(bad))
+    expect(error.path).toContain('discovery_channel')
+  })
+
+  it('accepts legacy entries missing discovery_channel and next_survey_eligible_at', () => {
+    // #given a legacy entry from before the cadence migration landed
+    const ok = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+        },
+      ],
+    }
+    // #when the schema validates it
+    // #then it accepts the entry; downstream code defaults missing channel to 'collab'
+    // and missing eligible-at to immediately-eligible until the cadence migration runs
+    expect(isReposFile(ok)).toBe(true)
+    expect(() => assertReposFile(ok)).not.toThrow()
+  })
+
+  it('rejects next_survey_eligible_at as a number', () => {
+    const bad = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: 42,
+        },
+      ],
+    }
+    expect(isReposFile(bad)).toBe(false)
+    const error = catchSchemaError(() => assertReposFile(bad))
+    expect(error.path).toContain('next_survey_eligible_at')
+  })
+
+  it('isDiscoveryChannel accepts the three valid values', () => {
+    expect(isDiscoveryChannel('collab')).toBe(true)
+    expect(isDiscoveryChannel('owned')).toBe(true)
+    expect(isDiscoveryChannel('contrib')).toBe(true)
+  })
+
+  it('isDiscoveryChannel rejects invalid values', () => {
+    expect(isDiscoveryChannel('partner')).toBe(false)
+    expect(isDiscoveryChannel('')).toBe(false)
+    expect(isDiscoveryChannel(null)).toBe(false)
+    expect(isDiscoveryChannel(undefined)).toBe(false)
+    expect(isDiscoveryChannel(42)).toBe(false)
   })
 
   it('rejects non-string entry in with-renovate list', () => {

--- a/scripts/schemas.ts
+++ b/scripts/schemas.ts
@@ -32,10 +32,28 @@ export interface RepoEntry {
   last_survey_status: SurveyStatus | null
   has_fro_bot_workflow: boolean
   has_renovate: boolean
+  /**
+   * Which channel surfaced this entry. Sticky after first write — reconcile never auto-rewrites it.
+   * Operators can re-classify by editing `metadata/repos.yaml` on the `data` branch directly.
+   *
+   * Optional during the rollout window: legacy entries without a channel are treated as `'collab'`
+   * by default. The cadence migration path will tighten this to required after `data` is migrated.
+   */
+  discovery_channel?: DiscoveryChannel
+  /**
+   * ISO date (YYYY-MM-DD) at which this entry becomes eligible for re-survey, or `null` for
+   * entries that have never been surveyed (treat as immediately eligible).
+   *
+   * Optional during the rollout window: legacy entries without an eligibility date are treated
+   * as immediately eligible. The cadence migration path will tighten this to required after
+   * `data` is migrated.
+   */
+  next_survey_eligible_at?: string | null
 }
 
 export type OnboardingStatus = 'pending' | 'onboarded' | 'failed' | 'lost-access' | 'pending-review'
 export type SurveyStatus = 'success' | 'failure'
+export type DiscoveryChannel = 'collab' | 'owned' | 'contrib'
 
 export interface RenovateFile {
   repositories: {
@@ -122,7 +140,11 @@ function isRepoEntry(value: unknown): value is RepoEntry {
     (value.last_survey_at === null || typeof value.last_survey_at === 'string') &&
     (value.last_survey_status === null || isSurveyStatus(value.last_survey_status)) &&
     typeof value.has_fro_bot_workflow === 'boolean' &&
-    typeof value.has_renovate === 'boolean'
+    typeof value.has_renovate === 'boolean' &&
+    (value.discovery_channel === undefined || isDiscoveryChannel(value.discovery_channel)) &&
+    (value.next_survey_eligible_at === undefined ||
+      value.next_survey_eligible_at === null ||
+      typeof value.next_survey_eligible_at === 'string')
   )
 }
 
@@ -144,6 +166,14 @@ function assertRepoEntry(value: unknown, path: string): asserts value is RepoEnt
     throw new SchemaValidationError(`${path}.has_fro_bot_workflow`, 'expected boolean')
   if (typeof value.has_renovate !== 'boolean')
     throw new SchemaValidationError(`${path}.has_renovate`, 'expected boolean')
+  if (value.discovery_channel !== undefined && !isDiscoveryChannel(value.discovery_channel))
+    throw new SchemaValidationError(`${path}.discovery_channel`, 'expected one of: collab, owned, contrib (or omitted)')
+  if (
+    value.next_survey_eligible_at !== undefined &&
+    value.next_survey_eligible_at !== null &&
+    typeof value.next_survey_eligible_at !== 'string'
+  )
+    throw new SchemaValidationError(`${path}.next_survey_eligible_at`, 'expected string, null, or omitted')
 }
 
 function isOnboardingStatus(value: unknown): value is OnboardingStatus {
@@ -158,6 +188,10 @@ function isOnboardingStatus(value: unknown): value is OnboardingStatus {
 
 function isSurveyStatus(value: unknown): value is SurveyStatus {
   return value === 'success' || value === 'failure'
+}
+
+export function isDiscoveryChannel(value: unknown): value is DiscoveryChannel {
+  return value === 'collab' || value === 'owned' || value === 'contrib'
 }
 
 export function isRenovateFile(value: unknown): value is RenovateFile {


### PR DESCRIPTION
## Summary

Adds the schema scaffolding for multi-channel repo discovery and per-repo survey cadence. Two new fields on `RepoEntry`:

- `discovery_channel`: `'collab' | 'owned' | 'contrib'` — tags how a repo entered the tracked list
- `next_survey_eligible_at`: ISO date string — controls when reconcile may dispatch the next survey

Both fields are optional in this PR. The cadence engine, the data-branch backfill, and the schema-tightening edit all land atomically in the follow-on PR. Optional-during-rollout means legacy entries on `data` keep validating while autonomous workflows continue running; producers always emit defaults so new rows never look legacy-shaped.

## Why optional, not required

Making these fields required would crash every autonomous workflow on first run after merge. Reconcile, handle-invitation, record-survey-result, and reset-survey-status all call `assertReposFile` inside their commit-mutator closures — they validate live data on the unprotected `data` branch every run. The data branch holds 17 legacy entries with neither field. Required fields → rejected validation → failed mutator → no commit → cascade through merge-data and beyond.

Optional in the loose phase, required in the tight phase. Tightening happens in the follow-on PR atomically with the migration producer that backfills any remaining legacy rows.

## Why no `metadata/repos.yaml` change in this PR

`metadata/*.yaml` is auto-managed and protected by the `Check Wiki Authority` CI guard — only PRs opened by `fro-bot` / `fro-bot[bot]` can land changes to those files. The legitimate path is `data`-branch writes by an autonomous workflow, then promotion via the weekly merge-data PR.

The follow-on PR ships `migrateRepoEntry`, which runs inside reconcile under `fro-bot[bot]` identity. It computes `last_survey_at + 30d + jitter(owner, name, last_survey_at)` for legacy entries on `data`, where jitter is a deterministic 0–3 day spread. After backfill, max same-day eligibility is 6 (cap is 12), so cap-12 starvation cannot occur. Same end state, correct authority path.

## What's in this PR

- `scripts/schemas.ts` — new `DiscoveryChannel` union, `isDiscoveryChannel` guard, optional fields on `RepoEntry`, runtime guard accepts both new and legacy shapes
- `scripts/repos-metadata.ts` — `addRepoEntry` writes both new fields with defaults; new `discovery_channel` input
- `scripts/handle-invitation.ts` — explicitly tags new collab entries
- `scripts/reconcile-repos.ts` — type signature updates only; no behavior changes (cadence engine deferred)
- `metadata/README.md` — documents the new fields, channel taxonomy, and eligibility formula
- 6 new test scenarios on `schemas.test.ts`, 4 on `repos-metadata.test.ts`, 1 on `handle-invitation.test.ts` (round-trip via `assertReposFile`)
- Plan + brainstorm + best-practices learning under `docs/`

## What's not in this PR

- `metadata/repos.yaml` backfill (moves to follow-on; runs via autonomous path)
- Cadence engine (jitter helper, `recordSurveyResult` writing `next_survey_eligible_at`)
- Migration producer (`migrateRepoEntry` for legacy rows on `data`)
- Schema tightening (drop `?` from both fields)
- `summary.migrated` counter
- Owned and contrib discovery channels (probe + integration in reconcile)
- Dispatch eligibility check using `next_survey_eligible_at`

These all land in the follow-on plan at `docs/plans/2026-05-05-001-feat-survey-cadence-and-multi-channel-discovery-plan.md`.

## Verification

- `pnpm check-types` — clean
- `pnpm test` — 317/317
- `pnpm lint` — clean

After merge, the next reconcile cron run continues to behave exactly as before (the cadence engine isn't wired yet). The first observable change comes when the follow-on PR lands.