### PR TITLE
feat(cadence): add per-channel survey eligibility with deterministic jitter

### DIFF
--- a/docs/plans/2026-05-05-001-feat-survey-cadence-and-multi-channel-discovery-plan.md
+++ b/docs/plans/2026-05-05-001-feat-survey-cadence-and-multi-channel-discovery-plan.md
@@ -251,7 +251,7 @@ The pure engine boundary stays clean. New I/O (owned + contrib enumeration) live
 
 ---
 
-- [ ] **Unit 2: Cadence engine — eligibility check + jitter helper**
+- [x] **Unit 2: Cadence engine — eligibility check + jitter helper**
 
 **Goal:** Replace `isSurveyStale` with `isEligibleForSurvey` that consults `next_survey_eligible_at`. Add `computeNextEligibleAt` helper to `repos-metadata.ts`. Wire `recordSurveyResult` to set the new field on every survey outcome. This unit makes the cadence model real for entries that already have the new field; Unit 4's migration handles the legacy path.
 

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -7,6 +7,7 @@ import {describe, expect, it, vi} from 'vitest'
 import {
   DISPATCH_DEFAULTS,
   handleReconcile,
+  isEligibleForSurvey,
   isSurveyStale,
   loadDispatchStaggerFromEnv,
   loadMaxDispatchesPerRunFromEnv,
@@ -375,19 +376,23 @@ describe('reconcileRepos', () => {
 
   describe('mixed and edge cases', () => {
     it('handles multiple simultaneous changes (new + lost + refresh) in one run', () => {
-      // Fresh surveys on both — not stale, so no re-survey dispatch from the staleness gate.
+      // Fresh surveys on both — next_survey_eligible_at is in the future (post-NOW), so
+      // the cadence gate excludes them. NOW = 2026-04-17; eligibility 2026-05-09 keeps
+      // them out of the dispatch list.
       const drift = makeEntry({
         name: 'drift-repo',
         onboarding_status: 'onboarded',
         has_renovate: false,
         last_survey_at: '2026-04-10',
         last_survey_status: 'success',
+        next_survey_eligible_at: '2026-05-09',
       })
       const gone = makeEntry({
         name: 'gone-repo',
         onboarding_status: 'onboarded',
         last_survey_at: '2026-04-10',
         last_survey_status: 'success',
+        next_survey_eligible_at: '2026-05-09',
       })
 
       const result = reconcileRepos(
@@ -585,12 +590,13 @@ describe('reconcileRepos', () => {
     it('does not dispatch pending entry with recent successful survey', () => {
       // #given a pending entry that was surveyed successfully recently (promotion
       // should have moved it to onboarded, but even if it didn't, the success +
-      // non-stale combination means no re-dispatch is needed)
+      // not-yet-eligible combination means no re-dispatch is needed)
       const entry = makeEntry({
         name: 'recently-succeeded',
         onboarding_status: 'pending',
         last_survey_at: '2026-04-16',
         last_survey_status: 'success',
+        next_survey_eligible_at: '2026-05-15',
       })
       const result = reconcileRepos(
         makeInput({
@@ -598,8 +604,32 @@ describe('reconcileRepos', () => {
           accessList: [makeAccess({name: 'recently-succeeded'})],
         }),
       )
-      // #then no dispatch — success + within staleness window → skip
+      // #then no dispatch — success + not-yet-eligible → skip
       expect(result.dispatches).toEqual([])
+    })
+
+    // Integration: full reconcileRepos pipeline through isEligibleForSurvey with a
+    // past eligibility date. Pins the wiring at classifyTracked:318/322 — proves the
+    // helper is actually consulted on the dispatch path, not just exercised in unit-test
+    // isolation. Without this, a future refactor that drops the isEligibleForSurvey call
+    // from classifyTracked would still pass all standalone helper tests.
+    it('dispatches an onboarded entry whose next_survey_eligible_at has passed', () => {
+      // #given an onboarded entry whose eligibility was 2 weeks ago (NOW = 2026-04-17)
+      const entry = makeEntry({
+        name: 'overdue-repo',
+        onboarding_status: 'onboarded',
+        last_survey_at: '2026-03-01',
+        last_survey_status: 'success',
+        next_survey_eligible_at: '2026-04-03',
+      })
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({name: 'overdue-repo'})],
+        }),
+      )
+      // #then the entry is dispatched (eligibility passed)
+      expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'overdue-repo'}])
     })
   })
 })
@@ -911,7 +941,8 @@ describe('handleReconcile (I/O shell)', () => {
       const existing: ReposFile = {
         version: 1,
         repos: [
-          // Fresh survey — not stale, so the test isolates the field-probe behavior.
+          // Fresh survey — next_survey_eligible_at in the future, so the test isolates
+          // the field-probe behavior from the cadence dispatch gate.
           makeEntry({
             name: 'probe-fail-repo',
             onboarding_status: 'onboarded',
@@ -919,6 +950,7 @@ describe('handleReconcile (I/O shell)', () => {
             has_renovate: true,
             last_survey_at: '2026-04-10',
             last_survey_status: 'success',
+            next_survey_eligible_at: '2026-05-09',
           }),
         ],
       }
@@ -1943,6 +1975,33 @@ describe('isSurveyStale', () => {
     const anchor = new Date('2026-04-01T00:00:00Z')
     const now = new Date(anchor.getTime() + JUST_AFTER)
     expect(isSurveyStale('2026-04-01', now)).toBe(true)
+  })
+})
+
+describe('isEligibleForSurvey', () => {
+  // Cadence model: null next_survey_eligible_at means "never computed" → always eligible
+  it('returns true when next_survey_eligible_at is null (never surveyed)', () => {
+    expect(isEligibleForSurvey(null, new Date('2026-05-01T12:00:00Z'))).toBe(true)
+  })
+
+  // Cadence model: a malformed eligible-at string treated as eligible (don't lose coverage)
+  it('returns true when next_survey_eligible_at is a malformed date string', () => {
+    expect(isEligibleForSurvey('not-a-date', new Date('2026-05-01T12:00:00Z'))).toBe(true)
+  })
+
+  // Boundary: now equals eligible-at → eligible (inclusive boundary)
+  it('returns true when now equals next_survey_eligible_at (inclusive boundary)', () => {
+    expect(isEligibleForSurvey('2026-05-01', new Date('2026-05-01T00:00:00Z'))).toBe(true)
+  })
+
+  // Boundary: now is one day before eligible-at → not eligible
+  it('returns false when now is one day before next_survey_eligible_at', () => {
+    expect(isEligibleForSurvey('2026-05-01', new Date('2026-04-30T23:59:59Z'))).toBe(false)
+  })
+
+  // Boundary: now is one day after eligible-at → eligible
+  it('returns true when now is one day after next_survey_eligible_at', () => {
+    expect(isEligibleForSurvey('2026-05-01', new Date('2026-05-02T00:00:00Z'))).toBe(true)
   })
 })
 

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -315,11 +315,11 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
   // The actual dispatch may still be deferred by the per-run cap; entries that are
   // genuinely fresh never become candidates so they don't compete for dispatch slots.
   // `pending-review` entries are excluded — they require human approval first.
-  if (entry.onboarding_status === 'onboarded' && isSurveyStale(entry.last_survey_at, params.now)) {
+  if (entry.onboarding_status === 'onboarded' && isEligibleForSurvey(entry.next_survey_eligible_at, params.now)) {
     dispatches.push({owner: entry.owner, repo: entry.name})
   } else if (
     entry.onboarding_status === 'pending' &&
-    (entry.last_survey_status !== 'success' || isSurveyStale(entry.last_survey_at, params.now))
+    (entry.last_survey_status !== 'success' || isEligibleForSurvey(entry.next_survey_eligible_at, params.now))
   ) {
     dispatches.push({owner: entry.owner, repo: entry.name})
   }
@@ -363,12 +363,40 @@ export const SURVEY_STALENESS_MS = 30 * 24 * 60 * 60 * 1000
  * A null `last_survey_at` signals "never surveyed" and is always stale. A malformed date
  * string is also treated as stale so recoverable metadata corruption doesn't silently
  * suppress coverage.
+ *
+ * @deprecated Use {@link isEligibleForSurvey} for new dispatch decisions. The fixed-30d
+ * model is being replaced by per-channel eligibility via `next_survey_eligible_at`,
+ * computed by `recordSurveyResult` from the channel's base interval plus deterministic
+ * jitter. This export is preserved only for the migration path that backfills
+ * `next_survey_eligible_at` from `last_survey_at` on legacy entries; once the migration
+ * is complete this function will be removed.
  */
 export function isSurveyStale(lastSurveyAt: string | null, now: Date): boolean {
   if (lastSurveyAt === null) return true
   const lastMs = Date.parse(`${lastSurveyAt}T00:00:00Z`)
   if (!Number.isFinite(lastMs)) return true
   return now.getTime() - lastMs >= SURVEY_STALENESS_MS
+}
+
+/**
+ * Return true when the entry should be a candidate for the next survey dispatch under
+ * the cadence-engine model.
+ *
+ * Boundary semantics: an entry whose `next_survey_eligible_at` is exactly today (UTC
+ * midnight) is eligible. The same inclusive-boundary contract as {@link isSurveyStale} —
+ * the daily cron's "now" reaches the eligibility instant exactly once and dispatch fires
+ * on that run.
+ *
+ * A null `next_survey_eligible_at` signals "never computed" and is always eligible
+ * (matching the semantics of a never-surveyed entry under the legacy model). A
+ * malformed date string is also treated as eligible so recoverable metadata corruption
+ * doesn't silently suppress coverage.
+ */
+export function isEligibleForSurvey(nextSurveyEligibleAt: string | null | undefined, now: Date): boolean {
+  if (nextSurveyEligibleAt === null || nextSurveyEligibleAt === undefined) return true
+  const eligibleMs = Date.parse(`${nextSurveyEligibleAt}T00:00:00Z`)
+  if (!Number.isFinite(eligibleMs)) return true
+  return now.getTime() >= eligibleMs
 }
 
 interface RawIssue {

--- a/scripts/repos-metadata.test.ts
+++ b/scripts/repos-metadata.test.ts
@@ -1,7 +1,13 @@
 import type {ReposFile} from './schemas.ts'
 
 import {describe, expect, it} from 'vitest'
-import {addRepoEntry, recordSurveyResult, RepoEntryNotFoundError, resetSurveyResult} from './repos-metadata.ts'
+import {
+  addRepoEntry,
+  computeNextEligibleAt,
+  recordSurveyResult,
+  RepoEntryNotFoundError,
+  resetSurveyResult,
+} from './repos-metadata.ts'
 
 const EMPTY_REPOS: ReposFile = {version: 1, repos: []}
 const NOW = new Date('2026-04-17T12:00:00Z')
@@ -573,5 +579,377 @@ describe('resetSurveyResult', () => {
     // #when resetting a nonexistent entry
     // #then the shared RepoEntryNotFoundError surfaces (same typed error used by recordSurveyResult)
     expect(() => resetSurveyResult(current, {owner: 'ghost', repo: 'nowhere'})).toThrow(RepoEntryNotFoundError)
+  })
+
+  // Cadence model: reset clears next_survey_eligible_at so onboarded entries are dispatched again
+  // Recovery contract under cadence: reset MUST clear next_survey_eligible_at, otherwise an
+  // onboarded entry's dispatch gate (isEligibleForSurvey) silently keeps the entry blocked
+  // until the eligibility date passes — defeating the recovery primitive.
+  it('clears next_survey_eligible_at to null so onboarded entries become dispatch-eligible immediately', () => {
+    // #given an onboarded entry with a future eligibility date set by a successful survey
+    const current: ReposFile = {
+      version: 1,
+      repos: [
+        {
+          owner: 'alice',
+          name: 'project',
+          added: '2026-04-01',
+          onboarding_status: 'onboarded',
+          last_survey_at: '2026-05-01',
+          last_survey_status: 'success',
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: '2026-05-31',
+        },
+      ],
+    }
+
+    // #when the entry is reset
+    const result = resetSurveyResult(current, {owner: 'alice', repo: 'project'})
+
+    // #then all three survey-tracking fields are null
+    expect(result.repos[0]?.last_survey_at).toBeNull()
+    expect(result.repos[0]?.last_survey_status).toBeNull()
+    expect(result.repos[0]?.next_survey_eligible_at).toBeNull()
+    // #and other fields are preserved (onboarded status, channel)
+    expect(result.repos[0]?.onboarding_status).toBe('onboarded')
+    expect(result.repos[0]?.discovery_channel).toBe('collab')
+  })
+})
+
+describe('computeNextEligibleAt', () => {
+  // Determinism: same (owner, repo, baseDate) yields the same output across calls
+  it('is deterministic for the same inputs', () => {
+    const baseDate = new Date('2026-05-01T00:00:00Z')
+    const a = computeNextEligibleAt({owner: 'alice', repo: 'project', channel: 'collab', baseDate})
+    const b = computeNextEligibleAt({owner: 'alice', repo: 'project', channel: 'collab', baseDate})
+    expect(a).toBe(b)
+  })
+
+  // Per-channel base interval: collab = 30d
+  it('returns an ISO date 30..33 days after baseDate for collab channel', () => {
+    const baseDate = new Date('2026-05-01T12:00:00Z')
+    const result = computeNextEligibleAt({owner: 'alice', repo: 'project', channel: 'collab', baseDate})
+    const resultMs = Date.parse(`${result}T00:00:00Z`)
+    const baseMs = Date.parse('2026-05-01T00:00:00Z')
+    const diffDays = (resultMs - baseMs) / (24 * 60 * 60 * 1000)
+    expect(diffDays).toBeGreaterThanOrEqual(30)
+    expect(diffDays).toBeLessThanOrEqual(33)
+  })
+
+  // Per-channel base interval: owned = 14d
+  it('returns an ISO date 14..17 days after baseDate for owned channel', () => {
+    const baseDate = new Date('2026-05-01T12:00:00Z')
+    const result = computeNextEligibleAt({owner: 'fro-bot', repo: 'agent', channel: 'owned', baseDate})
+    const resultMs = Date.parse(`${result}T00:00:00Z`)
+    const baseMs = Date.parse('2026-05-01T00:00:00Z')
+    const diffDays = (resultMs - baseMs) / (24 * 60 * 60 * 1000)
+    expect(diffDays).toBeGreaterThanOrEqual(14)
+    expect(diffDays).toBeLessThanOrEqual(17)
+  })
+
+  // Per-channel base interval: contrib = 21d
+  it('returns an ISO date 21..24 days after baseDate for contrib channel', () => {
+    const baseDate = new Date('2026-05-01T12:00:00Z')
+    const result = computeNextEligibleAt({owner: 'bfra-me', repo: '.github', channel: 'contrib', baseDate})
+    const resultMs = Date.parse(`${result}T00:00:00Z`)
+    const baseMs = Date.parse('2026-05-01T00:00:00Z')
+    const diffDays = (resultMs - baseMs) / (24 * 60 * 60 * 1000)
+    expect(diffDays).toBeGreaterThanOrEqual(21)
+    expect(diffDays).toBeLessThanOrEqual(24)
+  })
+
+  // Midnight stability contract: seed is YYYY-MM-DD slice, NOT the Date object.
+  // Two calls 50ms apart on the same UTC date produce the same output.
+  // Two calls on opposite sides of UTC midnight produce DIFFERENT outputs.
+  it('uses the YYYY-MM-DD slice of baseDate as the seed (midnight-stable)', () => {
+    // Same UTC date, 50ms apart → same seed → same output
+    const sameDay1 = computeNextEligibleAt({
+      owner: 'alice',
+      repo: 'project',
+      channel: 'collab',
+      baseDate: new Date('2026-05-05T12:00:00.000Z'),
+    })
+    const sameDay2 = computeNextEligibleAt({
+      owner: 'alice',
+      repo: 'project',
+      channel: 'collab',
+      baseDate: new Date('2026-05-05T12:00:00.050Z'),
+    })
+    expect(sameDay1).toBe(sameDay2)
+
+    // Opposite sides of midnight → different YYYY-MM-DD → seeds differ → outputs differ.
+    // Exact outputs computed offline using the same SHA-256 + first-4-bytes-uint32 + mod-4
+    // formula. Pinning exact outputs (vs a tolerance) ensures any drift in seed format,
+    // hash algorithm, or jitter modulus is caught immediately.
+    //
+    // alice/project @ 2026-05-04 collab → 2026-06-05 (30d + 2d jitter)
+    // alice/project @ 2026-05-05 collab → 2026-06-06 (30d + 2d jitter)
+    // Same jitter bucket here, but the +1d shift in baseDate carries through.
+    const beforeMidnight = computeNextEligibleAt({
+      owner: 'alice',
+      repo: 'project',
+      channel: 'collab',
+      baseDate: new Date('2026-05-04T23:59:59.999Z'),
+    })
+    const afterMidnight = computeNextEligibleAt({
+      owner: 'alice',
+      repo: 'project',
+      channel: 'collab',
+      baseDate: new Date('2026-05-05T00:00:00.001Z'),
+    })
+    expect(beforeMidnight).toBe('2026-06-05')
+    expect(afterMidnight).toBe('2026-06-06')
+    expect(beforeMidnight).not.toBe(afterMidnight)
+  })
+
+  // Different repo pairs at the same baseDate produce different jitter (sample distribution check)
+  it('produces different jitter values across distinct (owner, repo) pairs', () => {
+    const baseDate = new Date('2026-05-01T12:00:00Z')
+    const results = [
+      computeNextEligibleAt({owner: 'alice', repo: 'one', channel: 'collab', baseDate}),
+      computeNextEligibleAt({owner: 'alice', repo: 'two', channel: 'collab', baseDate}),
+      computeNextEligibleAt({owner: 'bob', repo: 'one', channel: 'collab', baseDate}),
+      computeNextEligibleAt({owner: 'bob', repo: 'two', channel: 'collab', baseDate}),
+      computeNextEligibleAt({owner: 'carol', repo: 'three', channel: 'collab', baseDate}),
+    ]
+    // Across 5 distinct pairs, expect at least 2 distinct outputs (jitter range is 0..3 days).
+    const distinct = new Set(results)
+    expect(distinct.size).toBeGreaterThanOrEqual(2)
+  })
+
+  // Output format: ISO YYYY-MM-DD only, no time component
+  it('returns ISO date strings of the form YYYY-MM-DD', () => {
+    const result = computeNextEligibleAt({
+      owner: 'alice',
+      repo: 'project',
+      channel: 'collab',
+      baseDate: new Date('2026-05-01T00:00:00Z'),
+    })
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  // Exact-output pinning per channel: locks the deterministic SHA-256 jitter formula
+  // to specific outputs. If any of these break, the seed format, hash algorithm, or
+  // jitter modulus changed silently — range-regex tests would have missed it.
+  it('produces exact deterministic outputs for pinned (owner, repo, channel, baseDate) fixtures', () => {
+    expect(
+      computeNextEligibleAt({
+        owner: 'alice',
+        repo: 'project',
+        channel: 'collab',
+        baseDate: new Date('2026-05-01T12:00:00Z'),
+      }),
+    ).toBe('2026-06-03')
+
+    expect(
+      computeNextEligibleAt({
+        owner: 'fro-bot',
+        repo: 'agent',
+        channel: 'owned',
+        baseDate: new Date('2026-05-01T12:00:00Z'),
+      }),
+    ).toBe('2026-05-15')
+
+    expect(
+      computeNextEligibleAt({
+        owner: 'bfra-me',
+        repo: '.github',
+        channel: 'contrib',
+        baseDate: new Date('2026-05-01T12:00:00Z'),
+      }),
+    ).toBe('2026-05-22')
+  })
+
+  // Year-boundary arithmetic: 2026-12-31 + 30d + jitter must roll into 2027 correctly.
+  // Pins MS-based date math against a future refactor to component-based date arithmetic
+  // (e.g., setUTCDate) that could regress month/year-boundary edges undetected.
+  it('handles year-boundary arithmetic correctly', () => {
+    // Computed offline: alice/project @ 2026-12-31 collab = 2027-02-02 (30d + 3d jitter)
+    expect(
+      computeNextEligibleAt({
+        owner: 'alice',
+        repo: 'project',
+        channel: 'collab',
+        baseDate: new Date('2026-12-31T12:00:00Z'),
+      }),
+    ).toBe('2027-02-02')
+  })
+})
+
+describe('recordSurveyResult — next_survey_eligible_at', () => {
+  // Cadence wiring: success outcome writes next_survey_eligible_at via computeNextEligibleAt
+  it('sets next_survey_eligible_at on successful survey using collab interval', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [
+        {
+          owner: 'alice',
+          name: 'project',
+          added: '2026-04-01',
+          onboarding_status: 'onboarded',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
+        },
+      ],
+    }
+
+    const at = new Date('2026-05-01T12:00:00Z')
+    const result = recordSurveyResult(current, {owner: 'alice', repo: 'project', at, status: 'success'})
+
+    const eligibleAt = result.repos[0]?.next_survey_eligible_at
+    expect(eligibleAt).not.toBeNull()
+    // Collab base 30d + jitter 0..3 → 2026-05-31..2026-06-03
+    expect(eligibleAt).toMatch(/^2026-(05-31|06-0[1-3])$/)
+  })
+
+  // Cadence wiring: failure outcome ALSO writes next_survey_eligible_at (using same formula)
+  it('sets next_survey_eligible_at on failed survey using the same formula', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [
+        {
+          owner: 'alice',
+          name: 'project',
+          added: '2026-04-01',
+          onboarding_status: 'onboarded',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
+        },
+      ],
+    }
+
+    const at = new Date('2026-05-01T12:00:00Z')
+    const result = recordSurveyResult(current, {owner: 'alice', repo: 'project', at, status: 'failure'})
+
+    const eligibleAt = result.repos[0]?.next_survey_eligible_at
+    expect(eligibleAt).not.toBeNull()
+    expect(eligibleAt).toMatch(/^2026-(05-31|06-0[1-3])$/)
+  })
+
+  // Cadence wiring: per-channel intervals — owned uses 14d
+  it('uses owned-channel interval (14d) for an owned-channel entry', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'agent',
+          added: '2026-04-01',
+          onboarding_status: 'onboarded',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'owned',
+          next_survey_eligible_at: null,
+        },
+      ],
+    }
+
+    const at = new Date('2026-05-01T12:00:00Z')
+    const result = recordSurveyResult(current, {owner: 'fro-bot', repo: 'agent', at, status: 'success'})
+
+    const eligibleAt = result.repos[0]?.next_survey_eligible_at
+    expect(eligibleAt).not.toBeNull()
+    // Owned base 14d + jitter 0..3 → 2026-05-15..2026-05-18
+    expect(eligibleAt).toMatch(/^2026-05-1[5-8]$/)
+  })
+
+  // Cadence wiring: per-channel intervals — contrib uses 21d
+  it('uses contrib-channel interval (21d) for a contrib-channel entry', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [
+        {
+          owner: 'bfra-me',
+          name: '.github',
+          added: '2026-04-01',
+          onboarding_status: 'onboarded',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'contrib',
+          next_survey_eligible_at: null,
+        },
+      ],
+    }
+
+    const at = new Date('2026-05-01T12:00:00Z')
+    const result = recordSurveyResult(current, {owner: 'bfra-me', repo: '.github', at, status: 'success'})
+
+    const eligibleAt = result.repos[0]?.next_survey_eligible_at
+    expect(eligibleAt).not.toBeNull()
+    // Contrib base 21d + jitter 0..3 → 2026-05-22..2026-05-25
+    expect(eligibleAt).toMatch(/^2026-05-2[2-5]$/)
+  })
+
+  // Cadence wiring: legacy entry (discovery_channel undefined) falls back to collab interval
+  // Pins the contract that the `match.discovery_channel ?? 'collab'` fallback in recordSurveyResult
+  // exists for: legacy entries without the field still get a valid eligibility date computed.
+  it('uses collab interval (30d) for legacy entries with discovery_channel undefined', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [
+        {
+          owner: 'alice',
+          name: 'legacy-repo',
+          added: '2026-01-01',
+          onboarding_status: 'onboarded',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          // discovery_channel intentionally omitted — simulates a legacy entry
+          // that hasn't been migrated to the cadence model yet.
+          next_survey_eligible_at: null,
+        },
+      ],
+    }
+
+    const at = new Date('2026-05-01T12:00:00Z')
+    const result = recordSurveyResult(current, {owner: 'alice', repo: 'legacy-repo', at, status: 'success'})
+
+    const eligibleAt = result.repos[0]?.next_survey_eligible_at
+    expect(eligibleAt).not.toBeNull()
+    // Collab fallback: base 30d + jitter 0..3 → 2026-05-31..2026-06-03
+    expect(eligibleAt).toMatch(/^2026-(05-31|06-0[1-3])$/)
+  })
+
+  // Cadence wiring: pending → onboarded promotion still works alongside next_survey_eligible_at write
+  it('still promotes pending → onboarded on first success while writing next_survey_eligible_at', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [
+        {
+          owner: 'alice',
+          name: 'project',
+          added: '2026-04-01',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
+        },
+      ],
+    }
+
+    const at = new Date('2026-05-01T12:00:00Z')
+    const result = recordSurveyResult(current, {owner: 'alice', repo: 'project', at, status: 'success'})
+
+    expect(result.repos[0]?.onboarding_status).toBe('onboarded')
+    expect(result.repos[0]?.next_survey_eligible_at).not.toBeNull()
   })
 })

