### PR TITLE
feat(cadence): add owned and contrib discovery channels with structural forge resistance

### DIFF
--- a/.github/workflows/reconcile-repos.yaml
+++ b/.github/workflows/reconcile-repos.yaml
@@ -29,6 +29,10 @@ jobs:
         with:
           app-id: ${{ secrets.APPLICATION_ID }}
           private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          # Scope the token to the whole installation, not just this repo, so cross-org
+          # contrib probes (`scripts/reconcile-repos.ts`) and any future App calls outside
+          # this repo can succeed. Mirrors update-metadata.yaml and dispatch-renovate.yaml.
+          owner: ${{ github.repository_owner }}
 
       - name: ⤵ Checkout Branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/docs/plans/2026-05-05-001-feat-survey-cadence-and-multi-channel-discovery-plan.md
+++ b/docs/plans/2026-05-05-001-feat-survey-cadence-and-multi-channel-discovery-plan.md
@@ -304,7 +304,7 @@ The pure engine boundary stays clean. New I/O (owned + contrib enumeration) live
 
 ---
 
-- [ ] **Unit 3: Allowlist surface for contrib + I/O shell discovery passes**
+- [x] **Unit 3: Allowlist surface for contrib + I/O shell discovery passes**
 
 **Goal:** Extend `metadata/allowlist.yaml` schema with `approved_contrib_orgs` + `approved_contrib_repos`. Add owned-channel and contrib-channel discovery passes to the reconcile I/O shell. Both passes feed into the existing `accessList` and flow through `reconcileRepos` unchanged.
 

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -6,7 +6,7 @@ This directory contains the Fro Bot control plane's public, versioned, auditable
 
 ### `allowlist.yaml`
 
-Approved inviters whose collaboration invitations Fro Bot may accept.
+Operator-curated trust surface: who Fro Bot accepts invitations from, plus which cross-org repos can surface via the `contrib` discovery channel.
 
 ```yaml
 version: 1
@@ -14,7 +14,19 @@ approved_inviters:
   - username: string
     added: ISO date
     role: string
+# Optional. Empty/missing = no contrib-channel discovery.
+approved_contrib_orgs:
+  - string  # GitHub org login (e.g., "bfra-me")
+# Optional. Empty/missing = no contrib-channel direct probes.
+approved_contrib_repos:
+  - string  # "owner/name" (e.g., "bfra-me/.github")
 ```
+
+- `approved_inviters` — collaboration invitations from these usernames are auto-accepted by `poll-invitations.yaml`.
+- `approved_contrib_repos` — direct list of `owner/name` strings probed individually for `.github/workflows/fro-bot.yaml`. The probe parses the workflow as YAML and checks that a job-level or step-level `uses:` value points at `fro-bot/agent` (or a sub-path under it). The Fro Bot App must be installed on each named repo first.
+- `approved_contrib_orgs` — **not yet supported in v1.** Cross-org enumeration requires minting per-installation App tokens, which is deferred to a future plan. A non-empty value triggers a warn and is otherwise ignored. Until that infrastructure lands, surface specific cross-org repos via `approved_contrib_repos`.
+
+The content probe is the trust signal: file presence alone is forge-able, but a structural `uses: fro-bot/agent@<ref>` directive proves the operator of that repo opted in. Comments, `name:` strings, `run:` shell, and `with:` inputs that mention `fro-bot/agent` are not action sources and do not pass the check.
 
 Update convention: human-maintained; edits land via the `data` branch (see [Editing metadata files](#editing-metadata-files) below).
 

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -1,16 +1,19 @@
 import type {CommitMetadataParams, CommitMetadataResult} from './commit-metadata.ts'
 import type {AllowlistFile, RepoEntry, ReposFile} from './schemas.ts'
+import {Buffer} from 'node:buffer'
 import process from 'node:process'
 
 import {describe, expect, it, vi} from 'vitest'
 
 import {
+  containsFroBotAgentReference,
   DISPATCH_DEFAULTS,
   handleReconcile,
   isEligibleForSurvey,
   isSurveyStale,
   loadDispatchStaggerFromEnv,
   loadMaxDispatchesPerRunFromEnv,
+  mergeAccessChannels,
   ReconcileError,
   reconcileRepos,
   SURVEY_STALENESS_MS,
@@ -632,6 +635,220 @@ describe('reconcileRepos', () => {
       expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'overdue-repo'}])
     })
   })
