### PR TITLE
feat(privacy): wire private and node_id fields with sticky preservation and 5-state probe

### DIFF
--- a/docs/plans/2026-05-05-002-feat-private-repo-handling-plan.md
+++ b/docs/plans/2026-05-05-002-feat-private-repo-handling-plan.md
@@ -326,7 +326,7 @@ persona/
 
 ---
 
-- [ ] **Unit 1: Schema fields for `private` and `node_id`**
+- [x] **Unit 1: Schema fields for `private` and `node_id`**
 
 **Goal:** Add optional `private?: boolean` and `node_id?: string` to `RepoEntry`. Loose-then-tight; no runtime behavior change yet.
 
@@ -361,7 +361,7 @@ persona/
 
 ---
 
-- [ ] **Unit 2: 5-state probe with sticky preservation**
+- [x] **Unit 2: 5-state probe with sticky preservation**
 
 **Goal:** Reconcile probe distinguishes 5 states (public, private, access-lost, transient, malformed) with explicit semantics. Indeterminate responses preserve prior `private` value (sticky); access-lost fails closed.
 

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -1490,6 +1490,22 @@ describe('fetchPerRepoStatus 5-state classification', () => {
     expect(result.get('fro-bot/weird-repo')).toEqual({status: 'malformed'})
   })
 