--- a/scripts/repos-metadata.ts
+++ b/scripts/repos-metadata.ts
@@ -8,6 +8,8 @@
  * duplicate `owner+name` and preserves existing entries as-is.
  */
 
+import {createHash} from 'node:crypto'
+
 import {
   assertReposFile,
   type DiscoveryChannel,
@@ -15,6 +17,69 @@ import {
   type ReposFile,
   type SurveyStatus,
 } from './schemas.ts'
+
+/**
+ * Per-channel base survey interval, in days. The actual eligibility date adds a
+ * deterministic jitter of 0..{@link JITTER_MAX_DAYS} days on top.
+ *
+ * - `collab` (30d): operator-invited collaborator repos
+ * - `owned` (14d): repos in the fro-bot org itself; tightest cadence so the agent's own
+ *   surface area stays current
+ * - `contrib` (21d): cross-org repos surfaced via `metadata/allowlist.yaml`
+ */
+export const CHANNEL_INTERVAL_DAYS = {
+  collab: 30,
+  owned: 14,
+  contrib: 21,
+} as const satisfies Record<DiscoveryChannel, number>
+
+/**
+ * Maximum jitter added to a base interval, in days. The actual jitter for a given
+ * `(owner, repo, baseDate)` triple is in `[0, JITTER_MAX_DAYS]` and is deterministic.
+ */
+export const JITTER_MAX_DAYS = 3
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+export interface ComputeNextEligibleAtInput {
+  owner: string
+  repo: string
+  channel: DiscoveryChannel
+  baseDate: Date
+}
+
+/**
+ * Compute the ISO date (YYYY-MM-DD, UTC) when a repo becomes eligible for its next
+ * survey, given the base date (typically `last_survey_at`), the discovery channel
+ * (which sets the base interval), and the repo identifiers (which seed jitter).
+ *
+ * Formula: `baseDate + CHANNEL_INTERVAL_DAYS[channel] + jitter` days, where jitter is
+ * derived deterministically from `${owner}/${repo}@${baseDate-as-YYYY-MM-DD-UTC}`
+ * via SHA-256 → first 4 bytes as big-endian uint32 → modulo `(JITTER_MAX_DAYS + 1)`.
+ *
+ * Midnight stability: the jitter seed is the YYYY-MM-DD slice of `baseDate` in UTC,
+ * NOT the full Date. Two calls with `baseDate` values 1 ms apart on the same UTC day
+ * produce identical outputs; calls on opposite sides of UTC midnight may differ
+ * because the seed string itself differs. This contract is required so within-process
+ * `commitMetadata` 409 retries (the mutator re-runs against the same `at` value) write
+ * the same eligibility date. Cross-process retries (e.g., human re-trigger after
+ * `CONFLICT_EXHAUSTED`) capture the retry's clock, so eligibility may shift by 1 day if
+ * the retry crosses UTC midnight; callers that need cross-process stability should pin
+ * `at` to a logical instant such as the original workflow's `github.run_started_at`.
+ */
+export function computeNextEligibleAt(input: ComputeNextEligibleAtInput): string {
+  const surveyDateString = input.baseDate.toISOString().slice(0, 10)
+  const seed = `${input.owner}/${input.repo}@${surveyDateString}`
+  const hash = createHash('sha256').update(seed).digest()
+  const uint32 = hash.readUInt32BE(0)
+  const jitterDays = uint32 % (JITTER_MAX_DAYS + 1)
+
+  const baseMs = Date.parse(`${surveyDateString}T00:00:00Z`)
+  const offsetDays = CHANNEL_INTERVAL_DAYS[input.channel] + jitterDays
+  const eligibleMs = baseMs + offsetDays * MS_PER_DAY
+
+  return new Date(eligibleMs).toISOString().slice(0, 10)
+}
 
 export interface AddRepoEntryInput {
   owner: string
@@ -116,11 +181,25 @@ export function recordSurveyResult(current: unknown, input: RecordSurveyResultIn
   const nextStatus =
     input.status === 'success' && match.onboarding_status === 'pending' ? 'onboarded' : match.onboarding_status
 
+  // Compute the next-eligible date using the entry's discovery channel. The cadence
+  // model writes this on every survey outcome — both success and failure — so a failed
+  // survey doesn't immediately re-dispatch on the next reconcile cron (which would burn
+  // dispatch slots while the underlying problem persists). Channel defaults to 'collab'
+  // when the field is absent on a legacy entry that hasn't been migrated yet.
+  const channel: DiscoveryChannel = match.discovery_channel ?? 'collab'
+  const nextEligibleAt = computeNextEligibleAt({
+    owner: input.owner,
+    repo: input.repo,
+    channel,
+    baseDate: input.at,
+  })
+
   const updated = {
     ...match,
     onboarding_status: nextStatus,
     last_survey_at: input.at.toISOString().slice(0, 10),
     last_survey_status: input.status,
+    next_survey_eligible_at: nextEligibleAt,
   }
 
   const nextRepos = [...current.repos]
@@ -138,13 +217,23 @@ export interface ResetSurveyResultInput {
 }
 
 /**
- * Reset `last_survey_at` and `last_survey_status` to `null` on an existing entry.
+ * Reset survey-tracking fields to `null` on an existing entry, forcing reconcile to
+ * treat the repo as never-surveyed and re-dispatch on the next cron.
+ *
+ * Clears three fields:
+ * - `last_survey_at` (legacy staleness signal)
+ * - `last_survey_status` (legacy success/failure marker)
+ * - `next_survey_eligible_at` (cadence-engine eligibility gate)
+ *
+ * All three must be cleared together. Under the cadence model, `next_survey_eligible_at`
+ * is the authoritative dispatch gate (see `isEligibleForSurvey` in `reconcile-repos.ts`);
+ * leaving it populated would cause `classifyTracked` to silently skip the entry even
+ * after reset, defeating the recovery contract.
  *
  * Used to recover from misclassified survey outcomes — e.g. when a wiki-commit failure
  * was recorded as `success` under an older `SURVEY_STATUS` expression, causing the
- * reconcile staleness gate to skip the repo for 30 days despite no wiki content landing.
- * Clearing the fields back to `null` forces reconcile to treat the repo as never-surveyed
- * and re-dispatch it on the next cron.
+ * dispatch gate to skip the repo for the full cadence window despite no wiki content
+ * landing.
  *
  * Throws `RepoEntryNotFoundError` when the entry is missing — callers should enumerate
  * known contaminated entries and fail loudly on typos.
@@ -169,6 +258,7 @@ export function resetSurveyResult(current: unknown, input: ResetSurveyResultInpu
     ...match,
     last_survey_at: null,
     last_survey_status: null,
+    next_survey_eligible_at: null,
   }
 
   const nextRepos = [...current.repos]


### PR DESCRIPTION
## What changes

Replaces the fixed 30-day staleness gate with a per-repo `next_survey_eligible_at` field. Reconcile dispatches when the eligibility date has passed; `recordSurveyResult` writes the new field on every survey outcome.

## Why

The fixed-30d model produces dispatch herds: most tracked repos get surveyed in the same window, become re-eligible together 30 days later, drain through the 12-dispatch cap in 2-3 days, then idle for ~28 days. The wiki goes dark for stretches even though `reconcile` reports `success`.

This swaps the dispatch gate to per-channel cadence + deterministic jitter:

| Channel   | Base interval | Rationale                                              |
| --------- | ------------- | ------------------------------------------------------ |
| `collab`  | 30 days       | Operator-invited collaborator repos                    |
| `owned`   | 14 days       | The agent's own surface area; tightest cadence         |
| `contrib` | 21 days       | Cross-org repos surfaced via `metadata/allowlist.yaml` |
<!-- table not formatted: invalid structure -->

Jitter is 0-3 days per repo per cadence cycle, derived from `SHA-256("${owner}/${repo}@${YYYY-MM-DD-UTC}")` so two repos in the same cohort scatter across the eligibility window instead of dispatching the same day.

This is a partial fix for the herd pattern: jitter widens the dispatch burst from 2-3 days to 5-6, and per-channel intervals reduce idle stretches for owned/contrib repos. The structural answer (a per-day quota model that always dispatches the N oldest-eligible regardless of threshold) is deferred to a future plan.

## How

- **`scripts/repos-metadata.ts`** — new `computeNextEligibleAt({owner, repo, channel, baseDate})` helper. `recordSurveyResult` calls it on both success and failure paths so a failed survey doesn't immediately re-dispatch on the next cron (which would burn dispatch slots while the underlying problem persists).

- **`scripts/reconcile-repos.ts`** — new `isEligibleForSurvey(nextSurveyEligibleAt, now)` helper consulted in `classifyTracked`. The legacy `isSurveyStale` and `SURVEY_STALENESS_MS` exports are kept as `@deprecated` for the migration path that backfills `next_survey_eligible_at` from `last_survey_at` on legacy entries; both are removed when that migration ships.

- **Midnight stability** — the jitter seed is the YYYY-MM-DD slice of `baseDate` in UTC, not the full Date. Two `recordSurveyResult` calls 50ms apart on the same UTC day produce identical eligibility dates, so within-process `commitMetadata` 409 retries converge. Cross-process retries (human re-trigger after `CONFLICT_EXHAUSTED`) capture the retry's clock; the docstring notes this and recommends pinning `at` to `github.run_started_at` for cross-process stability.

- **`resetSurveyResult`** — now also clears `next_survey_eligible_at`. Without this, the operator's documented recovery primitive ("reset = re-dispatch on next cron") would silently fail for onboarded entries because the new dispatch gate would keep the entry blocked until the eligibility date passed.

## Test scenarios covered

22 new tests + 3 existing fixtures updated:

- Determinism, midnight stability, per-channel intervals, year-boundary arithmetic, exact-output pinning per channel
- `isEligibleForSurvey` boundary semantics (null, inclusive boundary, malformed string, undefined)
- `recordSurveyResult` writes eligibility on success and failure for collab/owned/contrib + legacy-channel-undefined fallback
- Full reconcile pipeline integration: onboarded entry with past `next_survey_eligible_at` is dispatched
- Legacy fallback: entry with `discovery_channel: undefined` falls back to collab interval
- Recovery contract: `resetSurveyResult` on an onboarded entry with future eligibility produces a dispatch-ready entry

## Behavior on the rollout window

The first reconcile cron after this lands sees every existing tracked entry with `next_survey_eligible_at: null` (the field was added in #3234 with default `null`). Null means "never computed" → eligible. Bounded by `MAX_DISPATCHES_PER_RUN: 12`, so the rollout produces at most one normal-sized dispatch wave, then settles into per-channel cadence as `recordSurveyResult` populates the field.

## Out of scope

- **Migration of `discovery_channel` defaults** — Unit 4 of the same plan handles backfilling the field for entries that arrived via reconcile/handle-invitation between schema landing and cadence engine landing. Until then, `recordSurveyResult` defaults missing `discovery_channel` to `'collab'` (30d).
- **`prioritizeDispatches` sort key** — currently sorts by `last_survey_at`; the cadence model would prefer `next_survey_eligible_at`. Unit 4 territory.
- **Failure-aware backoff** — a chronically-failing repo currently costs one LLM run per cadence cycle indefinitely. Future plan.
- **Schema validation tightening** — `next_survey_eligible_at` accepts arbitrary strings today (not regex-validated). Operator typo on `data` would surface as fail-open eligibility. Worth a follow-up.

## Plan reference

Implements Unit 2 of `docs/plans/2026-05-05-001-feat-survey-cadence-and-multi-channel-discovery-plan.md`. Plan checkbox flipped in this PR.