+
+  describe('discovery channels (owned + contrib)', () => {
+    // Owned and contrib are pre-trusted: owned because we own the repo, contrib because
+    // the operator named it explicitly in metadata/allowlist.yaml. Both bypass the
+    // pending-review issue path that exists for non-allowlisted collab newcomers.
+
+    it('tags an owned newcomer with discovery_channel: owned and dispatches as pending', () => {
+      // #given an accessible repo from the fro-bot owned channel, not yet tracked
+      const result = reconcileRepos(
+        makeInput({
+          accessList: [makeAccess({owner: 'fro-bot', name: 'agent', node_id: 'R_agent'})],
+          accessChannelByKey: new Map([['fro-bot/agent', 'owned']]),
+        }),
+      )
+
+      // #then it's added as pending with discovery_channel: owned, dispatch queued, no issue
+      expect(result.nextRepos.repos).toHaveLength(1)
+      expect(result.nextRepos.repos[0]).toMatchObject({
+        owner: 'fro-bot',
+        name: 'agent',
+        onboarding_status: 'pending',
+        discovery_channel: 'owned',
+      })
+      expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'agent'}])
+      expect(result.issues).toEqual([])
+      expect(result.summary.added).toBe(1)
+      expect(result.summary.pendingReview).toBe(0)
+    })
+
+    it('tags a contrib newcomer with discovery_channel: contrib and dispatches as pending', () => {
+      // #given a contrib repo surfaced via the allowlist's approved_contrib_orgs
+      const result = reconcileRepos(
+        makeInput({
+          accessList: [makeAccess({owner: 'bfra-me', name: '.github', node_id: 'R_bfra_gh'})],
+          accessChannelByKey: new Map([['bfra-me/.github', 'contrib']]),
+        }),
+      )
+
+      // #then dispatched with discovery_channel: contrib; no pending-review issue
+      expect(result.nextRepos.repos[0]?.discovery_channel).toBe('contrib')
+      expect(result.dispatches).toEqual([{owner: 'bfra-me', repo: '.github'}])
+      expect(result.issues).toEqual([])
+      expect(result.summary.added).toBe(1)
+      expect(result.summary.pendingReview).toBe(0)
+    })
+
+    it('falls back to discovery_channel: collab when accessChannelByKey is missing the entry', () => {
+      // #given a collab access list (channel map missing the key — preserves existing behavior)
+      const result = reconcileRepos(
+        makeInput({
+          accessList: [makeAccess({owner: 'marcusrbrown', name: 'new-repo'})],
+          allowlist: makeAllowlist(['marcusrbrown']),
+          // accessChannelByKey not supplied — defaults to all-collab
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]?.discovery_channel).toBe('collab')
+      expect(result.dispatches).toEqual([{owner: 'marcusrbrown', repo: 'new-repo'}])
+    })
+
+    it('skips pending-review for owned newcomers from a non-allowlisted owner', () => {
+      // #given an owned-channel newcomer with empty allowlist
+      // #then it bypasses the allowlist gate (owned is always trusted)
+      const result = reconcileRepos(
+        makeInput({
+          accessList: [makeAccess({owner: 'fro-bot', name: 'agent', node_id: 'R_agent'})],
+          accessChannelByKey: new Map([['fro-bot/agent', 'owned']]),
+          allowlist: makeAllowlist([]), // intentionally empty
+        }),
+      )
+
+      expect(result.summary.added).toBe(1)
+      expect(result.summary.pendingReview).toBe(0)
+      expect(result.dispatches).toHaveLength(1)
+      expect(result.issues).toEqual([])
+    })
+
+    it('skips pending-review for contrib newcomers regardless of approved_inviters', () => {
+      // #given a contrib newcomer whose owner is not in approved_inviters
+      // #then dispatched directly; allowlist-via-channel-map is sufficient trust
+      const result = reconcileRepos(
+        makeInput({
+          accessList: [makeAccess({owner: 'bfra-me', name: 'renovate-action', node_id: 'R_bfra_ren'})],
+          accessChannelByKey: new Map([['bfra-me/renovate-action', 'contrib']]),
+          allowlist: makeAllowlist([]),
+        }),
+      )
+
+      expect(result.summary.added).toBe(1)
+      expect(result.summary.pendingReview).toBe(0)
+      expect(result.dispatches).toEqual([{owner: 'bfra-me', repo: 'renovate-action'}])
+      expect(result.issues).toEqual([])
+    })
+
+    it('preserves discovery_channel on tracked owned entries through field refresh', () => {
+      // #given a tracked owned entry whose probed fields drift
+      const entry = makeEntry({
+        owner: 'fro-bot',
+        name: 'agent',
+        onboarding_status: 'onboarded',
+        discovery_channel: 'owned',
+        next_survey_eligible_at: '2026-05-01', // not yet eligible
+      })
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({owner: 'fro-bot', name: 'agent', node_id: 'R_agent'})],
+          accessChannelByKey: new Map([['fro-bot/agent', 'owned']]),
+          fieldProbes: new Map([['fro-bot/agent', {has_fro_bot_workflow: true, has_renovate: true}]]),
+        }),
+      )
+
+      // #then channel is preserved (sticky); fields refresh
+      expect(result.nextRepos.repos[0]?.discovery_channel).toBe('owned')
+      expect(result.nextRepos.repos[0]?.has_fro_bot_workflow).toBe(true)
+      expect(result.nextRepos.repos[0]?.has_renovate).toBe(true)
+      expect(result.summary.refreshed).toBe(1)
+    })
+
+    it('flips a contrib entry to lost-access when the access list drops it', () => {
+      // #given a tracked contrib entry no longer surfaced (e.g., fro-bot.yaml was deleted)
+      const entry = makeEntry({
+        owner: 'bfra-me',
+        name: '.github',
+        onboarding_status: 'onboarded',
+        discovery_channel: 'contrib',
+      })
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [], // not in any channel's access list anymore
+          perRepoStatus: new Map([['bfra-me/.github', {status: 'revoked'}]]),
+        }),
+      )
+
+      // #then status flips to lost-access; channel is preserved
+      expect(result.nextRepos.repos[0]?.onboarding_status).toBe('lost-access')
+      expect(result.nextRepos.repos[0]?.discovery_channel).toBe('contrib')
+      expect(result.summary.lostAccess).toBe(1)
+    })
+
+    it('regains a contrib entry when the access list resurfaces it', () => {
+      // #given a lost-access contrib entry that re-appears via access list
+      const entry = makeEntry({
+        owner: 'bfra-me',
+        name: '.github',
+        onboarding_status: 'lost-access',
+        discovery_channel: 'contrib',
+      })
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({owner: 'bfra-me', name: '.github', node_id: 'R_bfra_gh'})],
+          accessChannelByKey: new Map([['bfra-me/.github', 'contrib']]),
+        }),
+      )
+
+      // #then regained as pending; dispatched directly (contrib is trusted, no issue)
+      expect(result.nextRepos.repos[0]?.onboarding_status).toBe('pending')
+      expect(result.summary.regained).toBe(1)
+      expect(result.dispatches).toEqual([{owner: 'bfra-me', repo: '.github'}])
+      expect(result.issues).toEqual([])
+    })
+
+    it('regains an owned entry without filing a pending-review issue', () => {
+      const entry = makeEntry({
+        owner: 'fro-bot',
+        name: 'systematic',
+        onboarding_status: 'lost-access',
+        discovery_channel: 'owned',
+      })
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({owner: 'fro-bot', name: 'systematic', node_id: 'R_sys'})],
+          accessChannelByKey: new Map([['fro-bot/systematic', 'owned']]),
+          allowlist: makeAllowlist([]), // owner not in approved_inviters; channel trust suffices
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]?.onboarding_status).toBe('pending')
+      expect(result.summary.regained).toBe(1)
+      expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'systematic'}])
+      expect(result.issues).toEqual([])
+    })
+
+    it('handles a mixed access list with collab + owned + contrib in one pass', () => {
+      // #given access entries spanning all three channels
+      const result = reconcileRepos(
+        makeInput({
+          accessList: [
+            makeAccess({owner: 'marcusrbrown', name: 'collab-repo'}),
+            makeAccess({owner: 'fro-bot', name: 'agent', node_id: 'R_agent'}),
+            makeAccess({owner: 'bfra-me', name: '.github', node_id: 'R_bfra_gh'}),
+          ],
+          accessChannelByKey: new Map([
+            ['fro-bot/agent', 'owned'],
+            ['bfra-me/.github', 'contrib'],
+            // marcusrbrown/collab-repo intentionally absent — defaults to collab
+          ]),
+          allowlist: makeAllowlist(['marcusrbrown']),
+        }),
+      )
+
+      expect(result.nextRepos.repos).toHaveLength(3)
+      expect(result.summary.added).toBe(3)
+      expect(result.summary.pendingReview).toBe(0)
+      expect(result.dispatches).toHaveLength(3)
+      const byName = new Map(result.nextRepos.repos.map(r => [r.name, r.discovery_channel]))
+      expect(byName.get('collab-repo')).toBe('collab')
+      expect(byName.get('agent')).toBe('owned')
+      expect(byName.get('.github')).toBe('contrib')
+    })
+  })
 })
 
 //
@@ -705,6 +922,30 @@ function notFoundGetBranch(): (params: unknown) => Promise<never> {
   }
 }
 
