### PR TITLE
feat(privacy): redact private repo metadata writes

### DIFF
--- a/docs/plans/2026-05-05-002-feat-private-repo-handling-plan.md
+++ b/docs/plans/2026-05-05-002-feat-private-repo-handling-plan.md
@@ -256,7 +256,7 @@ scripts/
   schemas.test.ts                    MODIFY
   repos-metadata.ts                  MODIFY (Unit 3: redacted-form writes in all mutators)
   repos-metadata.test.ts             MODIFY
-  reconcile-repos.ts                 MODIFY (Units 2, 5, 9: 5-state probe, dispatch gate, transition detection)
+  reconcile-repos.ts                 MODIFY (Units 2, 3, 5, 9: 5-state probe, redacted newcomer write inputs, dispatch gate, transition detection)
   reconcile-repos.test.ts            MODIFY
   handle-invitation.ts               MODIFY (Unit 4: read `private` from invitation, write redacted, redacted commit message)
   handle-invitation.test.ts          MODIFY
@@ -405,7 +405,7 @@ persona/
 
 ---
 
-- [ ] **Unit 3: Always-redacted writes in mutators**
+- [x] **Unit 3: Always-redacted writes in mutators**
 
 **Goal:** Modify all three mutators (`addRepoEntry`, `recordSurveyResult`, `resetSurveyResult`) to write redacted form for `private: true` entries. The redacted form (`owner: '[REDACTED]'`, `name: <node_id>`, `private: true`, `node_id: <actual>`) is what lands on `data` immediately. No "redact in transit" lifecycle.
 
@@ -416,6 +416,9 @@ persona/
 **Files:**
 - Modify: `scripts/repos-metadata.ts`
 - Modify: `scripts/repos-metadata.test.ts`
+- Modify: `scripts/reconcile-repos.ts` (pass access-list privacy fields into `addRepoEntry`)
+- Modify: `scripts/reconcile-repos.test.ts`
+- Add/modify: survey result/reset CLI tests for node-ID target handling
 
 **Execution note:** Test-first. The mutators' contract change is the highest-risk part of this plan — each mutator gets RED tests for the redacted-form output before implementation.
 

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -158,12 +158,156 @@ describe('reconcileRepos', () => {
       expect(result.summary.pendingReview).toBe(1)
     })
 
