### PR TITLE
feat(cadence): retire fixed-staleness model and add per-channel observability

### DIFF
--- a/docs/plans/2026-05-05-001-feat-survey-cadence-and-multi-channel-discovery-plan.md
+++ b/docs/plans/2026-05-05-001-feat-survey-cadence-and-multi-channel-discovery-plan.md
@@ -361,7 +361,7 @@ The pure engine boundary stays clean. New I/O (owned + contrib enumeration) live
 
 ---
 
-- [ ] **Unit 4: Migration + cleanup of `SURVEY_STALENESS_MS`**
+- [x] **Unit 4: Migration + cleanup of `SURVEY_STALENESS_MS`**
 
 **Goal:** Make the migration of legacy entries automatic on first post-rollout reconcile run. Remove the `SURVEY_STALENESS_MS` constant and `isSurveyStale` legacy export now that all callers are migrated. This is the unit that "flips the switch" for cadence — after this lands, `next_survey_eligible_at` is the only source of truth.
 

--- a/docs/plans/2026-05-05-001-feat-survey-cadence-and-multi-channel-discovery-plan.md
+++ b/docs/plans/2026-05-05-001-feat-survey-cadence-and-multi-channel-discovery-plan.md
@@ -406,7 +406,7 @@ The pure engine boundary stays clean. New I/O (owned + contrib enumeration) live
 
 ---
 
-- [ ] **Unit 5: Per-channel observability**
+- [x] **Unit 5: Per-channel observability**
 
 **Goal:** Extend the reconcile JSON output with per-channel counters and add an info-level log line on first survey for new-channel entries. Operator can now answer "how much did each channel contribute today?" by reading the JSON output alone.
 

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -1,5 +1,5 @@
 import type {CommitMetadataParams, CommitMetadataResult} from './commit-metadata.ts'
-import type {AllowlistFile, RepoEntry, ReposFile} from './schemas.ts'
+import type {AllowlistFile, DiscoveryChannel, RepoEntry, ReposFile} from './schemas.ts'
 import {Buffer} from 'node:buffer'
 import process from 'node:process'
 
@@ -42,6 +42,14 @@ function makeAccess(overrides: Partial<AccessListEntry> = {}): AccessListEntry {
     private: false,
     node_id: 'R_default',
     ...overrides,
+  }
+}
+
+function emptyChannelStats() {
+  return {
+    collab: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
+    owned: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
+    contrib: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
   }
 }
 
@@ -102,6 +110,12 @@ describe('reconcileRepos', () => {
         refreshed: 0,
         migrated: 0,
         unchanged: 0,
+        // dispatched/deferred populated by the I/O shell, not the engine
+        byChannel: {
+          collab: {tracked: 1, dispatched: 0, deferred: 0, lostAccess: 0},
+          owned: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
+          contrib: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
+        },
       })
     })
 
@@ -428,6 +442,12 @@ describe('reconcileRepos', () => {
         refreshed: 1,
         migrated: 0,
         unchanged: 0,
+        // dispatched/deferred populated by the I/O shell, not the engine
+        byChannel: {
+          collab: {tracked: 3, dispatched: 0, deferred: 0, lostAccess: 1},
+          owned: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
+          contrib: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
+        },
       })
     })
 
@@ -454,6 +474,11 @@ describe('reconcileRepos', () => {
         refreshed: 0,
         migrated: 0,
         unchanged: 1,
+        byChannel: {
+          collab: {tracked: 1, dispatched: 0, deferred: 0, lostAccess: 0},
+          owned: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
+          contrib: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
+        },
       })
     })
 
@@ -471,6 +496,7 @@ describe('reconcileRepos', () => {
         refreshed: 0,
         migrated: 0,
         unchanged: 0,
+        byChannel: emptyChannelStats(),
       })
     })
 
@@ -1025,8 +1051,14 @@ function makeReadMetadata(
   }
 }
 
-function silentLogger(): {warn: ReturnType<typeof vi.fn<(message: string) => void>>} {
-  return {warn: vi.fn<(message: string) => void>()}
+function silentLogger(): {
+  warn: ReturnType<typeof vi.fn<(message: string) => void>>
+  info: ReturnType<typeof vi.fn<(message: string) => void>>
+} {
+  return {
+    warn: vi.fn<(message: string) => void>(),
+    info: vi.fn<(message: string) => void>(),
+  }
 }
 
 function baseParams(overrides: Partial<HandleReconcileParams> = {}): HandleReconcileParams {
@@ -2490,6 +2522,141 @@ jobs:
       expect(result.dispatches).toBe(3)
     })
   })