+  it('HTTP 200 with empty node_id → malformed (matches schema constraint)', async () => {
+    // The schema's runtime guard requires node_id.length > 0. Accepting an empty string
+    // here would defer the failure to assertReposFile with a less actionable error path.
+    // Match the schema constraint at probe time.
+    const reposGet = vi.fn(async () => ({
+      data: {private: false, node_id: ''} as RepoGetResponse,
+    }))
+    const userOctokit = mockOctokit({reposGet: reposGet as never})
+    const logger = silentLogger()
+
+    const result = await fetchPerRepoStatus(userOctokit, reposFileWith('fro-bot', 'empty-id-repo'), [], logger)
+
+    expect(result.get('fro-bot/empty-id-repo')).toEqual({status: 'malformed'})
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('malformed repos.get response'))
+  })
+
   it('HTTP 422 (other 4xx) → throws ReconcileError', async () => {
     expect.assertions(1)
     const reposGet = vi.fn(async () => {

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -8,6 +8,7 @@ import {describe, expect, it, vi} from 'vitest'
 import {
   containsFroBotAgentReference,
   DISPATCH_DEFAULTS,
+  fetchPerRepoStatus,
   formatCommitMessage,
   handleReconcile,
   isEligibleForSurvey,
@@ -21,6 +22,7 @@ import {
   type HandleReconcileParams,
   type OctokitClient,
   type ReconcileInput,
+  type RepoStatusProbe,
 } from './reconcile-repos.ts'
 import {addRepoEntry} from './repos-metadata.ts'
 import {assertReposFile} from './schemas.ts'
@@ -42,6 +44,13 @@ function makeAccess(overrides: Partial<AccessListEntry> = {}): AccessListEntry {
     private: false,
     node_id: 'R_default',
     ...overrides,
+  }
+}
+
+function reposFileWith(owner: string, name: string): ReposFile {
+  return {
+    version: 1,
+    repos: [makeEntry({owner, name})],
   }
 }
 
@@ -109,6 +118,8 @@ describe('reconcileRepos', () => {
         lostAccess: 0,
         refreshed: 0,
         migrated: 0,
+        transient: 0,
+        malformed: 0,
         unchanged: 0,
         // dispatched/deferred populated by the I/O shell, not the engine
         byChannel: {
@@ -197,7 +208,12 @@ describe('reconcileRepos', () => {
 
   describe('tracked entries — still accessible', () => {
     it('leaves a pending-review, still-accessible entry unchanged when no field drift', () => {
-      const entry = makeEntry({onboarding_status: 'pending-review', name: 'stable-repo'})
+      const entry = makeEntry({
+        onboarding_status: 'pending-review',
+        name: 'stable-repo',
+        private: false,
+        node_id: 'R_default',
+      })
       const result = reconcileRepos(
         makeInput({
           currentRepos: {version: 1, repos: [entry]},
@@ -280,6 +296,7 @@ describe('reconcileRepos', () => {
       expect(result.nextRepos.repos[0]).toEqual({
         ...entry,
         onboarding_status: 'lost-access',
+        private: true,
       })
       expect(result.summary.lostAccess).toBe(1)
     })
@@ -325,6 +342,34 @@ describe('reconcileRepos', () => {
       expect(result.summary.unchanged).toBe(1)
       expect(result.summary.lostAccess).toBe(0)
     })
+
+    it('treats tracked repo absent from access list with probe=transient — no change', () => {
+      const entry = makeEntry({name: 'flaky-repo', onboarding_status: 'onboarded'})
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          perRepoStatus: new Map([['fro-bot/flaky-repo', {status: 'transient', httpStatus: 502}]]),
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]).toEqual(entry)
+      expect(result.summary.unchanged).toBe(1)
+      expect(result.summary.lostAccess).toBe(0)
+    })
+
+    it('treats tracked repo absent from access list with probe=malformed — no change', () => {
+      const entry = makeEntry({name: 'broken-repo', onboarding_status: 'onboarded'})
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          perRepoStatus: new Map([['fro-bot/broken-repo', {status: 'malformed'}]]),
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]).toEqual(entry)
+      expect(result.summary.unchanged).toBe(1)
+      expect(result.summary.lostAccess).toBe(0)
+    })
   })
 
   describe('tracked entries — regained access', () => {
@@ -351,6 +396,8 @@ describe('reconcileRepos', () => {
       expect(result.nextRepos.repos[0]).toEqual({
         ...entry,
         onboarding_status: 'pending',
+        private: false,
+        node_id: 'R_default',
       })
       expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'returned-repo'}])
       expect(result.issues).toEqual([])
@@ -376,6 +423,8 @@ describe('reconcileRepos', () => {
       expect(result.nextRepos.repos[0]).toEqual({
         ...entry,
         onboarding_status: 'pending-review',
+        private: false,
+        node_id: 'R_sus',
       })
       expect(result.dispatches).toEqual([])
       expect(result.issues).toEqual([
@@ -389,6 +438,375 @@ describe('reconcileRepos', () => {
         },
       ])
       expect(result.summary.regained).toBe(1)
+    })
+  })
+
+  describe('private/node_id merge from access list and probes', () => {
+    it('writes private:false and node_id from access list for a public still-accessible repo (no prior fields)', () => {
+      const entry = makeEntry({name: 'pub-repo'})
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({name: 'pub-repo', private: false, node_id: 'R_pub'})],
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]).toMatchObject({
+        name: 'pub-repo',
+        private: false,
+        node_id: 'R_pub',
+      })
+      expect(result.summary.refreshed).toBe(1)
+      expect(result.summary.unchanged).toBe(0)
+    })
+
+    it('writes private:true and node_id from access list for a private still-accessible repo (no prior fields)', () => {
+      const entry = makeEntry({name: 'priv-repo'})
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({name: 'priv-repo', private: true, node_id: 'R_priv'})],
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]).toMatchObject({
+        name: 'priv-repo',
+        private: true,
+        node_id: 'R_priv',
+      })
+      expect(result.summary.refreshed).toBe(1)
+      expect(result.summary.unchanged).toBe(0)
+    })
+
+    it('treats matching private/node_id as idempotent — no refresh bump', () => {
+      const entry = makeEntry({name: 'stable', private: true, node_id: 'R_priv'})
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({name: 'stable', private: true, node_id: 'R_priv'})],
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]).toEqual(entry)
+      expect(result.summary.unchanged).toBe(1)
+      expect(result.summary.refreshed).toBe(0)
+    })
+
+    it('bumps refreshed on public→private transition (same node_id)', () => {
+      const entry = makeEntry({name: 'flip-repo', private: false, node_id: 'R_x'})
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({name: 'flip-repo', private: true, node_id: 'R_x'})],
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]).toMatchObject({
+        name: 'flip-repo',
+        private: true,
+        node_id: 'R_x',
+      })
+      expect(result.summary.refreshed).toBe(1)
+      // No transition signal here; that's covered by a later unit.
+    })
+
+    it('applies fail-safe private:true on probe-decided lost-access (deleted, had prior private:false)', () => {
+      const entry = makeEntry({name: 'deleted-repo', private: false, node_id: 'R_del'})
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          perRepoStatus: new Map([['fro-bot/deleted-repo', {status: 'deleted'}]]),
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]).toMatchObject({
+        name: 'deleted-repo',
+        onboarding_status: 'lost-access',
+        private: true,
+        node_id: 'R_del',
+      })
+      expect(result.summary.lostAccess).toBe(1)
+    })
+
+    it('applies fail-safe private:true on probe-decided lost-access (revoked, no prior private field)', () => {
+      const entry = makeEntry({name: 'revoked-repo'}) // no private, no node_id
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          perRepoStatus: new Map([['fro-bot/revoked-repo', {status: 'revoked'}]]),
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]).toMatchObject({
+        name: 'revoked-repo',
+        onboarding_status: 'lost-access',
+        private: true,
+      })
+      // No prior node_id, so the entry should not have node_id introduced
+      expect(result.nextRepos.repos[0]).not.toHaveProperty('node_id')
+      expect(result.summary.lostAccess).toBe(1)
+    })
+
+    it('applies fail-safe private:true on archived access-lost (overrides access.private:false)', () => {
+      const entry = makeEntry({name: 'archived-repo', onboarding_status: 'onboarded'})
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({name: 'archived-repo', archived: true, private: false, node_id: 'R_arch'})],
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]).toMatchObject({
+        name: 'archived-repo',
+        onboarding_status: 'lost-access',
+        private: true, // fail-safe overrides access.private:false
+        node_id: 'R_arch',
+      })
+      expect(result.summary.lostAccess).toBe(1)
+    })
+
+    it('preserves sticky private on transient probe (entry had prior private:true)', () => {
+      const entry = makeEntry({name: 'flaky-repo', private: true, node_id: 'R_flaky'})
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          perRepoStatus: new Map([['fro-bot/flaky-repo', {status: 'transient', httpStatus: 502}]]),
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]).toEqual(entry)
+      expect(result.nextRepos.repos[0]?.private).toBe(true)
+      expect(result.summary.unchanged).toBe(1)
+      expect(result.summary.lostAccess).toBe(0)
+    })
+
+    it('preserves sticky absent-private on malformed probe (no prior private field)', () => {
+      const entry = makeEntry({name: 'broken-repo'}) // no private, no node_id
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          perRepoStatus: new Map([['fro-bot/broken-repo', {status: 'malformed'}]]),
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]).toEqual(entry)
+      expect(result.nextRepos.repos[0]).not.toHaveProperty('private')
+      expect(result.summary.unchanged).toBe(1)
+    })
+
+    it('regain writes live private/node_id from access list (overrides sticky)', () => {
+      const entry = makeEntry({
+        name: 'returned-repo',
+        onboarding_status: 'lost-access',
+        private: true,
+        node_id: 'R_old',
+      })
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({name: 'returned-repo', private: false, node_id: 'R_new'})],
+          allowlist: makeAllowlist(['fro-bot']),
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]).toMatchObject({
+        name: 'returned-repo',
+        onboarding_status: 'pending',
+        private: false,
+        node_id: 'R_new',
+      })
+      expect(result.summary.regained).toBe(1)
+    })
+
+    it('integration: mixed states produce correct per-entry private/node_id', () => {
+      // Three entries:
+      // 1. still-accessible — entry has private:false, access has private:true (changed)
+      // 2. access-lost via probe (deleted) — entry has private:false, expect fail-safe true
+      // 3. regain — entry was lost-access with private:true, access shows private:false
+      const stillAccessible = makeEntry({
+        name: 'still-ok',
+        private: false,
+        node_id: 'R_ok',
+      })
+      const gone = makeEntry({
+        name: 'gone-repo',
+        private: false,
+        node_id: 'R_gone',
+      })
+      const returning = makeEntry({
+        name: 'returning-repo',
+        onboarding_status: 'lost-access',
+        private: true,
+        node_id: 'R_stale',
+      })
+
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [stillAccessible, gone, returning]},
+          accessList: [
+            makeAccess({name: 'still-ok', private: true, node_id: 'R_ok'}), // privacy flipped
+            makeAccess({name: 'returning-repo', private: false, node_id: 'R_fresh'}),
+          ],
+          perRepoStatus: new Map([['fro-bot/gone-repo', {status: 'deleted'}]]),
+          allowlist: makeAllowlist(['fro-bot']),
+        }),
+      )
+
+      expect(result.nextRepos.repos).toHaveLength(3)
+      const byName = new Map(result.nextRepos.repos.map(r => [r.name, r]))
+
+      // still-accessible: writes live access data (private:true)
+      expect(byName.get('still-ok')).toMatchObject({
+        onboarding_status: 'onboarded',
+        private: true,
+        node_id: 'R_ok',
+      })
+
+      // access-lost: fail-safe private:true, preserves prior node_id
+      expect(byName.get('gone-repo')).toMatchObject({
+        onboarding_status: 'lost-access',
+        private: true,
+        node_id: 'R_gone',
+      })
+
+      // regain: writes live access data (private:false overrides sticky private:true)
+      expect(byName.get('returning-repo')).toMatchObject({
+        onboarding_status: 'pending',
+        private: false,
+        node_id: 'R_fresh',
+      })
+    })
+
+    it('preserves absent private on transient probe with no prior privacy state', () => {
+      // Symmetric to the malformed-no-prior test above. Transient must not introduce
+      // a private:false default; legacy entries must remain absent until a real probe lands.
+      const entry = makeEntry({name: 'transient-legacy'})
+      // Confirm the fixture is genuinely without `private`/`node_id`.
+      expect(entry).not.toHaveProperty('private')
+      expect(entry).not.toHaveProperty('node_id')
+
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [],
+          perRepoStatus: new Map([['fro-bot/transient-legacy', {status: 'transient', httpStatus: 502}]]),
+        }),
+      )
+
+      const next = result.nextRepos.repos[0]
+      expect(next).not.toHaveProperty('private')
+      expect(next).not.toHaveProperty('node_id')
+      expect(result.summary.unchanged).toBe(1)
+      expect(result.summary.lostAccess).toBe(0)
+    })
+
+    it('integration: all 5 probe states in one run produce correct per-entry shape', () => {
+      // Extends the 3-state integration above to exercise transient + malformed alongside
+      // still-accessible / deleted / regain in a single reconcile pass. Plan scenario #11
+      // explicitly requires "all 5 probe states in one run."
+      const stillOk = makeEntry({name: 'still-ok-five', private: false, node_id: 'R_ok'})
+      const goneDeleted = makeEntry({name: 'gone-five', private: false, node_id: 'R_gone'})
+      const transientPriorPrivate = makeEntry({name: 'flaky-five', private: true, node_id: 'R_flaky'})
+      const malformedLegacy = makeEntry({name: 'malformed-five'})
+      const returning = makeEntry({
+        name: 'returning-five',
+        onboarding_status: 'lost-access',
+        private: true,
+        node_id: 'R_stale',
+      })
+
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {
+            version: 1,
+            repos: [stillOk, goneDeleted, transientPriorPrivate, malformedLegacy, returning],
+          },
+          accessList: [
+            makeAccess({name: 'still-ok-five', private: false, node_id: 'R_ok'}),
+            makeAccess({name: 'returning-five', private: false, node_id: 'R_fresh'}),
+          ],
+          perRepoStatus: new Map([
+            ['fro-bot/gone-five', {status: 'deleted'}],
+            ['fro-bot/flaky-five', {status: 'transient', httpStatus: 503}],
+            ['fro-bot/malformed-five', {status: 'malformed'}],
+          ]),
+          allowlist: makeAllowlist(['fro-bot']),
+        }),
+      )
+
+      expect(result.nextRepos.repos).toHaveLength(5)
+      const byName = new Map(result.nextRepos.repos.map(r => [r.name, r]))
+
+      // still-accessible: live access data, idempotent (no refresh because nothing changed).
+      expect(byName.get('still-ok-five')).toEqual(stillOk)
+
+      // deleted: fail-safe private:true, preserves prior node_id.
+      expect(byName.get('gone-five')).toMatchObject({
+        onboarding_status: 'lost-access',
+        private: true,
+        node_id: 'R_gone',
+      })
+
+      // transient + prior private:true: sticky-preserved (no flip, no field churn).
+      expect(byName.get('flaky-five')).toEqual(transientPriorPrivate)
+
+      // malformed + legacy (no prior private): sticky-preserve absence, no fields introduced.
+      expect(byName.get('malformed-five')).not.toHaveProperty('private')
+      expect(byName.get('malformed-five')).not.toHaveProperty('node_id')
+
+      // regain: writes live access data over sticky.
+      expect(byName.get('returning-five')).toMatchObject({
+        onboarding_status: 'pending',
+        private: false,
+        node_id: 'R_fresh',
+      })
+
+      // Summary shape: 1 lost-access (gone), 3 unchanged (still-ok + flaky + malformed),
+      // 1 added/refresh delta from regain.
+      expect(result.summary.lostAccess).toBe(1)
+      expect(result.summary.unchanged).toBeGreaterThanOrEqual(3)
+    })
+
+    it('bumps summary.transient and summary.malformed independently when probes degrade', () => {
+      // Distinct counters let operators distinguish API-incident days (sustained transient)
+      // from upstream contract anomalies (sustained malformed) without cross-referencing
+      // warn logs in the Actions UI.
+      const flaky = makeEntry({name: 'flaky-counter', private: true, node_id: 'R_flaky'})
+      const malformedEntry = makeEntry({name: 'malformed-counter', private: false, node_id: 'R_malf'})
+
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [flaky, malformedEntry]},
+          accessList: [],
+          perRepoStatus: new Map([
+            ['fro-bot/flaky-counter', {status: 'transient', httpStatus: 502}],
+            ['fro-bot/malformed-counter', {status: 'malformed'}],
+          ]),
+        }),
+      )
+
+      expect(result.summary.transient).toBe(1)
+      expect(result.summary.malformed).toBe(1)
+      expect(result.summary.unchanged).toBe(2)
+      expect(result.summary.lostAccess).toBe(0)
+    })
+
+    it('throws on unknown probe state — exhaustiveness guard', () => {
+      // RepoStatusProbe is a discriminated union with a default branch that asserts the
+      // probe variant has been narrowed to `never`. Adding a new variant later without
+      // updating the switch must fail loudly rather than silently flipping to lost-access.
+      const entry = makeEntry({name: 'novel-state'})
+      const bogusProbe = {status: 'cosmic-ray-bit-flip'} as unknown as RepoStatusProbe
+
+      expect(() =>
+        reconcileRepos(
+          makeInput({
+            currentRepos: {version: 1, repos: [entry]},
+            accessList: [],
+            perRepoStatus: new Map([['fro-bot/novel-state', bogusProbe]]),
+          }),
+        ),
+      ).toThrow(/unhandled RepoStatusProbe variant/)
     })
   })
 