+/**
+ * Build a getContent mock that returns base64-encoded fro-bot.yaml content for
+ * specific repos and 404 for everything else. Used by the discovery-channels
+ * integration tests to verify forge-resistance + content-probe behavior end-to-end.
+ */
+function contentByRepo(
+  byOwnerName: Map<string, string>,
+): (params: {owner: string; repo: string; path: string}) => Promise<unknown> {
+  return async ({owner, repo, path}) => {
+    if (path !== '.github/workflows/fro-bot.yaml') {
+      throw apiError(404, 'Not Found')
+    }
+    const content = byOwnerName.get(`${owner}/${repo}`)
+    if (content === undefined) throw apiError(404, 'Not Found')
+    return {
+      data: {
+        type: 'file',
+        encoding: 'base64',
+        content: Buffer.from(content, 'utf8').toString('base64'),
+      },
+    }
+  }
+}
+
 function mockOctokit(overrides: OctokitMockOverrides = {}): OctokitClient {
   const defaultListForAuthenticatedUser: (opts: unknown) => Promise<{data: AccessListApiEntry[]}> = async () => ({
     data: [],
@@ -750,6 +991,14 @@ function mockOctokit(overrides: OctokitMockOverrides = {}): OctokitClient {
       },
       actions: {
         createWorkflowDispatch: overrides.createWorkflowDispatch ?? (async () => undefined),
+      },
+      apps: {
+        // Stub for the App-installation enumeration used by fetchOwnedRepos. Returns
+        // an empty `data` array so the default paginate (which unwraps `response.data`)
+        // produces an empty list, matching the production behavior of paginate
+        // automatically extracting the `repositories` array from this endpoint.
+        // Tests that need real owned-repo behavior pass `paginate: appPaginate(fixtures)`.
+        listReposAccessibleToInstallation: async () => ({data: []}),
       },
       issues: {
         create: overrides.issuesCreate ?? (async () => ({data: {number: 1}})),
@@ -1944,6 +2193,299 @@ describe('handleReconcile (I/O shell)', () => {
       }
     })
   })
+
+  describe('discovery channels (owned + contrib through full pipeline)', () => {
+    // These tests exercise fetchOwnedRepos and fetchContribRepos via handleReconcile,
+    // not just the engine. The mock `paginate` returns the owned-org repo list; the
+    // mock `getContent` serves fro-bot.yaml content for contrib probes.
+
+    interface InstallationRepoFixture {
+      owner: {login: string}
+      name: string
+      archived: boolean
+      fork: boolean
+      private: boolean
+      node_id: string
+    }
+
+    function makeInstallationRepo(overrides: Partial<InstallationRepoFixture> = {}): InstallationRepoFixture {
+      return {
+        owner: {login: 'fro-bot'},
+        name: 'agent',
+        archived: false,
+        fork: false,
+        private: false,
+        node_id: 'R_inst',
+        ...overrides,
+      }
+    }
+
+    /**
+     * App-side paginate mock for `apps.listReposAccessibleToInstallation`. Always
+     * returns the supplied installation repo list regardless of which function the
+     * shell passes in. The real Octokit paginate auto-extracts `data.repositories`;
+     * tests bypass that machinery and provide the unwrapped list directly.
+     */
+    function appPaginate(
+      installationRepos: InstallationRepoFixture[],
+    ): (fn: unknown, opts: unknown) => Promise<unknown[]> {
+      return async () => installationRepos
+    }
+    // `contentByRepo` is hoisted to module scope (see top of file).
+
+    const TRUSTED_WORKFLOW = `name: Fro Bot
+on: [issues, pull_request]
+jobs:
+  agent:
+    uses: fro-bot/agent/.github/workflows/fro-bot.yaml@v0.42.1
+`
+
+    const SPOOFED_WORKFLOW = `name: not-the-agent
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "fro-bot/agent is great"
+`
+
+    it('owned channel: surfaces fro-bot org repos with discovery_channel: owned, skips fro-bot/.github', async () => {
+      // #given the App installation enumeration returns 4 fro-bot repos including .github
+      const installationRepos = [
+        makeInstallationRepo({name: 'agent', node_id: 'R_agent'}),
+        makeInstallationRepo({name: 'systematic', node_id: 'R_systematic'}),
+        makeInstallationRepo({name: 'fro-bot.github.io', node_id: 'R_pages'}),
+        makeInstallationRepo({name: '.github', node_id: 'R_self_excluded'}),
+      ]
+
+      const commitMetadata = vi.fn(async () => ({committed: true, sha: 's', attempts: 1}))
+
+      // #when reconcile runs
+      const result = await handleReconcile(
+        baseParams({
+          appOctokit: mockOctokit({paginate: appPaginate(installationRepos)}),
+          readMetadata: makeReadMetadata(),
+          commitMetadata: commitMetadata as never,
+        }),
+      )
+
+      // #then 3 owned repos are surfaced (.github excluded), all with channel=owned
+      expect(result.summary.added).toBe(3)
+      expect(result.dispatches).toBe(3)
+      expect(result.summary.pendingReview).toBe(0) // owned bypasses pending-review
+    })
+
+    it('owned channel: skips archived and forked repos', async () => {
+      const installationRepos = [
+        makeInstallationRepo({name: 'agent', node_id: 'R_agent'}),
+        makeInstallationRepo({name: 'archive-test', node_id: 'R_arch', archived: true}),
+        makeInstallationRepo({name: 'fork-test', node_id: 'R_fork', fork: true}),
+      ]
+
+      const commitMetadata = vi.fn(async () => ({committed: true, sha: 's', attempts: 1}))
+
+      const result = await handleReconcile(
+        baseParams({
+          appOctokit: mockOctokit({paginate: appPaginate(installationRepos)}),
+          readMetadata: makeReadMetadata(),
+          commitMetadata: commitMetadata as never,
+        }),
+      )
+
+      // Only `agent` should survive both filters
+      expect(result.summary.added).toBe(1)
+    })
+
+    it('contrib channel: surfaces approved_contrib_repos with content-verified fro-bot.yaml', async () => {
+      // #given allowlist with two contrib repos
+      const allowlist: AllowlistFile = {
+        version: 1,
+        approved_inviters: [],
+        approved_contrib_repos: ['bfra-me/.github', 'other-org/no-workflow'],
+      }
+
+      // #and bfra-me/.github has a trusted workflow; other-org/no-workflow has none
+      const contentMap = new Map([['bfra-me/.github', TRUSTED_WORKFLOW]])
+
+      // reposGet drives both probeContribRepoMetadata (for contrib) and the per-repo
+      // status probe (for tracked entries). We need to handle both.
+      const reposGet = async ({owner, repo}: {owner: string; repo: string}) => {
+        if (owner === 'bfra-me' && repo === '.github') {
+          return {data: {archived: false, fork: false, private: false, node_id: 'R_bfra_gh'} as RepoGetResponse}
+        }
+        if (owner === 'other-org' && repo === 'no-workflow') {
+          return {data: {archived: false, fork: false, private: false, node_id: 'R_other'} as RepoGetResponse}
+        }
+        return {data: {archived: false, private: false, node_id: 'R_default'} as RepoGetResponse}
+      }
+
+      const commitMetadata = vi.fn(async () => ({committed: true, sha: 's', attempts: 1}))
+
+      const result = await handleReconcile(
+        baseParams({
+          appOctokit: mockOctokit({
+            paginate: appPaginate([]), // no owned repos
+            getContent: contentByRepo(contentMap),
+            reposGet,
+          }),
+          readMetadata: makeReadMetadata({allowlist}),
+          commitMetadata: commitMetadata as never,
+        }),
+      )
+
+      // Only bfra-me/.github passes content verification
+      expect(result.summary.added).toBe(1)
+      expect(result.summary.pendingReview).toBe(0) // contrib bypasses pending-review
+    })
+
+    it('contrib channel: rejects repos with spoofed fro-bot.yaml (forge resistance)', async () => {
+      // #given allowlist names a repo whose fro-bot.yaml only mentions fro-bot/agent
+      // in a non-uses position (run: echo)
+      const allowlist: AllowlistFile = {
+        version: 1,
+        approved_inviters: [],
+        approved_contrib_repos: ['attacker-org/spoof-repo'],
+      }
+
+      const contentMap = new Map([['attacker-org/spoof-repo', SPOOFED_WORKFLOW]])
+
+      const reposGet = async ({owner, repo}: {owner: string; repo: string}) => {
+        if (owner === 'attacker-org' && repo === 'spoof-repo') {
+          return {
+            data: {archived: false, fork: false, private: false, node_id: 'R_attacker'} as RepoGetResponse,
+          }
+        }
+        return {data: {archived: false, private: false, node_id: 'R_default'} as RepoGetResponse}
+      }
+
+      const commitMetadata = vi.fn(async () => ({committed: true, sha: 's', attempts: 1}))
+
+      const result = await handleReconcile(
+        baseParams({
+          appOctokit: mockOctokit({
+            paginate: appPaginate([]),
+            getContent: contentByRepo(contentMap),
+            reposGet,
+          }),
+          readMetadata: makeReadMetadata({allowlist}),
+          commitMetadata: commitMetadata as never,
+        }),
+      )
+
+      // Spoofed workflow is rejected; nothing is added
+      expect(result.summary.added).toBe(0)
+    })
+
+    it('contrib channel: distinguishes 403 (App not installed) from 404 (no signal file) in warn logs', async () => {
+      const allowlist: AllowlistFile = {
+        version: 1,
+        approved_inviters: [],
+        approved_contrib_repos: ['locked-org/private-repo', 'open-org/no-workflow'],
+      }
+
+      const reposGet = async ({owner}: {owner: string; repo: string}) => {
+        if (owner === 'locked-org') throw apiError(403, 'Forbidden')
+        if (owner === 'open-org') {
+          return {data: {archived: false, fork: false, private: false, node_id: 'R_open'} as RepoGetResponse}
+        }
+        return {data: {archived: false, private: false, node_id: 'R_default'} as RepoGetResponse}
+      }
+
+      const logger = silentLogger()
+      const commitMetadata = vi.fn(async () => ({committed: true, sha: 's', attempts: 1}))
+
+      await handleReconcile(
+        baseParams({
+          appOctokit: mockOctokit({
+            paginate: appPaginate([]),
+            reposGet,
+            // open-org/no-workflow has no fro-bot.yaml — getContent throws 404 by default
+          }),
+          readMetadata: makeReadMetadata({allowlist}),
+          commitMetadata: commitMetadata as never,
+          logger,
+        }),
+      )
+
+      // 403 logs distinctly from 404
+      const warnMessages = logger.warn.mock.calls.map(call => call[0])
+      const has403Warn = warnMessages.some(m => /locked-org\/private-repo.*403.*App not installed/.test(m))
+      expect(has403Warn).toBe(true)
+    })
+
+    it('contrib channel: warns when approved_contrib_orgs is set (v1 ignores it)', async () => {
+      const allowlist: AllowlistFile = {
+        version: 1,
+        approved_inviters: [],
+        approved_contrib_orgs: ['bfra-me'],
+        approved_contrib_repos: [],
+      }
+
+      const logger = silentLogger()
+      const commitMetadata = vi.fn(async () => ({committed: true, sha: 's', attempts: 1}))
+
+      await handleReconcile(
+        baseParams({
+          appOctokit: mockOctokit({paginate: appPaginate([])}),
+          readMetadata: makeReadMetadata({allowlist}),
+          commitMetadata: commitMetadata as never,
+          logger,
+        }),
+      )
+
+      const warnMessages = logger.warn.mock.calls.map(call => call[0])
+      const hasOrgsWarn = warnMessages.some(m => m.includes('approved_contrib_orgs is not yet supported'))
+      expect(hasOrgsWarn).toBe(true)
+    })
+
+    it('mixed pipeline: collab + owned + contrib all surface with correct channels', async () => {
+      // #given collab access list, owned installation repos, and contrib allowlist
+      const collabRepos: AccessListApiEntry[] = [
+        {owner: {login: 'marcusrbrown'}, name: 'collab-repo', archived: false, private: false, node_id: 'R_collab'},
+      ]
+
+      const installationRepos = [makeInstallationRepo({name: 'agent', node_id: 'R_agent'})]
+
+      const allowlist: AllowlistFile = {
+        version: 1,
+        approved_inviters: [{username: 'marcusrbrown', added: '2026-01-01', role: 'owner'}],
+        approved_contrib_repos: ['bfra-me/.github'],
+      }
+
+      const reposGet = async ({owner, repo}: {owner: string; repo: string}) => {
+        if (owner === 'bfra-me' && repo === '.github') {
+          return {data: {archived: false, fork: false, private: false, node_id: 'R_bfra'} as RepoGetResponse}
+        }
+        return {data: {archived: false, private: false, node_id: 'R_default'} as RepoGetResponse}
+      }
+
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({data: collabRepos}),
+      })
+
+      const appOctokit = mockOctokit({
+        paginate: appPaginate(installationRepos),
+        getContent: contentByRepo(new Map([['bfra-me/.github', TRUSTED_WORKFLOW]])),
+        reposGet,
+      })
+
+      const commitMetadata = vi.fn(async () => ({committed: true, sha: 's', attempts: 1}))
+
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit,
+          readMetadata: makeReadMetadata({allowlist}),
+          commitMetadata: commitMetadata as never,
+        }),
+      )
+
+      // 3 entries: collab + owned + contrib
+      expect(result.summary.added).toBe(3)
+      expect(result.summary.pendingReview).toBe(0)
+      expect(result.dispatches).toBe(3)
+    })
+  })
 })
 
 describe('isSurveyStale', () => {
@@ -2106,5 +2648,257 @@ describe('loadMaxDispatchesPerRunFromEnv', () => {
     withEnv('-1', () => {
       expect(loadMaxDispatchesPerRunFromEnv()).toBe(-1)
     })
+  })
+})
+
+//
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure helper tests for discovery-channel shell logic
+// ─────────────────────────────────────────────────────────────────────────────
+//
+
+describe('containsFroBotAgentReference (forge resistance)', () => {
+  it('accepts a workflow that calls fro-bot/agent with a version tag', () => {
+    const yaml = `name: Fro Bot
+on: [issues, pull_request]
+jobs:
+  agent:
+    uses: fro-bot/agent/.github/workflows/fro-bot.yaml@v0.42.1
+`
+    expect(containsFroBotAgentReference(yaml)).toBe(true)
+  })
+
+  it('accepts a workflow that calls fro-bot/agent at main', () => {
+    const yaml = `jobs:
+  agent:
+    uses: fro-bot/agent/.github/workflows/fro-bot.yaml@main
+`
+    expect(containsFroBotAgentReference(yaml)).toBe(true)
+  })
+
+  it('accepts a workflow that calls fro-bot/agent at a SHA', () => {
+    const yaml = `jobs:
+  agent:
+    uses: fro-bot/agent@6c45d8ce66b0b69f1b80b23f283ed455deb59517
+`
+    expect(containsFroBotAgentReference(yaml)).toBe(true)
+  })
+
+  it('rejects an empty string', () => {
+    expect(containsFroBotAgentReference('')).toBe(false)
+  })
+
+  it('rejects a workflow that does not reference fro-bot/agent', () => {
+    const yaml = `name: foo
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hello
+`
+    expect(containsFroBotAgentReference(yaml)).toBe(false)
+  })
+
+  it('rejects a workflow that mentions fro-bot but not fro-bot/agent', () => {
+    // Forge attempt: drop the literal string `fro-bot` somewhere in a workflow file
+    // without actually invoking the agent action. Should not pass.
+    const yaml = `name: not-the-agent
+on: [push]
+jobs:
+  spoof:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "fro-bot is cool"
+`
+    expect(containsFroBotAgentReference(yaml)).toBe(false)
+  })
+
+  it('rejects a YAML referencing fro-bot/something-else', () => {
+    const yaml = `jobs:
+  agent:
+    uses: fro-bot/something-else@main
+`
+    expect(containsFroBotAgentReference(yaml)).toBe(false)
+  })
+
+  it('rejects fro-bot/agent appearing only in a comment', () => {
+    // Adversarial: spoof attempt via comment-only reference. The agent isn't actually
+    // invoked anywhere — the comment is just text the parser ignores.
+    const yaml = `# uses: fro-bot/agent@main (someday maybe)
+name: spoof
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo not-the-agent
+`
+    expect(containsFroBotAgentReference(yaml)).toBe(false)
+  })
+
+  it('rejects fro-bot/agent appearing only in a string value (name field)', () => {
+    // Adversarial: spoof via string literal in a non-uses position.
+    const yaml = `name: 'fro-bot/agent (just kidding)'
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hello
+`
+    expect(containsFroBotAgentReference(yaml)).toBe(false)
+  })
+
+  it('rejects fro-bot/agent appearing only in a run: shell command', () => {
+    // Adversarial: spoof via run-shell content.
+    const yaml = `name: spoof
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "fro-bot/agent is cool"
+`
+    expect(containsFroBotAgentReference(yaml)).toBe(false)
+  })
+
+  it('rejects fro-bot/agent appearing only in a with: input value', () => {
+    // Adversarial: spoof via `with:` action input.
+    const yaml = `name: spoof
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: fro-bot/agent
+`
+    expect(containsFroBotAgentReference(yaml)).toBe(false)
+  })
+
+  it('rejects fro-bot/agent-fork (typo-squat via shared prefix)', () => {
+    // Adversarial: a different action whose path happens to start with `fro-bot/agent`.
+    // The structural check requires exact path match, not substring.
+    const yaml = `jobs:
+  agent:
+    uses: fro-bot/agent-fork@main
+`
+    expect(containsFroBotAgentReference(yaml)).toBe(false)
+  })
+
+  it('rejects not-fro-bot/agent (typo-squat via owner)', () => {
+    const yaml = `jobs:
+  agent:
+    uses: not-fro-bot/agent@main
+`
+    expect(containsFroBotAgentReference(yaml)).toBe(false)
+  })
+
+  it('rejects malformed YAML (parse failure fails closed)', () => {
+    expect(containsFroBotAgentReference(': not\nvalid: : yaml :\n - -')).toBe(false)
+  })
+
+  it('rejects a YAML scalar (no jobs structure)', () => {
+    expect(containsFroBotAgentReference('just a string')).toBe(false)
+  })
+})
+
+function makeMergeEntry(owner: string, name: string): AccessListEntry {
+  return {owner, name, archived: false, private: false, node_id: `R_${owner}_${name}`}
+}
+
+describe('mergeAccessChannels (precedence + dedup)', () => {
+  // Local alias to keep test bodies short without recreating the helper per-test.
+  const entry = makeMergeEntry
+
+  it('returns empty results when all channels are empty', () => {
+    const result = mergeAccessChannels({collab: [], owned: [], contrib: []})
+    expect(result.accessList).toEqual([])
+    expect(result.accessChannelByKey.size).toBe(0)
+  })
+
+  it('tags collab-only entries with collab channel', () => {
+    const result = mergeAccessChannels({collab: [entry('marcusrbrown', 'foo')], owned: [], contrib: []})
+    expect(result.accessList).toHaveLength(1)
+    expect(result.accessChannelByKey.get('marcusrbrown/foo')).toBe('collab')
+  })
+
+  it('tags owned-only entries with owned channel', () => {
+    const result = mergeAccessChannels({collab: [], owned: [entry('fro-bot', 'agent')], contrib: []})
+    expect(result.accessList).toHaveLength(1)
+    expect(result.accessChannelByKey.get('fro-bot/agent')).toBe('owned')
+  })
+
+  it('tags contrib-only entries with contrib channel', () => {
+    const result = mergeAccessChannels({collab: [], owned: [], contrib: [entry('bfra-me', '.github')]})
+    expect(result.accessList).toHaveLength(1)
+    expect(result.accessChannelByKey.get('bfra-me/.github')).toBe('contrib')
+  })
+
+  it('collab wins over owned for the same key', () => {
+    // #given the same owner/name appears in both collab and owned
+    const result = mergeAccessChannels({
+      collab: [entry('fro-bot', 'agent')],
+      owned: [entry('fro-bot', 'agent')],
+      contrib: [],
+    })
+    // #then collab wins; only one entry; no duplicate keys
+    expect(result.accessList).toHaveLength(1)
+    expect(result.accessChannelByKey.get('fro-bot/agent')).toBe('collab')
+  })
+
+  it('owned wins over contrib for the same key', () => {
+    const result = mergeAccessChannels({
+      collab: [],
+      owned: [entry('shared', 'repo')],
+      contrib: [entry('shared', 'repo')],
+    })
+    expect(result.accessList).toHaveLength(1)
+    expect(result.accessChannelByKey.get('shared/repo')).toBe('owned')
+  })
+
+  it('collab wins over both owned and contrib for the same key', () => {
+    const result = mergeAccessChannels({
+      collab: [entry('shared', 'repo')],
+      owned: [entry('shared', 'repo')],
+      contrib: [entry('shared', 'repo')],
+    })
+    expect(result.accessList).toHaveLength(1)
+    expect(result.accessChannelByKey.get('shared/repo')).toBe('collab')
+  })
+
+  it('preserves all three channels when keys are distinct', () => {
+    const result = mergeAccessChannels({
+      collab: [entry('marcusrbrown', 'collab')],
+      owned: [entry('fro-bot', 'agent')],
+      contrib: [entry('bfra-me', '.github')],
+    })
+    expect(result.accessList).toHaveLength(3)
+    expect(result.accessChannelByKey.get('marcusrbrown/collab')).toBe('collab')
+    expect(result.accessChannelByKey.get('fro-bot/agent')).toBe('owned')
+    expect(result.accessChannelByKey.get('bfra-me/.github')).toBe('contrib')
+  })
+
+  it('produces an accessList that passes validateAccessList (no duplicates)', () => {
+    // #given overlapping channels
+    const result = mergeAccessChannels({
+      collab: [entry('shared', 'repo'), entry('marcusrbrown', 'foo')],
+      owned: [entry('shared', 'repo'), entry('fro-bot', 'agent')],
+      contrib: [entry('bfra-me', '.github')],
+    })
+    // #then reconcileRepos accepts it without throwing on the duplicate-key check
+    expect(() =>
+      reconcileRepos({
+        currentRepos: {version: 1, repos: []},
+        accessList: result.accessList,
+        accessChannelByKey: result.accessChannelByKey,
+        perRepoStatus: new Map(),
+        allowlist: makeAllowlist(['marcusrbrown']),
+        fieldProbes: new Map(),
+        now: NOW,
+      }),
+    ).not.toThrow()
   })
 })

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -36,6 +36,9 @@
  * contract, whole-state replacement would silently drop concurrently-added entries.
  */
 