+
+  describe('per-channel observability', () => {
+    it('emits first-survey info log for never-surveyed owned entries only', async () => {
+      // GIVEN one owned entry with last_survey_at: null already onboarded
+      const entry: RepoEntry = {
+        owner: 'fro-bot',
+        name: 'agent',
+        added: '2026-05-01',
+        onboarding_status: 'onboarded',
+        last_survey_at: null,
+        last_survey_status: null,
+        has_fro_bot_workflow: true,
+        has_renovate: false,
+        discovery_channel: 'owned',
+        next_survey_eligible_at: null,
+      }
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: vi.fn(async () => ({
+          data: [{owner: {login: 'fro-bot'}, name: 'agent', archived: false, private: false, node_id: 'R_a'}],
+        })),
+      })
+      const logger = silentLogger()
+
+      await handleReconcile(
+        baseParams({
+          userOctokit,
+          readMetadata: makeReadMetadata({repos: {version: 1, repos: [entry]}}),
+          logger,
+        }),
+      )
+
+      const infoCalls = logger.info.mock.calls.flat()
+      expect(infoCalls).toContain('reconcile: first survey for new owned entry: fro-bot/agent')
+    })
+
+    it('does NOT emit first-survey info log for collab newcomers', async () => {
+      // GIVEN a collab newcomer (allowlisted owner, fresh dispatch)
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: vi.fn(async () => ({
+          data: [
+            {owner: {login: 'marcusrbrown'}, name: 'collab-newcomer', archived: false, private: false, node_id: 'R_c'},
+          ],
+        })),
+      })
+      const logger = silentLogger()
+
+      await handleReconcile(
+        baseParams({
+          userOctokit,
+          readMetadata: makeReadMetadata({
+            repos: {version: 1, repos: []},
+            allowlist: makeAllowlist(['marcusrbrown']),
+          }),
+          logger,
+        }),
+      )
+
+      const infoCalls = logger.info.mock.calls.flat()
+      expect(infoCalls.some((c: string) => c.includes('first survey for new collab'))).toBe(false)
+    })
+
+    it('does NOT re-emit first-survey log when an owned entry already has a last_survey_at', async () => {
+      // GIVEN an owned entry that has already been surveyed once
+      const entry: RepoEntry = {
+        owner: 'fro-bot',
+        name: 'agent',
+        added: '2026-05-01',
+        onboarding_status: 'onboarded',
+        last_survey_at: '2026-04-01', // previously surveyed
+        last_survey_status: 'success',
+        has_fro_bot_workflow: true,
+        has_renovate: false,
+        discovery_channel: 'owned',
+        next_survey_eligible_at: '2026-04-20', // eligible (past)
+      }
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: vi.fn(async () => ({
+          data: [{owner: {login: 'fro-bot'}, name: 'agent', archived: false, private: false, node_id: 'R_a'}],
+        })),
+      })
+      const logger = silentLogger()
+
+      await handleReconcile(
+        baseParams({
+          userOctokit,
+          readMetadata: makeReadMetadata({repos: {version: 1, repos: [entry]}}),
+          logger,
+        }),
+      )
+
+      const infoCalls = logger.info.mock.calls.flat()
+      expect(infoCalls.some((c: string) => c.includes('first survey for new'))).toBe(false)
+    })
+
+    it('populates byChannel.dispatched and byChannel.deferred after cap selection', async () => {
+      // GIVEN 3 collab entries that are all eligible, with maxDispatchesPerRun=2
+      const entries: RepoEntry[] = ['a', 'b', 'c'].map(name => ({
+        owner: 'marcusrbrown',
+        name,
+        added: '2026-01-01',
+        onboarding_status: 'onboarded',
+        last_survey_at: null,
+        last_survey_status: null,
+        has_fro_bot_workflow: false,
+        has_renovate: false,
+        discovery_channel: 'collab',
+        next_survey_eligible_at: null,
+      }))
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: vi.fn(async () => ({
+          data: entries.map(e => ({
+            owner: {login: e.owner},
+            name: e.name,
+            archived: false,
+            private: false,
+            node_id: `R_${e.name}`,
+          })),
+        })),
+      })
+
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          readMetadata: makeReadMetadata({repos: {version: 1, repos: entries}}),
+          maxDispatchesPerRun: 2,
+        }),
+      )
+
+      // 2 dispatched, 1 deferred — all collab
+      expect(result.summary.byChannel.collab.dispatched).toBe(2)
+      expect(result.summary.byChannel.collab.deferred).toBe(1)
+      expect(result.summary.byChannel.owned.dispatched).toBe(0)
+      expect(result.summary.byChannel.contrib.dispatched).toBe(0)
+    })
+  })
 })
 
 describe('migrateRepoEntry', () => {
@@ -2673,6 +2840,7 @@ describe('formatCommitMessage', () => {
         refreshed: 2,
         migrated: 0,
         unchanged: 0,
+        byChannel: emptyChannelStats(),
       }),
     ).toBe('chore(reconcile): +1 new, 0 pending-review, 0 lost-access, 2 refreshes')
   })
@@ -2687,6 +2855,7 @@ describe('formatCommitMessage', () => {
         refreshed: 0,
         migrated: 18,
         unchanged: 0,
+        byChannel: emptyChannelStats(),
       }),
     ).toBe('chore(reconcile): +0 new, 0 pending-review, 0 lost-access, 0 refreshes, +18 migrated')
   })
@@ -2701,6 +2870,7 @@ describe('formatCommitMessage', () => {
         refreshed: 1,
         migrated: 18,
         unchanged: 0,
+        byChannel: emptyChannelStats(),
       }),
     ).toBe('chore(reconcile): +1 new, 0 pending-review, 0 lost-access, 1 refreshes, +18 migrated')
   })
@@ -3086,5 +3256,81 @@ describe('mergeAccessChannels (precedence + dedup)', () => {
         now: NOW,
       }),
     ).not.toThrow()