+    it('writes redacted metadata for a private newcomer from the access list', () => {
+      const result = reconcileRepos(
+        makeInput({
+          accessList: [
+            makeAccess({owner: 'private-owner', name: 'secret-repo', node_id: 'R_kgDOPRIVATE', private: true}),
+          ],
+          allowlist: makeAllowlist(['private-owner']),
+        }),
+      )
+
+      expect(result.nextRepos.repos).toHaveLength(1)
+      expect(result.nextRepos.repos[0]).toMatchObject({
+        owner: '[REDACTED]',
+        name: 'R_kgDOPRIVATE',
+        private: true,
+        node_id: 'R_kgDOPRIVATE',
+        onboarding_status: 'pending',
+      })
+      expect(JSON.stringify(result.nextRepos)).not.toContain('private-owner')
+      expect(JSON.stringify(result.nextRepos)).not.toContain('secret-repo')
+      expect(result.dispatches).toEqual([])
+      expect(result.summary.added).toBe(1)
+    })
+
+    it('redacts an existing canonical entry when access-list visibility flips private', () => {
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {
+            version: 1,
+            repos: [
+              makeEntry({
+                owner: 'private-owner',
+                name: 'secret-repo',
+                private: false,
+                node_id: 'R_kgDOPRIVATE',
+                last_survey_status: 'success',
+                next_survey_eligible_at: '2026-12-31',
+              }),
+            ],
+          },
+          accessList: [
+            makeAccess({owner: 'private-owner', name: 'secret-repo', node_id: 'R_kgDOPRIVATE', private: true}),
+          ],
+          allowlist: makeAllowlist(['private-owner']),
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]).toMatchObject({
+        owner: '[REDACTED]',
+        name: 'R_kgDOPRIVATE',
+        private: true,
+        node_id: 'R_kgDOPRIVATE',
+      })
+      expect(JSON.stringify(result.nextRepos)).not.toContain('private-owner')
+      expect(JSON.stringify(result.nextRepos)).not.toContain('secret-repo')
+      expect(result.summary.refreshed).toBe(1)
+    })
+
+    it('matches redacted tracked entries to canonical access-list entries by node_id', () => {
+      const tracked = makeEntry({
+        owner: '[REDACTED]',
+        name: 'R_kgDOPRIVATE',
+        private: true,
+        node_id: 'R_kgDOPRIVATE',
+        onboarding_status: 'onboarded',
+        last_survey_status: 'success',
+        next_survey_eligible_at: '2026-12-31',
+      })
+
+      const currentRepos: ReposFile = {version: 1, repos: [tracked]}
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos,
+          accessList: [
+            makeAccess({owner: 'private-owner', name: 'secret-repo', node_id: 'R_kgDOPRIVATE', private: true}),
+          ],
+          allowlist: makeAllowlist(['private-owner']),
+        }),
+      )
+
+      expect(result.nextRepos).toBe(currentRepos)
+      expect(result.nextRepos.repos).toEqual([tracked])
+      expect(result.summary.lostAccess).toBe(0)
+      expect(result.summary.unchanged).toBe(1)
+    })
+
+    it('regains a redacted private lost-access entry without dispatching it', () => {
+      const tracked = makeEntry({
+        owner: '[REDACTED]',
+        name: 'R_kgDOPRIVATE',
+        private: true,
+        node_id: 'R_kgDOPRIVATE',
+        onboarding_status: 'lost-access',
+      })
+
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [tracked]},
+          accessList: [
+            makeAccess({owner: 'private-owner', name: 'secret-repo', node_id: 'R_kgDOPRIVATE', private: true}),
+          ],
+          allowlist: makeAllowlist(['private-owner']),
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]).toMatchObject({
+        owner: '[REDACTED]',
+        name: 'R_kgDOPRIVATE',
+        private: true,
+        node_id: 'R_kgDOPRIVATE',
+        onboarding_status: 'pending',
+      })
+      expect(result.dispatches).toEqual([])
+      expect(result.summary.regained).toBe(1)
+    })
+
+    it('fail-closes a redacted private tracked entry missing from the access list', () => {
+      const tracked = makeEntry({
+        owner: '[REDACTED]',
+        name: 'R_missing',
+        private: true,
+        node_id: 'R_missing',
+        onboarding_status: 'onboarded',
+      })
+
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [tracked]},
+          accessList: [],
+          perRepoStatus: new Map(),
+        }),
+      )
+
+      expect(result.nextRepos.repos[0]).toMatchObject({
+        owner: '[REDACTED]',
+        name: 'R_missing',
+        private: true,
+        node_id: 'R_missing',
+        onboarding_status: 'lost-access',
+      })
+      expect(result.summary.lostAccess).toBe(1)
+      expect(result.summary.unchanged).toBe(0)
+    })
+
     it('rolls up ≥2 non-allowlisted newcomers from the same owner into a single issue', () => {
       const result = reconcileRepos(
         makeInput({
           accessList: [
             makeAccess({owner: 'stranger', name: 'repo-a', node_id: 'R_a', private: false}),
-            makeAccess({owner: 'stranger', name: 'repo-b', node_id: 'R_b', private: true}),
+            makeAccess({owner: 'stranger', name: 'repo-b', node_id: 'R_b', private: false}),
           ],
           allowlist: makeAllowlist([]),
         }),
@@ -178,7 +322,7 @@ describe('reconcileRepos', () => {
           reason: 'unsolicited-new',
           entries: [
             {repo: 'repo-a', private: false, node_id: 'R_a'},
-            {repo: 'repo-b', private: true, node_id: 'R_b'},
+            {repo: 'repo-b', private: false, node_id: 'R_b'},
           ],
         },
       ])
@@ -228,11 +372,18 @@ describe('reconcileRepos', () => {
 
       // THEN the newcomer is NOT added (suppressed by node_id match)
       expect(result.nextRepos.repos).toHaveLength(1)
-      expect(result.nextRepos.repos[0]).toBe(tracked)
+      expect(result.nextRepos.repos[0]).toMatchObject({
+        owner: '[REDACTED]',
+        name: 'R_kgDOSVJgdw',
+        node_id: 'R_kgDOSVJgdw',
+        private: true,
+        onboarding_status: 'pending',
+      })
       expect(result.dispatches).toEqual([])
       expect(result.issues).toEqual([])
       expect(result.summary.added).toBe(0)
       expect(result.summary.pendingReview).toBe(0)
+      expect(result.summary.regained).toBe(1)
     })
 
     it('suppresses a newcomer whose node_id matches a redacted entry that lacks a node_id field (legacy redaction)', () => {
@@ -559,7 +710,8 @@ describe('reconcileRepos', () => {
       )
 
       expect(result.nextRepos.repos[0]).toMatchObject({
-        name: 'priv-repo',
+        owner: '[REDACTED]',
+        name: 'R_priv',
         private: true,
         node_id: 'R_priv',
       })
@@ -568,7 +720,7 @@ describe('reconcileRepos', () => {
     })
 
     it('treats matching private/node_id as idempotent — no refresh bump', () => {
-      const entry = makeEntry({name: 'stable', private: true, node_id: 'R_priv'})
+      const entry = makeEntry({owner: '[REDACTED]', name: 'R_priv', private: true, node_id: 'R_priv'})
       const result = reconcileRepos(
         makeInput({
           currentRepos: {version: 1, repos: [entry]},
@@ -591,7 +743,8 @@ describe('reconcileRepos', () => {
       )
 
       expect(result.nextRepos.repos[0]).toMatchObject({
-        name: 'flip-repo',
+        owner: '[REDACTED]',
+        name: 'R_x',
         private: true,
         node_id: 'R_x',
       })
@@ -609,7 +762,8 @@ describe('reconcileRepos', () => {
       )
 
       expect(result.nextRepos.repos[0]).toMatchObject({
-        name: 'deleted-repo',
+        owner: '[REDACTED]',
+        name: 'R_del',
         onboarding_status: 'lost-access',
         private: true,
         node_id: 'R_del',
@@ -646,7 +800,8 @@ describe('reconcileRepos', () => {
       )
 
       expect(result.nextRepos.repos[0]).toMatchObject({
-        name: 'archived-repo',
+        owner: '[REDACTED]',
+        name: 'R_arch',
         onboarding_status: 'lost-access',
         private: true, // fail-safe overrides access.private:false
         node_id: 'R_arch',
@@ -743,16 +898,21 @@ describe('reconcileRepos', () => {
 
       expect(result.nextRepos.repos).toHaveLength(3)
       const byName = new Map(result.nextRepos.repos.map(r => [r.name, r]))
+      const byNodeId = new Map(result.nextRepos.repos.map(r => [r.node_id, r]))
 
       // still-accessible: writes live access data (private:true)
-      expect(byName.get('still-ok')).toMatchObject({
+      expect(byNodeId.get('R_ok')).toMatchObject({
+        owner: '[REDACTED]',
+        name: 'R_ok',
         onboarding_status: 'onboarded',
         private: true,
         node_id: 'R_ok',
       })
 
       // access-lost: fail-safe private:true, preserves prior node_id
-      expect(byName.get('gone-repo')).toMatchObject({
+      expect(byNodeId.get('R_gone')).toMatchObject({
+        owner: '[REDACTED]',
+        name: 'R_gone',
         onboarding_status: 'lost-access',
         private: true,
         node_id: 'R_gone',
@@ -825,12 +985,15 @@ describe('reconcileRepos', () => {
 
       expect(result.nextRepos.repos).toHaveLength(5)
       const byName = new Map(result.nextRepos.repos.map(r => [r.name, r]))
+      const byNodeId = new Map(result.nextRepos.repos.map(r => [r.node_id, r]))
 
       // still-accessible: live access data, idempotent (no refresh because nothing changed).
       expect(byName.get('still-ok-five')).toEqual(stillOk)
 
       // deleted: fail-safe private:true, preserves prior node_id.
-      expect(byName.get('gone-five')).toMatchObject({
+      expect(byNodeId.get('R_gone')).toMatchObject({
+        owner: '[REDACTED]',
+        name: 'R_gone',
         onboarding_status: 'lost-access',
         private: true,
         node_id: 'R_gone',
@@ -1045,7 +1208,14 @@ describe('reconcileRepos', () => {
 
       const direct = addRepoEntry(
         {version: 1, repos: []},
-        {owner: 'trusted', repo: 'parity-repo', now: NOW, onboarding_status: 'pending'},
+        {
+          owner: 'trusted',
+          repo: 'parity-repo',
+          now: NOW,
+          private: false,
+          node_id: 'R_parity',
+          onboarding_status: 'pending',
+        },
       )
 
       // Schema-validated on both sides, then structural equality
@@ -1419,6 +1589,31 @@ describe('fetchPerRepoStatus 5-state classification', () => {
 
     expect(result.get('fro-bot/secret-repo')).toEqual({status: 'revoked'})
     expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('does not probe a redacted entry that is present in the access list by node_id', async () => {
+    const reposGet = vi.fn(async () => {
+      throw new Error('should not probe redacted identity')
+    })
+    const userOctokit = mockOctokit({reposGet: reposGet as never})
+    const logger = silentLogger()
+    const currentRepos: ReposFile = {
+      version: 1,
+      repos: [
+        makeEntry({
+          owner: '[REDACTED]',
+          name: 'R_kgDOPRIVATE',
+          private: true,
+          node_id: 'R_kgDOPRIVATE',
+        }),
+      ],
+    }
+    const accessList = [makeAccess({owner: 'private-owner', name: 'secret-repo', node_id: 'R_kgDOPRIVATE'})]
+
+    const result = await fetchPerRepoStatus(userOctokit, currentRepos, accessList, logger)
+
+    expect(result.size).toBe(0)
+    expect(reposGet).not.toHaveBeenCalled()
   })
 
   it('HTTP 404 → deleted', async () => {
@@ -2444,6 +2639,41 @@ describe('handleReconcile (I/O shell)', () => {
       expect(params?.body).toContain('R_priv')
     })
 
+    it('does not roll up private pending-review issues by owner', async () => {
+      const issuesCreate = vi.fn(async (_params: unknown) => ({data: {number: 10}}))
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {owner: {login: 'stranger'}, name: 'secret-a', archived: false, private: true, node_id: 'R_priv_a'},
+            {owner: {login: 'stranger'}, name: 'secret-b', archived: false, private: true, node_id: 'R_priv_b'},
+          ],
+        }),
+      })
+
+      await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({issuesCreate}),
+          readMetadata: makeReadMetadata({}),
+          commitMetadata: vi.fn(async () => ({committed: true, sha: 's', attempts: 1})) as never,
+        }),
+      )
+
+      expect(issuesCreate).toHaveBeenCalledTimes(2)
+      const payloads = issuesCreate.mock.calls.map(call => call[0]) as unknown as {
+        title: string
+        body: string
+        labels: string[]
+      }[]
+      for (const params of payloads) {
+        expect(params.title).not.toContain('stranger')
+        expect(params.title).not.toContain('secret-')
+        expect(params.body).not.toContain('stranger')
+        expect(params.body).not.toContain('secret-')
+        expect(params.labels).not.toContain('reconcile:rollup-pending-review')
+      }
+    })
+
     it('continues through remaining issues when one issue creation fails', async () => {
       let created = 0
       const issuesCreate = vi.fn(async () => {
@@ -2563,6 +2793,57 @@ describe('handleReconcile (I/O shell)', () => {
               archived: false,
               private: false,
               node_id: 'R_sus',
+            },
+          ],
+        }),
+      })
+
+      await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({issuesListForRepo, issuesUpdate}),
+          readMetadata: makeReadMetadata({repos: existing}),
+          commitMetadata: vi.fn(async () => ({committed: false, attempts: 1})) as never,
+        }),
+      )
+
+      expect(issuesUpdate).not.toHaveBeenCalled()
+    })
+
+    it('does NOT auto-close a private pending-review issue whose redacted subject is still pending-review', async () => {
+      const existing: ReposFile = {
+        version: 1,
+        repos: [
+          makeEntry({
+            owner: '[REDACTED]',
+            name: 'R_priv',
+            private: true,
+            node_id: 'R_priv',
+            onboarding_status: 'pending-review',
+          }),
+        ],
+      }
+      const issuesUpdate = vi.fn(async () => ({data: {}}))
+      const issuesListForRepo = vi.fn(async () => ({
+        data: [
+          {
+            number: 8,
+            title: 'Unsolicited collaborator grant: private repo',
+            body: '<!-- reconcile:subject:node_id=R_priv -->',
+            state: 'open' as const,
+            labels: [{name: 'reconcile:pending-review'}],
+          },
+        ],
+      }))
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {
+              owner: {login: 'stranger'},
+              name: 'secret-repo',
+              archived: false,
+              private: true,
+              node_id: 'R_priv',
             },
           ],
         }),

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -54,7 +54,7 @@ import {
   type DataBranchBootstrapParams,
   type DataBranchBootstrapResult,
 } from './data-branch-bootstrap.ts'
-import {addRepoEntry, computeNextEligibleAt} from './repos-metadata.ts'
+import {addRepoEntry, computeNextEligibleAt, normalizeRepoEntryForStorage} from './repos-metadata.ts'
 import {
   assertAllowlistFile,
   assertReposFile,
@@ -246,6 +246,7 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
   validateAccessList(accessList)
 
   const accessByKey = indexAccessList(accessList)
+  const accessByNodeId = indexAccessListByNodeId(accessList)
   const allowlistedOwners = new Set(allowlist.approved_inviters.map(i => i.username))
 
   const summary: ReconcileSummary = {
@@ -276,6 +277,7 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
       entry,
       key,
       accessByKey,
+      accessByNodeId,
       accessChannelByKey,
       perRepoStatus,
       fieldProbes,
@@ -328,12 +330,15 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
       owner: access.owner,
       repo: access.name,
       now,
+      private: access.private,
+      node_id: access.node_id,
       onboarding_status: status,
       discovery_channel: channel,
     })
 
     if (trusted) {
       summary.added += 1
+      if (access.private) continue
       dispatches.push({owner: access.owner, repo: access.name})
     } else {
       summary.pendingReview += 1
@@ -370,6 +375,7 @@ interface ClassifyTrackedParams {
   entry: RepoEntry
   key: string
   accessByKey: Map<string, AccessListEntry>
+  accessByNodeId: Map<string, AccessListEntry>
   accessChannelByKey: Map<string, DiscoveryChannel>
   perRepoStatus: Map<string, RepoStatusProbe>
   fieldProbes: Map<string, FieldProbe>
@@ -387,7 +393,17 @@ interface ClassifyTrackedParams {
  * pattern (see `processInvitation` in `handle-invitation.ts`).
  */
 function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
-  const {accessByKey, perRepoStatus, fieldProbes, allowlistedOwners, summary, dispatches, rawIssues, now} = params
+  const {
+    accessByKey,
+    accessByNodeId,
+    perRepoStatus,
+    fieldProbes,
+    allowlistedOwners,
+    summary,
+    dispatches,
+    rawIssues,
+    now,
+  } = params
 
   // Backfill new schema fields on legacy entries before any other logic. Idempotent on
   // already-populated entries (returns by reference) so steady-state runs don't bump the
@@ -398,9 +414,20 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
   }
   const entry = migrated
   const key = params.key
-  const access = accessByKey.get(key)
+  const access = accessForTrackedEntry(entry, key, accessByKey, accessByNodeId)
+  const accessKey = access === undefined ? key : repoKey(access.owner, access.name)
 
   if (access === undefined) {
+    if (entry.owner === '[REDACTED]' && storedRepoNodeId(entry) !== undefined) {
+      if (entry.onboarding_status === 'lost-access') {
+        summary.unchanged += 1
+        return entry
+      }
+      summary.lostAccess += 1
+      summary.byChannel[entry.discovery_channel ?? 'collab'].lostAccess += 1
+      return normalizeLostAccessEntry(entry)
+    }
+
     // Not in the access list — probe decides lost-access vs transient inconsistency.
     const probe = perRepoStatus.get(key)
     if (probe === undefined) {
@@ -449,7 +476,7 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
         }
         summary.lostAccess += 1
         summary.byChannel[entry.discovery_channel ?? 'collab'].lostAccess += 1
-        return {...entry, onboarding_status: 'lost-access', private: true}
+        return normalizeLostAccessEntry(entry)
       }
       default: {
         // Exhaustiveness guard. Adding a new RepoStatusProbe variant must update the
@@ -469,11 +496,29 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
     summary.lostAccess += 1
     summary.byChannel[entry.discovery_channel ?? 'collab'].lostAccess += 1
     return {
-      ...entry,
+      ...normalizeRepoEntryForStorage(entry, {
+        owner: access.owner,
+        repo: access.name,
+        private: true,
+        node_id: access.node_id,
+      }),
       onboarding_status: 'lost-access',
+    }
+  }
+
+  if (access.private && entry.onboarding_status !== 'lost-access') {
+    const normalized = normalizeRepoEntryForStorage(entry, {
+      owner: access.owner,
+      repo: access.name,
       private: true,
       node_id: access.node_id,
+    })
+    if (normalized === entry) {
+      summary.unchanged += 1
+      return entry
     }
+    summary.refreshed += 1
+    return normalized
   }
 
   if (entry.onboarding_status === 'lost-access') {
@@ -482,22 +527,32 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
     // prefers the entry's stored channel (sticky); falls back to the live access-list
     // channel for legacy pre-Unit-3 entries that have no recorded channel; ultimately
     // defaults to `collab` if neither source has it.
-    const channel = entry.discovery_channel ?? params.accessChannelByKey.get(key) ?? 'collab'
-    const trusted = isTrustedChannel(channel, entry.owner, allowlistedOwners)
+    const channel = entry.discovery_channel ?? params.accessChannelByKey.get(accessKey) ?? 'collab'
+    const trusted = isTrustedChannel(channel, access.owner, allowlistedOwners)
     const nextStatus: OnboardingStatus = trusted ? 'pending' : 'pending-review'
     summary.regained += 1
     if (trusted) {
-      dispatches.push({owner: entry.owner, repo: entry.name})
+      if (!access.private) {
+        dispatches.push({owner: access.owner, repo: access.name})
+      }
     } else {
       rawIssues.push({
-        owner: entry.owner,
-        repo: entry.name,
+        owner: access.owner,
+        repo: access.name,
         reason: 'unsolicited-regain',
         private: access.private,
         node_id: access.node_id,
       })
     }
-    return {...entry, onboarding_status: nextStatus, private: access.private, node_id: access.node_id}
+    return {
+      ...normalizeRepoEntryForStorage(entry, {
+        owner: access.owner,
+        repo: access.name,
+        private: access.private,
+        node_id: access.node_id,
+      }),
+      onboarding_status: nextStatus,
+    }
   }
 
   // Still-accessible tracked entry.
@@ -515,28 +570,30 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
   // genuinely fresh never become candidates so they don't compete for dispatch slots.
   // `pending-review` entries are excluded — they require human approval first.
   if (entry.onboarding_status === 'onboarded' && isEligibleForSurvey(entry.next_survey_eligible_at, params.now)) {
-    dispatches.push({owner: entry.owner, repo: entry.name})
+    dispatches.push({owner: access.owner, repo: access.name})
   } else if (
     entry.onboarding_status === 'pending' &&
     (entry.last_survey_status !== 'success' || isEligibleForSurvey(entry.next_survey_eligible_at, params.now))
   ) {
-    dispatches.push({owner: entry.owner, repo: entry.name})
+    dispatches.push({owner: access.owner, repo: access.name})
   }
 
   // Field refresh: apply probe results when they disagree with tracked fields,
   // and write live private/node_id from the access list when they differ.
-  const probe = fieldProbes.get(key)
+  const probe = fieldProbes.get(key) ?? fieldProbes.get(accessKey)
   const accessPrivate = access.private
   const accessNodeId = access.node_id
+  const storageInput = {owner: access.owner, repo: access.name, private: accessPrivate, node_id: accessNodeId}
 
   if (probe === undefined) {
     // No field probe — but access list still has private/node_id. Apply if changed.
-    if (entry.private === accessPrivate && entry.node_id === accessNodeId) {
+    const normalized = normalizeRepoEntryForStorage(entry, storageInput)
+    if (normalized === entry) {
       summary.unchanged += 1
       return entry
     }
     summary.refreshed += 1
-    return {...entry, private: accessPrivate, node_id: accessNodeId}
+    return normalized
   }
 
   const fieldsMatch =
@@ -548,13 +605,11 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
     return entry
   }
   summary.refreshed += 1
-  return {
-    ...entry,
+  return normalizeRepoEntryForStorage({
+    ...normalizeRepoEntryForStorage(entry, storageInput),
     has_fro_bot_workflow: probe.has_fro_bot_workflow,
     has_renovate: probe.has_renovate,
-    private: accessPrivate,
-    node_id: accessNodeId,
-  }
+  })
 }
 
 /**
@@ -651,18 +706,32 @@ function buildIssueQueue(raw: RawIssue[]): IssueQueueEntry[] {
 
   const issues: IssueQueueEntry[] = []
   for (const bucket of groups.values()) {
-    if (bucket.length >= 2) {
-      const first = bucket[0]
+    const privateEntries = bucket.filter(item => item.private)
+    const publicEntries = bucket.filter(item => !item.private)
+
+    if (publicEntries.length >= 2) {
+      const first = publicEntries[0]
       if (first === undefined) continue // unreachable; satisfies noUncheckedIndexedAccess
       issues.push({
         kind: 'per-owner-rollup',
         owner: first.owner,
         reason: first.reason,
-        entries: bucket.map(item => ({repo: item.repo, private: item.private, node_id: item.node_id})),
+        entries: publicEntries.map(item => ({repo: item.repo, private: item.private, node_id: item.node_id})),
       })
-      continue
+    } else {
+      for (const item of publicEntries) {
+        issues.push({
+          kind: 'per-repo',
+          owner: item.owner,
+          repo: item.repo,
+          reason: item.reason,
+          private: item.private,
+          node_id: item.node_id,
+        })
+      }
     }
-    for (const item of bucket) {
+
+    for (const item of privateEntries) {
       issues.push({
         kind: 'per-repo',
         owner: item.owner,
@@ -695,6 +764,40 @@ function indexAccessList(accessList: AccessListEntry[]): Map<string, AccessListE
     map.set(repoKey(entry.owner, entry.name), entry)
   }
   return map
+}
+
+function indexAccessListByNodeId(accessList: AccessListEntry[]): Map<string, AccessListEntry> {
+  const map = new Map<string, AccessListEntry>()
+  for (const entry of accessList) {
+    map.set(entry.node_id, entry)
+  }
+  return map
+}
+
+function storedRepoNodeId(entry: RepoEntry): string | undefined {
+  if (entry.node_id !== undefined) return entry.node_id
+  if (entry.owner === '[REDACTED]') return entry.name
+  return undefined
+}
+
+function accessForTrackedEntry(
+  entry: RepoEntry,
+  key: string,
+  accessByKey: Map<string, AccessListEntry>,
+  accessByNodeId: Map<string, AccessListEntry>,
+): AccessListEntry | undefined {
+  return accessByKey.get(key) ?? accessByNodeId.get(storedRepoNodeId(entry) ?? '')
+}
+
+function normalizeLostAccessEntry(entry: RepoEntry): RepoEntry {
+  const nodeId = storedRepoNodeId(entry)
+  if (nodeId === undefined) {
+    return {...entry, onboarding_status: 'lost-access', private: true}
+  }
+  return {
+    ...normalizeRepoEntryForStorage(entry, {private: true, node_id: nodeId}),
+    onboarding_status: 'lost-access',
+  }
 }
 
 function validateAccessList(accessList: AccessListEntry[]): void {
@@ -1288,10 +1391,14 @@ export async function fetchPerRepoStatus(
   logger: {warn: (message: string) => void},
 ): Promise<Map<string, RepoStatusProbe>> {
   const accessKeys = new Set(accessList.map(a => `${a.owner}/${a.name}`))
+  const accessNodeIds = new Set(accessList.map(a => a.node_id))
   const map = new Map<string, RepoStatusProbe>()
   for (const entry of currentRepos.repos) {
     const key = `${entry.owner}/${entry.name}`
     if (accessKeys.has(key)) continue
+    const nodeId = storedRepoNodeId(entry)
+    if (nodeId !== undefined && accessNodeIds.has(nodeId)) continue
+    if (entry.owner === '[REDACTED]') continue
     try {
       const response = await userOctokit.rest.repos.get({owner: entry.owner, repo: entry.name})
       // Reachable (200) but we weren't in /user/repos → access was revoked.
@@ -1357,14 +1464,16 @@ async function fetchFieldProbes(
   accessList: AccessListEntry[],
   logger: ReconcileLogger,
 ): Promise<{probes: Map<string, FieldProbe>; failed: number}> {
-  const accessKeys = new Set(accessList.filter(a => a.archived === false).map(a => `${a.owner}/${a.name}`))
+  const accessByKey = indexAccessList(accessList.filter(a => a.archived === false))
+  const accessByNodeId = indexAccessListByNodeId(accessList.filter(a => a.archived === false))
   const map = new Map<string, FieldProbe>()
   let failed = 0
   for (const entry of currentRepos.repos) {
     const key = `${entry.owner}/${entry.name}`
-    if (!accessKeys.has(key)) continue // only probe still-accessible tracked entries
+    const access = accessForTrackedEntry(entry, key, accessByKey, accessByNodeId)
+    if (access === undefined) continue // only probe still-accessible tracked entries
     try {
-      const probe = await probeSingleRepo(userOctokit, entry.owner, entry.name)
+      const probe = await probeSingleRepo(userOctokit, access.owner, access.name)
       map.set(key, probe)
     } catch (error: unknown) {
       // Non-blocking: omit from map so reconcileRepos treats as no-field-change.
@@ -2050,11 +2159,15 @@ async function autoCloseStaleIssues(params: {
   const pendingReviewNodeIds = new Set<string>()
   const pendingReviewOwners = new Map<string, number>()
   const accessByKey = new Map(params.accessList.map(a => [`${a.owner}/${a.name}`, a]))
+  const accessByNodeId = indexAccessListByNodeId(params.accessList)
   for (const entry of params.nextRepos.repos) {
     if (entry.onboarding_status !== 'pending-review') continue
-    const access = accessByKey.get(`${entry.owner}/${entry.name}`)
-    if (access !== undefined) pendingReviewNodeIds.add(access.node_id)
-    pendingReviewOwners.set(entry.owner, (pendingReviewOwners.get(entry.owner) ?? 0) + 1)
+    const nodeId = storedRepoNodeId(entry)
+    const access = accessByKey.get(`${entry.owner}/${entry.name}`) ?? accessByNodeId.get(nodeId ?? '')
+    const reviewNodeId = access?.node_id ?? nodeId
+    if (reviewNodeId !== undefined) pendingReviewNodeIds.add(reviewNodeId)
+    const reviewOwner = access?.owner ?? entry.owner
+    pendingReviewOwners.set(reviewOwner, (pendingReviewOwners.get(reviewOwner) ?? 0) + 1)
   }
 
   let closed = 0

--- a/scripts/record-survey-result.test.ts
+++ b/scripts/record-survey-result.test.ts
@@ -1,0 +1,70 @@
+import {describe, expect, it} from 'vitest'
+
+import {
+  buildRecordSurveyResultInput,
+  formatRecordSurveyResultError,
+  formatSurveyResultTarget,
+} from './record-survey-result.ts'
+import {RepoEntryNotFoundError} from './repos-metadata.ts'
+
+describe('buildRecordSurveyResultInput', () => {
+  it('includes private/node_id when supplied by the workflow environment', () => {
+    const input = buildRecordSurveyResultInput({
+      REPO_OWNER: 'private-owner',
+      REPO_NAME: 'secret-repo',
+      REPO_PRIVATE: 'true',
+      REPO_NODE_ID: 'R_kgDOPRIVATE',
+      SURVEY_STATUS: 'success',
+      SURVEY_AT: '2026-05-08T12:34:56Z',
+    })
+
+    expect(input).toMatchObject({
+      owner: 'private-owner',
+      repo: 'secret-repo',
+      private: true,
+      node_id: 'R_kgDOPRIVATE',
+      status: 'success',
+    })
+    expect(input.at.toISOString()).toBe('2026-05-08T12:34:56.000Z')
+  })
+
+  it('requires REPO_NODE_ID when REPO_PRIVATE is true', () => {
+    expect(() =>
+      buildRecordSurveyResultInput({
+        REPO_OWNER: 'private-owner',
+        REPO_NAME: 'secret-repo',
+        REPO_PRIVATE: 'true',
+        SURVEY_STATUS: 'success',
+      }),
+    ).toThrow('REPO_NODE_ID is required when REPO_PRIVATE is true')
+  })
+})
+
+describe('formatSurveyResultTarget', () => {
+  it('uses node_id instead of owner/name for private targets', () => {
+    const target = formatSurveyResultTarget({
+      owner: 'private-owner',
+      repo: 'secret-repo',
+      private: true,
+      node_id: 'R_kgDOPRIVATE',
+    })
+
+    expect(target).toBe('R_kgDOPRIVATE')
+  })
+})
+
+describe('formatRecordSurveyResultError', () => {
+  it('omits canonical owner/repo from private not-found errors', () => {
+    const message = formatRecordSurveyResultError(new RepoEntryNotFoundError('private-owner', 'secret-repo'), {
+      REPO_OWNER: 'private-owner',
+      REPO_NAME: 'secret-repo',
+      REPO_PRIVATE: 'true',
+      REPO_NODE_ID: 'R_kgDOPRIVATE',
+      SURVEY_STATUS: 'success',
+    })
+
+    expect(message).toContain('R_kgDOPRIVATE')
+    expect(message).not.toContain('private-owner')
+    expect(message).not.toContain('secret-repo')
+  })
+})

--- a/scripts/record-survey-result.ts
+++ b/scripts/record-survey-result.ts
@@ -1,7 +1,7 @@
 import process from 'node:process'
 
 import {commitMetadata} from './commit-metadata.ts'
-import {recordSurveyResult, RepoEntryNotFoundError} from './repos-metadata.ts'
+import {recordSurveyResult, RepoEntryNotFoundError, type RecordSurveyResultInput} from './repos-metadata.ts'
 
 /**
  * Write the outcome of a Survey Repo run back to `metadata/repos.yaml` on the `data` branch.
@@ -13,6 +13,8 @@ import {recordSurveyResult, RepoEntryNotFoundError} from './repos-metadata.ts'
  * Inputs (env vars):
  *   REPO_OWNER        — target repository owner (e.g. "marcusrbrown")
  *   REPO_NAME         — target repository name (e.g. ".dotfiles")
+ *   REPO_PRIVATE      — optional "true" | "false" visibility hint
+ *   REPO_NODE_ID      — optional GitHub GraphQL node ID; required when REPO_PRIVATE=true
  *   SURVEY_STATUS     — "success" | "failure"
  *   SURVEY_AT         — ISO 8601 timestamp; defaults to "now" if absent
  *   GITHUB_TOKEN      — FRO_BOT_PAT (writes to `data`; classic PAT with repo scope)
@@ -25,29 +27,77 @@ import {recordSurveyResult, RepoEntryNotFoundError} from './repos-metadata.ts'
  * exist — reconcile is the canonical writer for new entries).
  */
 async function main(): Promise<void> {
-  const owner = requiredEnv('REPO_OWNER')
-  const name = requiredEnv('REPO_NAME')
-  const status = parseStatus(requiredEnv('SURVEY_STATUS'))
-  const at = parseAt(process.env.SURVEY_AT)
+  const input = buildRecordSurveyResultInput(process.env)
+  const target = formatSurveyResultTarget(input)
   const [controlPlaneOwner, controlPlaneRepo] = splitControlPlane(requiredEnv('GITHUB_REPOSITORY'))
 
   const result = await commitMetadata({
     owner: controlPlaneOwner,
     repo: controlPlaneRepo,
     path: 'metadata/repos.yaml',
-    message: `chore(reconcile): record survey ${status} for ${owner}/${name}`,
-    mutator: (current: unknown) => recordSurveyResult(current, {owner, repo: name, at, status}),
+    message: `chore(reconcile): record survey ${input.status} for ${target}`,
+    mutator: (current: unknown) => recordSurveyResult(current, input),
   })
 
   if (result.committed) {
     process.stdout.write(
-      `${JSON.stringify({committed: true, sha: result.sha, attempts: result.attempts, owner, name, status})}\n`,
+      `${JSON.stringify({committed: true, sha: result.sha, attempts: result.attempts, target, status: input.status})}\n`,
     )
     return
   }
 
   // No-op commit (mutator returned the same file) — valid when status + date already match.
-  process.stdout.write(`${JSON.stringify({committed: false, attempts: result.attempts, owner, name, status})}\n`)
+  process.stdout.write(
+    `${JSON.stringify({committed: false, attempts: result.attempts, target, status: input.status})}\n`,
+  )
+}
+
+export function buildRecordSurveyResultInput(env: NodeJS.ProcessEnv): RecordSurveyResultInput {
+  const privateFlag = parseOptionalBoolean('REPO_PRIVATE', env.REPO_PRIVATE)
+  const nodeId = optionalEnv(env, 'REPO_NODE_ID')
+
+  if (privateFlag === true && nodeId === undefined) {
+    throw new Error('REPO_NODE_ID is required when REPO_PRIVATE is true')
+  }
+
+  return {
+    owner: requiredEnvFrom(env, 'REPO_OWNER'),
+    repo: requiredEnvFrom(env, 'REPO_NAME'),
+    ...(privateFlag === undefined ? {} : {private: privateFlag}),
+    ...(nodeId === undefined ? {} : {node_id: nodeId}),
+    at: parseAt(env.SURVEY_AT),
+    status: parseStatus(requiredEnvFrom(env, 'SURVEY_STATUS')),
+  }
+}
+
+export function formatSurveyResultTarget(
+  input: Pick<RecordSurveyResultInput, 'owner' | 'repo' | 'private' | 'node_id'>,
+): string {
+  if (input.private === true) {
+    if (input.node_id === undefined) {
+      throw new Error('node_id is required for private repos')
+    }
+    return input.node_id
+  }
+  return `${input.owner}/${input.repo}`
+}
+
+export function formatRecordSurveyResultError(error: unknown, env: NodeJS.ProcessEnv): string {
+  if (error instanceof RepoEntryNotFoundError) {
+    const target = safeSurveyResultTarget(env)
+    if (target !== undefined) {
+      return `metadata/repos.yaml has no entry for ${target}`
+    }
+  }
+  return error instanceof Error ? error.message : String(error)
+}
+
+function safeSurveyResultTarget(env: NodeJS.ProcessEnv): string | undefined {
+  try {
+    return formatSurveyResultTarget(buildRecordSurveyResultInput(env))
+  } catch {
+    return undefined
+  }
 }
 
 function parseStatus(raw: string): 'success' | 'failure' {
@@ -73,11 +123,27 @@ function splitControlPlane(raw: string): [string, string] {
 }
 
 function requiredEnv(name: string): string {
-  const value = process.env[name]
+  return requiredEnvFrom(process.env, name)
+}
+
+function requiredEnvFrom(env: NodeJS.ProcessEnv, name: string): string {
+  const value = env[name]
   if (value === undefined || value === '') {
     throw new Error(`${name} is required`)
   }
   return value
+}
+
+function optionalEnv(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const value = env[name]
+  return value === undefined || value === '' ? undefined : value
+}
+
+function parseOptionalBoolean(name: string, raw: string | undefined): boolean | undefined {
+  if (raw === undefined || raw === '') return undefined
+  if (raw === 'true') return true
+  if (raw === 'false') return false
+  throw new Error(`${name} must be 'true' or 'false', got '${raw}'`)
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
@@ -88,10 +154,12 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     // hasn't added the repo yet, which is legitimate when a manual survey dispatch runs
     // against an un-onboarded repo. Exit 0 so the workflow doesn't mark the run as failed.
     if (error instanceof RepoEntryNotFoundError) {
-      process.stderr.write(`record-survey-result: ${error.message}; skipping (non-fatal)\n`)
+      process.stderr.write(
+        `record-survey-result: ${formatRecordSurveyResultError(error, process.env)}; skipping (non-fatal)\n`,
+      )
       process.exit(0)
     }
-    process.stderr.write(`record-survey-result: ${error instanceof Error ? error.message : String(error)}\n`)
+    process.stderr.write(`record-survey-result: ${formatRecordSurveyResultError(error, process.env)}\n`)
     process.exit(1)
   }
 }

--- a/scripts/repos-metadata.test.ts
+++ b/scripts/repos-metadata.test.ts
@@ -1,4 +1,4 @@
-import type {ReposFile} from './schemas.ts'
+import type {RepoEntry, ReposFile} from './schemas.ts'
 
 import {describe, expect, it} from 'vitest'
 import {
@@ -11,6 +11,24 @@ import {
 
 const EMPTY_REPOS: ReposFile = {version: 1, repos: []}
 const NOW = new Date('2026-04-17T12:00:00Z')
+const PRIVATE_NODE_ID = 'R_kgDOPRIVATE'
+const PUBLIC_NODE_ID = 'R_kgDOPUBLIC'
+
+function repoEntry(overrides: Partial<RepoEntry> = {}): RepoEntry {
+  return {
+    owner: 'alice',
+    name: 'project',
+    added: '2026-04-17',
+    onboarding_status: 'pending',
+    last_survey_at: null,
+    last_survey_status: null,
+    has_fro_bot_workflow: false,
+    has_renovate: false,
+    discovery_channel: 'collab',
+    next_survey_eligible_at: null,
+    ...overrides,
+  }
+}
 
 describe('addRepoEntry', () => {
   // Behavioral contract: default onboarding_status is 'pending'
@@ -35,6 +53,56 @@ describe('addRepoEntry', () => {
       discovery_channel: 'collab',
       next_survey_eligible_at: null,
     })
+  })
+
+  // Privacy contract: public repos keep canonical owner/name while carrying node_id.
+  it('writes canonical form when adding a public repo with node_id', () => {
+    const result = addRepoEntry(EMPTY_REPOS, {
+      owner: 'alice',
+      repo: 'project',
+      now: NOW,
+      private: false,
+      node_id: PUBLIC_NODE_ID,
+    })
+
+    expect(result.repos[0]).toMatchObject({
+      owner: 'alice',
+      name: 'project',
+      private: false,
+      node_id: PUBLIC_NODE_ID,
+    })
+  })
+
+  // Privacy contract: private repos are redacted before they reach metadata/repos.yaml.
+  it('writes redacted form when adding a private repo with node_id', () => {
+    const result = addRepoEntry(EMPTY_REPOS, {
+      owner: 'private-owner',
+      repo: 'secret-repo',
+      now: NOW,
+      private: true,
+      node_id: PRIVATE_NODE_ID,
+    })
+
+    expect(result.repos[0]).toMatchObject({
+      owner: '[REDACTED]',
+      name: PRIVATE_NODE_ID,
+      private: true,
+      node_id: PRIVATE_NODE_ID,
+    })
+    expect(JSON.stringify(result)).not.toContain('private-owner')
+    expect(JSON.stringify(result)).not.toContain('secret-repo')
+  })
+
+  // Privacy contract: a private entry cannot be persisted without a redaction key.
+  it('throws when adding a private repo without node_id', () => {
+    expect(() =>
+      addRepoEntry(EMPTY_REPOS, {
+        owner: 'private-owner',
+        repo: 'secret-repo',
+        now: NOW,
+        private: true,
+      }),
+    ).toThrow('node_id is required for private repos')
   })
 
   // Cadence-and-discovery: defaults discovery_channel to 'collab' when not specified
@@ -116,6 +184,69 @@ describe('addRepoEntry', () => {
     }
     const result = addRepoEntry(existing, {owner: 'alice', repo: 'project', now: NOW})
     expect(result).toBe(existing)
+  })
+
+  // Privacy contract: node_id is the stable key for redacted entries.
+  it('does not add a duplicate when a redacted entry already exists with the same node_id', () => {
+    const existingEntry = repoEntry({
+      owner: '[REDACTED]',
+      name: PRIVATE_NODE_ID,
+      private: true,
+      node_id: PRIVATE_NODE_ID,
+    })
+    const current: ReposFile = {version: 1, repos: [existingEntry]}
+
+    const result = addRepoEntry(current, {
+      owner: 'private-owner',
+      repo: 'secret-repo',
+      now: NOW,
+      private: true,
+      node_id: PRIVATE_NODE_ID,
+    })
+
+    expect(result.repos).toHaveLength(1)
+    expect(result.repos[0]).toEqual(existingEntry)
+  })
+
+  // Privacy contract: a formerly canonical entry is redacted when the same node_id flips private.
+  it('redacts an existing canonical entry when the matching node_id is added as private', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [
+        repoEntry({
+          owner: 'private-owner',
+          name: 'secret-repo',
+          added: '2026-05-05',
+          onboarding_status: 'onboarded',
+          last_survey_at: '2026-05-06',
+          last_survey_status: 'success',
+          private: false,
+          node_id: PRIVATE_NODE_ID,
+        }),
+      ],
+    }
+
+    const result = addRepoEntry(current, {
+      owner: 'private-owner',
+      repo: 'secret-repo',
+      now: NOW,
+      private: true,
+      node_id: PRIVATE_NODE_ID,
+    })
+
+    expect(result.repos).toHaveLength(1)
+    expect(result.repos[0]).toMatchObject({
+      owner: '[REDACTED]',
+      name: PRIVATE_NODE_ID,
+      added: '2026-05-05',
+      onboarding_status: 'onboarded',
+      last_survey_at: '2026-05-06',
+      last_survey_status: 'success',
+      private: true,
+      node_id: PRIVATE_NODE_ID,
+    })
+    expect(JSON.stringify(result)).not.toContain('private-owner')
+    expect(JSON.stringify(result)).not.toContain('secret-repo')
   })
 
   // Behavioral contract: idempotency ignores requested status (existing entry preserved)
@@ -241,6 +372,81 @@ describe('recordSurveyResult', () => {
 
     expect(result.repos[0]?.last_survey_at).toBe('2026-04-18')
     expect(result.repos[0]?.last_survey_status).toBe('success')
+  })
+
+  // Privacy contract: public entries stay canonical while survey outcomes update.
+  it('preserves canonical form when recording a public repo survey result by node_id', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [repoEntry({private: false, node_id: PUBLIC_NODE_ID})],
+    }
+
+    const result = recordSurveyResult(current, {
+      owner: 'alice',
+      repo: 'project',
+      node_id: PUBLIC_NODE_ID,
+      private: false,
+      at: NOW,
+      status: 'success',
+    })
+
+    expect(result.repos[0]).toMatchObject({
+      owner: 'alice',
+      name: 'project',
+      private: false,
+      node_id: PUBLIC_NODE_ID,
+      last_survey_at: '2026-04-17',
+      last_survey_status: 'success',
+    })
+  })
+
+  // Privacy contract: redacted entries are found by node_id and stay redacted.
+  it('preserves redacted form when recording a private repo survey result by node_id', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [
+        repoEntry({
+          owner: '[REDACTED]',
+          name: PRIVATE_NODE_ID,
+          private: true,
+          node_id: PRIVATE_NODE_ID,
+        }),
+      ],
+    }
+
+    const result = recordSurveyResult(current, {
+      owner: 'private-owner',
+      repo: 'secret-repo',
+      node_id: PRIVATE_NODE_ID,
+      private: true,
+      at: new Date('2026-05-07T05:17:00Z'),
+      status: 'success',
+    })
+
+    expect(result.repos[0]).toMatchObject({
+      owner: '[REDACTED]',
+      name: PRIVATE_NODE_ID,
+      private: true,
+      node_id: PRIVATE_NODE_ID,
+      onboarding_status: 'onboarded',
+      last_survey_at: '2026-05-07',
+      last_survey_status: 'success',
+    })
+    expect(JSON.stringify(result)).not.toContain('private-owner')
+    expect(JSON.stringify(result)).not.toContain('secret-repo')
+  })
+
+  // Privacy contract: a private update cannot identify the target without node_id.
+  it('throws when recording a private repo survey result without node_id', () => {
+    expect(() =>
+      recordSurveyResult(EMPTY_REPOS, {
+        owner: 'private-owner',
+        repo: 'secret-repo',
+        private: true,
+        at: NOW,
+        status: 'success',
+      }),
+    ).toThrow('node_id is required for private repos')
   })
 
   // Behavioral contract: pure — original input unchanged
@@ -498,6 +704,55 @@ describe('resetSurveyResult', () => {
       discovery_channel: 'collab',
       next_survey_eligible_at: null,
     })
+  })
+
+  // Privacy contract: redacted entries are found by node_id and stay redacted during reset.
+  it('preserves redacted form when resetting a private repo by node_id', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [
+        repoEntry({
+          owner: '[REDACTED]',
+          name: PRIVATE_NODE_ID,
+          private: true,
+          node_id: PRIVATE_NODE_ID,
+          onboarding_status: 'onboarded',
+          last_survey_at: '2026-05-07',
+          last_survey_status: 'success',
+          next_survey_eligible_at: '2026-06-07',
+        }),
+      ],
+    }
+
+    const result = resetSurveyResult(current, {
+      owner: 'private-owner',
+      repo: 'secret-repo',
+      node_id: PRIVATE_NODE_ID,
+      private: true,
+    })
+
+    expect(result.repos[0]).toMatchObject({
+      owner: '[REDACTED]',
+      name: PRIVATE_NODE_ID,
+      private: true,
+      node_id: PRIVATE_NODE_ID,
+      last_survey_at: null,
+      last_survey_status: null,
+      next_survey_eligible_at: null,
+    })
+    expect(JSON.stringify(result)).not.toContain('private-owner')
+    expect(JSON.stringify(result)).not.toContain('secret-repo')
+  })
+
+  // Privacy contract: a private reset cannot identify the target without node_id.
+  it('throws when resetting a private repo without node_id', () => {
+    expect(() =>
+      resetSurveyResult(EMPTY_REPOS, {
+        owner: 'private-owner',
+        repo: 'secret-repo',
+        private: true,
+      }),
+    ).toThrow('node_id is required for private repos')
   })
 
   // Behavioral contract: pure function — never mutates input

--- a/scripts/repos-metadata.ts
+++ b/scripts/repos-metadata.ts
@@ -5,7 +5,8 @@
  * `recordSurveyResult`; operators recovering from a misclassified survey result use
  * `resetSurveyResult` to clear `last_survey_at`/`last_survey_status` back to null. All
  * three are pure functions that never mutate inputs. `addRepoEntry` is idempotent on
- * duplicate `owner+name` and preserves existing entries as-is.
+ * duplicate repo identities and preserves existing entries as-is unless a privacy-state
+ * change requires canonical identifiers to be redacted.
  */
 
 import {createHash} from 'node:crypto'
@@ -14,9 +15,105 @@ import {
   assertReposFile,
   type DiscoveryChannel,
   type OnboardingStatus,
+  type RepoEntry,
   type ReposFile,
   type SurveyStatus,
 } from './schemas.ts'
+
+const REDACTED_OWNER = '[REDACTED]'
+
+export interface RepoIdentityInput {
+  owner: string
+  repo: string
+  private?: boolean
+  node_id?: string
+}
+
+function assertPrivateNodeId(input: Pick<RepoIdentityInput, 'private' | 'node_id'>): void {
+  if (input.private === true && (input.node_id === undefined || input.node_id.trim() === '')) {
+    throw new Error('node_id is required for private repos')
+  }
+}
+
+function definedPrivacyFields(input: Pick<RepoIdentityInput, 'private' | 'node_id'>): Partial<RepoEntry> {
+  const fields: Partial<RepoEntry> = {}
+
+  if (input.private !== undefined) {
+    fields.private = input.private
+  }
+
+  if (input.node_id !== undefined) {
+    fields.node_id = input.node_id
+  }
+
+  return fields
+}
+
+function findRepoEntryIndex(repos: readonly RepoEntry[], input: RepoIdentityInput): number {
+  if (input.node_id !== undefined) {
+    const nodeIdMatch = repos.findIndex(entry => entry.node_id === input.node_id)
+    if (nodeIdMatch !== -1) {
+      return nodeIdMatch
+    }
+
+    const redactedNameMatch = repos.findIndex(entry => entry.owner === REDACTED_OWNER && entry.name === input.node_id)
+    if (redactedNameMatch !== -1) {
+      return redactedNameMatch
+    }
+  }
+
+  return repos.findIndex(entry => entry.owner === input.owner && entry.name === input.repo)
+}
+
+export function normalizeRepoEntryForStorage(entry: RepoEntry, input: Partial<RepoIdentityInput> = {}): RepoEntry {
+  const nextPrivate = input.private ?? entry.private
+  const nextNodeId = input.node_id ?? entry.node_id ?? (entry.owner === REDACTED_OWNER ? entry.name : undefined)
+
+  if (nextPrivate === true) {
+    assertPrivateNodeId({private: true, node_id: nextNodeId})
+    const redactedName = nextNodeId
+    if (redactedName === undefined) {
+      throw new Error('node_id is required for private repos')
+    }
+
+    if (
+      entry.owner === REDACTED_OWNER &&
+      entry.name === redactedName &&
+      entry.private === true &&
+      entry.node_id === redactedName
+    ) {
+      return entry
+    }
+
+    return {
+      ...entry,
+      owner: REDACTED_OWNER,
+      name: redactedName,
+      private: true,
+      node_id: redactedName,
+    }
+  }
+
+  const nextOwner = input.private === false && input.owner !== undefined ? input.owner : entry.owner
+  const nextName = input.private === false && input.repo !== undefined ? input.repo : entry.name
+  const nextEntry = {
+    ...entry,
+    owner: nextOwner,
+    name: nextName,
+    ...definedPrivacyFields({private: input.private, node_id: nextNodeId}),
+  }
+
+  if (
+    nextEntry.owner === entry.owner &&
+    nextEntry.name === entry.name &&
+    nextEntry.private === entry.private &&
+    nextEntry.node_id === entry.node_id
+  ) {
+    return entry
+  }
+
+  return nextEntry
+}
 
 /**
  * Per-channel base survey interval, in days. The actual eligibility date adds a
@@ -85,6 +182,10 @@ export interface AddRepoEntryInput {
   owner: string
   repo: string
   now: Date
+  /** Whether the repo is private. When true, `node_id` is required and owner/name are redacted. */
+  private?: boolean
+  /** GitHub GraphQL global node ID. Required when `private` is true. */
+  node_id?: string
   /**
    * Onboarding status for the new entry. Defaults to `'pending'` to match the original
    * invitation-acceptance path. Reconcile passes `'pending-review'` when the repo owner is
@@ -105,48 +206,72 @@ export interface AddRepoEntryInput {
 
 /**
  * Add a new repo entry to the repos metadata file. Idempotent: returns the input unchanged
- * (by reference) when an entry with the same `owner + name` already exists, regardless of
- * the requested `onboarding_status`. Callers that need to change status of an existing entry
- * must do so through a different code path.
+ * (by reference) when an entry with the same repo identity already exists and no privacy
+ * normalization is needed, regardless of the requested `onboarding_status`. Callers that
+ * need to change status of an existing entry must do so through a different code path.
  *
  * Pure function: never mutates `current` in place. When adding, returns a fresh top-level
  * object with a fresh `repos` array.
  *
- * Privacy fields (`private`, `node_id`) are intentionally omitted at creation time and
- * populated on the next reconcile pass via the access-list / probe merge in
- * `classifyTracked`. Treat absence as "not yet observed" — downstream consumers must
+ * Private entries are always written in redacted form (`owner: '[REDACTED]'`,
+ * `name: <node_id>`). Public entries keep canonical owner/name and carry `node_id` when
+ * supplied. Treat absence of `private` as "not yet observed" — downstream consumers must
  * default to fail-safe (treat-as-private) for entries lacking `private`.
  */
 export function addRepoEntry(current: unknown, input: AddRepoEntryInput): ReposFile {
   assertReposFile(current, 'repos')
+  assertPrivateNodeId(input)
 
-  if (current.repos.some(entry => entry.owner === input.owner && entry.name === input.repo)) {
+  const matchIndex = findRepoEntryIndex(current.repos, input)
+  if (matchIndex !== -1) {
+    const match = current.repos[matchIndex]
+    if (match === undefined) {
+      return current
+    }
+
+    const normalized = normalizeRepoEntryForStorage(match, input)
+    if (normalized === match) {
+      return current
+    }
+
+    const nextRepos = [...current.repos]
+    nextRepos[matchIndex] = normalized
+
+    return {
+      ...current,
+      repos: nextRepos,
+    }
+  }
+
+  const nextEntry = normalizeRepoEntryForStorage({
+    owner: input.owner,
+    name: input.repo,
+    added: input.now.toISOString().slice(0, 10),
+    onboarding_status: input.onboarding_status ?? 'pending',
+    last_survey_at: null,
+    last_survey_status: null,
+    has_fro_bot_workflow: false,
+    has_renovate: false,
+    discovery_channel: input.discovery_channel ?? 'collab',
+    next_survey_eligible_at: null,
+    ...definedPrivacyFields(input),
+  })
+
+  if (current.repos.some(entry => entry.node_id !== undefined && entry.node_id === nextEntry.node_id)) {
     return current
   }
 
   return {
     ...current,
-    repos: [
-      ...current.repos,
-      {
-        owner: input.owner,
-        name: input.repo,
-        added: input.now.toISOString().slice(0, 10),
-        onboarding_status: input.onboarding_status ?? 'pending',
-        last_survey_at: null,
-        last_survey_status: null,
-        has_fro_bot_workflow: false,
-        has_renovate: false,
-        discovery_channel: input.discovery_channel ?? 'collab',
-        next_survey_eligible_at: null,
-      },
-    ],
+    repos: [...current.repos, nextEntry],
   }
 }
 
 export interface RecordSurveyResultInput {
   owner: string
   repo: string
+  private?: boolean
+  node_id?: string
   at: Date
   status: SurveyStatus
 }
@@ -167,8 +292,9 @@ export interface RecordSurveyResultInput {
  */
 export function recordSurveyResult(current: unknown, input: RecordSurveyResultInput): ReposFile {
   assertReposFile(current, 'repos')
+  assertPrivateNodeId(input)
 
-  const matchIndex = current.repos.findIndex(entry => entry.owner === input.owner && entry.name === input.repo)
+  const matchIndex = findRepoEntryIndex(current.repos, input)
   if (matchIndex === -1) {
     throw new RepoEntryNotFoundError(input.owner, input.repo)
   }
@@ -192,20 +318,21 @@ export function recordSurveyResult(current: unknown, input: RecordSurveyResultIn
   // dispatch slots while the underlying problem persists). Channel defaults to 'collab'
   // when the field is absent on a legacy entry that hasn't been migrated yet.
   const channel: DiscoveryChannel = match.discovery_channel ?? 'collab'
+  const normalizedMatch = normalizeRepoEntryForStorage(match, input)
   const nextEligibleAt = computeNextEligibleAt({
-    owner: input.owner,
-    repo: input.repo,
+    owner: normalizedMatch.owner,
+    repo: normalizedMatch.name,
     channel,
     baseDate: input.at,
   })
 
-  const updated = {
-    ...match,
+  const updated = normalizeRepoEntryForStorage({
+    ...normalizedMatch,
     onboarding_status: nextStatus,
     last_survey_at: input.at.toISOString().slice(0, 10),
     last_survey_status: input.status,
     next_survey_eligible_at: nextEligibleAt,
-  }
+  })
 
   const nextRepos = [...current.repos]
   nextRepos[matchIndex] = updated
@@ -219,6 +346,8 @@ export function recordSurveyResult(current: unknown, input: RecordSurveyResultIn
 export interface ResetSurveyResultInput {
   owner: string
   repo: string
+  private?: boolean
+  node_id?: string
 }
 
 /**
@@ -248,8 +377,9 @@ export interface ResetSurveyResultInput {
  */
 export function resetSurveyResult(current: unknown, input: ResetSurveyResultInput): ReposFile {
   assertReposFile(current, 'repos')
+  assertPrivateNodeId(input)
 
-  const matchIndex = current.repos.findIndex(entry => entry.owner === input.owner && entry.name === input.repo)
+  const matchIndex = findRepoEntryIndex(current.repos, input)
   if (matchIndex === -1) {
     throw new RepoEntryNotFoundError(input.owner, input.repo)
   }
@@ -259,12 +389,12 @@ export function resetSurveyResult(current: unknown, input: ResetSurveyResultInpu
     throw new RepoEntryNotFoundError(input.owner, input.repo)
   }
 
-  const updated = {
-    ...match,
+  const updated = normalizeRepoEntryForStorage({
+    ...normalizeRepoEntryForStorage(match, input),
     last_survey_at: null,
     last_survey_status: null,
     next_survey_eligible_at: null,
-  }
+  })
 
   const nextRepos = [...current.repos]
   nextRepos[matchIndex] = updated

--- a/scripts/reset-survey-status.test.ts
+++ b/scripts/reset-survey-status.test.ts
@@ -1,0 +1,28 @@
+import {describe, expect, it} from 'vitest'
+
+import {formatResetSurveyTarget, parseTargets} from './reset-survey-status.ts'
+
+describe('parseTargets', () => {
+  it('parses canonical owner/name targets', () => {
+    expect(parseTargets('alice/project')).toEqual([{owner: 'alice', name: 'project'}])
+  })
+
+  it('parses node_id targets without requiring canonical owner/name', () => {
+    expect(parseTargets('node_id:R_kgDOPRIVATE')).toEqual([
+      {owner: '[REDACTED]', name: 'R_kgDOPRIVATE', private: true, node_id: 'R_kgDOPRIVATE'},
+    ])
+  })
+})
+
+describe('formatResetSurveyTarget', () => {
+  it('uses node_id instead of owner/name for private targets', () => {
+    expect(
+      formatResetSurveyTarget({
+        owner: '[REDACTED]',
+        name: 'R_kgDOPRIVATE',
+        private: true,
+        node_id: 'R_kgDOPRIVATE',
+      }),
+    ).toBe('R_kgDOPRIVATE')
+  })
+})

--- a/scripts/reset-survey-status.ts
+++ b/scripts/reset-survey-status.ts
@@ -1,7 +1,7 @@
 import process from 'node:process'
 
 import {commitMetadata} from './commit-metadata.ts'
-import {RepoEntryNotFoundError, resetSurveyResult} from './repos-metadata.ts'
+import {RepoEntryNotFoundError, resetSurveyResult, type ResetSurveyResultInput} from './repos-metadata.ts'
 
 /**
  * Reset `last_survey_at` and `last_survey_status` to `null` for one or more entries in
@@ -13,9 +13,8 @@ import {RepoEntryNotFoundError, resetSurveyResult} from './repos-metadata.ts'
  * re-dispatch on the next cron instead of waiting the default 30 days.
  *
  * Inputs (env vars):
- *   TARGETS           — comma-separated list of `owner/name` entries (e.g.
- *                       `marcusrbrown/.dotfiles,marcusrbrown/.github`). Whitespace around
- *                       entries and repeated commas are ignored.
+ *   TARGETS           — comma-separated list of `owner/name` or `node_id:<id>` entries.
+ *                       Whitespace around entries and repeated commas are ignored.
  *   GITHUB_TOKEN      — App installation token with `contents:write` on the control-plane
  *                       repo (minted via `actions/create-github-app-token`). Required so
  *                       the commit on `data` is authored by `fro-bot[bot]` and passes the
@@ -34,25 +33,30 @@ async function main(): Promise<void> {
   const [controlPlaneOwner, controlPlaneRepo] = splitControlPlane(requiredEnv('GITHUB_REPOSITORY'))
 
   const results: {
-    owner: string
-    name: string
+    target: string
     committed: boolean
     attempts: number
     sha?: string
   }[] = []
 
-  for (const {owner, name} of targets) {
+  for (const targetInput of targets) {
+    const target = formatResetSurveyTarget(targetInput)
     const result = await commitMetadata({
       owner: controlPlaneOwner,
       repo: controlPlaneRepo,
       path: 'metadata/repos.yaml',
-      message: `chore(recovery): reset survey status for ${owner}/${name}`,
-      mutator: (current: unknown) => resetSurveyResult(current, {owner, repo: name}),
+      message: `chore(recovery): reset survey status for ${target}`,
+      mutator: (current: unknown) =>
+        resetSurveyResult(current, {
+          owner: targetInput.owner,
+          repo: targetInput.name,
+          private: targetInput.private,
+          node_id: targetInput.node_id,
+        }),
     })
 
     results.push({
-      owner,
-      name,
+      target,
       committed: result.committed,
       attempts: result.attempts,
       ...(result.committed ? {sha: result.sha} : {}),
@@ -62,7 +66,7 @@ async function main(): Promise<void> {
   process.stdout.write(`${JSON.stringify({targets: results.length, results}, null, 2)}\n`)
 }
 
-function parseTargets(raw: string): {owner: string; name: string}[] {
+export function parseTargets(raw: string): ResetSurveyTarget[] {
   const entries = raw
     .split(',')
     .map(entry => entry.trim())
@@ -73,12 +77,32 @@ function parseTargets(raw: string): {owner: string; name: string}[] {
   }
 
   return entries.map(entry => {
+    if (entry.startsWith('node_id:')) {
+      const nodeId = entry.slice('node_id:'.length)
+      if (nodeId === '') {
+        throw new Error(`TARGETS node_id entry must include a value, got '${entry}'`)
+      }
+      return {owner: '[REDACTED]', name: nodeId, private: true, node_id: nodeId}
+    }
+
     const [owner, name] = entry.split('/')
     if (owner === undefined || name === undefined || owner === '' || name === '') {
       throw new Error(`TARGETS entry must be 'owner/name', got '${entry}'`)
     }
     return {owner, name}
   })
+}
+
+export type ResetSurveyTarget = Pick<ResetSurveyResultInput, 'owner' | 'private' | 'node_id'> & {name: string}
+
+export function formatResetSurveyTarget(target: ResetSurveyTarget): string {
+  if (target.private === true) {
+    if (target.node_id === undefined) {
+      throw new Error('node_id is required for private repos')
+    }
+    return target.node_id
+  }
+  return `${target.owner}/${target.name}`
 }
 
 function splitControlPlane(raw: string): [string, string] {


### PR DESCRIPTION
## Summary
- write private repo metadata in redacted node-ID form across add, survey-result, and reset mutators
- match private entries by node_id during reconcile, suppress private survey dispatches, and fail-close redacted entries missing from the access list
- keep private pending-review issue payloads and survey-result logging free of canonical owner/repo names

## Verification
- pnpm test scripts/repos-metadata.test.ts scripts/reconcile-repos.test.ts scripts/record-survey-result.test.ts scripts/reset-survey-status.test.ts
- pnpm bootstrap
- pnpm check-types
- pnpm lint
- pnpm test
