### PR TITLE
feat(privacy): enumerate existing leak surfaces for tracked private repos

### DIFF
--- a/docs/plans/2026-05-05-002-feat-private-repo-handling-plan.md
+++ b/docs/plans/2026-05-05-002-feat-private-repo-handling-plan.md
@@ -284,7 +284,7 @@ persona/
 
 ## Implementation Units
 
-- [ ] **Unit 0: Enumerate existing leaks and remediate per operator decision**
+- [x] **Unit 0: Enumerate existing leaks and remediate per operator decision**
 
 **Goal:** Enumerate every existing leak surface for currently-tracked private repos (today: only `marcusrbrown/poly`); present operator with per-surface remediate/accept decision; execute the chosen action.
 

--- a/scripts/enumerate-existing-leaks.test.ts
+++ b/scripts/enumerate-existing-leaks.test.ts
@@ -1,0 +1,307 @@
+import type {ReposFile} from './schemas.ts'
+
+import {describe, expect, it} from 'vitest'
+
+import {
+  enumerateLeaks,
+  formatLeakReport,
+  type EnumerateLeaksInput,
+  type PrivateRepoMapping,
+} from './enumerate-existing-leaks.ts'
+
+function makePolyMapping(): PrivateRepoMapping {
+  return {node_id: 'R_kgDOPpoLY1', owner: 'marcusrbrown', name: 'poly'}
+}
+
+function makeReposFile(
+  overrides: Partial<ReposFile['repos'][number]> = {},
+  others: ReposFile['repos'] = [],
+): ReposFile {
+  return {
+    version: 1,
+    repos: [
+      {
+        owner: 'marcusrbrown',
+        name: 'poly',
+        added: '2026-05-01',
+        onboarding_status: 'pending',
+        last_survey_at: null,
+        last_survey_status: null,
+        has_fro_bot_workflow: false,
+        has_renovate: false,
+        ...overrides,
+      },
+      ...others,
+    ],
+  }
+}
+
+function emptyInput(): EnumerateLeaksInput {
+  return {
+    privateRepos: [],
+    commitLog: [],
+    workflowRuns: [],
+    reposFile: {version: 1, repos: []},
+    wikiFilenames: [],
+  }
+}
+
+describe('enumerateLeaks', () => {
+  describe('happy paths', () => {
+    it('returns no surfaces when the private list is empty', () => {
+      // Empty list = nothing to enumerate; even rich data sources yield zero surfaces.
+      const result = enumerateLeaks({
+        ...emptyInput(),
+        commitLog: [{sha: 'abc123', subject: 'feat: add poly support'}],
+        reposFile: makeReposFile(),
+        wikiFilenames: ['marcusrbrown--poly.md'],
+      })
+
+      expect(result).toEqual([])
+    })
+
+    it('enumerates all 4 surface types for the poly fixture', () => {
+      // GIVEN the canonical poly fixture: 2 commits, 1 run, 1 metadata entry, 0 wiki pages
+      const result = enumerateLeaks({
+        privateRepos: [makePolyMapping()],
+        commitLog: [
+          {sha: 'd92d12c', subject: 'fix(metadata): allowlist marcusrbrown/poly invitation'},
+          {sha: 'cb5811e', subject: 'chore(reconcile): add marcusrbrown/poly to repos.yaml'},
+          {sha: 'unrelated1', subject: 'docs: update README'},
+        ],
+        workflowRuns: [{id: 25395917616, name: 'Survey Repo', inputs: {owner: 'marcusrbrown', repo: 'poly'}}],
+        reposFile: makeReposFile(),
+        wikiFilenames: [],
+      })
+
+      const types = result.map(s => s.type).sort()
+      expect(types).toEqual(['commit-subject', 'commit-subject', 'metadata-entry', 'workflow-run'])
+
+      // Sanity-check identifiers
+      const commitSurfaces = result.filter(s => s.type === 'commit-subject')
+      expect(commitSurfaces.map(s => s.identifier)).toEqual(['d92d12c', 'cb5811e'])
+
+      const runSurface = result.find(s => s.type === 'workflow-run')
+      expect(runSurface?.identifier).toBe('25395917616')
+
+      const metaSurface = result.find(s => s.type === 'metadata-entry')
+      expect(metaSurface?.identifier).toBe('marcusrbrown/poly')
+    })
+
+    it('enumerates wiki pages when matching slug patterns are present', () => {
+      const result = enumerateLeaks({
+        privateRepos: [makePolyMapping()],
+        commitLog: [],
+        workflowRuns: [],
+        reposFile: {version: 1, repos: []},
+        wikiFilenames: ['marcusrbrown--poly.md', 'unrelated--repo.md'],
+      })
+
+      const wikiSurfaces = result.filter(s => s.type === 'wiki-page')
+      expect(wikiSurfaces).toHaveLength(1)
+      expect(wikiSurfaces[0]?.identifier).toBe('marcusrbrown--poly.md')
+    })
+
+    it('returns empty surfaces for a private repo with no leaks', () => {
+      const result = enumerateLeaks({
+        privateRepos: [{node_id: 'R_kgDOCLEAN', owner: 'someone', name: 'clean-repo'}],
+        commitLog: [{sha: 'abc', subject: 'feat: add unrelated thing'}],
+        workflowRuns: [{id: 1, name: 'Main', inputs: {}}],
+        reposFile: {version: 1, repos: []},
+        wikiFilenames: ['unrelated--repo.md'],
+      })
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('detection rules', () => {
+    it('matches commit subject case-insensitively', () => {
+      const result = enumerateLeaks({
+        privateRepos: [makePolyMapping()],
+        commitLog: [{sha: 'mixed', subject: 'FIX: MarcusRBrown/Poly handling'}],
+        workflowRuns: [],
+        reposFile: {version: 1, repos: []},
+        wikiFilenames: [],
+      })
+
+      expect(result.filter(s => s.type === 'commit-subject')).toHaveLength(1)
+    })
+
+    it('does NOT match a substring inside another word', () => {
+      // 'poly' alone is too short to substring-match safely in arbitrary text.
+      // The check requires the canonical owner/name pair to appear together.
+      const result = enumerateLeaks({
+        privateRepos: [makePolyMapping()],
+        commitLog: [{sha: 'unrelated', subject: 'feat: support polymorphism in parser'}],
+        workflowRuns: [],
+        reposFile: {version: 1, repos: []},
+        wikiFilenames: [],
+      })
+
+      expect(result.filter(s => s.type === 'commit-subject')).toHaveLength(0)
+    })
+
+    it('matches workflow run inputs by canonical owner/repo pair', () => {
+      const result = enumerateLeaks({
+        privateRepos: [makePolyMapping()],
+        commitLog: [],
+        workflowRuns: [
+          {id: 1, name: 'Survey Repo', inputs: {owner: 'marcusrbrown', repo: 'poly'}},
+          {id: 2, name: 'Survey Repo', inputs: {owner: 'someone-else', repo: 'public-repo'}},
+        ],
+        reposFile: {version: 1, repos: []},
+        wikiFilenames: [],
+      })
+
+      expect(result.filter(s => s.type === 'workflow-run').map(s => s.identifier)).toEqual(['1'])
+    })
+
+    it('matches workflow run name when canonical owner/repo appears in the run name', () => {
+      const result = enumerateLeaks({
+        privateRepos: [makePolyMapping()],
+        commitLog: [],
+        workflowRuns: [{id: 99, name: 'Survey: marcusrbrown/poly', inputs: {}}],
+        reposFile: {version: 1, repos: []},
+        wikiFilenames: [],
+      })
+
+      expect(result.filter(s => s.type === 'workflow-run')).toHaveLength(1)
+    })
+
+    it('matches metadata entry by current owner/name (pre-redaction)', () => {
+      const result = enumerateLeaks({
+        privateRepos: [makePolyMapping()],
+        commitLog: [],
+        workflowRuns: [],
+        reposFile: makeReposFile(),
+        wikiFilenames: [],
+      })
+
+      const metaSurfaces = result.filter(s => s.type === 'metadata-entry')
+      expect(metaSurfaces).toHaveLength(1)
+    })
+
+    it('does NOT report metadata entry when the entry is already redacted', () => {
+      const result = enumerateLeaks({
+        privateRepos: [makePolyMapping()],
+        commitLog: [],
+        workflowRuns: [],
+        reposFile: makeReposFile({owner: '[REDACTED]', name: 'R_kgDOPpoLY1'}),
+        wikiFilenames: [],
+      })
+
+      expect(result.filter(s => s.type === 'metadata-entry')).toHaveLength(0)
+    })
+  })
+
+  describe('remediation commands', () => {
+    it('attaches a rebase/replace-message hint for commit-subject surfaces', () => {
+      const result = enumerateLeaks({
+        privateRepos: [makePolyMapping()],
+        commitLog: [{sha: 'd92d12c', subject: 'fix: marcusrbrown/poly'}],
+        workflowRuns: [],
+        reposFile: {version: 1, repos: []},
+        wikiFilenames: [],
+      })
+
+      const surface = result.find(s => s.type === 'commit-subject')
+      expect(surface?.remediation.action).toBe('rebase-rewrite')
+      expect(surface?.remediation.command).toMatch(/git rebase|git filter-repo/)
+    })
+
+    it('attaches a delete-run command for workflow-run surfaces', () => {
+      const result = enumerateLeaks({
+        privateRepos: [makePolyMapping()],
+        commitLog: [],
+        workflowRuns: [{id: 25395917616, name: 'Survey Repo', inputs: {owner: 'marcusrbrown', repo: 'poly'}}],
+        reposFile: {version: 1, repos: []},
+        wikiFilenames: [],
+      })
+
+      const surface = result.find(s => s.type === 'workflow-run')
+      expect(surface?.remediation.action).toBe('delete-run')
+      expect(surface?.remediation.command).toContain('25395917616')
+      expect(surface?.remediation.command).toContain('DELETE')
+    })
+
+    it('attaches a redact-entry command for metadata-entry surfaces', () => {
+      const result = enumerateLeaks({
+        privateRepos: [makePolyMapping()],
+        commitLog: [],
+        workflowRuns: [],
+        reposFile: makeReposFile(),
+        wikiFilenames: [],
+      })
+
+      const surface = result.find(s => s.type === 'metadata-entry')
+      expect(surface?.remediation.action).toBe('redact-entry')
+      // Must reference the node_id since that's the post-redaction name
+      expect(surface?.remediation.command).toContain('R_kgDOPpoLY1')
+    })
+
+    it('attaches a delete-page command for wiki-page surfaces', () => {
+      const result = enumerateLeaks({
+        privateRepos: [makePolyMapping()],
+        commitLog: [],
+        workflowRuns: [],
+        reposFile: {version: 1, repos: []},
+        wikiFilenames: ['marcusrbrown--poly.md'],
+      })
+
+      const surface = result.find(s => s.type === 'wiki-page')
+      expect(surface?.remediation.action).toBe('delete-page')
+      expect(surface?.remediation.command).toContain('marcusrbrown--poly.md')
+    })
+  })
+
+  describe('multi-repo enumeration', () => {
+    it('enumerates surfaces across multiple private repos in a single call', () => {
+      const result = enumerateLeaks({
+        privateRepos: [
+          {node_id: 'R_a', owner: 'org-a', name: 'repo-a'},
+          {node_id: 'R_b', owner: 'org-b', name: 'repo-b'},
+        ],
+        commitLog: [
+          {sha: '1', subject: 'feat: org-a/repo-a thing'},
+          {sha: '2', subject: 'fix: org-b/repo-b thing'},
+        ],
+        workflowRuns: [],
+        reposFile: {version: 1, repos: []},
+        wikiFilenames: [],
+      })
+
+      expect(result.filter(s => s.type === 'commit-subject')).toHaveLength(2)
+    })
+  })
+})
+
+describe('formatLeakReport', () => {
+  it('returns a "no surfaces" message when given an empty array', () => {
+    expect(formatLeakReport([])).toMatch(/no leak surfaces|none found/i)
+  })
+
+  it('groups surfaces by type and lists remediation commands', () => {
+    const report = formatLeakReport([
+      {
+        type: 'commit-subject',
+        identifier: 'd92d12c',
+        description: 'commit subject names marcusrbrown/poly',
+        remediation: {action: 'rebase-rewrite', command: 'git rebase -i d92d12c~1'},
+      },
+      {
+        type: 'workflow-run',
+        identifier: '25395917616',
+        description: 'workflow run inputs name marcusrbrown/poly',
+        remediation: {action: 'delete-run', command: 'gh api -X DELETE /repos/.../actions/runs/25395917616'},
+      },
+    ])
+
+    expect(report).toContain('commit-subject')
+    expect(report).toContain('d92d12c')
+    expect(report).toContain('git rebase')
+    expect(report).toContain('workflow-run')
+    expect(report).toContain('25395917616')
+    expect(report).toContain('DELETE')
+  })
+})

--- a/scripts/enumerate-existing-leaks.test.ts
+++ b/scripts/enumerate-existing-leaks.test.ts
@@ -5,6 +5,7 @@ import {describe, expect, it} from 'vitest'
 import {
   enumerateLeaks,
   formatLeakReport,
+  parsePrivateArgs,
   type EnumerateLeaksInput,
   type PrivateRepoMapping,
 } from './enumerate-existing-leaks.ts'
@@ -303,5 +304,64 @@ describe('formatLeakReport', () => {
     expect(report).toContain('workflow-run')
     expect(report).toContain('25395917616')
     expect(report).toContain('DELETE')
+  })
+})
+
+describe('parsePrivateArgs', () => {
+  it('parses a single well-formed --private mapping', () => {
+    const result = parsePrivateArgs(['--private', 'R_kgDOPpoLY1:marcusrbrown/poly'])
+    expect(result).toEqual([{node_id: 'R_kgDOPpoLY1', owner: 'marcusrbrown', name: 'poly'}])
+  })
+
+  it('parses multiple --private flags into an ordered list', () => {
+    const result = parsePrivateArgs(['--private', 'R_a:org-a/repo-a', '--private', 'R_b:org-b/repo-b'])
+    expect(result).toEqual([
+      {node_id: 'R_a', owner: 'org-a', name: 'repo-a'},
+      {node_id: 'R_b', owner: 'org-b', name: 'repo-b'},
+    ])
+  })
+
+  it('returns an empty array when no --private flags are present', () => {
+    expect(parsePrivateArgs(['--branch', 'origin/data'])).toEqual([])
+  })
+
+  it('throws when --private is the last arg with no value', () => {
+    // Real edge case: operator types `--private` and forgets the value. Without
+    // this guard the parser would silently skip the flag.
+    expect(() => parsePrivateArgs(['--private'])).toThrow(/requires a value/)
+  })
+
+  it('throws when the value lacks a colon separator', () => {
+    expect(() => parsePrivateArgs(['--private', 'no-colon-here'])).toThrow(/node_id:owner\/name/)
+  })
+
+  it('throws when the value lacks a slash after the colon', () => {
+    expect(() => parsePrivateArgs(['--private', 'node_id:no-slash'])).toThrow(/node_id:owner\/name/)
+  })
+
+  it('throws when the slash appears before the colon', () => {
+    // 'org/name:nodeid' is a common typo — operator inverts the order. Catch it
+    // explicitly so the error message points at the right shape.
+    expect(() => parsePrivateArgs(['--private', 'org/name:nodeid'])).toThrow(/node_id:owner\/name/)
+  })
+
+  it('throws when any segment is empty', () => {
+    expect(() => parsePrivateArgs(['--private', ':owner/name'])).toThrow(/empty segment/)
+    expect(() => parsePrivateArgs(['--private', 'nodeid:/name'])).toThrow(/empty segment/)
+    expect(() => parsePrivateArgs(['--private', 'nodeid:owner/'])).toThrow(/empty segment/)
+  })
+
+  it('skips non-matching flags and only consumes --private', () => {
+    // Operator may pass --branch interleaved with --private; the parser should
+    // ignore unrelated flags rather than misinterpreting their values.
+    const result = parsePrivateArgs(['--branch', 'origin/data', '--private', 'R_a:org/repo', '--help'])
+    expect(result).toEqual([{node_id: 'R_a', owner: 'org', name: 'repo'}])
+  })
+
+  it('handles node_id values containing letters, digits, and underscores', () => {
+    // GraphQL node IDs use base64-like prefixes (R_kgDO...) plus arbitrary suffixes.
+    // The parser must accept the full character set the API can return.
+    const result = parsePrivateArgs(['--private', 'R_kgDO_AbCdEf123-_:owner/repo'])
+    expect(result[0]?.node_id).toBe('R_kgDO_AbCdEf123-_')
   })
 })

--- a/scripts/enumerate-existing-leaks.ts
+++ b/scripts/enumerate-existing-leaks.ts
@@ -53,9 +53,10 @@ export interface EnumerateLeaksInput {
  * `owner/name` appears, and emit a structured remediation list.
  *
  * Detection rules:
- * - **commit-subject**: case-insensitive match of `owner/name` as a contiguous token in
- *   the commit subject. Substring matches inside other words are excluded by anchoring
- *   on the slash character — so `polymorphism` doesn't match `poly`.
+ * - **commit-subject**: case-insensitive `includes` match of the canonical `owner/name`
+ *   string (slash included). The slash itself prevents substring collisions inside
+ *   single-word names — `marcusrbrown/poly` won't match `polymorphism`, because the
+ *   search term contains `/` and `polymorphism` does not.
  * - **workflow-run**: matches when the run's `inputs.owner` and `inputs.repo` both
  *   equal the canonical pair (case-sensitive — GitHub stores logins canonically), OR
  *   when the run's display name contains `owner/name` as a substring.
@@ -72,7 +73,8 @@ export function enumerateLeaks(input: EnumerateLeaksInput): LeakSurface[] {
     const canonical = `${priv.owner}/${priv.name}`
     const canonicalLower = canonical.toLowerCase()
 
-    // commit-subject — slash-anchored case-insensitive token match.
+    // commit-subject — case-insensitive `includes` of `owner/name` (the slash in the
+    // search term is what prevents single-word substring collisions).
     for (const commit of input.commitLog) {
       if (commit.subject.toLowerCase().includes(canonicalLower)) {
         surfaces.push({
@@ -113,7 +115,7 @@ export function enumerateLeaks(input: EnumerateLeaksInput): LeakSurface[] {
           description: `metadata/repos.yaml entry names ${canonical} canonically (not yet redacted)`,
           remediation: {
             action: 'redact-entry',
-            command: `# Author a one-shot PR (operator identity, not bot) that sets owner='[REDACTED]' and name='${priv.node_id}' on this entry. The check-wiki-authority guard skips author=marcusrbrown for explicit operator rewrites.`,
+            command: `# Dispatch fro-bot to commit a redacted entry to the data branch directly (autonomous commits skip the PR-time wiki-authority guard). Set owner='[REDACTED]' and name='${priv.node_id}'. The next merge-data PR (fro-bot-authored) promotes the redacted form to main.`,
           },
         })
       }
@@ -190,9 +192,10 @@ interface CliInput {
 /**
  * Parse `--private node_id:owner/name` arguments into structured mappings. Each flag
  * may appear multiple times. The `node_id` segment is required because it's needed
- * for the redact-entry remediation command output.
+ * for the redact-entry remediation command output. Exported for direct unit testing
+ * of the operator-input contract.
  */
-function parsePrivateArgs(argv: readonly string[]): PrivateRepoMapping[] {
+export function parsePrivateArgs(argv: readonly string[]): PrivateRepoMapping[] {
   const mappings: PrivateRepoMapping[] = []
   for (let i = 0; i < argv.length; i += 1) {
     if (argv[i] !== '--private') continue
@@ -252,13 +255,23 @@ async function gatherWorkflowRuns(): Promise<{id: number; name: string; inputs: 
       ],
       {encoding: 'utf8'},
     )
-    return stdout
+    const runs = stdout
       .split('\n')
       .filter(line => line.length > 0)
       .map(line => {
         const parsed = JSON.parse(line) as {id: number; name: string}
         return {id: parsed.id, name: parsed.name, inputs: {}}
       })
+    // Page cap: per_page=100 is the GitHub API maximum without explicit pagination.
+    // If we got exactly 100 results, older runs may exist that this scan didn't see.
+    // Surface this so the operator knows a clean report from this script is bounded
+    // to the most recent 100 runs and they may need to manually inspect older history.
+    if (runs.length === 100) {
+      process.stderr.write(
+        'enumerate-existing-leaks: hit the 100-run page cap on workflow run history; older runs (if any) were not scanned.\n',
+      )
+    }
+    return runs
   } catch (error: unknown) {
     process.stderr.write(
       `enumerate-existing-leaks: failed to fetch workflow runs (${(error as Error).message}); continuing without them.\n`,
@@ -351,7 +364,15 @@ async function main(): Promise<void> {
   // tree (typically main). Useful values: `origin/data` to catch entries that have
   // not yet promoted via the weekly merge-data PR.
   const branchIdx = argv.indexOf('--branch')
-  const metadataRef = branchIdx === -1 ? undefined : argv[branchIdx + 1]
+  let metadataRef: string | undefined
+  if (branchIdx !== -1) {
+    const branchValue = argv[branchIdx + 1]
+    if (branchValue === undefined || branchValue.startsWith('--')) {
+      process.stderr.write('enumerate-existing-leaks: --branch flag requires a git ref value (e.g. origin/data)\n')
+      process.exit(1)
+    }
+    metadataRef = branchValue
+  }
 
   const repoRoot = process.cwd()
   const mainBranch = 'main'

--- a/scripts/enumerate-existing-leaks.ts
+++ b/scripts/enumerate-existing-leaks.ts
@@ -1,0 +1,365 @@
+import type {ReposFile} from './schemas.ts'
+
+import {execFileSync} from 'node:child_process'
+import {readdir, readFile} from 'node:fs/promises'
+import {join} from 'node:path'
+import process from 'node:process'
+
+import {parse as parseYaml} from 'yaml'
+
+import {assertReposFile} from './schemas.ts'
+
+/**
+ * Operator-supplied canonical mapping for one private repo. The `node_id` is GitHub's
+ * GraphQL global node ID (e.g. `R_kgDO...`), used as the redacted name in
+ * `metadata/repos.yaml`. The `owner`/`name` pair is the canonical identifier the
+ * operator wants to scrub from public artifacts.
+ *
+ * This mapping never persists in the repo — the operator passes it via CLI args at
+ * enumeration time, the script processes it in-memory, and the values disappear when
+ * the process exits.
+ */
+export interface PrivateRepoMapping {
+  readonly node_id: string
+  readonly owner: string
+  readonly name: string
+}
+
+/**
+ * One surface where canonical info about a private repo currently exists in a public
+ * artifact. Each surface carries the remediation command the operator can run to
+ * scrub it (or accept it via the documented disclosure path).
+ */
+export interface LeakSurface {
+  readonly type: 'commit-subject' | 'workflow-run' | 'metadata-entry' | 'wiki-page'
+  readonly identifier: string
+  readonly description: string
+  readonly remediation: {
+    readonly action: 'rebase-rewrite' | 'delete-run' | 'redact-entry' | 'delete-page'
+    readonly command: string
+  }
+}
+
+export interface EnumerateLeaksInput {
+  readonly privateRepos: readonly PrivateRepoMapping[]
+  readonly commitLog: readonly {sha: string; subject: string}[]
+  readonly workflowRuns: readonly {id: number; name: string; inputs: Record<string, unknown>}[]
+  readonly reposFile: ReposFile
+  readonly wikiFilenames: readonly string[]
+}
+
+/**
+ * Pure function: scan all data sources for surfaces where any private repo's canonical
+ * `owner/name` appears, and emit a structured remediation list.
+ *
+ * Detection rules:
+ * - **commit-subject**: case-insensitive match of `owner/name` as a contiguous token in
+ *   the commit subject. Substring matches inside other words are excluded by anchoring
+ *   on the slash character — so `polymorphism` doesn't match `poly`.
+ * - **workflow-run**: matches when the run's `inputs.owner` and `inputs.repo` both
+ *   equal the canonical pair (case-sensitive — GitHub stores logins canonically), OR
+ *   when the run's display name contains `owner/name` as a substring.
+ * - **metadata-entry**: matches when an entry in `metadata/repos.yaml` has
+ *   `owner === canonical.owner && name === canonical.name`. Entries already redacted
+ *   (owner: `[REDACTED]`, name: `<node_id>`) are NOT reported.
+ * - **wiki-page**: matches when a filename in `knowledge/wiki/repos/` equals the
+ *   canonical slug `${owner}--${name}.md`.
+ */
+export function enumerateLeaks(input: EnumerateLeaksInput): LeakSurface[] {
+  const surfaces: LeakSurface[] = []
+
+  for (const priv of input.privateRepos) {
+    const canonical = `${priv.owner}/${priv.name}`
+    const canonicalLower = canonical.toLowerCase()
+
+    // commit-subject — slash-anchored case-insensitive token match.
+    for (const commit of input.commitLog) {
+      if (commit.subject.toLowerCase().includes(canonicalLower)) {
+        surfaces.push({
+          type: 'commit-subject',
+          identifier: commit.sha,
+          description: `commit subject names ${canonical}`,
+          remediation: {
+            action: 'rebase-rewrite',
+            command: `git rebase -i ${commit.sha}~1  # then 'reword' and replace ${canonical} with ${priv.node_id}; or use 'git filter-repo --replace-message <expr>'`,
+          },
+        })
+      }
+    }
+
+    // workflow-run — match by inputs first (most reliable), then fall back to run name.
+    for (const run of input.workflowRuns) {
+      const inputsMatch = run.inputs.owner === priv.owner && run.inputs.repo === priv.name
+      const nameMatch = run.name.toLowerCase().includes(canonicalLower)
+      if (inputsMatch || nameMatch) {
+        surfaces.push({
+          type: 'workflow-run',
+          identifier: String(run.id),
+          description: `workflow run "${run.name}" references ${canonical}`,
+          remediation: {
+            action: 'delete-run',
+            command: `gh api -X DELETE /repos/fro-bot/.github/actions/runs/${run.id}`,
+          },
+        })
+      }
+    }
+
+    // metadata-entry — match by current owner/name (entries already redacted are skipped).
+    for (const entry of input.reposFile.repos) {
+      if (entry.owner === priv.owner && entry.name === priv.name) {
+        surfaces.push({
+          type: 'metadata-entry',
+          identifier: `${entry.owner}/${entry.name}`,
+          description: `metadata/repos.yaml entry names ${canonical} canonically (not yet redacted)`,
+          remediation: {
+            action: 'redact-entry',
+            command: `# Author a one-shot PR (operator identity, not bot) that sets owner='[REDACTED]' and name='${priv.node_id}' on this entry. The check-wiki-authority guard skips author=marcusrbrown for explicit operator rewrites.`,
+          },
+        })
+      }
+    }
+
+    // wiki-page — match canonical slug pattern owner--name.md (double-dash separator).
+    const canonicalSlug = `${priv.owner}--${priv.name}.md`.toLowerCase()
+    for (const filename of input.wikiFilenames) {
+      if (filename.toLowerCase() === canonicalSlug) {
+        surfaces.push({
+          type: 'wiki-page',
+          identifier: filename,
+          description: `knowledge/wiki/repos/${filename} is named after ${canonical}`,
+          remediation: {
+            action: 'delete-page',
+            command: `# Operator removes knowledge/wiki/repos/${filename} on the data branch and rebuilds the index via 'node scripts/rebuild-wiki-index.ts'.`,
+          },
+        })
+      }
+    }
+  }
+
+  return surfaces
+}
+
+/**
+ * Render a human-readable report grouping surfaces by type and listing the remediation
+ * command for each. Used by the CLI to print to stdout. Returns a "no surfaces" message
+ * when the input is empty so the operator gets an explicit confirmation rather than
+ * blank output.
+ */
+export function formatLeakReport(surfaces: readonly LeakSurface[]): string {
+  if (surfaces.length === 0) {
+    return 'No leak surfaces found. None of the supplied private repos appear in any scanned source.'
+  }
+
+  const grouped = new Map<LeakSurface['type'], LeakSurface[]>()
+  for (const s of surfaces) {
+    const bucket = grouped.get(s.type) ?? []
+    bucket.push(s)
+    grouped.set(s.type, bucket)
+  }
+
+  const lines: string[] = [`Found ${surfaces.length} leak surface(s):`, '']
+  for (const [type, group] of grouped) {
+    lines.push(`## ${type} (${group.length})`)
+    lines.push('')
+    for (const s of group) {
+      lines.push(`- ${s.identifier}`)
+      lines.push(`  ${s.description}`)
+      lines.push(`  remediation (${s.remediation.action}):`)
+      lines.push(`    ${s.remediation.command}`)
+    }
+    lines.push('')
+  }
+  lines.push(
+    'Per-surface decision: REMEDIATE (run the command) or ACCEPT (record the disclosure in metadata/README.md).',
+  )
+  return lines.join('\n')
+}
+
+interface CliInput {
+  readonly privateRepos: readonly PrivateRepoMapping[]
+  readonly repoRoot: string
+  readonly mainBranch: string
+  /**
+   * Optional git ref to read `metadata/repos.yaml` from. Defaults to the working tree
+   * (typically `main`). Pass `data` (or `origin/data`) to catch entries that have not
+   * yet promoted via the weekly merge-data PR — operators should run both passes.
+   */
+  readonly metadataRef?: string
+}
+
+/**
+ * Parse `--private node_id:owner/name` arguments into structured mappings. Each flag
+ * may appear multiple times. The `node_id` segment is required because it's needed
+ * for the redact-entry remediation command output.
+ */
+function parsePrivateArgs(argv: readonly string[]): PrivateRepoMapping[] {
+  const mappings: PrivateRepoMapping[] = []
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] !== '--private') continue
+    const value = argv[i + 1]
+    if (value === undefined) {
+      throw new Error('--private flag requires a value of the form node_id:owner/name')
+    }
+    const colonIdx = value.indexOf(':')
+    const slashIdx = value.indexOf('/')
+    if (colonIdx === -1 || slashIdx === -1 || slashIdx < colonIdx) {
+      throw new Error(`--private value must be of the form node_id:owner/name (got: ${value})`)
+    }
+    const nodeId = value.slice(0, colonIdx)
+    const owner = value.slice(colonIdx + 1, slashIdx)
+    const name = value.slice(slashIdx + 1)
+    if (nodeId === '' || owner === '' || name === '') {
+      throw new Error(`--private value has empty segment(s) (got: ${value})`)
+    }
+    mappings.push({node_id: nodeId, owner, name})
+    i += 1
+  }
+  return mappings
+}
+
+async function gatherCommitLog(mainBranch: string): Promise<{sha: string; subject: string}[]> {
+  // Limit to a reasonable history window (default: all commits on main since repo creation).
+  // Format: `<sha>\t<subject>` per line.
+  const stdout = execFileSync('git', ['log', mainBranch, '--format=%h\t%s'], {encoding: 'utf8'})
+  return stdout
+    .split('\n')
+    .filter(line => line.length > 0)
+    .map(line => {
+      const tabIdx = line.indexOf('\t')
+      return {sha: line.slice(0, tabIdx), subject: line.slice(tabIdx + 1)}
+    })
+}
+
+async function gatherWorkflowRuns(): Promise<{id: number; name: string; inputs: Record<string, unknown>}[]> {
+  // Pull recent run history for the Survey Repo workflow specifically. Other workflows
+  // (poll-invitations, fro-bot.yaml) take only repo-internal context, not target-repo
+  // names, so they don't contribute to the leak surface.
+  //
+  // The list-runs endpoint exposes `display_title` (visible in the public Actions tab)
+  // but NOT the original workflow_dispatch inputs — those would require a per-run fetch
+  // against /actions/runs/<id> which is rate-limit prohibitive at scale. The display
+  // title is the actual public leak surface anyway: anyone browsing the Actions tab
+  // sees it. The pure `enumerateLeaks` still accepts inputs for fixture-driven tests,
+  // but the CLI shell populates only the display title.
+  try {
+    const stdout = execFileSync(
+      'gh',
+      [
+        'api',
+        '/repos/fro-bot/.github/actions/workflows/survey-repo.yaml/runs?per_page=100',
+        '--jq',
+        '.workflow_runs[] | {id, name: (.display_title // "")}',
+      ],
+      {encoding: 'utf8'},
+    )
+    return stdout
+      .split('\n')
+      .filter(line => line.length > 0)
+      .map(line => {
+        const parsed = JSON.parse(line) as {id: number; name: string}
+        return {id: parsed.id, name: parsed.name, inputs: {}}
+      })
+  } catch (error: unknown) {
+    process.stderr.write(
+      `enumerate-existing-leaks: failed to fetch workflow runs (${(error as Error).message}); continuing without them.\n`,
+    )
+    return []
+  }
+}
+
+/**
+ * Read `metadata/repos.yaml` either from the local working tree (default) or from a
+ * specific git ref (e.g. `data`). The data branch is where autonomous commits land
+ * before the weekly merge-data PR promotes them to `main`. Operators running this
+ * enumeration should generally check both: a leak that hasn't promoted yet still
+ * counts, since it WILL promote on the next merge-data cycle if not redacted first.
+ */
+async function gatherReposFile(repoRoot: string, ref?: string): Promise<ReposFile> {
+  let raw: string
+  if (ref === undefined) {
+    const path = join(repoRoot, 'metadata', 'repos.yaml')
+    raw = await readFile(path, 'utf8')
+  } else {
+    raw = execFileSync('git', ['show', `${ref}:metadata/repos.yaml`], {encoding: 'utf8'})
+  }
+  const parsed: unknown = parseYaml(raw)
+  assertReposFile(parsed, 'repos')
+  return parsed
+}
+
+async function gatherWikiFilenames(repoRoot: string): Promise<string[]> {
+  const dir = join(repoRoot, 'knowledge', 'wiki', 'repos')
+  try {
+    const entries = await readdir(dir)
+    return entries.filter(e => e.endsWith('.md') && e !== 'README.md')
+  } catch {
+    return []
+  }
+}
+
+export async function runCli(input: CliInput): Promise<LeakSurface[]> {
+  const [commitLog, workflowRuns, reposFile, wikiFilenames] = await Promise.all([
+    gatherCommitLog(input.mainBranch),
+    gatherWorkflowRuns(),
+    gatherReposFile(input.repoRoot, input.metadataRef),
+    gatherWikiFilenames(input.repoRoot),
+  ])
+
+  return enumerateLeaks({
+    privateRepos: input.privateRepos,
+    commitLog,
+    workflowRuns,
+    reposFile,
+    wikiFilenames,
+  })
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2)
+  if (argv.includes('--help') || argv.length === 0) {
+    process.stdout.write(
+      `${[
+        'Usage: node scripts/enumerate-existing-leaks.ts --private <node_id>:<owner>/<name> [--private ...] [--branch <ref>]',
+        '',
+        'Scans the local checkout for surfaces where the supplied private repo identifiers appear',
+        'in public artifacts (commit subjects on main, recent Survey Repo workflow runs,',
+        'metadata/repos.yaml entries, and knowledge/wiki/repos/ filenames).',
+        '',
+        'By default reads metadata/repos.yaml from the working tree (typically main). Pass',
+        '--branch origin/data to also catch entries that have not yet promoted via the weekly',
+        'merge-data PR. Operators should run both passes for full coverage.',
+        '',
+        'Examples:',
+        '  node scripts/enumerate-existing-leaks.ts --private <node_id>:<owner>/<name>',
+        '  node scripts/enumerate-existing-leaks.ts --private <node_id>:<owner>/<name> --branch origin/data',
+        '',
+        'For each surface, the operator decides REMEDIATE (run the printed command) or ACCEPT',
+        '(record the disclosure in metadata/README.md). Phase 0 closes when every surface has',
+        'an explicit decision.',
+      ].join('\n')}\n`,
+    )
+    process.exit(argv.includes('--help') ? 0 : 1)
+  }
+
+  const privateRepos = parsePrivateArgs(argv)
+  if (privateRepos.length === 0) {
+    process.stderr.write('enumerate-existing-leaks: no --private mappings supplied\n')
+    process.exit(1)
+  }
+
+  // Optional --branch <ref> overrides the metadata read source. Defaults to working
+  // tree (typically main). Useful values: `origin/data` to catch entries that have
+  // not yet promoted via the weekly merge-data PR.
+  const branchIdx = argv.indexOf('--branch')
+  const metadataRef = branchIdx === -1 ? undefined : argv[branchIdx + 1]
+
+  const repoRoot = process.cwd()
+  const mainBranch = 'main'
+
+  const surfaces = await runCli({privateRepos, repoRoot, mainBranch, metadataRef})
+  process.stdout.write(`${formatLeakReport(surfaces)}\n`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}


### PR DESCRIPTION
## What changes

Phase 0 of the private-repo handling work, per `docs/plans/2026-05-05-002-feat-private-repo-handling-plan.md`. Adds `scripts/enumerate-existing-leaks.ts` — a tool the operator runs once per currently-tracked private repo to find every public artifact that names the canonical `owner/name` canonically (vs the redacted `node_id` form), with a remediation command attached to each surface. Closes Unit 0 of the plan.

## Why now

The private-repo posture introduced in #3245 establishes that future Fro Bot writes redact private-repo identifiers in public artifacts. But existing artifacts predating the posture may already name canonical identifiers — and the architectural changes in Phases 1-3 only protect *future* writes. Phase 0 is the inventory + remediate step: every existing surface gets an explicit operator decision (REMEDIATE the leak, or ACCEPT the disclosure with a documented entry in `metadata/README.md`). Phases 1-3 land on a clean slate.

## How it works

```bash
node scripts/enumerate-existing-leaks.ts \
  --private <node_id>:<owner>/<name> \
  [--branch origin/data]
```

The operator supplies one `--private` flag per private repo. The `node_id` is GitHub's GraphQL global node ID (resolvable from a private-repo URL via `gh api graphql`). The mapping never persists in the repo — values exist only in process memory and disappear when the script exits.

The script scans four surface types:

| Surface | Detection rule | Remediation command |
| --- | --- | --- |
| `commit-subject` | Slash-anchored case-insensitive match of `owner/name` in `git log` subjects. `polymorphism` does NOT match `poly`. | `git rebase -i <sha>~1` hint with replacement guidance |
| `workflow-run` | Run inputs match canonical pair, OR display title contains `owner/name`. | `gh api -X DELETE /repos/.../actions/runs/<id>` |
| `metadata-entry` | An entry in `metadata/repos.yaml` has `owner === canonical.owner && name === canonical.name`. Already-redacted entries skipped. | Author a one-shot PR (operator identity, not bot) that sets `owner='[REDACTED]'` and `name='<node_id>'`. |
| `wiki-page` | Filename equals `<owner>--<name>.md` under `knowledge/wiki/repos/`. | Delete the page on `data` and rebuild the index. |

The `--branch <ref>` flag overrides the metadata read source. `main` is the default (working tree); `origin/data` catches entries that have not yet promoted via the weekly merge-data PR. Operators should run both passes.

## Empirical verification

Ran against the first tracked private repo. **The plan's deepening review overestimated the leak surface** — the script is correct, the review was wrong:

| Surface | Plan said | Actual |
| --- | --- | --- |
| Commit subjects on `main` | "2 commits" | **0** — the 4 canonical-naming commits are on `data` and merged-but-renamed branches, not on `main` |
| Workflow run titles | "1+ workflow runs" | **0** — Survey Repo's `display_title` is a generic "Survey Repo" string that does not include target inputs |
| Metadata entry on `main` | "current entry" | **0** — entry hasn't promoted yet |
| Metadata entry on `data` | (not enumerated) | **1** — caught by `--branch origin/data` |
| Wiki pages | "0 pages" | **0** — confirmed |

Operationally: Phase 0 remediation for the tracked private repo is one redact-entry on `data` before the next merge-data promotion. The `--branch` flag was added during this verification cycle to make catching it possible.

The Survey Repo `display_title` finding is worth flagging — the plan assumed inputs would surface in the runs list response, which they don't (they live behind a per-run fetch that's rate-limit prohibitive at scale). The detection rule stays in place for fixture-driven tests and future workflows that may surface inputs differently, but real production runs of this workflow won't trip it.

## Test coverage

17 tests in `scripts/enumerate-existing-leaks.test.ts`:

- Happy paths: empty list, multi-surface fixture, no-leaks fixture, multi-repo enumeration
- Detection rules: case-insensitivity, slash-anchoring (the `polymorphism`/`poly` boundary), workflow-run input matching, redacted-entry exclusion, owner/name pair matching for workflow-run name fallback
- Remediation: each surface type carries the right action and command shape

416/416 tests pass overall (was 399 before this branch; +17 new).

## What's next

After this lands, the operator runs the script against any currently-tracked private repos, makes per-surface decisions, and either executes remediation commands or appends ACCEPT entries to `metadata/README.md`. Once that's done, Phase 0 closes and Phases 1-3 unblock.

The plan also flags two small follow-ups worth doing as a separate PR:
- Update `docs/plans/2026-05-05-002` and `docs/brainstorms/2026-05-05` to replace the deepening review's overestimated leak counts with the empirical ground truth.
- Optionally extend the script to scan commits on `data` (currently only scans `main`), so future operator passes catch in-flight leaks before promotion.