### PR TITLE
feat(privacy): suppress re-discovery of redacted repos via node_id index

### DIFF
--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -204,6 +204,95 @@ describe('reconcileRepos', () => {
       expect(result.summary.added).toBe(1)
       expect(result.summary.pendingReview).toBe(2)
     })
+
+    it('suppresses a newcomer whose node_id matches an existing tracked entry (re-discovery via renamed/redacted entry)', () => {
+      // GIVEN a tracked entry with a known node_id under one identity
+      // AND an accessList result with the same node_id but a different owner/name
+      // (e.g. after Phase 0 redaction renamed owner/name on an entry but the
+      //  reconcile cron rediscovers the canonical owner/name from /user/repos)
+      // WHEN reconciling
+      const tracked = makeEntry({
+        owner: '[REDACTED]',
+        name: 'R_kgDOSVJgdw',
+        node_id: 'R_kgDOSVJgdw',
+        private: true,
+        onboarding_status: 'lost-access',
+      })
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [tracked]},
+          accessList: [makeAccess({owner: 'marcusrbrown', name: 'poly', node_id: 'R_kgDOSVJgdw', private: true})],
+          allowlist: makeAllowlist(['marcusrbrown']),
+        }),
+      )
+
+      // THEN the newcomer is NOT added (suppressed by node_id match)
+      expect(result.nextRepos.repos).toHaveLength(1)
+      expect(result.nextRepos.repos[0]).toBe(tracked)
+      expect(result.dispatches).toEqual([])
+      expect(result.issues).toEqual([])
+      expect(result.summary.added).toBe(0)
+      expect(result.summary.pendingReview).toBe(0)
+    })
+
+    it('suppresses a newcomer whose node_id matches a redacted entry that lacks a node_id field (legacy redaction)', () => {
+      // GIVEN a Phase-0-redacted entry where owner='[REDACTED]' and name=node_id
+      // (legacy shape: the redacted entry has no separate node_id field)
+      // AND the canonical name surfaces in accessList with the matching node_id
+      // WHEN reconciling
+      // Build a redacted entry shape WITHOUT node_id (legacy Phase 0 shape:
+      // node_id lives in `name`, no separate field). makeEntry sets node_id by
+      // default, so build the entry inline rather than destructuring it away.
+      const redactedNoNodeId: RepoEntry = {
+        owner: '[REDACTED]',
+        name: 'R_kgDOSVJgdw',
+        added: '2026-05-05',
+        onboarding_status: 'lost-access',
+        last_survey_at: null,
+        last_survey_status: null,
+        has_fro_bot_workflow: false,
+        has_renovate: false,
+        private: true,
+        discovery_channel: 'collab',
+        next_survey_eligible_at: null,
+      }
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [redactedNoNodeId]},
+          accessList: [makeAccess({owner: 'marcusrbrown', name: 'poly', node_id: 'R_kgDOSVJgdw', private: true})],
+          allowlist: makeAllowlist(['marcusrbrown']),
+        }),
+      )
+
+      // THEN the newcomer is suppressed by name-as-node_id fallback for redacted entries
+      expect(result.nextRepos.repos).toHaveLength(1)
+      expect(result.dispatches).toEqual([])
+      expect(result.issues).toEqual([])
+      expect(result.summary.added).toBe(0)
+    })
+
+    it('does NOT suppress a newcomer whose node_id matches no existing entry', () => {
+      // GIVEN a tracked entry with a known node_id
+      // AND an accessList result with a different node_id
+      // WHEN reconciling
+      const tracked = makeEntry({name: 'existing', node_id: 'R_existing'})
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [tracked]},
+          accessList: [
+            makeAccess({name: 'existing', node_id: 'R_existing'}),
+            makeAccess({owner: 'marcusrbrown', name: 'genuinely-new', node_id: 'R_new'}),
+          ],
+          allowlist: makeAllowlist(['marcusrbrown']),
+        }),
+      )
+
+      // THEN the genuinely-new newcomer is added normally (the tracked entry's
+      // own first-survey dispatch is incidental and not what this test cares about)
+      expect(result.nextRepos.repos).toHaveLength(2)
+      expect(result.dispatches).toContainEqual({owner: 'marcusrbrown', repo: 'genuinely-new'})
+      expect(result.summary.added).toBe(1)
+    })
   })
 
   describe('tracked entries — still accessible', () => {

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -289,10 +289,31 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
 
   let next: ReposFile = {...currentRepos, repos: nextEntries}
 
+  // Build the set of node_ids that any tracked entry already represents. This
+  // guards against re-discovery: when a private repo's owner/name has been
+  // redacted, the next /user/repos enumeration returns the canonical owner/name
+  // again. Without this set, Pass 2 would treat that as a brand-new newcomer
+  // and re-add a sibling entry under the canonical identity, undoing the
+  // redaction. The set covers two shapes:
+  //   1. Modern entries with `node_id` populated (post-Unit-2 reconciles).
+  //   2. Legacy redacted entries where `owner === '[REDACTED]'` and the
+  //      `node_id` lives in the `name` field (Phase 0 redaction shape, before
+  //      a separate `node_id` field was populated on redacted entries).
+  const knownNodeIds = new Set<string>()
+  for (const entry of nextEntries) {
+    if (entry.node_id !== undefined) {
+      knownNodeIds.add(entry.node_id)
+    }
+    if (entry.owner === '[REDACTED]') {
+      knownNodeIds.add(entry.name)
+    }
+  }
+
   // Pass 2 — add newcomers (accessible repos not yet tracked).
   for (const access of accessList) {
     const key = repoKey(access.owner, access.name)
     if (trackedKeys.has(key)) continue
+    if (knownNodeIds.has(access.node_id)) continue // tracked under a different (likely redacted) identity.
     if (access.archived) continue // untracked + archived: no history worth capturing; skip silently.
 
     // Channel determines the trust path. Owned (we own the repo) and contrib (operator


### PR DESCRIPTION
Reconcile's Pass 2 identifies newcomers by `owner/name`. That worked fine until private-repo redaction landed: after Phase 0 redacts a tracked entry's `owner` and `name` to `[REDACTED]/<node_id>`, the next `/user/repos` enumeration still returns the canonical name. Pass 2 sees an `owner/name` it doesn't recognize, classifies it as a brand-new collab newcomer, adds a sibling entry under the canonical identity, and re-dispatches a survey that re-leaks the redacted content into the wiki.

This change closes that path. Before Pass 2 runs, the engine builds a `Set<string>` of `node_id`s represented by every tracked entry — including the legacy Phase 0 redaction shape where `node_id` lives in the `name` field rather than a separate column. Pass 2 then skips any access-list result whose `node_id` is already known, regardless of which channel discovered it or whether the new identity would otherwise pass allowlist gating.

The same scenario actually occurred on `data` between the Phase 0 redaction (2026-05-06) and the 2026-05-07 reconcile cron, which re-discovered the canonical owner/name and re-surveyed the repo. The re-leaked surfaces (wiki page, topic page, log entry, index entry, canonical metadata entry) were cleaned up directly on `data` in commit `e79db4c`; this PR closes the recurrence path so the next reconcile can't reopen it.

## What changes

- **`scripts/reconcile-repos.ts`** — new `knownNodeIds` set built from `nextEntries` before Pass 2; new `if (knownNodeIds.has(access.node_id)) continue;` guard placed before the archived/allowlist branches. The set covers two entry shapes: modern entries with `node_id` populated, and legacy redacted entries (`owner === '[REDACTED]'`, `node_id` in `name`).

- **`scripts/reconcile-repos.test.ts`** — three new tests:
  - Newcomer suppressed when its `node_id` matches a tracked entry with an explicit `node_id` field.
  - Newcomer suppressed when its `node_id` matches a legacy redacted entry that has no `node_id` field.
  - Newcomer NOT suppressed when its `node_id` is genuinely new — existing behavior unchanged.

## What does not change

- Pass 1 (classification of tracked entries) is untouched.
- The `private`/`node_id` write paths in `classifyTracked` are untouched.
- Allowlist gating, pending-review issue creation, and per-owner rollup are untouched.
- `addRepoEntry`, `recordSurveyResult`, and other mutators are untouched.

## Verification

- 471/471 tests pass (was 469 baseline; +2 net new, +3 added minus +1 reorganized into the new section).
- `pnpm check-types` clean.
- `pnpm lint` clean.

## Follow-ups not in this PR

- The redacted entry on `data` lacks a separate `node_id` field (it's encoded in `name`). A future redaction-write change should populate `node_id` directly on redaction so the legacy-shape fallback can eventually retire. Until then, the fallback covers existing entries.
- Phase 0's enumeration script and cleanup contract are unchanged. The discovery-time exclusion here is independent of the wiki-authority guard and the integrity check.