+  })
+})
+
+describe('reconcileRepos byChannel summary', () => {
+  it('counts tracked entries per channel', () => {
+    // GIVEN 3 entries: 2 collab, 1 owned (no access changes, no probe drift)
+    const entries = [
+      makeEntry({owner: 'marcusrbrown', name: 'a', discovery_channel: 'collab'}),
+      makeEntry({owner: 'marcusrbrown', name: 'b', discovery_channel: 'collab'}),
+      makeEntry({owner: 'fro-bot', name: 'agent', discovery_channel: 'owned'}),
+    ]
+    const accessList = entries.map(e => makeAccess({owner: e.owner, name: e.name, node_id: `R_${e.name}`}))
+    const channelMap = new Map<string, DiscoveryChannel>(
+      entries.map(e => [`${e.owner}/${e.name}`, e.discovery_channel ?? 'collab']),
+    )
+    const fieldProbes = new Map(
+      entries.map(e => [
+        `${e.owner}/${e.name}`,
+        {has_fro_bot_workflow: e.has_fro_bot_workflow, has_renovate: e.has_renovate},
+      ]),
+    )
+
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: entries},
+        accessList,
+        accessChannelByKey: channelMap,
+        fieldProbes,
+      }),
+    )
+
+    expect(result.summary.byChannel.collab.tracked).toBe(2)
+    expect(result.summary.byChannel.owned.tracked).toBe(1)
+    expect(result.summary.byChannel.contrib.tracked).toBe(0)
+  })
+
+  it('counts lost-access transitions per channel', () => {
+    // GIVEN one onboarded contrib entry that is no longer in the access list
+    const lost = makeEntry({
+      owner: 'bfra-me',
+      name: 'gone-repo',
+      onboarding_status: 'onboarded',
+      discovery_channel: 'contrib',
+    })
+
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [lost]},
+        accessList: [],
+        perRepoStatus: new Map([['bfra-me/gone-repo', {status: 'archived'}]]),
+      }),
+    )
+
+    expect(result.summary.byChannel.contrib.lostAccess).toBe(1)
+    expect(result.summary.byChannel.collab.lostAccess).toBe(0)
+    expect(result.summary.byChannel.owned.lostAccess).toBe(0)
+  })
+
+  it('counts newcomers per channel (added entries inherit channel from accessChannelByKey)', () => {
+    const channelMap = new Map<string, DiscoveryChannel>([
+      ['fro-bot/agent', 'owned'],
+      ['bfra-me/works', 'contrib'],
+    ])
+    const result = reconcileRepos(
+      makeInput({
+        accessList: [
+          makeAccess({owner: 'fro-bot', name: 'agent', node_id: 'R_a'}),
+          makeAccess({owner: 'bfra-me', name: 'works', node_id: 'R_w'}),
+        ],
+        accessChannelByKey: channelMap,
+      }),
+    )
+
+    expect(result.summary.byChannel.owned.tracked).toBe(1)
+    expect(result.summary.byChannel.contrib.tracked).toBe(1)
+    expect(result.summary.byChannel.collab.tracked).toBe(0)
   })
 })

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -8,15 +8,15 @@ import {describe, expect, it, vi} from 'vitest'
 import {
   containsFroBotAgentReference,
   DISPATCH_DEFAULTS,
+  formatCommitMessage,
   handleReconcile,
   isEligibleForSurvey,
-  isSurveyStale,
   loadDispatchStaggerFromEnv,
   loadMaxDispatchesPerRunFromEnv,
   mergeAccessChannels,
+  migrateRepoEntry,
   ReconcileError,
   reconcileRepos,
-  SURVEY_STALENESS_MS,
   type AccessListEntry,
   type HandleReconcileParams,
   type OctokitClient,
@@ -100,6 +100,7 @@ describe('reconcileRepos', () => {
         regained: 0,
         lostAccess: 0,
         refreshed: 0,
+        migrated: 0,
         unchanged: 0,
       })
     })
@@ -425,6 +426,7 @@ describe('reconcileRepos', () => {
         regained: 0,
         lostAccess: 1,
         refreshed: 1,
+        migrated: 0,
         unchanged: 0,
       })
     })
@@ -450,6 +452,7 @@ describe('reconcileRepos', () => {
         regained: 0,
         lostAccess: 0,
         refreshed: 0,
+        migrated: 0,
         unchanged: 1,
       })
     })
@@ -466,6 +469,7 @@ describe('reconcileRepos', () => {
         regained: 0,
         lostAccess: 0,
         refreshed: 0,
+        migrated: 0,
         unchanged: 0,
       })
     })
@@ -2488,35 +2492,217 @@ jobs:
   })
 })
 