@@ -441,6 +859,8 @@ describe('reconcileRepos', () => {
         lostAccess: 1,
         refreshed: 1,
         migrated: 0,
+        transient: 0,
+        malformed: 0,
         unchanged: 0,
         // dispatched/deferred populated by the I/O shell, not the engine
         byChannel: {
@@ -453,8 +873,14 @@ describe('reconcileRepos', () => {
 
     it('reports all-zero counters and value-equal nextRepos when nothing changes', () => {
       // Use pending-review: it's excluded from the dispatch gate, so this entry
-      // truly produces zero side-effects.
-      const entry = makeEntry({name: 'stable-repo', onboarding_status: 'pending-review'})
+      // truly produces zero side-effects. Add matching private/node_id so the
+      // privacy field check is also a no-op.
+      const entry = makeEntry({
+        name: 'stable-repo',
+        onboarding_status: 'pending-review',
+        private: false,
+        node_id: 'R_default',
+      })
       const current: ReposFile = {version: 1, repos: [entry]}
       const result = reconcileRepos(
         makeInput({
@@ -473,6 +899,8 @@ describe('reconcileRepos', () => {
         lostAccess: 0,
         refreshed: 0,
         migrated: 0,
+        transient: 0,
+        malformed: 0,
         unchanged: 1,
         byChannel: {
           collab: {tracked: 1, dispatched: 0, deferred: 0, lostAccess: 0},
@@ -495,6 +923,8 @@ describe('reconcileRepos', () => {
         lostAccess: 0,
         refreshed: 0,
         migrated: 0,
+        transient: 0,
+        malformed: 0,
         unchanged: 0,
         byChannel: emptyChannelStats(),
       })
@@ -502,7 +932,8 @@ describe('reconcileRepos', () => {
 
     it('merges safely on concurrent-writer retry: entry added between calls is preserved', () => {
       // GIVEN an initial currentRepos@v1 reconciled once
-      const entryA = makeEntry({name: 'a-repo', onboarding_status: 'pending'})
+      // Add matching private/node_id so the privacy field check is also a no-op.
+      const entryA = makeEntry({name: 'a-repo', onboarding_status: 'pending', private: false, node_id: 'R_default'})
       const v1: ReposFile = {version: 1, repos: [entryA]}
       const accessList = [makeAccess({name: 'a-repo'})]
       reconcileRepos(makeInput({currentRepos: v1, accessList}))
@@ -883,6 +1314,198 @@ describe('reconcileRepos', () => {
 
 //
 // ─────────────────────────────────────────────────────────────────────────────
+// fetchPerRepoStatus — 5-state classification unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+//
+
+describe('fetchPerRepoStatus 5-state classification', () => {
+  it('HTTP 200 with valid body, entry not in access list → revoked', async () => {
+    const reposGet = vi.fn(async () => ({
+      data: {private: true, node_id: 'R_test'} as RepoGetResponse,
+    }))
+    const userOctokit = mockOctokit({reposGet: reposGet as never})
+    const logger = silentLogger()
+
+    const result = await fetchPerRepoStatus(userOctokit, reposFileWith('fro-bot', 'secret-repo'), [], logger)
+
+    expect(result.get('fro-bot/secret-repo')).toEqual({status: 'revoked'})
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('HTTP 404 → deleted', async () => {
+    const reposGet = vi.fn(async () => {
+      throw apiError(404, 'Not Found')
+    })
+    const userOctokit = mockOctokit({reposGet: reposGet as never})
+    const logger = silentLogger()
+
+    const result = await fetchPerRepoStatus(userOctokit, reposFileWith('fro-bot', 'gone-repo'), [], logger)
+
+    expect(result.get('fro-bot/gone-repo')).toEqual({status: 'deleted'})
+  })
+
+  it('HTTP 451 → revoked', async () => {
+    const reposGet = vi.fn(async () => {
+      throw apiError(451, 'Unavailable For Legal Reasons')
+    })
+    const userOctokit = mockOctokit({reposGet: reposGet as never})
+    const logger = silentLogger()
+
+    const result = await fetchPerRepoStatus(userOctokit, reposFileWith('fro-bot', 'taken-down-repo'), [], logger)
+
+    expect(result.get('fro-bot/taken-down-repo')).toEqual({status: 'revoked'})
+  })
+
+  it('HTTP 403 → revoked', async () => {
+    const reposGet = vi.fn(async () => {
+      throw apiError(403, 'Forbidden')
+    })
+    const userOctokit = mockOctokit({reposGet: reposGet as never})
+    const logger = silentLogger()
+
+    const result = await fetchPerRepoStatus(userOctokit, reposFileWith('fro-bot', 'blocked-repo'), [], logger)
+
+    expect(result.get('fro-bot/blocked-repo')).toEqual({status: 'revoked'})
+  })
+
+  it('HTTP 429 → transient (primary rate-limit, not revoked)', async () => {
+    const reposGet = vi.fn(async () => {
+      throw apiError(429, 'Too Many Requests')
+    })
+    const userOctokit = mockOctokit({reposGet: reposGet as never})
+    const logger = silentLogger()
+
+    const result = await fetchPerRepoStatus(userOctokit, reposFileWith('fro-bot', 'rate-limited'), [], logger)
+
+    expect(result.get('fro-bot/rate-limited')).toEqual({status: 'transient', httpStatus: 429})
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('rate-limit'))
+  })
+
+  it('HTTP 403 with Retry-After header → transient (secondary rate-limit, not revoked)', async () => {
+    const reposGet = vi.fn(async () => {
+      throw Object.assign(new Error('Forbidden'), {
+        status: 403,
+        response: {headers: {'retry-after': '60'}},
+      })
+    })
+    const userOctokit = mockOctokit({reposGet: reposGet as never})
+    const logger = silentLogger()
+
+    const result = await fetchPerRepoStatus(userOctokit, reposFileWith('fro-bot', 'secondary-limited'), [], logger)
+
+    expect(result.get('fro-bot/secondary-limited')).toEqual({status: 'transient', httpStatus: 403})
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('rate-limit'))
+  })
+
+  it('HTTP 403 with x-ratelimit-remaining: 0 → transient (rate-limit signal in headers)', async () => {
+    const reposGet = vi.fn(async () => {
+      throw Object.assign(new Error('API rate limit exceeded'), {
+        status: 403,
+        response: {headers: {'x-ratelimit-remaining': '0'}},
+      })
+    })
+    const userOctokit = mockOctokit({reposGet: reposGet as never})
+    const logger = silentLogger()
+
+    const result = await fetchPerRepoStatus(userOctokit, reposFileWith('fro-bot', 'header-limited'), [], logger)
+
+    expect(result.get('fro-bot/header-limited')).toEqual({status: 'transient', httpStatus: 403})
+  })
+
+  it('HTTP 403 with rate-limit message body → transient (rate-limit signal in body)', async () => {
+    const reposGet = vi.fn(async () => {
+      throw Object.assign(new Error('You have triggered an abuse detection mechanism'), {
+        status: 403,
+      })
+    })
+    const userOctokit = mockOctokit({reposGet: reposGet as never})
+    const logger = silentLogger()
+
+    const result = await fetchPerRepoStatus(userOctokit, reposFileWith('fro-bot', 'abuse-flagged'), [], logger)
+
+    expect(result.get('fro-bot/abuse-flagged')).toEqual({status: 'transient', httpStatus: 403})
+  })
+
+  it('HTTP 502 → transient with httpStatus', async () => {
+    const reposGet = vi.fn(async () => {
+      throw apiError(502, 'Bad Gateway')
+    })
+    const userOctokit = mockOctokit({reposGet: reposGet as never})
+    const logger = silentLogger()
+
+    const result = await fetchPerRepoStatus(userOctokit, reposFileWith('fro-bot', 'flaky-repo'), [], logger)
+
+    expect(result.get('fro-bot/flaky-repo')).toEqual({status: 'transient', httpStatus: 502})
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('transient API error (502)'))
+  })
+
+  it('HTTP 503 → transient with httpStatus', async () => {
+    const reposGet = vi.fn(async () => {
+      throw apiError(503, 'Service Unavailable')
+    })
+    const userOctokit = mockOctokit({reposGet: reposGet as never})
+    const logger = silentLogger()
+
+    const result = await fetchPerRepoStatus(userOctokit, reposFileWith('fro-bot', 'overloaded-repo'), [], logger)
+
+    expect(result.get('fro-bot/overloaded-repo')).toEqual({status: 'transient', httpStatus: 503})
+  })
+
+  it('network error → transient without httpStatus', async () => {
+    const reposGet = vi.fn(async () => {
+      throw new Error('ECONNRESET')
+    })
+    const userOctokit = mockOctokit({reposGet: reposGet as never})
+    const logger = silentLogger()
+
+    const result = await fetchPerRepoStatus(userOctokit, reposFileWith('fro-bot', 'offline-repo'), [], logger)
+
+    expect(result.get('fro-bot/offline-repo')).toEqual({status: 'transient'})
+    expect(result.get('fro-bot/offline-repo')).not.toHaveProperty('httpStatus')
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('network error'))
+  })
+
+  it('HTTP 200 with malformed body (empty data) → malformed', async () => {
+    const reposGet = vi.fn(async () => ({
+      data: {} as RepoGetResponse,
+    }))
+    const userOctokit = mockOctokit({reposGet: reposGet as never})
+    const logger = silentLogger()
+
+    const result = await fetchPerRepoStatus(userOctokit, reposFileWith('fro-bot', 'broken-repo'), [], logger)
+
+    expect(result.get('fro-bot/broken-repo')).toEqual({status: 'malformed'})
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('malformed repos.get response'))
+  })
+
+  it('HTTP 200 malformed body with private as non-boolean → malformed', async () => {
+    const reposGet = vi.fn(async () => ({
+      data: {private: 'not-a-bool', node_id: 'R_ok'} as unknown as RepoGetResponse,
+    }))
+    const userOctokit = mockOctokit({reposGet: reposGet as never})
+    const logger = silentLogger()
+
+    const result = await fetchPerRepoStatus(userOctokit, reposFileWith('fro-bot', 'weird-repo'), [], logger)
+
+    expect(result.get('fro-bot/weird-repo')).toEqual({status: 'malformed'})
+  })
+
+  it('HTTP 422 (other 4xx) → throws ReconcileError', async () => {
+    expect.assertions(1)
+    const reposGet = vi.fn(async () => {
+      throw apiError(422, 'Unprocessable')
+    })
+    const userOctokit = mockOctokit({reposGet: reposGet as never})
+    const logger = silentLogger()
+
+    await expect(fetchPerRepoStatus(userOctokit, reposFileWith('fro-bot', 'weird-repo'), [], logger)).rejects.toThrow(
+      ReconcileError,
+    )
+  })
+})
+
+//
+// ─────────────────────────────────────────────────────────────────────────────
 // Unit 3 — I/O shell tests for `handleReconcile`
 // ─────────────────────────────────────────────────────────────────────────────
 //
@@ -1191,9 +1814,12 @@ describe('handleReconcile (I/O shell)', () => {
       const issuesCreate = vi.fn(async () => ({data: {number: 1}}))
       // Use pending-review: it's excluded from the dispatch gate, so the entry
       // truly produces zero side-effects (no dispatches, no commits).
+      // Add matching private/node_id matching the mock access-list entry below.
       const existing: ReposFile = {
         version: 1,
-        repos: [makeEntry({name: 'stable-repo', onboarding_status: 'pending-review'})],
+        repos: [
+          makeEntry({name: 'stable-repo', onboarding_status: 'pending-review', private: false, node_id: 'R_stable'}),
+        ],
       }
       const userOctokit = mockOctokit({
         listForAuthenticatedUser: async () => ({
@@ -1233,6 +1859,8 @@ describe('handleReconcile (I/O shell)', () => {
             onboarding_status: 'onboarded',
             has_fro_bot_workflow: true,
             has_renovate: true,
+            private: false,
+            node_id: 'R_x',
             last_survey_at: '2026-04-10',
             last_survey_status: 'success',
             next_survey_eligible_at: '2026-05-09',
@@ -2777,6 +3405,8 @@ describe('reconcileRepos legacy migration', () => {
       last_survey_at: '2026-04-01',
       discovery_channel: 'collab',
       next_survey_eligible_at: '2026-05-01',
+      private: false,
+      node_id: 'R_mig',
     })
 
     const result = reconcileRepos(
@@ -2839,6 +3469,8 @@ describe('formatCommitMessage', () => {
         lostAccess: 0,
         refreshed: 2,
         migrated: 0,
+        transient: 0,
+        malformed: 0,
         unchanged: 0,
         byChannel: emptyChannelStats(),
       }),
@@ -2854,6 +3486,8 @@ describe('formatCommitMessage', () => {
         lostAccess: 0,
         refreshed: 0,
         migrated: 18,
+        transient: 0,
+        malformed: 0,
         unchanged: 0,
         byChannel: emptyChannelStats(),
       }),
@@ -2869,6 +3503,8 @@ describe('formatCommitMessage', () => {
         lostAccess: 0,
         refreshed: 1,
         migrated: 18,
+        transient: 0,
+        malformed: 0,
         unchanged: 0,
         byChannel: emptyChannelStats(),
       }),

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -390,6 +390,12 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
     switch (probe.status) {
       case 'still-accessible': {
         // Transient inconsistency between the access-list enumeration and the per-repo probe.
+        // The probe carries fresh `private`/`node_id` from `repos.get`, but we deliberately
+        // discard them: the access-list snapshot is the system of record for visibility, and
+        // writing privacy fields from a probe that disagrees with it would propagate the
+        // inconsistency rather than wait for it to resolve. The next cron's enumeration will
+        // either re-include the entry (writing fresh fields via the field-refresh path) or
+        // produce a consistent classification. Sticky preservation is the conservative choice.
         summary.unchanged += 1
         return entry
       }
@@ -1268,7 +1274,14 @@ export async function fetchPerRepoStatus(
     try {
       const response = await userOctokit.rest.repos.get({owner: entry.owner, repo: entry.name})
       // Reachable (200) but we weren't in /user/repos → access was revoked.
-      if (typeof response.data?.private !== 'boolean' || typeof response.data?.node_id !== 'string') {
+      // Empty `node_id` on a 200 also classifies as malformed: the schema's own constraint
+      // is `node_id.length > 0`, so accepting an empty string here would only defer the
+      // failure to `assertReposFile` with a less-actionable error message.
+      if (
+        typeof response.data?.private !== 'boolean' ||
+        typeof response.data?.node_id !== 'string' ||
+        response.data.node_id.length === 0
+      ) {
         logger.warn(
           `reconcile: malformed repos.get response (node_id=${entry.node_id ?? 'unknown'}); sticky-preserving prior state`,
         )
@@ -2219,7 +2232,13 @@ function isGitHubRateLimit(error: unknown): boolean {
   const response = isRecord(error.response) ? error.response : undefined
   const headers = response !== undefined && isRecord(response.headers) ? response.headers : undefined
   if (headers !== undefined) {
+    // `Retry-After`: presence alone signals rate-limit. GitHub only sets this header on
+    // rate-limit and unavailable-for-legal-reasons responses; any value (seconds or HTTP
+    // date) means "back off."
     if (headers['retry-after'] !== undefined) return true
+    // `x-ratelimit-remaining`: present on every response with a number-as-string value
+    // (e.g. "4998"). Only the literal "0" signals exhausted budget; non-zero values are
+    // not rate-limit signals. Octokit normalizes header values to strings.
     if (headers['x-ratelimit-remaining'] === '0') return true
   }
   // Body messages — Octokit surfaces these via `error.message` or the response data.

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -95,11 +95,27 @@ export interface AccessListEntry {
   node_id: string
 }
 
+/**
+ * Result of probing a single tracked repo's status via `GET /repos/{owner}/{name}`.
+ *
+ * - `deleted`          — HTTP 404 (repo gone).
+ * - `archived`         — Pass‑1 detection from the access-list `archived` field (not a probe result).
+ * - `revoked`          - HTTP 451 (DMCA/takedown) or HTTP 403 (blocked/suspended), or the
+ *                        repo exists (HTTP 200) but the entry is not in the access list.
+ * - `still-accessible` — HTTP 200 with valid body; the entry is in the access list (produced
+ *                        by the field‑probe pass, not `fetchPerRepoStatus`).
+ * - `transient`        — HTTP 5xx or network error; could not determine status this run.
+ *                        Sticky‑preserve the prior state.
+ * - `malformed`        — HTTP 200 but the response body is missing `private` (boolean) or
+ *                        `node_id` (string). Sticky‑preserve the prior state and log a diagnostic.
+ */
 export type RepoStatusProbe =
   | {status: 'deleted'}
   | {status: 'archived'}
   | {status: 'revoked'}
   | {status: 'still-accessible'; private: boolean; node_id: string}
+  | {status: 'transient'; httpStatus?: number}
+  | {status: 'malformed'}
 
 export interface FieldProbe {
   has_fro_bot_workflow: boolean
@@ -187,6 +203,21 @@ export interface ReconcileSummary {
   migrated: number
   unchanged: number
   /**
+   * Number of tracked entries whose probe returned a `transient` classification this run
+   * (HTTP 5xx, network error, or rate-limit). The entry's prior privacy state is
+   * sticky-preserved; no fields are written. A non-zero value paired with a quiet
+   * `refreshed`/`lostAccess` indicates the run took the sticky-preserve path on probe
+   * failures rather than completing classification — distinguishes a healthy quiet day
+   * from an API-incident silent-degradation day.
+   */
+  transient: number
+  /**
+   * Number of tracked entries whose probe returned `malformed` (HTTP 200 with an
+   * unusable response body) this run. Sticky-preserved like `transient`. Persistent
+   * non-zero values across runs suggest an upstream API contract change worth investigating.
+   */
+  malformed: number
+  /**
    * Per-channel activity breakdown. See {@link ChannelStats} for field semantics. The
    * engine populates `tracked` and `lostAccess`; the shell populates `dispatched` and
    * `deferred` after cap selection.
@@ -225,6 +256,8 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
     refreshed: 0,
     migrated: 0,
     unchanged: 0,
+    transient: 0,
+    malformed: 0,
     byChannel: {
       collab: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
       owned: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
@@ -354,19 +387,50 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
       summary.unchanged += 1
       return entry
     }
-    if (probe.status === 'still-accessible') {
-      // Transient inconsistency between the access-list enumeration and the per-repo probe.
-      summary.unchanged += 1
-      return entry
+    switch (probe.status) {
+      case 'still-accessible': {
+        // Transient inconsistency between the access-list enumeration and the per-repo probe.
+        summary.unchanged += 1
+        return entry
+      }
+      case 'transient': {
+        // Could not classify this run; preserve sticky state. `...entry` keeps prior
+        // private/node_id (or absence thereof) intact — no field is introduced or cleared.
+        // Bumps both `unchanged` (so the run-summary line still adds up) and `transient`
+        // (so a 5xx storm is visible as a non-zero counter rather than indistinguishable
+        // from a healthy quiet day).
+        summary.unchanged += 1
+        summary.transient += 1
+        return entry
+      }
+      case 'malformed': {
+        // Same shape as transient; separate counter distinguishes upstream API contract
+        // anomalies (200 with unusable body) from infrastructure-level transients.
+        summary.unchanged += 1
+        summary.malformed += 1
+        return entry
+      }
+      case 'deleted':
+      case 'archived':
+      case 'revoked': {
+        // Flip to lost-access unless already there. Fail-safe: write `private: true`
+        // because we cannot reach the repo to confirm visibility. `...entry` preserves
+        // prior `node_id` if any (no fresh source available on this branch).
+        if (entry.onboarding_status === 'lost-access') {
+          summary.unchanged += 1
+          return entry
+        }
+        summary.lostAccess += 1
+        summary.byChannel[entry.discovery_channel ?? 'collab'].lostAccess += 1
+        return {...entry, onboarding_status: 'lost-access', private: true}
+      }
+      default: {
+        // Exhaustiveness guard. Adding a new RepoStatusProbe variant must update the
+        // switch above instead of silently falling through to lost-access.
+        const exhaustive: never = probe
+        throw new Error(`reconcile: unhandled RepoStatusProbe variant: ${JSON.stringify(exhaustive)}`)
+      }
     }
-    // deleted / archived / revoked — flip to lost-access unless already there.
-    if (entry.onboarding_status === 'lost-access') {
-      summary.unchanged += 1
-      return entry
-    }
-    summary.lostAccess += 1
-    summary.byChannel[entry.discovery_channel ?? 'collab'].lostAccess += 1
-    return {...entry, onboarding_status: 'lost-access'}
   }
 
   if (access.archived) {
@@ -377,7 +441,12 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
     }
     summary.lostAccess += 1
     summary.byChannel[entry.discovery_channel ?? 'collab'].lostAccess += 1
-    return {...entry, onboarding_status: 'lost-access'}
+    return {
+      ...entry,
+      onboarding_status: 'lost-access',
+      private: true,
+      node_id: access.node_id,
+    }
   }
 
   if (entry.onboarding_status === 'lost-access') {
@@ -401,7 +470,7 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
         node_id: access.node_id,
       })
     }
-    return {...entry, onboarding_status: nextStatus}
+    return {...entry, onboarding_status: nextStatus, private: access.private, node_id: access.node_id}
   }
 
   // Still-accessible tracked entry.
@@ -427,14 +496,27 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
     dispatches.push({owner: entry.owner, repo: entry.name})
   }
 
-  // Field refresh: apply probe results when they disagree with tracked fields.
+  // Field refresh: apply probe results when they disagree with tracked fields,
+  // and write live private/node_id from the access list when they differ.
   const probe = fieldProbes.get(key)
+  const accessPrivate = access.private
+  const accessNodeId = access.node_id
+
   if (probe === undefined) {
-    // No probe data — preserve existing field values (do not overwrite with undefined).
-    summary.unchanged += 1
-    return entry
+    // No field probe — but access list still has private/node_id. Apply if changed.
+    if (entry.private === accessPrivate && entry.node_id === accessNodeId) {
+      summary.unchanged += 1
+      return entry
+    }
+    summary.refreshed += 1
+    return {...entry, private: accessPrivate, node_id: accessNodeId}
   }
-  if (probe.has_fro_bot_workflow === entry.has_fro_bot_workflow && probe.has_renovate === entry.has_renovate) {
+
+  const fieldsMatch =
+    probe.has_fro_bot_workflow === entry.has_fro_bot_workflow && probe.has_renovate === entry.has_renovate
+  const privacyMatch = entry.private === accessPrivate && entry.node_id === accessNodeId
+
+  if (fieldsMatch && privacyMatch) {
     summary.unchanged += 1
     return entry
   }
@@ -443,6 +525,8 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
     ...entry,
     has_fro_bot_workflow: probe.has_fro_bot_workflow,
     has_renovate: probe.has_renovate,
+    private: accessPrivate,
+    node_id: accessNodeId,
   }
 }
 
@@ -817,7 +901,7 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
   })
 
   // 4. For each tracked entry missing from the access list, probe `GET /repos/{o}/{r}`.
-  const perRepoStatus = await fetchPerRepoStatus(userOctokit, currentRepos, accessList)
+  const perRepoStatus = await fetchPerRepoStatus(userOctokit, currentRepos, accessList, logger)
 
   // 5. Field probes for still-accessible tracked entries.
   const fieldProbeOutcome = await fetchFieldProbes(userOctokit, currentRepos, accessList, logger)
@@ -1159,10 +1243,22 @@ async function fetchAccessList(userOctokit: OctokitClient): Promise<AccessListEn
   }
 }
 
-async function fetchPerRepoStatus(
+/**
+ * Probes each tracked entry that no longer appears in the access list and classifies
+ * the result into one of the {@link RepoStatusProbe} states. Never throws on
+ * classifiable errors (404/451/403/5xx/network/malformed); only unclassified 4xx
+ * responses propagate as `ReconcileError` to surface unexpected GitHub-side changes.
+ *
+ * Exported only for unit tests. The sole production caller is `handleReconcile` in
+ * this same file.
+ *
+ * @internal
+ */
+export async function fetchPerRepoStatus(
   userOctokit: OctokitClient,
   currentRepos: ReposFile,
   accessList: AccessListEntry[],
+  logger: {warn: (message: string) => void},
 ): Promise<Map<string, RepoStatusProbe>> {
   const accessKeys = new Set(accessList.map(a => `${a.owner}/${a.name}`))
   const map = new Map<string, RepoStatusProbe>()
@@ -1170,12 +1266,49 @@ async function fetchPerRepoStatus(
     const key = `${entry.owner}/${entry.name}`
     if (accessKeys.has(key)) continue
     try {
-      await userOctokit.rest.repos.get({owner: entry.owner, repo: entry.name})
+      const response = await userOctokit.rest.repos.get({owner: entry.owner, repo: entry.name})
       // Reachable (200) but we weren't in /user/repos → access was revoked.
+      if (typeof response.data?.private !== 'boolean' || typeof response.data?.node_id !== 'string') {
+        logger.warn(
+          `reconcile: malformed repos.get response (node_id=${entry.node_id ?? 'unknown'}); sticky-preserving prior state`,
+        )
+        map.set(key, {status: 'malformed'})
+        continue
+      }
       map.set(key, {status: 'revoked'})
     } catch (error: unknown) {
       if (isApiStatus(error, 404)) {
         map.set(key, {status: 'deleted'})
+        continue
+      }
+      // Rate-limit detection runs before the bare 403/451 → revoked branch. GitHub's
+      // primary rate-limit returns 429; secondary returns 403 with rate-limit headers
+      // or message. Misclassifying these as revoked cascades false lost-access flips.
+      if (isGitHubRateLimit(error)) {
+        const status = isRecord(error) && typeof error.status === 'number' ? error.status : undefined
+        logger.warn(
+          `reconcile: GitHub rate-limit (status=${status ?? 'unknown'}) probing tracked entry (node_id=${entry.node_id ?? 'unknown'}); sticky-preserving prior state`,
+        )
+        map.set(key, status === undefined ? {status: 'transient'} : {status: 'transient', httpStatus: status})
+        continue
+      }
+      if (isApiStatus(error, 451) || isApiStatus(error, 403)) {
+        map.set(key, {status: 'revoked'})
+        continue
+      }
+      if (isRecord(error) && typeof error.status === 'number' && error.status >= 500 && error.status < 600) {
+        logger.warn(
+          `reconcile: transient API error (${error.status}) probing tracked entry (node_id=${entry.node_id ?? 'unknown'}); sticky-preserving prior state`,
+        )
+        map.set(key, {status: 'transient', httpStatus: error.status})
+        continue
+      }
+      // Network errors and unclassified errors — also transient.
+      if (isRecord(error) && typeof error.status !== 'number') {
+        logger.warn(
+          `reconcile: network error probing tracked entry (node_id=${entry.node_id ?? 'unknown'}); sticky-preserving prior state`,
+        )
+        map.set(key, {status: 'transient'})
         continue
       }
       throw toApiError(error, `probing repo status for tracked entry`)
@@ -2067,6 +2200,37 @@ function isApiStatus(error: unknown, status: number): boolean {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Distinguish a rate-limited 403/429 from a genuinely access-revoked 403. GitHub's
+ * primary rate-limit returns 429; secondary rate-limits and abuse detection return 403
+ * with one of: a `Retry-After` header, `x-ratelimit-remaining: 0`, or a body message
+ * containing "rate limit" / "abuse detection". Treating these as `revoked` would cascade
+ * false lost-access flips and amplify the rate-limit problem on the next cron's regain
+ * dispatches; classifying as `transient` lets sticky preservation hold while the next
+ * run retries naturally.
+ */
+function isGitHubRateLimit(error: unknown): boolean {
+  if (!isRecord(error)) return false
+  if (error.status === 429) return true
+  if (error.status !== 403) return false
+  // Octokit RequestError exposes the response payload via `error.response`.
+  const response = isRecord(error.response) ? error.response : undefined
+  const headers = response !== undefined && isRecord(response.headers) ? response.headers : undefined
+  if (headers !== undefined) {
+    if (headers['retry-after'] !== undefined) return true
+    if (headers['x-ratelimit-remaining'] === '0') return true
+  }
+  // Body messages — Octokit surfaces these via `error.message` or the response data.
+  const messageSource =
+    typeof error.message === 'string'
+      ? error.message
+      : response !== undefined && isRecord(response.data) && typeof response.data.message === 'string'
+        ? response.data.message
+        : ''
+  const message = messageSource.toLowerCase()
+  return message.includes('rate limit') || message.includes('abuse detection') || message.includes('secondary rate')
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/scripts/repos-metadata.ts
+++ b/scripts/repos-metadata.ts
@@ -111,6 +111,11 @@ export interface AddRepoEntryInput {
  *
  * Pure function: never mutates `current` in place. When adding, returns a fresh top-level
  * object with a fresh `repos` array.
+ *
+ * Privacy fields (`private`, `node_id`) are intentionally omitted at creation time and
+ * populated on the next reconcile pass via the access-list / probe merge in
+ * `classifyTracked`. Treat absence as "not yet observed" — downstream consumers must
+ * default to fail-safe (treat-as-private) for entries lacking `private`.
  */
 export function addRepoEntry(current: unknown, input: AddRepoEntryInput): ReposFile {
   assertReposFile(current, 'repos')

--- a/scripts/schemas.test.ts
+++ b/scripts/schemas.test.ts
@@ -323,6 +323,249 @@ describe('schemas — rejection cases', () => {
     expect(isDiscoveryChannel(42)).toBe(false)
   })
 
+  it('accepts entry with private: true and node_id', () => {
+    const ok = {
+      version: 1,
+      repos: [
+        {
+          owner: 'marcusrbrown',
+          name: 'poly',
+          added: '2026-05-05',
+          onboarding_status: 'onboarded',
+          last_survey_at: '2026-05-06',
+          last_survey_status: 'success',
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: '2026-06-08',
+          private: true,
+          node_id: 'R_kgDOSVJgdw',
+        },
+      ],
+    }
+    expect(isReposFile(ok)).toBe(true)
+    expect(() => assertReposFile(ok)).not.toThrow()
+  })
+
+  it('accepts entry with private: false and node_id', () => {
+    const ok = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'agent',
+          added: '2026-05-05',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'owned',
+          next_survey_eligible_at: null,
+          private: false,
+          node_id: 'R_kgDOPublic',
+        },
+      ],
+    }
+    expect(isReposFile(ok)).toBe(true)
+    expect(() => assertReposFile(ok)).not.toThrow()
+  })
+
+  it('accepts redacted entry shape (private: true, owner: [REDACTED], name: <node_id>)', () => {
+    // #given a private entry already in its always-redacted form
+    const ok = {
+      version: 1,
+      repos: [
+        {
+          owner: '[REDACTED]',
+          name: 'R_kgDOSVJgdw',
+          added: '2026-05-05',
+          onboarding_status: 'onboarded',
+          last_survey_at: '2026-05-06',
+          last_survey_status: 'success',
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: '2026-06-08',
+          private: true,
+          node_id: 'R_kgDOSVJgdw',
+        },
+      ],
+    }
+    // #when the schema validates the entry
+    // #then it accepts because owner and name are still strings;
+    // the schema does not enforce semantic shape
+    expect(isReposFile(ok)).toBe(true)
+    expect(() => assertReposFile(ok)).not.toThrow()
+  })
+
+  it('accepts legacy entries missing private and node_id', () => {
+    // #given a legacy entry from before the privacy migration
+    const ok = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
+        },
+      ],
+    }
+    expect(isReposFile(ok)).toBe(true)
+    expect(() => assertReposFile(ok)).not.toThrow()
+  })
+
+  it('rejects null private', () => {
+    const bad = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
+          private: null,
+        },
+      ],
+    }
+    expect(isReposFile(bad)).toBe(false)
+    const error = catchSchemaError(() => assertReposFile(bad))
+    expect(error.path).toContain('private')
+  })
+
+  it('rejects numeric private', () => {
+    const bad = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
+          private: 1,
+        },
+      ],
+    }
+    expect(isReposFile(bad)).toBe(false)
+    const error = catchSchemaError(() => assertReposFile(bad))
+    expect(error.path).toContain('private')
+  })
+
+  it('rejects string private (not boolean)', () => {
+    const bad = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
+          private: 'yes',
+        },
+      ],
+    }
+    expect(isReposFile(bad)).toBe(false)
+    const error = catchSchemaError(() => assertReposFile(bad))
+    expect(error.path).toContain('private')
+  })
+
+  it('rejects null node_id', () => {
+    const bad = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
+          node_id: null,
+        },
+      ],
+    }
+    expect(isReposFile(bad)).toBe(false)
+    const error = catchSchemaError(() => assertReposFile(bad))
+    expect(error.path).toContain('node_id')
+  })
+
+  it('rejects empty-string node_id', () => {
+    const bad = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
+          node_id: '',
+        },
+      ],
+    }
+    expect(isReposFile(bad)).toBe(false)
+    const error = catchSchemaError(() => assertReposFile(bad))
+    expect(error.path).toContain('node_id')
+  })
+
+  it('rejects numeric node_id', () => {
+    const bad = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
+          node_id: 12345,
+        },
+      ],
+    }
+    expect(isReposFile(bad)).toBe(false)
+    const error = catchSchemaError(() => assertReposFile(bad))
+    expect(error.path).toContain('node_id')
+  })
+
   it('rejects non-string entry in with-renovate list', () => {
     const bad = {repositories: {'with-renovate': ['valid', 42]}}
     expect(isRenovateFile(bad)).toBe(false)

--- a/scripts/schemas.ts
+++ b/scripts/schemas.ts
@@ -61,6 +61,24 @@ export interface RepoEntry {
    * `data` is migrated.
    */
   next_survey_eligible_at?: string | null
+  /**
+   * Whether this repo is private. Authoritative input for the privacy posture: when `true`,
+   * autonomous mutators write the entry in always-redacted form (`owner: '[REDACTED]'`,
+   * `name: <node_id>`) so canonical identifiers never reach `main`. Populated by reconcile's
+   * 5-state probe; preserved across transient/malformed responses (sticky).
+   *
+   * Optional during the rollout window: legacy entries from before the privacy migration
+   * have no value, and downstream code defaults absent to "treat as private until probe
+   * confirms otherwise" (fail-safe). Tightened to required after `data` is migrated.
+   */
+  private?: boolean
+  /**
+   * GitHub GraphQL global node ID (e.g. `R_kgDO...`). Stable across owner/name renames and
+   * doubles as the redacted name when `private: true`. Populated by reconcile's probe.
+   *
+   * Optional during the rollout window for the same reason as `private`. Tightened later.
+   */
+  node_id?: string
 }
 
 export type OnboardingStatus = 'pending' | 'onboarded' | 'failed' | 'lost-access' | 'pending-review'
@@ -201,7 +219,9 @@ function isRepoEntry(value: unknown): value is RepoEntry {
     (value.discovery_channel === undefined || isDiscoveryChannel(value.discovery_channel)) &&
     (value.next_survey_eligible_at === undefined ||
       value.next_survey_eligible_at === null ||
-      typeof value.next_survey_eligible_at === 'string')
+      typeof value.next_survey_eligible_at === 'string') &&
+    (value.private === undefined || typeof value.private === 'boolean') &&
+    (value.node_id === undefined || (typeof value.node_id === 'string' && value.node_id.length > 0))
   )
 }
 
@@ -231,6 +251,10 @@ function assertRepoEntry(value: unknown, path: string): asserts value is RepoEnt
     typeof value.next_survey_eligible_at !== 'string'
   )
     throw new SchemaValidationError(`${path}.next_survey_eligible_at`, 'expected string, null, or omitted')
+  if (value.private !== undefined && typeof value.private !== 'boolean')
+    throw new SchemaValidationError(`${path}.private`, 'expected boolean or omitted')
+  if (value.node_id !== undefined && (typeof value.node_id !== 'string' || value.node_id.length === 0))
+    throw new SchemaValidationError(`${path}.node_id`, 'expected non-empty string or omitted')
 }
 
 function isOnboardingStatus(value: unknown): value is OnboardingStatus {


### PR DESCRIPTION
First two units of the private-repo handling plan. Schema and reconcile-engine foundation that downstream privacy controls will consume — mutator redaction, social-broadcast gating, wiki-ingest filtering all build on the fields and probe states landed here.

## What changes

**Schema (loose-then-tight rollout):**

- `RepoEntry` gains optional `private?: boolean` and `node_id?: string`.
- Runtime guards reject malformed values (null, numeric, empty-string `node_id`); legacy entries on `data` continue to validate. Tightening to required is a deliberate follow-up after one reconcile cycle confirms `data` is fully migrated.

**Reconcile probe layer:**

- `RepoStatusProbe` extended from 4 to 6 variants. New: `transient` (5xx, network errors, GitHub rate-limits) and `malformed` (HTTP 200 with unusable body). Switch + `assertNever` guards exhaustiveness — adding a 7th variant later is a compile-time error rather than a silent flip to lost-access.
- `fetchPerRepoStatus` no longer crashes on HTTP 5xx, 451, 403, 429, network errors, or malformed bodies. Each classifies cleanly and the daily cron continues.
- GitHub rate-limit detection (`isGitHubRateLimit`) handles primary 429, secondary 403 with `Retry-After`, `x-ratelimit-remaining: 0`, and abuse-detection message bodies. Misclassifying these as `revoked` would cascade false lost-access flips and amplify the rate-limit problem on the next cron's regain dispatches.

**Merge layer (`classifyTracked`):**

- Live access-list `private`/`node_id` flow into the entry on still-accessible, regain, and field-refresh paths.
- Sticky preservation on `transient` / `malformed`: prior privacy state remains exactly as-is — no fields introduced or cleared. A 502 storm doesn't wipe a private repo's known-private state.
- Fail-safe construction on every access-lost path: writes `private: true` regardless of the access-list snapshot's value. We can't reach the repo to confirm visibility, so default to safe.

**Observability:**

- `ReconcileSummary` gains `transient` and `malformed` counters. A 5xx storm is now distinguishable from a healthy quiet day in run-end JSON.
- Probe warn logs use `node_id` (not `owner/name`) — privacy posture stays intact even on noisy days when private repos hit transient errors.

## Behavior change worth flagging

`fetchPerRepoStatus` previously threw on every non-404 error. The daily reconcile cron would crash loudly on a 5xx storm. After this PR, those errors classify as `transient` and the run continues with sticky-preservation. Trade-off: cron crashes drop, observability moves from "log line at top of failed run" to "non-zero `transient` counter in JSON output". The new counters make the failure surface visible without blocking the run.

Unclassified 4xx (like 401 token rotation) still throws. Those are config errors, not transient.

## Plan reference

`docs/plans/2026-05-05-002-feat-private-repo-handling-plan.md` — Units 1 and 2 of 12.

## Tests

467 passing (+8 vs main). Coverage includes all 5 probe states in a single integration run, sticky-preservation across legacy entries with no prior `private` field, fail-safe overrides on archived/deleted/revoked, regain writes, exhaustiveness runtime enforcement, and rate-limit detection across all four signal paths.

## Residual / future work

- Hung Octokit `repos.get` requests rely on workflow-level timeout (pre-existing across all scripts; separate hardening pass).
- Per-entry `transient` warns on a sustained API incident could be aggregated into one summary warn at end-of-pass; couples cleanly with the new counters.
- `node_id` rotation detection (deleted-and-recreated repo with same `owner/name`) is deferred to the visibility-flip detection unit later in the plan.