+import type {RestEndpointMethodTypes} from '@octokit/rest'
+
+import {Buffer} from 'node:buffer'
 import {readFile} from 'node:fs/promises'
 import process from 'node:process'
 import {Octokit} from '@octokit/rest'
@@ -56,10 +59,29 @@ import {
   assertAllowlistFile,
   assertReposFile,
   type AllowlistFile,
+  type DiscoveryChannel,
   type OnboardingStatus,
   type RepoEntry,
   type ReposFile,
 } from './schemas.ts'
+
+/**
+ * Whether a discovery-channel + access-list combination is pre-trusted (skips the
+ * `pending-review` issue path that exists for non-allowlisted collab newcomers).
+ *
+ * Trust derivation:
+ * - `owned` — fro-bot's own org repos, trusted by ownership.
+ * - `contrib` — surfaced via `metadata/allowlist.yaml` allowlist + content-verified probe.
+ * - `collab` — collab access AND owner is in `approved_inviters`. Otherwise pending-review.
+ *
+ * Load-bearing for the security boundary: the same predicate runs at Pass 2 newcomer
+ * insertion AND the regain transition. Extracted to one place so a future change to the
+ * trust contract can't drift between the two sites.
+ */
+function isTrustedChannel(channel: DiscoveryChannel, owner: string, allowlistedOwners: Set<string>): boolean {
+  if (channel === 'owned' || channel === 'contrib') return true
+  return allowlistedOwners.has(owner)
+}
 
 export interface AccessListEntry {
   owner: string
@@ -92,6 +114,14 @@ export interface ReconcileInput {
   allowlist: AllowlistFile
   /** Map key format: `${owner}/${name}` (exact). Populated only for still-accessible tracked repos. */
   fieldProbes: Map<string, FieldProbe>
+  /**
+   * Map key format: `${owner}/${name}` (exact). Records which discovery channel surfaced
+   * each access-list entry. Missing keys default to `'collab'` so existing single-channel
+   * callers (collab-only) and tests work unchanged. The shell builds this map by tagging
+   * `/user/repos` results as `'collab'`, fro-bot org repos as `'owned'`, and allowlist-
+   * surfaced contrib repos as `'contrib'`.
+   */
+  accessChannelByKey?: Map<string, DiscoveryChannel>
   now: Date
 }
 
@@ -147,6 +177,7 @@ export interface ReconcileResult {
  */
 export function reconcileRepos(input: ReconcileInput): ReconcileResult {
   const {currentRepos, accessList, perRepoStatus, allowlist, fieldProbes, now} = input
+  const accessChannelByKey = input.accessChannelByKey ?? new Map<string, DiscoveryChannel>()
 
   validateAccessList(accessList)
 
@@ -173,6 +204,7 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
       entry,
       key,
       accessByKey,
+      accessChannelByKey,
       perRepoStatus,
       fieldProbes,
       allowlistedOwners,
@@ -191,17 +223,23 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
     if (trackedKeys.has(key)) continue
     if (access.archived) continue // untracked + archived: no history worth capturing; skip silently.
 
-    const allowlisted = allowlistedOwners.has(access.owner)
-    const status: OnboardingStatus = allowlisted ? 'pending' : 'pending-review'
+    // Channel determines the trust path. Owned (we own the repo) and contrib (operator
+    // explicitly listed it in metadata/allowlist.yaml's approved_contrib_*) are
+    // pre-trusted — they bypass the pending-review issue path that exists for
+    // non-allowlisted collab newcomers. See `isTrustedChannel` for the predicate.
+    const channel = accessChannelByKey.get(key) ?? 'collab'
+    const trusted = isTrustedChannel(channel, access.owner, allowlistedOwners)
+    const status: OnboardingStatus = trusted ? 'pending' : 'pending-review'
 
     next = addRepoEntry(next, {
       owner: access.owner,
       repo: access.name,
       now,
       onboarding_status: status,
+      discovery_channel: channel,
     })
 
-    if (allowlisted) {
+    if (trusted) {
       summary.added += 1
       dispatches.push({owner: access.owner, repo: access.name})
     } else {
@@ -230,6 +268,7 @@ interface ClassifyTrackedParams {
   entry: RepoEntry
   key: string
   accessByKey: Map<string, AccessListEntry>
+  accessChannelByKey: Map<string, DiscoveryChannel>
   perRepoStatus: Map<string, RepoStatusProbe>
   fieldProbes: Map<string, FieldProbe>
   allowlistedOwners: Set<string>
@@ -283,11 +322,16 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
   }
 
   if (entry.onboarding_status === 'lost-access') {
-    // Regain: entry was lost-access and is now back in the access list.
-    const allowlisted = allowlistedOwners.has(entry.owner)
-    const nextStatus: OnboardingStatus = allowlisted ? 'pending' : 'pending-review'
+    // Regain: entry was lost-access and is now back in the access list. Trust path
+    // mirrors Pass 2's newcomer logic via `isTrustedChannel`. Channel resolution
+    // prefers the entry's stored channel (sticky); falls back to the live access-list
+    // channel for legacy pre-Unit-3 entries that have no recorded channel; ultimately
+    // defaults to `collab` if neither source has it.
+    const channel = entry.discovery_channel ?? params.accessChannelByKey.get(key) ?? 'collab'
+    const trusted = isTrustedChannel(channel, entry.owner, allowlistedOwners)
+    const nextStatus: OnboardingStatus = trusted ? 'pending' : 'pending-review'
     summary.regained += 1
-    if (allowlisted) {
+    if (trusted) {
       dispatches.push({owner: entry.owner, repo: entry.name})
     } else {
       rawIssues.push({
@@ -675,8 +719,24 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
   const allowlist = await loadAllowlist(readMetadata, allowlistPath)
   const currentRepos = await loadRepos(readMetadata, reposPath)
 
-  // 3. Enumerate /user/repos (access list).
-  const accessList = await fetchAccessList(userOctokit)
+  // 3. Enumerate the access list across three discovery channels:
+  //    - collab:  `/user/repos?affiliation=collaborator` via the user PAT (`fetchAccessList`)
+  //    - owned:   fro-bot org repos via the App installation (`fetchOwnedRepos`)
+  //    - contrib: operator-allowlisted cross-org repos via the App, gated on a structural
+  //               `uses: fro-bot/agent@<ref>` check in `.github/workflows/fro-bot.yaml`
+  //               (`fetchContribRepos`). v1 supports `approved_contrib_repos` only;
+  //               `approved_contrib_orgs` is not yet enumerated (per-installation token
+  //               infrastructure required, deferred to a future plan).
+  //    Merge with collab > owned > contrib precedence so a collab entry wins on overlap and
+  //    `validateAccessList` (which rejects duplicates) doesn't throw.
+  const collabAccess = await fetchAccessList(userOctokit)
+  const ownedAccess = await fetchOwnedRepos(appOctokit, owner, logger)
+  const contribAccess = await fetchContribRepos(appOctokit, allowlist, logger)
+  const {accessList, accessChannelByKey} = mergeAccessChannels({
+    collab: collabAccess,
+    owned: ownedAccess,
+    contrib: contribAccess,
+  })
 
   // 4. For each tracked entry missing from the access list, probe `GET /repos/{o}/{r}`.
   const perRepoStatus = await fetchPerRepoStatus(userOctokit, currentRepos, accessList)
@@ -687,7 +747,15 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
   const probesFailed = fieldProbeOutcome.failed
 
   // 6. Run the pure engine to produce the change plan.
-  const plan = reconcileRepos({currentRepos, accessList, perRepoStatus, allowlist, fieldProbes, now})
+  const plan = reconcileRepos({
+    currentRepos,
+    accessList,
+    perRepoStatus,
+    allowlist,
+    fieldProbes,
+    accessChannelByKey,
+    now,
+  })
 
   const hasChanges = planHasChanges(plan)
   let integrityCheck: 'ok' | 'skipped-no-data-branch' | 'skipped-just-bootstrapped' = 'ok'
@@ -758,6 +826,7 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
           perRepoStatus,
           allowlist,
           fieldProbes,
+          accessChannelByKey,
           now,
         })
         return rerun.nextRepos
@@ -1089,6 +1158,299 @@ async function probeRenovateConfig(userOctokit: OctokitClient, owner: string, na
     }
   }
   return false
+}
+
+//
+// ─── Discovery channels (owned + contrib) ───────────────────────────────────
+//
+
+/**
+ * fro-bot/.github is excluded from the owned-channel discovery pass. The control-plane
+ * repo is the agent's own home and writing wiki content about itself produces a circular
+ * journal that pollutes the wiki.
+ */
+const OWNED_SELF_EXCLUDE = 'fro-bot/.github'
+const FRO_BOT_WORKFLOW_PATH = '.github/workflows/fro-bot.yaml'
+
+// Derived from the real Octokit response so SDK drift becomes a compile error.
+type InstallationRepo =
+  RestEndpointMethodTypes['apps']['listReposAccessibleToInstallation']['response']['data']['repositories'][number]
+
+/**
+ * Verify that a `.github/workflows/fro-bot.yaml` file actually invokes the `fro-bot/agent`
+ * action via a `uses:` directive. Forge resistance: parses the workflow as YAML and walks
+ * its job/step structure, checking only `uses:` values. Comments, `name:` strings, `run:`
+ * shell, and `with:` inputs are ignored — they're not action sources.
+ *
+ * Accepted patterns (any `uses:` value matching one of these):
+ * - `fro-bot/agent@<ref>`                                        (direct action)
+ * - `fro-bot/agent/<sub/path>/...@<ref>`                         (action's reusable workflow)
+ *
+ * The `<ref>` may be a SHA, semver tag (`v0.42.1`), or branch (`main`). Variants like
+ * `fro-bot/agent-fork@main` or `not-fro-bot/agent@main` are rejected — the path must be
+ * exactly `fro-bot/agent` (or a sub-path under it).
+ *
+ * Returns false for empty files, non-YAML content, and YAML that has no qualifying
+ * `uses:` value. Errors during parsing fail closed.
+ */
+export function containsFroBotAgentReference(yamlText: string): boolean {
+  if (yamlText.length === 0) return false
+  let parsed: unknown
+  try {
+    parsed = parse(yamlText)
+  } catch {
+    return false
+  }
+  if (!isRecord(parsed)) return false
+  const jobs = parsed.jobs
+  if (!isRecord(jobs)) return false
+  for (const job of Object.values(jobs)) {
+    if (!isRecord(job)) continue
+    // Reusable workflow call: `jobs.<id>.uses: fro-bot/agent/.github/workflows/...@ref`
+    if (typeof job.uses === 'string' && isFroBotAgentUses(job.uses)) return true
+    // Step-level uses: `jobs.<id>.steps[*].uses: fro-bot/agent@ref`
+    if (Array.isArray(job.steps)) {
+      for (const step of job.steps) {
+        if (isRecord(step) && typeof step.uses === 'string' && isFroBotAgentUses(step.uses)) {
+          return true
+        }
+      }
+    }
+  }
+  return false
+}
+
+/**
+ * A `uses:` value points at the fro-bot agent when its path component is exactly
+ * `fro-bot/agent` or `fro-bot/agent/<anything>`, followed by an `@<ref>`. Rejects
+ * `fro-bot/agent-fork`, `not-fro-bot/agent`, and any other typo-squat or substring spoof.
+ */
+function isFroBotAgentUses(value: string): boolean {
+  // Split on the first `@` so the path and ref can be checked independently — keeps
+  // the regex simple and avoids backtracking concerns from chained quantifiers.
+  const atIndex = value.indexOf('@')
+  if (atIndex < 1) return false // no `@`, or value starts with `@`
+  const path = value.slice(0, atIndex)
+  const ref = value.slice(atIndex + 1)
+  if (ref.length === 0) return false
+  if (/\s/.test(ref)) return false
+  if (path === 'fro-bot/agent') return true
+  if (!path.startsWith('fro-bot/agent/')) return false
+  // sub-path must be non-empty and contain no whitespace
+  const subPath = path.slice('fro-bot/agent/'.length)
+  return subPath.length > 0 && !/\s/.test(subPath)
+}
+
+/**
+ * Discover repos owned by `owner` that the App installation can reach. Skips archived,
+ * forks, and the self-exclude constant. Owned repos are pre-trusted (we own them), so the
+ * caller does NOT probe `fro-bot.yaml` content for these — owned trust comes from
+ * ownership, not from a workflow signal.
+ *
+ * Errors during enumeration log a structured warn and return an empty list rather than
+ * blocking the reconcile run. Cross-channel discovery is best-effort; collab access is
+ * the authoritative signal for repo presence.
+ */
+async function fetchOwnedRepos(
+  appOctokit: OctokitClient,
+  owner: string,
+  logger: ReconcileLogger,
+): Promise<AccessListEntry[]> {
+  let allRepos: InstallationRepo[]
+  try {
+    allRepos = await appOctokit.paginate(appOctokit.rest.apps.listReposAccessibleToInstallation, {
+      per_page: 100,
+    })
+  } catch (error: unknown) {
+    const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
+    logger.warn(`reconcile: owned-channel enumeration failed (status=${status}); continuing without owned repos.`)
+    return []
+  }
+
+  const entries: AccessListEntry[] = []
+  for (const repo of allRepos) {
+    if (repo.owner.login !== owner) continue
+    if (repo.archived) continue
+    if (repo.fork) continue
+    const key = `${owner}/${repo.name}`
+    if (key === OWNED_SELF_EXCLUDE) continue
+    entries.push({
+      owner,
+      name: repo.name,
+      archived: false,
+      private: repo.private,
+      node_id: repo.node_id,
+    })
+  }
+  return entries
+}
+
+/**
+ * Discover contrib-channel repos surfaced via `metadata/allowlist.yaml`'s
+ * `approved_contrib_repos`. For each `owner/name`, fetch repo metadata, skip
+ * archived/forks, then verify the trust signal by parsing
+ * `.github/workflows/fro-bot.yaml` and checking that a `uses:` directive points at
+ * `fro-bot/agent` (see `containsFroBotAgentReference` for the structural check).
+ *
+ * 403 (App not installed in the target repo's org) and 404 (no signal file or repo
+ * unreachable) result in silent omission with a structured warn that distinguishes the
+ * two — collapsing them masks installation drift. 5xx and other transient errors also
+ * log + omit.
+ *
+ * `approved_contrib_orgs` is intentionally NOT enumerated in v1: the
+ * `apps.listReposAccessibleToInstallation` endpoint is per-installation, not per-org, so
+ * cross-org enumeration would require minting a separate App installation token per org.
+ * Until that infrastructure lands, operators surface contrib repos one-at-a-time via
+ * `approved_contrib_repos`. A non-empty `approved_contrib_orgs` triggers a structured
+ * warn so the operator knows the field is being ignored.
+ */
+async function fetchContribRepos(
+  appOctokit: OctokitClient,
+  allowlist: AllowlistFile,
+  logger: ReconcileLogger,
+): Promise<AccessListEntry[]> {
+  if (allowlist.approved_contrib_orgs !== undefined && allowlist.approved_contrib_orgs.length > 0) {
+    logger.warn(
+      `reconcile: approved_contrib_orgs is not yet supported (requires per-org App installation tokens); ` +
+        `${allowlist.approved_contrib_orgs.length} org(s) ignored. Use approved_contrib_repos to surface specific repos.`,
+    )
+  }
+
+  const directRepos = allowlist.approved_contrib_repos ?? []
+  const seen = new Set<string>()
+  const entries: AccessListEntry[] = []
+
+  for (const ownerRepo of directRepos) {
+    const slashIndex = ownerRepo.indexOf('/')
+    if (slashIndex === -1) continue
+    const directOwner = ownerRepo.slice(0, slashIndex)
+    const directName = ownerRepo.slice(slashIndex + 1)
+    const key = `${directOwner}/${directName}`
+    if (seen.has(key)) continue
+    const meta = await probeContribRepoMetadata(appOctokit, directOwner, directName, logger)
+    if (meta === null) continue
+    if (meta.archived || meta.fork) continue
+    const probe = await probeContribWorkflow(appOctokit, directOwner, directName, logger)
+    if (probe === null) continue
+    if (!containsFroBotAgentReference(probe)) continue
+    entries.push({
+      owner: directOwner,
+      name: directName,
+      archived: false,
+      private: meta.private,
+      node_id: meta.node_id,
+    })
+    seen.add(key)
+  }
+
+  return entries
+}
+
+/**
+ * Fetch repo metadata (private flag, node_id, archived, fork) for a contrib direct-probe
+ * entry. Returns null when the repo is unreachable (404 = doesn't exist, 403 = App not
+ * installed). Distinguishes the two for operator-grade logging — silently collapsing 403
+ * to 404 would mask installation drift, the silent-failure mode that
+ * `docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md` warns
+ * about.
+ */
+async function probeContribRepoMetadata(
+  appOctokit: OctokitClient,
+  owner: string,
+  name: string,
+  logger: ReconcileLogger,
+): Promise<{private: boolean; node_id: string; archived: boolean; fork: boolean} | null> {
+  try {
+    const response = await appOctokit.rest.repos.get({owner, repo: name})
+    return {
+      private: response.data.private === true,
+      node_id: response.data.node_id,
+      archived: response.data.archived === true,
+      fork: response.data.fork === true,
+    }
+  } catch (error: unknown) {
+    if (isApiStatus(error, 404)) return null
+    if (isApiStatus(error, 403)) {
+      logger.warn(`reconcile: contrib-repo ${owner}/${name} returned 403 (App not installed in org); omitting.`)
+      return null
+    }
+    const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
+    logger.warn(`reconcile: contrib-repo ${owner}/${name} probe failed (status=${status}); omitting.`)
+    return null
+  }
+}
+
+/**
+ * Fetch the raw `.github/workflows/fro-bot.yaml` content for a candidate contrib repo.
+ * Returns null when the file is missing (404), the App lacks access (403), or the response
+ * is malformed. 403 is logged distinctly from 404 — the same forge-resistance + drift-
+ * visibility contract as `probeContribRepoMetadata`.
+ */
+async function probeContribWorkflow(
+  appOctokit: OctokitClient,
+  owner: string,
+  name: string,
+  logger: ReconcileLogger,
+): Promise<string | null> {
+  try {
+    const response = await appOctokit.rest.repos.getContent({
+      owner,
+      repo: name,
+      path: FRO_BOT_WORKFLOW_PATH,
+    })
+    // getContent returns a discriminated union — the file variant is the only one with
+    // a base64-encoded `content` field. Narrow on `type === 'file'` to let TypeScript
+    // pick the right branch without `as` casts.
+    const {data} = response
+    if (Array.isArray(data) || data.type !== 'file') return null
+    if (data.encoding !== 'base64') return null
+    return Buffer.from(data.content, 'base64').toString('utf8')
+  } catch (error: unknown) {
+    if (isApiStatus(error, 404)) return null
+    if (isApiStatus(error, 403)) {
+      logger.warn(`reconcile: contrib-repo ${owner}/${name} workflow probe returned 403 (App not installed); omitting.`)
+      return null
+    }
+    const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
+    logger.warn(`reconcile: contrib-repo ${owner}/${name} workflow probe failed (status=${status}); omitting.`)
+    return null
+  }
+}
+
+/**
+ * Merge per-channel access lists into the canonical access list + channel map. Precedence
+ * is `collab > owned > contrib`: when the same `owner/name` appears in multiple channels,
+ * the highest-precedence channel wins so `validateAccessList` (which rejects duplicate
+ * keys) sees a single entry.
+ */
+export function mergeAccessChannels(input: {
+  collab: AccessListEntry[]
+  owned: AccessListEntry[]
+  contrib: AccessListEntry[]
+}): {accessList: AccessListEntry[]; accessChannelByKey: Map<string, DiscoveryChannel>} {
+  const accessByKey = new Map<string, AccessListEntry>()
+  const channelByKey = new Map<string, DiscoveryChannel>()
+
+  // Order matters: collab first wins overlap with owned/contrib; owned wins over contrib.
+  for (const entry of input.collab) {
+    const key = repoKey(entry.owner, entry.name)
+    accessByKey.set(key, entry)
+    channelByKey.set(key, 'collab')
+  }
+  for (const entry of input.owned) {
+    const key = repoKey(entry.owner, entry.name)
+    if (accessByKey.has(key)) continue
+    accessByKey.set(key, entry)
+    channelByKey.set(key, 'owned')
+  }
+  for (const entry of input.contrib) {
+    const key = repoKey(entry.owner, entry.name)
+    if (accessByKey.has(key)) continue
+    accessByKey.set(key, entry)
+    channelByKey.set(key, 'contrib')
+  }
+
+  return {accessList: Array.from(accessByKey.values()), accessChannelByKey: channelByKey}
 }
 
 interface IntegrityCheckOkResult {

--- a/scripts/schemas.test.ts
+++ b/scripts/schemas.test.ts
@@ -356,3 +356,70 @@ describe('schemas — rejection cases', () => {
     expect(error.message).toContain(error.path)
   })
 })
+
+describe('AllowlistFile — approved_contrib_orgs + approved_contrib_repos', () => {
+  it('accepts a populated allowlist with both contrib arrays', () => {
+    const ok = {
+      version: 1,
+      approved_inviters: [{username: 'marcusrbrown', added: '2026-04-15', role: 'owner'}],
+      approved_contrib_orgs: ['bfra-me'],
+      approved_contrib_repos: ['some-org/foo', 'other-org/bar'],
+    }
+    expect(isAllowlistFile(ok)).toBe(true)
+    expect(() => assertAllowlistFile(ok)).not.toThrow()
+  })
+
+  it('accepts an allowlist with empty contrib arrays', () => {
+    const ok = {
+      version: 1,
+      approved_inviters: [],
+      approved_contrib_orgs: [],
+      approved_contrib_repos: [],
+    }
+    expect(isAllowlistFile(ok)).toBe(true)
+    expect(() => assertAllowlistFile(ok)).not.toThrow()
+  })
+
+  it('accepts a legacy allowlist missing both contrib fields (backward-compat)', () => {
+    // Existing metadata/allowlist.yaml predates contrib channel; loaders must accept it.
+    const ok = {version: 1, approved_inviters: []}
+    expect(isAllowlistFile(ok)).toBe(true)
+    expect(() => assertAllowlistFile(ok)).not.toThrow()
+  })
+
+  it('rejects approved_contrib_orgs containing non-string entry', () => {
+    const bad = {
+      version: 1,
+      approved_inviters: [],
+      approved_contrib_orgs: ['bfra-me', 42],
+      approved_contrib_repos: [],
+    }
+    expect(isAllowlistFile(bad)).toBe(false)
+    const error = catchSchemaError(() => assertAllowlistFile(bad))
+    expect(error.path).toContain('approved_contrib_orgs')
+  })
+
+  it('rejects approved_contrib_repos containing entry without owner/repo slash', () => {
+    const bad = {
+      version: 1,
+      approved_inviters: [],
+      approved_contrib_orgs: [],
+      approved_contrib_repos: ['just-a-name'],
+    }
+    expect(isAllowlistFile(bad)).toBe(false)
+    const error = catchSchemaError(() => assertAllowlistFile(bad))
+    expect(error.path).toContain('approved_contrib_repos')
+  })
+
+  it('rejects approved_contrib_orgs that is not an array', () => {
+    const bad = {
+      version: 1,
+      approved_inviters: [],
+      approved_contrib_orgs: 'bfra-me',
+      approved_contrib_repos: [],
+    }
+    expect(isAllowlistFile(bad)).toBe(false)
+    const error = catchSchemaError(() => assertAllowlistFile(bad))
+    expect(error.path).toContain('approved_contrib_orgs')
+  })
+})

--- a/scripts/schemas.ts
+++ b/scripts/schemas.ts
@@ -10,6 +10,18 @@
 export interface AllowlistFile {
   version: 1
   approved_inviters: ApprovedInviter[]
+  /**
+   * Operator-curated list of GitHub org logins. Repos under these orgs that contain
+   * `.github/workflows/fro-bot.yaml` are eligible to surface via the `contrib` channel.
+   * Optional during the rollout window; loaders treat missing as `[]` for backward compat.
+   */
+  approved_contrib_orgs?: string[]
+  /**
+   * Operator-curated list of `owner/name` strings. Each named repo is probed for
+   * `.github/workflows/fro-bot.yaml` and surfaced via the `contrib` channel when present.
+   * Optional during the rollout window; loaders treat missing as `[]` for backward compat.
+   */
+  approved_contrib_repos?: string[]
 }
 
 export interface ApprovedInviter {
@@ -71,6 +83,18 @@ export interface SocialCooldownEntry {
   repo?: string
 }
 
+/**
+ * GitHub identifier rules for `owner/name`:
+ * - Owner: 1-39 chars, alphanumeric or hyphens, no leading/trailing hyphen, no consecutive
+ *   hyphens. Same rule applies to user logins and org logins.
+ * - Repo: 1-100 chars, alphanumeric, hyphens, underscores, periods. Cannot be `.` or `..`.
+ *
+ * The pattern enforces both pieces. Defense-in-depth on operator-curated input — Octokit
+ * URL-encodes path params correctly, but rejecting invalid identifiers at parse time keeps
+ * typos and shell metachars out of `metadata/allowlist.yaml` entirely.
+ */
+const CONTRIB_REPO_PATTERN = /^[A-Z\d](?:[A-Z\d]|-(?=[A-Z\d])){0,38}\/(?!\.{1,2}$)[\w.-]{1,100}$/i
+
 export class SchemaValidationError extends Error {
   readonly path: string
 
@@ -85,7 +109,16 @@ export function isAllowlistFile(value: unknown): value is AllowlistFile {
   if (!isRecord(value)) return false
   if (value.version !== 1) return false
   if (!Array.isArray(value.approved_inviters)) return false
-  return value.approved_inviters.every(isApprovedInviter)
+  if (!value.approved_inviters.every(isApprovedInviter)) return false
+  if (value.approved_contrib_orgs !== undefined) {
+    if (!Array.isArray(value.approved_contrib_orgs)) return false
+    if (!value.approved_contrib_orgs.every(v => typeof v === 'string')) return false
+  }
+  if (value.approved_contrib_repos !== undefined) {
+    if (!Array.isArray(value.approved_contrib_repos)) return false
+    if (!value.approved_contrib_repos.every(v => typeof v === 'string' && CONTRIB_REPO_PATTERN.test(v))) return false
+  }
+  return true
 }
 
 export function assertAllowlistFile(value: unknown, path = 'allowlist'): asserts value is AllowlistFile {
@@ -96,6 +129,30 @@ export function assertAllowlistFile(value: unknown, path = 'allowlist'): asserts
   value.approved_inviters.forEach((entry, index) => {
     assertApprovedInviter(entry, `${path}.approved_inviters[${index}]`)
   })
+  if (value.approved_contrib_orgs !== undefined) {
+    if (!Array.isArray(value.approved_contrib_orgs))
+      throw new SchemaValidationError(`${path}.approved_contrib_orgs`, 'expected array of strings or omitted')
+    value.approved_contrib_orgs.forEach((entry, index) => {
+      if (typeof entry !== 'string')
+        throw new SchemaValidationError(`${path}.approved_contrib_orgs[${index}]`, 'expected string')
+    })
+  }
+  if (value.approved_contrib_repos !== undefined) {
+    if (!Array.isArray(value.approved_contrib_repos))
+      throw new SchemaValidationError(
+        `${path}.approved_contrib_repos`,
+        'expected array of "owner/name" strings or omitted',
+      )
+    value.approved_contrib_repos.forEach((entry, index) => {
+      if (typeof entry !== 'string')
+        throw new SchemaValidationError(`${path}.approved_contrib_repos[${index}]`, 'expected string')
+      if (!CONTRIB_REPO_PATTERN.test(entry))
+        throw new SchemaValidationError(
+          `${path}.approved_contrib_repos[${index}]`,
+          'expected GitHub "owner/name" identifier (e.g., "bfra-me/.github")',
+        )
+    })
+  }
 }
 
 function isApprovedInviter(value: unknown): value is ApprovedInviter {


### PR DESCRIPTION
## What changes

Two new repo discovery channels feed the daily reconcile pipeline:

- **`owned`** — fro-bot org repos discovered via the App installation (`apps.listReposAccessibleToInstallation`). Trusted by ownership; archived/forked repos and `fro-bot/.github` itself are filtered out at enumeration.
- **`contrib`** — operator-curated cross-org repos via `metadata/allowlist.yaml`'s new `approved_contrib_repos` list. Each entry is probed for `.github/workflows/fro-bot.yaml`; the workflow is parsed structurally and a job-level or step-level `uses:` directive must point at `fro-bot/agent` (or a sub-path under it).

Both channels feed the same `metadata/repos.yaml` — entries carry their `discovery_channel` field through the existing reconcile classification, dispatch, and lifecycle code unchanged.

## Why

The collab-only access list misses two real channels Fro Bot already operates in:

- The agent's own org. `fro-bot/agent`, `fro-bot/systematic`, and `fro-bot/fro-bot.github.io` weren't being surveyed despite being core to the project's identity.
- Cross-org repos that already invoke the agent action via their own `fro-bot.yaml` workflow. These repos are downstream consumers of the control plane but had no presence in the wiki.

Treating both as separate channels (rather than collapsing them into "collab") preserves attribution, lets each channel evolve its own cadence under the per-channel intervals from #3238, and isolates trust paths.

## Trust derivations

The trust predicate is now extracted to one function — `isTrustedChannel(channel, owner, allowlistedOwners)` — so a future change can't silently drift between Pass 2 newcomer insertion and the regain transition. Each channel earns trust differently:

| Channel   | Trust source                                                                                       | `pending-review` issue path |
| --------- | -------------------------------------------------------------------------------------------------- | --------------------------- |
| `collab`  | Owner is in `approved_inviters`                                                                    | Yes if not allowlisted        |
| `owned`   | Ownership of the repo                                                                              | Bypassed                      |
| `contrib` | Explicit operator allowlist entry **plus** content-verified `uses: fro-bot/agent@<ref>` directive | Bypassed                      |

## Forge resistance

The contrib trust signal is the entire security boundary for cross-org surfacing — anyone with push access to an allowlisted repo could otherwise trigger Fro Bot's agent against arbitrary code. The probe parses the workflow as YAML and checks **only** `jobs.<id>.uses` and `jobs.<id>.steps[].uses` values. It rejects:

- Comment-only mentions: `# fro-bot/agent` doesn't qualify
- String-literal mentions in `name:`, `run:`, or `with:` inputs
- Typo-squat variants: `fro-bot/agent-fork@main`, `fro-bot/agent.bak@v1`
- Owner-prefix spoofs: `not-fro-bot/agent@main`
- Malformed YAML (fails closed)

The check is permissive about ref shape — SHAs, semver tags (`@v0.42.1`), and branch refs (`@main`) all pass. It's permissive about sub-paths under the action — `fro-bot/agent/.github/workflows/fro-bot.yaml@<ref>` for reusable-workflow callers is accepted.

## What's deferred

`approved_contrib_orgs` is preserved in the schema as a forward-compatibility hook but is not enumerated at runtime in v1. The `apps.listReposAccessibleToInstallation` endpoint is per-installation, not per-org — cross-org enumeration would require minting a separate App installation token per allowlisted org. Until that infrastructure lands, operators surface specific cross-org repos one-at-a-time via `approved_contrib_repos`. A non-empty `approved_contrib_orgs` triggers a structured warn so the deferral is operator-visible.

## Workflow change

`reconcile-repos.yaml` mints its App token with `owner: ${{ github.repository_owner }}` to scope it to the whole installation rather than the calling repo. Mirrors the fix already applied to `update-metadata.yaml` and `dispatch-renovate.yaml` — without it, cross-org content probes would 403 even when the App is installed in the target org.

## Observability

403 (App not installed in target org) is logged distinctly from 404 (no signal file or repo unreachable). Collapsing them would mask installation drift, which is exactly the silent-failure mode `docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md` warns against.

## Test scenarios covered

386 tests total (was 339 before this branch; +47 net). Coverage spans:

- Schema: contrib allowlist accepts populated arrays, empty arrays, legacy missing fields; rejects non-strings, malformed `owner/name`, non-arrays
- Engine: 10 discovery-channel tests covering owned/contrib classification, channel-map fallback, pending-review bypass, field refresh stickiness, lost-access flow per channel, mixed-channel reconcile
- Forge resistance: 15 tests across all 5 documented spoof variants plus malformed YAML and sub-path acceptance
- Merge precedence: 9 tests pinning `collab > owned > contrib` precedence under all overlap combinations
- Integration: 7 tests through the full `handleReconcile` pipeline covering owned org enumeration, archived/fork filtering, contrib probe with content verification, 403 vs 404 distinction in warn logs, and a mixed collab + owned + contrib pipeline

## Out of scope

- **`approved_contrib_orgs` enumeration** — see "What's deferred" above. Future plan addresses per-installation App tokens.
- **Per-channel observability counters** in `ReconcileSummary` — Unit 5 territory.
- **Sticky channel re-classification audit signal** — operators can edit `metadata/repos.yaml` on `data` directly to change channel; the change is intentional per the schema docs but doesn't currently emit a re-onboarding signal.
- **Failure-aware backoff for chronically failing repos** — future plan.

## Plan reference

Implements Unit 3 of `docs/plans/2026-05-05-001-feat-survey-cadence-and-multi-channel-discovery-plan.md`. Plan checkbox flipped in this PR.