-describe('isSurveyStale', () => {
-  const JUST_BEFORE = SURVEY_STALENESS_MS - 1
-  const EXACTLY = SURVEY_STALENESS_MS
-  const JUST_AFTER = SURVEY_STALENESS_MS + 1
+describe('migrateRepoEntry', () => {
+  // Backfills new schema fields on legacy entries that predate the cadence rollout.
+  // Returns the input by reference when both fields are already populated (idempotent).
 
-  it('treats null as stale (never surveyed)', () => {
-    expect(isSurveyStale(null, new Date('2026-04-17T12:00:00Z'))).toBe(true)
+  it('backfills discovery_channel as collab and computes next_survey_eligible_at from last_survey_at', () => {
+    // GIVEN a legacy entry with last_survey_at populated and both new fields missing
+    const legacy = makeEntry({
+      last_survey_at: '2026-04-27',
+      discovery_channel: undefined,
+      next_survey_eligible_at: undefined,
+    })
+
+    // WHEN migrating
+    const migrated = migrateRepoEntry(legacy, NOW)
+
+    // THEN both fields are populated (channel = collab, eligibility = baseDate + 30d + jitter)
+    expect(migrated.discovery_channel).toBe('collab')
+    expect(migrated.next_survey_eligible_at).toMatch(/^2026-05-(2[7-9]|30)$/)
+    // AND nothing else changed
+    expect({
+      ...migrated,
+      discovery_channel: legacy.discovery_channel,
+      next_survey_eligible_at: legacy.next_survey_eligible_at,
+    }).toEqual(legacy)
   })
 
-  it('treats a malformed date string as stale (recoverable corruption)', () => {
-    expect(isSurveyStale('not-a-date', new Date('2026-04-17T12:00:00Z'))).toBe(true)
+  it('leaves next_survey_eligible_at null when last_survey_at is null', () => {
+    const legacy = makeEntry({
+      last_survey_at: null,
+      discovery_channel: undefined,
+      next_survey_eligible_at: undefined,
+    })
+
+    const migrated = migrateRepoEntry(legacy, NOW)
+
+    expect(migrated.discovery_channel).toBe('collab')
+    expect(migrated.next_survey_eligible_at).toBe(null)
   })
 
-  it('treats exactly 30 days old as stale (inclusive boundary)', () => {
-    const anchor = new Date('2026-04-01T00:00:00Z')
-    const now = new Date(anchor.getTime() + EXACTLY)
-    expect(isSurveyStale('2026-04-01', now)).toBe(true)
+  it('treats malformed last_survey_at as never-surveyed (next_survey_eligible_at = null)', () => {
+    const legacy = makeEntry({
+      last_survey_at: 'not-a-date',
+      discovery_channel: undefined,
+      next_survey_eligible_at: undefined,
+    })
+
+    const migrated = migrateRepoEntry(legacy, NOW)
+
+    expect(migrated.discovery_channel).toBe('collab')
+    expect(migrated.next_survey_eligible_at).toBe(null)
   })
 
-  it('treats just under 30 days as fresh', () => {
-    const anchor = new Date('2026-04-01T00:00:00Z')
-    const now = new Date(anchor.getTime() + JUST_BEFORE)
-    expect(isSurveyStale('2026-04-01', now)).toBe(false)
+  it('returns the input by reference when both fields are already populated (idempotent)', () => {
+    const fresh = makeEntry({
+      last_survey_at: '2026-04-27',
+      discovery_channel: 'owned',
+      next_survey_eligible_at: '2026-05-15',
+    })
+
+    const migrated = migrateRepoEntry(fresh, NOW)
+
+    expect(migrated).toBe(fresh) // referential equality
   })
 
-  it('treats just over 30 days as stale', () => {
-    const anchor = new Date('2026-04-01T00:00:00Z')
-    const now = new Date(anchor.getTime() + JUST_AFTER)
-    expect(isSurveyStale('2026-04-01', now)).toBe(true)
+  it('backfills only the missing field when only one is absent', () => {
+    // GIVEN an entry with channel set (e.g. by addRepoEntry default) but eligibility missing
+    const partial = makeEntry({
+      last_survey_at: '2026-04-27',
+      discovery_channel: 'owned',
+      next_survey_eligible_at: undefined,
+    })
+
+    const migrated = migrateRepoEntry(partial, NOW)
+
+    // THEN channel is preserved (not overwritten with 'collab')
+    expect(migrated.discovery_channel).toBe('owned')
+    // AND eligibility is computed using the existing channel's interval (owned = 14d)
+    expect(migrated.next_survey_eligible_at).toMatch(/^2026-05-(1[1-4])$/)
+  })
+})
+
+describe('reconcileRepos legacy migration', () => {
+  it('migrates legacy entries on first reconcile run and bumps summary.migrated', () => {
+    // GIVEN a tracked entry missing both new fields and an unchanged access list
+    const legacy = makeEntry({
+      owner: 'marcusrbrown',
+      name: 'legacy-repo',
+      onboarding_status: 'onboarded',
+      last_survey_at: '2026-04-01',
+      discovery_channel: undefined,
+      next_survey_eligible_at: undefined,
+    })
+
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [legacy]},
+        accessList: [makeAccess({owner: 'marcusrbrown', name: 'legacy-repo', node_id: 'R_legacy'})],
+        fieldProbes: new Map([['marcusrbrown/legacy-repo', {has_fro_bot_workflow: false, has_renovate: false}]]),
+      }),
+    )
+
+    // THEN summary.migrated counts the migration
+    expect(result.summary.migrated).toBe(1)
+    // AND the entry now carries both new fields
+    expect(result.nextRepos.repos[0]?.discovery_channel).toBe('collab')
+    // last_survey_at: 2026-04-01 + collab 30d + jitter[0..3] → 2026-05-01..04
+    expect(result.nextRepos.repos[0]?.next_survey_eligible_at).toMatch(/^2026-05-0[1-4]$/)
+  })
+
+  it('subsequent reconcile run on already-migrated state has summary.migrated === 0', () => {
+    // GIVEN an entry that has both new fields set (post-migration steady state)
+    const migrated = makeEntry({
+      owner: 'marcusrbrown',
+      name: 'migrated-repo',
+      onboarding_status: 'onboarded',
+      last_survey_at: '2026-04-01',
+      discovery_channel: 'collab',
+      next_survey_eligible_at: '2026-05-01',
+    })
+
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [migrated]},
+        accessList: [makeAccess({owner: 'marcusrbrown', name: 'migrated-repo', node_id: 'R_mig'})],
+        fieldProbes: new Map([['marcusrbrown/migrated-repo', {has_fro_bot_workflow: false, has_renovate: false}]]),
+      }),
+    )
+
+    expect(result.summary.migrated).toBe(0)
+    // AND nextRepos referential identity preserved (no-op fast path)
+    expect(result.nextRepos.repos[0]).toBe(migrated)
+  })
+
+  it('a migration-only run (no other changes) is NOT a no-op — produces a real commit plan', () => {
+    // GIVEN 18 legacy entries, all access still healthy, no field-probe drift
+    const legacyEntries = Array.from({length: 18}, (_, i) =>
+      makeEntry({
+        owner: 'marcusrbrown',
+        name: `legacy-${i.toString().padStart(2, '0')}`,
+        onboarding_status: 'onboarded',
+        last_survey_at: null, // never-surveyed → not eligible-storm
+        discovery_channel: undefined,
+        next_survey_eligible_at: undefined,
+      }),
+    )
+    const accessList = legacyEntries.map((e, i) => makeAccess({owner: e.owner, name: e.name, node_id: `R_l${i}`}))
+    const fieldProbes = new Map(
+      legacyEntries.map(e => [`${e.owner}/${e.name}`, {has_fro_bot_workflow: false, has_renovate: false}]),
+    )
+    const initial = {version: 1, repos: legacyEntries} as const
+
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: initial,
+        accessList,
+        fieldProbes,
+      }),
+    )
+
+    // THEN migrated counter is 18
+    expect(result.summary.migrated).toBe(18)
+    // AND the run is NOT classified as no-op (must produce a commit so the migration persists)
+    expect(result.nextRepos.repos).not.toBe(initial.repos)
+    // AND every entry is now populated
+    for (const entry of result.nextRepos.repos) {
+      expect(entry.discovery_channel).toBe('collab')
+    }
+  })
+})
+
+describe('formatCommitMessage', () => {
+  it('emits the steady-state format when summary.migrated === 0', () => {
+    expect(
+      formatCommitMessage({
+        added: 1,
+        pendingReview: 0,
+        regained: 0,
+        lostAccess: 0,
+        refreshed: 2,
+        migrated: 0,
+        unchanged: 0,
+      }),
+    ).toBe('chore(reconcile): +1 new, 0 pending-review, 0 lost-access, 2 refreshes')
+  })
+
+  it('appends the +N migrated suffix when summary.migrated > 0', () => {
+    expect(
+      formatCommitMessage({
+        added: 0,
+        pendingReview: 0,
+        regained: 0,
+        lostAccess: 0,
+        refreshed: 0,
+        migrated: 18,
+        unchanged: 0,
+      }),
+    ).toBe('chore(reconcile): +0 new, 0 pending-review, 0 lost-access, 0 refreshes, +18 migrated')
+  })
+
+  it('includes the migrated suffix alongside other non-zero counters', () => {
+    expect(
+      formatCommitMessage({
+        added: 1,
+        pendingReview: 0,
+        regained: 0,
+        lostAccess: 0,
+        refreshed: 1,
+        migrated: 18,
+        unchanged: 0,
+      }),
+    ).toBe('chore(reconcile): +1 new, 0 pending-review, 0 lost-access, 1 refreshes, +18 migrated')
   })
 })
 

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -54,7 +54,7 @@ import {
   type DataBranchBootstrapParams,
   type DataBranchBootstrapResult,
 } from './data-branch-bootstrap.ts'
-import {addRepoEntry} from './repos-metadata.ts'
+import {addRepoEntry, computeNextEligibleAt} from './repos-metadata.ts'
 import {
   assertAllowlistFile,
   assertReposFile,
@@ -158,6 +158,13 @@ export interface ReconcileSummary {
    * from the live signal and were rewritten this run. Steady-state field-probe drift only.
    */
   refreshed: number
+  /**
+   * Number of legacy entries backfilled this run (missing `discovery_channel` or
+   * `next_survey_eligible_at` populated by {@link migrateRepoEntry}). Distinct from
+   * `refreshed` so operators can tell one-time migration commits from steady-state
+   * field-probe drift. Drops to zero on the next run after migration completes.
+   */
+  migrated: number
   unchanged: number
 }
 
@@ -190,6 +197,7 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
     regained: 0,
     lostAccess: 0,
     refreshed: 0,
+    migrated: 0,
     unchanged: 0,
   }
   const dispatches: DispatchRequest[] = []
@@ -285,8 +293,17 @@ interface ClassifyTrackedParams {
  * pattern (see `processInvitation` in `handle-invitation.ts`).
  */
 function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
-  const {entry, key, accessByKey, perRepoStatus, fieldProbes, allowlistedOwners, summary, dispatches, rawIssues} =
-    params
+  const {accessByKey, perRepoStatus, fieldProbes, allowlistedOwners, summary, dispatches, rawIssues, now} = params
+
+  // Backfill new schema fields on legacy entries before any other logic. Idempotent on
+  // already-populated entries (returns by reference) so steady-state runs don't bump the
+  // migrated counter or break the no-op fast path.
+  const migrated = migrateRepoEntry(params.entry, now)
+  if (migrated !== params.entry) {
+    summary.migrated += 1
+  }
+  const entry = migrated
+  const key = params.key
   const access = accessByKey.get(key)
 
   if (access === undefined) {
@@ -388,38 +405,53 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
 }
 
 /**
- * Staleness threshold for survey re-dispatch. Entries are stale (and therefore candidates
- * for re-survey) when `last_survey_at` is null or when the elapsed time since
- * `last_survey_at` is 30 days or more. `last_survey_at` is an ISO calendar date, so
- * "elapsed time" is measured from midnight UTC of that date.
+ * Backfill the new cadence schema fields (`discovery_channel`, `next_survey_eligible_at`)
+ * on legacy entries that predate Unit 1's schema extension. Idempotent: returns the input
+ * by reference when both fields are already populated.
  *
- * Exposed for test-only boundary pinning; production callers use the full reconcile flow.
+ * Default channel is `'collab'` because every entry that existed before Unit 3's
+ * cross-channel discovery shipped came from collaborator invitations.
+ *
+ * Eligibility computation honors the entry's resolved channel — if `discovery_channel`
+ * is already set (e.g. by `addRepoEntry`'s default in Unit 1's loose-then-tight rollout
+ * window) but `next_survey_eligible_at` is missing, we use that channel's base interval,
+ * not collab's. This matters once Unit 3 ships, because owned-channel entries with a
+ * surfacing date but no eligibility must use the 14-day interval, not the 30-day one.
+ *
+ * Pure (no allocation when both fields are populated). Safe to call inside the mutator
+ * closure that 409-retries through `commitMetadata`.
  */
-export const SURVEY_STALENESS_MS = 30 * 24 * 60 * 60 * 1000
+export function migrateRepoEntry(entry: RepoEntry, _now: Date): RepoEntry {
+  const needsChannel = entry.discovery_channel === undefined
+  const needsEligibility = entry.next_survey_eligible_at === undefined
+  if (!needsChannel && !needsEligibility) return entry
 
-/**
- * Return true when the entry should be a candidate for the next survey dispatch.
- *
- * Boundary semantics: an entry surveyed exactly {@link SURVEY_STALENESS_MS} ago is stale
- * (inclusive threshold). This keeps the daily cron predictable — a repo last surveyed at
- * midnight UTC on day D is re-eligible at the day-D+30 cron run, not day-D+31.
- *
- * A null `last_survey_at` signals "never surveyed" and is always stale. A malformed date
- * string is also treated as stale so recoverable metadata corruption doesn't silently
- * suppress coverage.
- *
- * @deprecated Use {@link isEligibleForSurvey} for new dispatch decisions. The fixed-30d
- * model is being replaced by per-channel eligibility via `next_survey_eligible_at`,
- * computed by `recordSurveyResult` from the channel's base interval plus deterministic
- * jitter. This export is preserved only for the migration path that backfills
- * `next_survey_eligible_at` from `last_survey_at` on legacy entries; once the migration
- * is complete this function will be removed.
- */
-export function isSurveyStale(lastSurveyAt: string | null, now: Date): boolean {
-  if (lastSurveyAt === null) return true
-  const lastMs = Date.parse(`${lastSurveyAt}T00:00:00Z`)
-  if (!Number.isFinite(lastMs)) return true
-  return now.getTime() - lastMs >= SURVEY_STALENESS_MS
+  const channel: DiscoveryChannel = entry.discovery_channel ?? 'collab'
+  let nextSurveyEligibleAt: string | null = entry.next_survey_eligible_at ?? null
+  if (needsEligibility) {
+    if (entry.last_survey_at === null) {
+      nextSurveyEligibleAt = null
+    } else {
+      const baseMs = Date.parse(`${entry.last_survey_at}T00:00:00Z`)
+      if (Number.isFinite(baseMs)) {
+        nextSurveyEligibleAt = computeNextEligibleAt({
+          owner: entry.owner,
+          repo: entry.name,
+          channel,
+          baseDate: new Date(baseMs),
+        })
+      } else {
+        // Malformed last_survey_at — treat as never-surveyed for cadence purposes.
+        nextSurveyEligibleAt = null
+      }
+    }
+  }
+
+  return {
+    ...entry,
+    discovery_channel: channel,
+    next_survey_eligible_at: nextSurveyEligibleAt,
+  }
 }
 
 /**
@@ -427,9 +459,8 @@ export function isSurveyStale(lastSurveyAt: string | null, now: Date): boolean {
  * the cadence-engine model.
  *
  * Boundary semantics: an entry whose `next_survey_eligible_at` is exactly today (UTC
- * midnight) is eligible. The same inclusive-boundary contract as {@link isSurveyStale} —
- * the daily cron's "now" reaches the eligibility instant exactly once and dispatch fires
- * on that run.
+ * midnight) is eligible. The daily cron's "now" reaches the eligibility instant exactly
+ * once and dispatch fires on that run.
  *
  * A null `next_survey_eligible_at` signals "never computed" and is always eligible
  * (matching the semantics of a never-surveyed entry under the legacy model). A
@@ -499,6 +530,7 @@ function isNoOp(summary: ReconcileSummary, dispatches: DispatchRequest[], issues
     summary.regained === 0 &&
     summary.lostAccess === 0 &&
     summary.refreshed === 0 &&
+    summary.migrated === 0 &&
     dispatches.length === 0 &&
     issues.length === 0
   )
@@ -983,13 +1015,20 @@ function planHasChanges(plan: ReconcileResult): boolean {
     summary.regained > 0 ||
     summary.lostAccess > 0 ||
     summary.refreshed > 0 ||
+    summary.migrated > 0 ||
     plan.dispatches.length > 0 ||
     plan.issues.length > 0
   )
 }
 
-function formatCommitMessage(summary: ReconcileSummary): string {
-  return `chore(reconcile): +${summary.added} new, ${summary.pendingReview} pending-review, ${summary.lostAccess} lost-access, ${summary.refreshed} refreshes`
+/**
+ * Format the reconcile commit message. The `+N migrated` suffix appears only when
+ * `summary.migrated > 0` so steady-state runs keep the existing format and operators
+ * can spot the one-time migration commit easily.
+ */
+export function formatCommitMessage(summary: ReconcileSummary): string {
+  const base = `chore(reconcile): +${summary.added} new, ${summary.pendingReview} pending-review, ${summary.lostAccess} lost-access, ${summary.refreshed} refreshes`
+  return summary.migrated > 0 ? `${base}, +${summary.migrated} migrated` : base
 }
 
 async function loadAllowlist(readMetadata: (path: string) => Promise<unknown>, path: string): Promise<AllowlistFile> {

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -148,6 +148,26 @@ export interface PerOwnerRollupIssue {
 
 export type IssueQueueEntry = PerRepoIssue | PerOwnerRollupIssue
 
+/**
+ * Per-channel breakdown of reconcile activity for one run. Operators read these to
+ * answer "how much did each channel contribute today?" without aggregating manually.
+ *
+ * - `tracked`: entries on `nextRepos` carrying this channel after the run.
+ * - `dispatched`: dispatches actually fired this run (post-cap, post-rotation).
+ * - `deferred`: dispatch candidates excluded by the per-run cap. Sums to
+ *   `dispatchesDeferred` across all channels.
+ * - `lostAccess`: entries that flipped to `lost-access` this run.
+ *
+ * The shell populates `dispatched` and `deferred` after cap selection. The engine
+ * populates `tracked` and `lostAccess`.
+ */
+export interface ChannelStats {
+  tracked: number
+  dispatched: number
+  deferred: number
+  lostAccess: number
+}
+
 export interface ReconcileSummary {
   added: number
   pendingReview: number
@@ -166,6 +186,12 @@ export interface ReconcileSummary {
    */
   migrated: number
   unchanged: number
+  /**
+   * Per-channel activity breakdown. See {@link ChannelStats} for field semantics. The
+   * engine populates `tracked` and `lostAccess`; the shell populates `dispatched` and
+   * `deferred` after cap selection.
+   */
+  byChannel: Record<DiscoveryChannel, ChannelStats>
 }
 
 export interface ReconcileResult {
@@ -199,6 +225,11 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
     refreshed: 0,
     migrated: 0,
     unchanged: 0,
+    byChannel: {
+      collab: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
+      owned: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
+      contrib: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
+    },
   }
   const dispatches: DispatchRequest[] = []
   const rawIssues: RawIssue[] = []
@@ -264,6 +295,15 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
 
   const issues = buildIssueQueue(rawIssues)
 
+  // Populate per-channel tracked counts after both passes complete. Counts entries
+  // present on `next.repos` post-classification (excludes lost-access entries via the
+  // existing flow — `lost-access` entries remain in repos, only their onboarding_status
+  // changes, so they still count as tracked). The plan defines `tracked` as entries
+  // currently in `metadata/repos.yaml` for that channel, regardless of survey status.
+  for (const entry of next.repos) {
+    summary.byChannel[entry.discovery_channel ?? 'collab'].tracked += 1
+  }
+
   // Zero-change optimization: preserve currentRepos reference identity for cheap `===` probe.
   if (isNoOp(summary, dispatches, issues)) {
     return {nextRepos: currentRepos, dispatches, issues, summary}
@@ -325,6 +365,7 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
       return entry
     }
     summary.lostAccess += 1
+    summary.byChannel[entry.discovery_channel ?? 'collab'].lostAccess += 1
     return {...entry, onboarding_status: 'lost-access'}
   }
 
@@ -335,6 +376,7 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
       return entry
     }
     summary.lostAccess += 1
+    summary.byChannel[entry.discovery_channel ?? 'collab'].lostAccess += 1
     return {...entry, onboarding_status: 'lost-access'}
   }
 
@@ -647,6 +689,7 @@ export class ReconcileError extends Error {
 
 export interface ReconcileLogger {
   warn: (message: string) => void
+  info: (message: string) => void
 }
 
 export interface HandleReconcileParams {
@@ -732,7 +775,10 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
   const dispatchTimeoutMs = params.dispatchTimeoutMs ?? DEFAULT_DISPATCH_TIMEOUT_MS
   const dispatchStaggerMs = params.dispatchStaggerMs ?? loadDispatchStaggerFromEnv()
   const maxDispatchesPerRun = params.maxDispatchesPerRun ?? loadMaxDispatchesPerRunFromEnv()
-  const logger: ReconcileLogger = params.logger ?? {warn: message => process.stderr.write(`${message}\n`)}
+  const logger: ReconcileLogger = params.logger ?? {
+    warn: message => process.stderr.write(`${message}\n`),
+    info: message => process.stdout.write(`${message}\n`),
+  }
   const readMetadata = params.readMetadata ?? readMetadataFromDisk
   const commitMetadataImpl = params.commitMetadata ?? defaultCommitMetadata
   const bootstrap = params.bootstrapDataBranch ?? defaultBootstrapDataBranch
@@ -897,6 +943,21 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
   const selectedDispatches = rotatedDispatches.slice(0, dispatchCap)
   const dispatchesDeferred = prioritizedDispatches.length - selectedDispatches.length
 
+  // Index entries by key so the dispatch loop and the byChannel breakdown can resolve
+  // per-dispatch channel + last_survey_at without scanning nextRepos repeatedly.
+  const entryByKey = new Map(plan.nextRepos.repos.map(r => [`${r.owner}/${r.name}`, r]))
+
+  // Populate per-channel dispatch + deferred counts. The selected slice fires this run;
+  // the deferred slice (rotatedDispatches[dispatchCap..]) waits for next run.
+  for (const d of selectedDispatches) {
+    const entry = entryByKey.get(`${d.owner}/${d.repo}`)
+    plan.summary.byChannel[entry?.discovery_channel ?? 'collab'].dispatched += 1
+  }
+  for (const d of rotatedDispatches.slice(dispatchCap)) {
+    const entry = entryByKey.get(`${d.owner}/${d.repo}`)
+    plan.summary.byChannel[entry?.discovery_channel ?? 'collab'].deferred += 1
+  }
+
   const dispatchOutcome = await runDispatches({
     staggerMs: dispatchStaggerMs,
     sleep: params.dispatchSleep,
@@ -908,6 +969,7 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
     dispatches: selectedDispatches,
     timeoutMs: dispatchTimeoutMs,
     logger,
+    entryByKey,
   })
 
   // 10. Issue-creation loop (serial, non-blocking on failure).
@@ -1574,6 +1636,12 @@ async function runDispatches(params: {
   staggerMs: number
   logger: ReconcileLogger
   /**
+   * Per-key index of repos in `nextRepos` so the dispatch loop can resolve channel +
+   * last_survey_at without scanning. Used to emit the first-survey-of-channel info log
+   * for owned and contrib entries that have never been surveyed.
+   */
+  entryByKey: Map<string, RepoEntry>
+  /**
    * Sleep implementation. Injected for test speed — production uses `setTimeout`-backed
    * Promise; tests pass a no-op or a deterministic fake clock.
    */
@@ -1585,6 +1653,21 @@ async function runDispatches(params: {
   for (let i = 0; i < params.dispatches.length; i += 1) {
     const dispatch = params.dispatches[i]
     if (dispatch === undefined) continue
+
+    // First-survey-of-channel observability: emit an info line when an owned or contrib
+    // entry is being surveyed for the first time. Collab is intentionally excluded —
+    // the milestone matters less for the historical channel that's been around since
+    // the original collab-only design. Owned entries are auto-discovered (so seeing
+    // them flow through to first survey is meaningful), and contrib entries are
+    // operator-curated (so first-survey is the moment the trust signal was honored).
+    const entry = params.entryByKey.get(`${dispatch.owner}/${dispatch.repo}`)
+    if (entry !== undefined && entry.last_survey_at === null) {
+      const channel = entry.discovery_channel ?? 'collab'
+      if (channel === 'owned' || channel === 'contrib') {
+        params.logger.info(`reconcile: first survey for new ${channel} entry: ${dispatch.owner}/${dispatch.repo}`)
+      }
+    }
+
     // Stagger BETWEEN dispatches only — never before the first, never after the last.
     // This keeps the first survey's kickoff latency unchanged and avoids trailing idle time.
     if (i > 0 && params.staggerMs > 0) {


### PR DESCRIPTION
## What changes

Closes out the cadence engine work. Two commits:

1. **Retire the fixed-staleness model and migrate legacy entries automatically.** Removes `SURVEY_STALENESS_MS` and `isSurveyStale` (no remaining production callers after #3238 swapped dispatch logic to `isEligibleForSurvey`). Adds `migrateRepoEntry` that backfills `discovery_channel` (default `'collab'`) and `next_survey_eligible_at` (computed from `last_survey_at`) on legacy entries. Wired first thing into `classifyTracked`, idempotent on already-populated entries.
2. **Per-channel observability counters and first-survey log line.** `ReconcileSummary.byChannel: Record<DiscoveryChannel, ChannelStats>` covers `tracked`, `dispatched`, `deferred`, `lostAccess` per channel. Engine populates `tracked` and `lostAccess`; shell populates `dispatched` and `deferred` after cap selection. New `ReconcileLogger.info` channel; first-survey log emits for owned and contrib entries that have never been surveyed.

## Why

The fixed-30-day staleness model was the dispatch gate before #3238 introduced per-channel `next_survey_eligible_at`. After #3238 landed, `SURVEY_STALENESS_MS` was dead code with one purpose left: a transitional bridge for legacy entries on the `data` branch. This PR retires the bridge by automating the backfill — the first daily reconcile run after merge produces a single migration commit, every subsequent run reports `summary.migrated === 0`.

The observability counters answer a question operators couldn't answer before: which channel is doing the work each day? With three discovery channels feeding one repo list, "0 dispatches today" needed disambiguation between "no eligible repos in any channel" and "owned channel exhausted, contrib channel waiting". The breakdown shows up directly in the JSON output.

## Migration commit shape

The first reconcile run after merge produces a commit subject like:

```
chore(reconcile): +0 new, 0 pending-review, 0 lost-access, 0 refreshes, +N migrated
```

where N is the number of legacy entries backfilled (~18 today). The `+N migrated` suffix only appears when the count is non-zero, so steady-state commit messages are unchanged. `summary.migrated` is distinct from `summary.refreshed` — operators can grep for migration commits and field-probe-drift commits separately.

`migrateRepoEntry` respects whichever `discovery_channel` an entry already carries: an owned-channel entry with a survey date but no eligibility uses the 14-day interval, not the 30-day default. This matters because Unit 1's loose-then-tight rollout means some entries already have `discovery_channel` set without `next_survey_eligible_at`.

## byChannel breakdown contract

```jsonc
{
  "byChannel": {
    "collab": {"tracked": 18, "dispatched": 6, "deferred": 0, "lostAccess": 0},
    "owned":  {"tracked": 3,  "dispatched": 1, "deferred": 0, "lostAccess": 0},
    "contrib": {"tracked": 0, "dispatched": 0, "deferred": 0, "lostAccess": 0}
  }
}
```

Field semantics:

- `tracked`: entries currently on `metadata/repos.yaml` for this channel. Includes `lost-access` entries — they remain in the file, only their `onboarding_status` changes.
- `dispatched`: dispatches actually fired this run, post-cap and post-rotation.
- `deferred`: dispatch candidates excluded by the per-run cap. Sums to the existing top-level `dispatchesDeferred` across all channels.
- `lostAccess`: entries that flipped to `lost-access` this run.

The breakdown is a strict superset of the prior `ReconcileSummary` shape — external JSON consumers see new fields without anything moving or disappearing.

## First-survey log

When an owned or contrib entry is selected for dispatch with `last_survey_at: null`:

```
reconcile: first survey for new owned entry: fro-bot/agent
reconcile: first survey for new contrib entry: bfra-me/.github
```

Collab is excluded — the milestone matters less for the historical channel. Owned and contrib are signal events: owned because the entry was auto-discovered, contrib because the operator's allowlist trust signal was honored.

## What's NOT in this PR

- Schema tightening for `discovery_channel`/`next_survey_eligible_at` from optional to required (deferred to a follow-up after one daily reconcile cycle confirms `data` is fully migrated).
- Per-day quota model for true continuous wiki growth — the structural answer to "most days are zero-dispatch" at N=17 collab repos. Deferred to a future plan; trigger remains "30 days under the threshold model show >7 consecutive zero-dispatch days".
- Tunable per-channel intervals via env vars. Constants stay hardcoded for now; promotion is a small follow-up after observing real cadence.

## Test scenarios covered

399/399 tests passing (was 386 on main; +13 net new across both commits).

| Area | Coverage |
| ---- | -------- |
| `migrateRepoEntry` idempotency | 5 tests (both fields missing, only one missing, malformed `last_survey_at`, null `last_survey_at`, already populated) |
| Migration integration through `reconcileRepos` | 3 tests (single legacy entry, post-migration no-op preserving referential equality, 18-entry migration commit) |
| `formatCommitMessage` formats | 3 tests (steady-state, migration-only, mixed counters) |
| `byChannel` engine population | 3 tests (tracked counting per channel, lost-access counting, newcomers per channel) |
| Shell observability | 4 tests (first-survey for owned, NOT for collab, NOT for re-survey, dispatched/deferred after cap) |

## Plan reference

Implements Units 4 and 5 of `docs/plans/2026-05-05-001-feat-survey-cadence-and-multi-channel-discovery-plan.md`. Plan checkboxes flipped in this PR. With this merge, the plan's implementation phase is complete — outstanding work is deferred to follow-up plans (schema tightening, per-day quota model, env-var overrides).