### PR TITLE
feat(privacy): redact private invitation handling

### DIFF
--- a/.github/workflows/poll-invitations.yaml
+++ b/.github/workflows/poll-invitations.yaml
@@ -32,30 +32,30 @@ jobs:
         run: node scripts/handle-invitation.ts
 
       - name: 📣 Notify Discord
-        if: steps.poll.outputs.invitations_accepted > 0
+        if: steps.poll.outputs.public_invitations_accepted > 0
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          INVITATIONS_ACCEPTED: ${{ steps.poll.outputs.invitations_accepted }}
+          INVITATIONS_ACCEPTED: ${{ steps.poll.outputs.public_invitations_accepted }}
         run: |
           node scripts/discord-notify.ts \
             --message "🌐 Just joined ${INVITATIONS_ACCEPTED} new space(s) on GitHub. The network grows ✨" \
             --title "New Collaboration"
 
       - name: 🦋 Post to Bluesky
-        if: steps.poll.outputs.invitations_accepted > 0
+        if: steps.poll.outputs.public_invitations_accepted > 0
         env:
           BLUESKY_HANDLE: ${{ secrets.BLUESKY_HANDLE }}
           BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
-          INVITATIONS_ACCEPTED: ${{ steps.poll.outputs.invitations_accepted }}
+          INVITATIONS_ACCEPTED: ${{ steps.poll.outputs.public_invitations_accepted }}
         run: |
           node scripts/bluesky-post.ts \
             "🌐 Just accepted ${INVITATIONS_ACCEPTED} collaboration invitation(s) on GitHub. The network grows ✨ #GitHub #OpenSource"
 
       - name: 📓 Journal — invitation accepted
-        if: steps.poll.outputs.invitations_accepted > 0
+        if: steps.poll.outputs.public_invitations_accepted > 0
         env:
           GITHUB_TOKEN: ${{ secrets.FRO_BOT_PAT }}
-          INVITATIONS_ACCEPTED: ${{ steps.poll.outputs.invitations_accepted }}
+          INVITATIONS_ACCEPTED: ${{ steps.poll.outputs.public_invitations_accepted }}
         run: |
           node scripts/journal-entry.ts \
             --event invitation_accepted \

--- a/docs/plans/2026-05-05-002-feat-private-repo-handling-plan.md
+++ b/docs/plans/2026-05-05-002-feat-private-repo-handling-plan.md
@@ -451,7 +451,7 @@ persona/
 
 ---
 
-- [ ] **Unit 4: Poll-invitations gate and autonomous commit-message redaction**
+- [x] **Unit 4: Poll-invitations gate and autonomous commit-message redaction**
 
 **Goal:** `handle-invitation.ts` reads the invitation's `private` flag and writes a redacted entry when private. All autonomous commit messages from `addRepoEntry`, `recordSurveyResult`, `resetSurveyResult`, and any future mutator path use `node_id` (not `owner/repo`) for private repos.
 
@@ -462,14 +462,14 @@ persona/
 **Files:**
 - Modify: `scripts/handle-invitation.ts`
 - Modify: `scripts/handle-invitation.test.ts`
-- Modify: `scripts/record-survey-result.ts`
-- Modify: `scripts/reset-survey-status.ts`
-- Modify: `.github/workflows/poll-invitations.yaml` (run name uses `node_id` for in-flight log surface)
+- Verify existing private-aware commit targets in `scripts/record-survey-result.ts`
+- Verify existing private-aware commit targets in `scripts/reset-survey-status.ts`
+- Modify: `.github/workflows/poll-invitations.yaml` (notifications consume an explicit public-only invitation count)
 
 **Approach:**
 - `handle-invitation.ts`: extract `private` and `node_id` from the invitation API response; pass to `addRepoEntry` so the redacted form is written.
-- Commit messages: when an entry is `private: true`, the commit message uses `chore(metadata): accept invitation <node_id>` instead of `chore(metadata): add <owner>/<repo> from invitation polling`. Same pattern for survey-result and reset paths.
-- `poll-invitations.yaml` job name: `Poll invitations: <node_id>` for the matched invitation (instead of `Poll invitations: <owner>/<repo>`). The dispatch input echo at API-call time cannot be suppressed; mitigation is that the workflow only ever sees `node_id` post-resolution.
+- Commit messages: when an entry is `private: true`, the commit message uses `chore(metadata): accept invitation <node_id>` instead of `chore(metadata): add <owner>/<repo> from invitation polling`. Survey-result and reset paths already use the same `node_id` target formatting from earlier private-metadata work.
+- `poll-invitations.yaml`: use a public-only invitation count output for Discord, Bluesky, and journal notifications so accepted private invitations do not trigger public social surfaces.
 
 **Patterns to follow:**
 - Existing commit-message structure in `addRepoEntry`/`recordSurveyResult`/`resetSurveyResult`
@@ -483,6 +483,8 @@ persona/
 - Edge case: invitation API response missing `node_id` → script fails explicitly (cannot proceed without the key)
 - Edge case: invitation for private repo whose API response is malformed → script logs a structured error and skips the invitation (does not write a half-redacted entry)
 - Integration: full poll-invitations run with mixed public/private invitations produces correct redacted/canonical entries and commit messages
+- Regression: public-looking invitation rechecked after acceptance as private writes redacted metadata and skips survey dispatch
+- Regression: private skipped invitations and malformed privacy payloads without `node_id` never expose canonical owner/name
 
 **Verification:**
 - New tests pass

--- a/scripts/handle-invitation.test.ts
+++ b/scripts/handle-invitation.test.ts
@@ -1,16 +1,22 @@
 import type {CommitMetadataParams, CommitMetadataResult} from './commit-metadata.ts'
-import type {OctokitClient} from './handle-invitation.ts'
+import type {OctokitClient, RepositoryInvitation} from './handle-invitation.ts'
 
 import {describe, expect, it, vi} from 'vitest'
-import {handleInvitations, InvitationHandlingError} from './handle-invitation.ts'
+import {
+  countPublicAcceptedInvitations,
+  formatInvitationGithubOutput,
+  handleInvitations,
+  InvitationHandlingError,
+} from './handle-invitation.ts'
 import {assertReposFile} from './schemas.ts'
 
 type CommitMetadataMock = (params: CommitMetadataParams) => Promise<CommitMetadataResult>
 
 function mockOctokit(overrides?: {
   listInvitationsForAuthenticatedUser?: () => Promise<{
-    data: Invitation[]
+    data: RepositoryInvitation[]
   }>
+  getRepo?: (params: {owner: string; repo: string}) => Promise<{data: {node_id?: unknown; private?: unknown}}>
   acceptInvitationForAuthenticatedUser?: (params: {invitation_id: number}) => Promise<void>
   starRepoForAuthenticatedUser?: (params: {owner: string; repo: string}) => Promise<void>
   createWorkflowDispatch?: (params: {
@@ -31,6 +37,11 @@ function mockOctokit(overrides?: {
           data: {type: 'file' as const, sha: 'repos-sha', content: 'dmVyc2lvbjogMQpyZXBvczogW10K', encoding: 'base64'},
         }),
         createOrUpdateFileContents: async () => ({data: {commit: {sha: 'metadata-commit-sha'}}}),
+        get:
+          overrides?.getRepo ??
+          (async ({owner, repo}: {owner: string; repo: string}) => ({
+            data: {node_id: `R_${owner}_${repo}`, private: false},
+          })),
         listInvitationsForAuthenticatedUser:
           overrides?.listInvitationsForAuthenticatedUser ??
           (async () => ({
@@ -63,17 +74,15 @@ function mockOctokit(overrides?: {
   } as unknown as OctokitClient
 }
 
-interface Invitation {
-  id: number
-  inviter: {
-    login: string
-  }
-  repository: {
-    name: string
-    owner: {
-      login: string
+async function readTestMetadata(path: string): Promise<unknown> {
+  if (path === 'metadata/allowlist.yaml') {
+    return {
+      version: 1,
+      approved_inviters: [{username: 'marcusrbrown', added: '2025-04-15', role: 'owner'}],
     }
   }
+
+  return {version: 1, repos: []}
 }
 
 describe('handleInvitations', () => {
@@ -94,6 +103,8 @@ describe('handleInvitations', () => {
             inviter: {login: 'marcusrbrown'},
             repository: {
               name: 'hello-world',
+              node_id: 'R_kgDOPUBLIC',
+              private: false,
               owner: {login: 'fro-bot'},
             },
           },
@@ -115,16 +126,7 @@ describe('handleInvitations', () => {
       workflowRef: 'main',
       commitMetadata,
       bootstrapDataBranch: vi.fn(async () => ({})),
-      readMetadata: async (path: string) => {
-        if (path === 'metadata/allowlist.yaml') {
-          return {
-            version: 1,
-            approved_inviters: [{username: 'marcusrbrown', added: '2025-04-15', role: 'owner'}],
-          }
-        }
-
-        return {version: 1, repos: []}
-      },
+      readMetadata: readTestMetadata,
     })
 
     // #then it accepts, stars, records metadata, and dispatches the survey
@@ -150,6 +152,7 @@ describe('handleInvitations', () => {
     // #and the mutator persists discovery_channel: 'collab' so the entry surfaces
     // through the collab channel in reconcile reports
     const commitCall = commitMetadata.mock.calls[0]?.[0]
+    expect(commitCall?.message).toBe('chore(metadata): add fro-bot/hello-world from invitation polling')
     const mutator = commitCall?.mutator
     expect(typeof mutator).toBe('function')
     if (typeof mutator === 'function') {
@@ -157,7 +160,500 @@ describe('handleInvitations', () => {
       assertReposFile(newReposFile)
       expect(newReposFile.repos[0]?.discovery_channel).toBe('collab')
       expect(newReposFile.repos[0]?.next_survey_eligible_at).toBeNull()
+      expect(newReposFile.repos[0]?.private).toBe(false)
+      expect(newReposFile.repos[0]?.node_id).toBe('R_kgDOPUBLIC')
     }
+  })
+
+  it('fails closed when a public-looking invitation becomes private after acceptance', async () => {
+    const acceptInvitation = vi.fn(async () => undefined)
+    const starRepoForAuthenticatedUser = vi.fn(async () => undefined)
+    const createWorkflowDispatch = vi.fn(async () => undefined)
+    const commitMetadata = vi.fn<CommitMetadataMock>(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
+    const octokit = mockOctokit({
+      listInvitationsForAuthenticatedUser: async () => ({
+        data: [
+          {
+            id: 113,
+            inviter: {login: 'marcusrbrown'},
+            repository: {
+              name: 'flipped-repo',
+              node_id: 'R_kgDOFLIPPED',
+              private: false,
+              owner: {login: 'private-owner'},
+            },
+          },
+        ],
+      }),
+      getRepo: async () => ({data: {node_id: 'R_kgDOFLIPPED', private: true}}),
+      acceptInvitationForAuthenticatedUser: acceptInvitation,
+      starRepoForAuthenticatedUser,
+      createWorkflowDispatch,
+    })
+
+    const result = await handleInvitations({
+      octokit,
+      allowlistPath: 'metadata/allowlist.yaml',
+      reposPath: 'metadata/repos.yaml',
+      now: new Date('2026-04-16T12:00:00.000Z'),
+      workflowFile: 'survey.yaml',
+      workflowRef: 'main',
+      commitMetadata,
+      bootstrapDataBranch: vi.fn(async () => ({})),
+      readMetadata: readTestMetadata,
+    })
+
+    expect(result.processed).toEqual([
+      {
+        invitationId: 113,
+        inviter: 'marcusrbrown',
+        owner: '[REDACTED]',
+        repo: 'R_kgDOFLIPPED',
+        status: 'accepted',
+      },
+    ])
+    expect(acceptInvitation).toHaveBeenCalledWith({invitation_id: 113})
+    expect(starRepoForAuthenticatedUser).toHaveBeenCalledWith({owner: 'private-owner', repo: 'flipped-repo'})
+    expect(createWorkflowDispatch).not.toHaveBeenCalled()
+    expect(commitMetadata).toHaveBeenCalledOnce()
+    expect(commitMetadata.mock.calls[0]?.[0].message).toBe('chore(metadata): accept invitation R_kgDOFLIPPED')
+    const mutator = commitMetadata.mock.calls[0]?.[0].mutator
+    expect(typeof mutator).toBe('function')
+    if (typeof mutator === 'function') {
+      const newReposFile = mutator({version: 1, repos: []})
+      assertReposFile(newReposFile)
+      expect(newReposFile.repos[0]).toMatchObject({
+        owner: '[REDACTED]',
+        name: 'R_kgDOFLIPPED',
+        private: true,
+        node_id: 'R_kgDOFLIPPED',
+      })
+      expect(JSON.stringify(newReposFile)).not.toContain('private-owner')
+      expect(JSON.stringify(newReposFile)).not.toContain('flipped-repo')
+    }
+    expect(JSON.stringify(result)).not.toContain('private-owner')
+    expect(JSON.stringify(result)).not.toContain('flipped-repo')
+  })
+
+  it('fails public invitations that are missing node_id before accepting them', async () => {
+    const acceptInvitation = vi.fn(async () => undefined)
+    const commitMetadata = vi.fn<CommitMetadataMock>(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
+    const octokit = mockOctokit({
+      listInvitationsForAuthenticatedUser: async () => ({
+        data: [
+          {
+            id: 112,
+            inviter: {login: 'marcusrbrown'},
+            repository: {
+              name: 'public-repo',
+              private: false,
+              owner: {login: 'fro-bot'},
+            },
+          },
+        ],
+      }),
+      acceptInvitationForAuthenticatedUser: acceptInvitation,
+    })
+
+    const result = await handleInvitations({
+      octokit,
+      allowlistPath: 'metadata/allowlist.yaml',
+      reposPath: 'metadata/repos.yaml',
+      now: new Date('2026-04-16T12:00:00.000Z'),
+      workflowFile: 'survey.yaml',
+      workflowRef: 'main',
+      commitMetadata,
+      bootstrapDataBranch: vi.fn(async () => ({})),
+      readMetadata: readTestMetadata,
+    })
+
+    expect(result.processed).toEqual([
+      {
+        invitationId: 112,
+        inviter: 'marcusrbrown',
+        owner: 'fro-bot',
+        repo: 'public-repo',
+        status: 'failed',
+        errorCode: 'API_ERROR',
+        message: 'Invitation repository.node_id is required',
+      },
+    ])
+    expect(acceptInvitation).not.toHaveBeenCalled()
+    expect(commitMetadata).not.toHaveBeenCalled()
+  })
+
+  it('accepts private invitations without writing canonical names to public surfaces', async () => {
+    const acceptInvitation = vi.fn(async () => undefined)
+    const starRepoForAuthenticatedUser = vi.fn(async () => undefined)
+    const createWorkflowDispatch = vi.fn(async () => undefined)
+    const commitMetadata = vi.fn<CommitMetadataMock>(async () => ({
+      committed: true,
+      sha: 'commit-sha',
+      attempts: 1,
+    }))
+    const octokit = mockOctokit({
+      listInvitationsForAuthenticatedUser: async () => ({
+        data: [
+          {
+            id: 107,
+            inviter: {login: 'marcusrbrown'},
+            repository: {
+              name: 'secret-repo',
+              node_id: 'R_kgDOPRIVATE',
+              private: true,
+              owner: {login: 'private-owner'},
+            },
+          },
+        ],
+      }),
+      acceptInvitationForAuthenticatedUser: acceptInvitation,
+      starRepoForAuthenticatedUser,
+      createWorkflowDispatch,
+    })
+
+    const result = await handleInvitations({
+      octokit,
+      allowlistPath: 'metadata/allowlist.yaml',
+      reposPath: 'metadata/repos.yaml',
+      now: new Date('2026-04-16T12:00:00.000Z'),
+      workflowFile: 'survey.yaml',
+      workflowRef: 'main',
+      commitMetadata,
+      bootstrapDataBranch: vi.fn(async () => ({})),
+      readMetadata: readTestMetadata,
+    })
+
+    expect(result.processed).toEqual([
+      {
+        invitationId: 107,
+        inviter: 'marcusrbrown',
+        owner: '[REDACTED]',
+        repo: 'R_kgDOPRIVATE',
+        status: 'accepted',
+      },
+    ])
+    expect(acceptInvitation).toHaveBeenCalledWith({invitation_id: 107})
+    expect(starRepoForAuthenticatedUser).toHaveBeenCalledWith({owner: 'private-owner', repo: 'secret-repo'})
+    expect(createWorkflowDispatch).not.toHaveBeenCalled()
+    expect(commitMetadata).toHaveBeenCalledOnce()
+
+    const commitCall = commitMetadata.mock.calls[0]?.[0]
+    expect(commitCall?.message).toBe('chore(metadata): accept invitation R_kgDOPRIVATE')
+    const mutator = commitCall?.mutator
+    expect(typeof mutator).toBe('function')
+    if (typeof mutator === 'function') {
+      const newReposFile = mutator({version: 1, repos: []})
+      assertReposFile(newReposFile)
+      expect(newReposFile.repos[0]).toMatchObject({
+        owner: '[REDACTED]',
+        name: 'R_kgDOPRIVATE',
+        private: true,
+        node_id: 'R_kgDOPRIVATE',
+        discovery_channel: 'collab',
+      })
+      expect(JSON.stringify(newReposFile)).not.toContain('private-owner')
+      expect(JSON.stringify(newReposFile)).not.toContain('secret-repo')
+    }
+    expect(JSON.stringify(result)).not.toContain('private-owner')
+    expect(JSON.stringify(result)).not.toContain('secret-repo')
+  })
+
+  it('redacts private invitation failure messages from downstream API calls', async () => {
+    const acceptInvitation = vi.fn(async () => undefined)
+    const starRepoForAuthenticatedUser = vi.fn(async () => {
+      throw new Error('failed to star private-owner/secret-repo')
+    })
+    const commitMetadata = vi.fn<CommitMetadataMock>(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
+    const octokit = mockOctokit({
+      listInvitationsForAuthenticatedUser: async () => ({
+        data: [
+          {
+            id: 111,
+            inviter: {login: 'marcusrbrown'},
+            repository: {
+              name: 'secret-repo',
+              node_id: 'R_kgDOPRIVATE',
+              private: true,
+              owner: {login: 'private-owner'},
+            },
+          },
+        ],
+      }),
+      acceptInvitationForAuthenticatedUser: acceptInvitation,
+      starRepoForAuthenticatedUser,
+    })
+
+    const result = await handleInvitations({
+      octokit,
+      allowlistPath: 'metadata/allowlist.yaml',
+      reposPath: 'metadata/repos.yaml',
+      now: new Date('2026-04-16T12:00:00.000Z'),
+      workflowFile: 'survey.yaml',
+      workflowRef: 'main',
+      commitMetadata,
+      bootstrapDataBranch: vi.fn(async () => ({})),
+      readMetadata: readTestMetadata,
+    })
+
+    expect(result.processed).toEqual([
+      {
+        invitationId: 111,
+        inviter: 'marcusrbrown',
+        owner: '[REDACTED]',
+        repo: 'R_kgDOPRIVATE',
+        status: 'failed',
+        errorCode: 'API_ERROR',
+        message: 'Private invitation handling failed for R_kgDOPRIVATE',
+      },
+    ])
+    expect(commitMetadata).not.toHaveBeenCalled()
+    expect(JSON.stringify(result)).not.toContain('private-owner')
+    expect(JSON.stringify(result)).not.toContain('secret-repo')
+  })
+
+  it('fails private invitations that are missing node_id before accepting them', async () => {
+    const acceptInvitation = vi.fn(async () => undefined)
+    const commitMetadata = vi.fn<CommitMetadataMock>(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
+    const octokit = mockOctokit({
+      listInvitationsForAuthenticatedUser: async () => ({
+        data: [
+          {
+            id: 108,
+            inviter: {login: 'marcusrbrown'},
+            repository: {
+              name: 'secret-repo',
+              private: true,
+              owner: {login: 'private-owner'},
+            },
+          },
+        ],
+      }),
+      acceptInvitationForAuthenticatedUser: acceptInvitation,
+    })
+
+    const result = await handleInvitations({
+      octokit,
+      allowlistPath: 'metadata/allowlist.yaml',
+      reposPath: 'metadata/repos.yaml',
+      now: new Date('2026-04-16T12:00:00.000Z'),
+      workflowFile: 'survey.yaml',
+      workflowRef: 'main',
+      commitMetadata,
+      bootstrapDataBranch: vi.fn(async () => ({})),
+      readMetadata: readTestMetadata,
+    })
+
+    expect(result.processed).toEqual([
+      {
+        invitationId: 108,
+        inviter: 'marcusrbrown',
+        owner: '[REDACTED]',
+        repo: '[REDACTED]',
+        status: 'failed',
+        errorCode: 'API_ERROR',
+        message: 'Private invitation is missing repository.node_id',
+      },
+    ])
+    expect(acceptInvitation).not.toHaveBeenCalled()
+    expect(commitMetadata).not.toHaveBeenCalled()
+    expect(JSON.stringify(result)).not.toContain('private-owner')
+    expect(JSON.stringify(result)).not.toContain('secret-repo')
+  })
+
+  it('fails invitations with malformed private fields before accepting them', async () => {
+    const acceptInvitation = vi.fn(async () => undefined)
+    const commitMetadata = vi.fn<CommitMetadataMock>(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
+    const octokit = mockOctokit({
+      listInvitationsForAuthenticatedUser: async () => ({
+        data: [
+          {
+            id: 109,
+            inviter: {login: 'marcusrbrown'},
+            repository: {
+              name: 'secret-repo',
+              node_id: 'R_kgDOPRIVATE',
+              private: 'yes',
+              owner: {login: 'private-owner'},
+            },
+          },
+        ],
+      }),
+      acceptInvitationForAuthenticatedUser: acceptInvitation,
+    })
+
+    const result = await handleInvitations({
+      octokit,
+      allowlistPath: 'metadata/allowlist.yaml',
+      reposPath: 'metadata/repos.yaml',
+      now: new Date('2026-04-16T12:00:00.000Z'),
+      workflowFile: 'survey.yaml',
+      workflowRef: 'main',
+      commitMetadata,
+      bootstrapDataBranch: vi.fn(async () => ({})),
+      readMetadata: readTestMetadata,
+    })
+
+    expect(result.processed).toEqual([
+      {
+        invitationId: 109,
+        inviter: 'marcusrbrown',
+        owner: '[REDACTED]',
+        repo: 'R_kgDOPRIVATE',
+        status: 'failed',
+        errorCode: 'API_ERROR',
+        message: 'Invitation repository.private must be boolean when present',
+      },
+    ])
+    expect(acceptInvitation).not.toHaveBeenCalled()
+    expect(commitMetadata).not.toHaveBeenCalled()
+    expect(JSON.stringify(result)).not.toContain('private-owner')
+    expect(JSON.stringify(result)).not.toContain('secret-repo')
+  })
+
+  it('redacts malformed visibility payloads without node_id', async () => {
+    const acceptInvitation = vi.fn(async () => undefined)
+    const commitMetadata = vi.fn<CommitMetadataMock>(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
+    const octokit = mockOctokit({
+      listInvitationsForAuthenticatedUser: async () => ({
+        data: [
+          {
+            id: 114,
+            inviter: {login: 'marcusrbrown'},
+            repository: {
+              name: 'secret-repo',
+              private: 'yes',
+              owner: {login: 'private-owner'},
+            },
+          },
+        ],
+      }),
+      acceptInvitationForAuthenticatedUser: acceptInvitation,
+    })
+
+    const result = await handleInvitations({
+      octokit,
+      allowlistPath: 'metadata/allowlist.yaml',
+      reposPath: 'metadata/repos.yaml',
+      now: new Date('2026-04-16T12:00:00.000Z'),
+      workflowFile: 'survey.yaml',
+      workflowRef: 'main',
+      commitMetadata,
+      bootstrapDataBranch: vi.fn(async () => ({})),
+      readMetadata: readTestMetadata,
+    })
+
+    expect(result.processed).toEqual([
+      {
+        invitationId: 114,
+        inviter: 'marcusrbrown',
+        owner: '[REDACTED]',
+        repo: '[REDACTED]',
+        status: 'failed',
+        errorCode: 'API_ERROR',
+        message: 'Invitation repository.private must be boolean when present',
+      },
+    ])
+    expect(acceptInvitation).not.toHaveBeenCalled()
+    expect(commitMetadata).not.toHaveBeenCalled()
+    expect(JSON.stringify(result)).not.toContain('private-owner')
+    expect(JSON.stringify(result)).not.toContain('secret-repo')
+  })
+
+  it('fails invitations with missing private fields before accepting them', async () => {
+    const acceptInvitation = vi.fn(async () => undefined)
+    const commitMetadata = vi.fn<CommitMetadataMock>(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
+    const octokit = mockOctokit({
+      listInvitationsForAuthenticatedUser: async () => ({
+        data: [
+          {
+            id: 110,
+            inviter: {login: 'marcusrbrown'},
+            repository: {
+              name: 'unknown-visibility',
+              node_id: 'R_kgDOUNKNOWN',
+              owner: {login: 'private-owner'},
+            },
+          },
+        ],
+      }),
+      acceptInvitationForAuthenticatedUser: acceptInvitation,
+    })
+
+    const result = await handleInvitations({
+      octokit,
+      allowlistPath: 'metadata/allowlist.yaml',
+      reposPath: 'metadata/repos.yaml',
+      now: new Date('2026-04-16T12:00:00.000Z'),
+      workflowFile: 'survey.yaml',
+      workflowRef: 'main',
+      commitMetadata,
+      bootstrapDataBranch: vi.fn(async () => ({})),
+      readMetadata: readTestMetadata,
+    })
+
+    expect(result.processed).toEqual([
+      {
+        invitationId: 110,
+        inviter: 'marcusrbrown',
+        owner: '[REDACTED]',
+        repo: 'R_kgDOUNKNOWN',
+        status: 'failed',
+        errorCode: 'API_ERROR',
+        message: 'Invitation repository.private is required',
+      },
+    ])
+    expect(acceptInvitation).not.toHaveBeenCalled()
+    expect(commitMetadata).not.toHaveBeenCalled()
+    expect(JSON.stringify(result)).not.toContain('private-owner')
+    expect(JSON.stringify(result)).not.toContain('unknown-visibility')
+  })
+
+  it('redacts missing visibility payloads without node_id', async () => {
+    const acceptInvitation = vi.fn(async () => undefined)
+    const commitMetadata = vi.fn<CommitMetadataMock>(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
+    const octokit = mockOctokit({
+      listInvitationsForAuthenticatedUser: async () => ({
+        data: [
+          {
+            id: 116,
+            inviter: {login: 'marcusrbrown'},
+            repository: {
+              name: 'unknown-visibility',
+              owner: {login: 'private-owner'},
+            },
+          },
+        ],
+      }),
+      acceptInvitationForAuthenticatedUser: acceptInvitation,
+    })
+
+    const result = await handleInvitations({
+      octokit,
+      allowlistPath: 'metadata/allowlist.yaml',
+      reposPath: 'metadata/repos.yaml',
+      now: new Date('2026-04-16T12:00:00.000Z'),
+      workflowFile: 'survey.yaml',
+      workflowRef: 'main',
+      commitMetadata,
+      bootstrapDataBranch: vi.fn(async () => ({})),
+      readMetadata: readTestMetadata,
+    })
+
+    expect(result.processed).toEqual([
+      {
+        invitationId: 116,
+        inviter: 'marcusrbrown',
+        owner: '[REDACTED]',
+        repo: '[REDACTED]',
+        status: 'failed',
+        errorCode: 'API_ERROR',
+        message: 'Invitation repository.private is required',
+      },
+    ])
+    expect(acceptInvitation).not.toHaveBeenCalled()
+    expect(commitMetadata).not.toHaveBeenCalled()
+    expect(JSON.stringify(result)).not.toContain('private-owner')
+    expect(JSON.stringify(result)).not.toContain('unknown-visibility')
   })
 
   it('skips invitations from unapproved inviters', async () => {
@@ -171,6 +667,8 @@ describe('handleInvitations', () => {
             inviter: {login: 'random-user'},
             repository: {
               name: 'unknown-repo',
+              node_id: 'R_kgDOUNKNOWNPUBLIC',
+              private: false,
               owner: {login: 'someone-else'},
             },
           },
@@ -190,16 +688,7 @@ describe('handleInvitations', () => {
       workflowRef: 'main',
       commitMetadata,
       bootstrapDataBranch: vi.fn(async () => ({})),
-      readMetadata: async (path: string) => {
-        if (path === 'metadata/allowlist.yaml') {
-          return {
-            version: 1,
-            approved_inviters: [{username: 'marcusrbrown', added: '2025-04-15', role: 'owner'}],
-          }
-        }
-
-        return {version: 1, repos: []}
-      },
+      readMetadata: readTestMetadata,
     })
 
     // #then it skips the invitation and returns a skipped result
@@ -217,6 +706,55 @@ describe('handleInvitations', () => {
     expect(commitMetadata).not.toHaveBeenCalled()
   })
 
+  it('redacts skipped private invitations from unapproved inviters', async () => {
+    const acceptInvitation = vi.fn(async () => undefined)
+    const commitMetadata = vi.fn(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
+    const octokit = mockOctokit({
+      listInvitationsForAuthenticatedUser: async () => ({
+        data: [
+          {
+            id: 115,
+            inviter: {login: 'random-user'},
+            repository: {
+              name: 'secret-repo',
+              node_id: 'R_kgDOPRIVATE',
+              private: true,
+              owner: {login: 'private-owner'},
+            },
+          },
+        ],
+      }),
+      acceptInvitationForAuthenticatedUser: acceptInvitation,
+    })
+
+    const result = await handleInvitations({
+      octokit,
+      allowlistPath: 'metadata/allowlist.yaml',
+      reposPath: 'metadata/repos.yaml',
+      now: new Date('2026-04-16T12:00:00.000Z'),
+      workflowFile: 'survey.yaml',
+      workflowRef: 'main',
+      commitMetadata,
+      bootstrapDataBranch: vi.fn(async () => ({})),
+      readMetadata: readTestMetadata,
+    })
+
+    expect(result.processed).toEqual([
+      {
+        invitationId: 115,
+        inviter: 'random-user',
+        owner: '[REDACTED]',
+        repo: 'R_kgDOPRIVATE',
+        status: 'skipped',
+        reason: 'inviter-not-allowlisted',
+      },
+    ])
+    expect(acceptInvitation).not.toHaveBeenCalled()
+    expect(commitMetadata).not.toHaveBeenCalled()
+    expect(JSON.stringify(result)).not.toContain('private-owner')
+    expect(JSON.stringify(result)).not.toContain('secret-repo')
+  })
+
   it('continues processing when one invitation fails', async () => {
     const acceptInvitation = vi
       .fn<(params: {invitation_id: number}) => Promise<void>>()
@@ -231,12 +769,12 @@ describe('handleInvitations', () => {
           {
             id: 103,
             inviter: {login: 'marcusrbrown'},
-            repository: {name: 'broken-repo', owner: {login: 'fro-bot'}},
+            repository: {name: 'broken-repo', node_id: 'R_kgDOBROKEN', private: false, owner: {login: 'fro-bot'}},
           },
           {
             id: 104,
             inviter: {login: 'marcusrbrown'},
-            repository: {name: 'healthy-repo', owner: {login: 'fro-bot'}},
+            repository: {name: 'healthy-repo', node_id: 'R_kgDOHEALTHY', private: false, owner: {login: 'fro-bot'}},
           },
         ],
       }),
@@ -255,16 +793,7 @@ describe('handleInvitations', () => {
       workflowFile: 'survey.yaml',
       workflowRef: 'main',
       commitMetadata,
-      readMetadata: async (path: string) => {
-        if (path === 'metadata/allowlist.yaml') {
-          return {
-            version: 1,
-            approved_inviters: [{username: 'marcusrbrown', added: '2025-04-15', role: 'owner'}],
-          }
-        }
-
-        return {version: 1, repos: []}
-      },
+      readMetadata: readTestMetadata,
     })
 
     // #then other invitations still complete successfully
@@ -295,7 +824,12 @@ describe('handleInvitations', () => {
           {
             id: 105,
             inviter: {login: 'marcusrbrown'},
-            repository: {name: 'already-accepted', owner: {login: 'fro-bot'}},
+            repository: {
+              name: 'already-accepted',
+              node_id: 'R_kgDOACCEPTED',
+              private: false,
+              owner: {login: 'fro-bot'},
+            },
           },
         ],
       }),
@@ -314,16 +848,7 @@ describe('handleInvitations', () => {
       workflowFile: 'survey.yaml',
       workflowRef: 'main',
       commitMetadata,
-      readMetadata: async (path: string) => {
-        if (path === 'metadata/allowlist.yaml') {
-          return {
-            version: 1,
-            approved_inviters: [{username: 'marcusrbrown', added: '2025-04-15', role: 'owner'}],
-          }
-        }
-
-        return {version: 1, repos: []}
-      },
+      readMetadata: readTestMetadata,
     })
 
     // #then it treats the invite as successful instead of erroring
@@ -357,16 +882,7 @@ describe('handleInvitations', () => {
       workflowFile: 'survey.yaml',
       workflowRef: 'main',
       commitMetadata: vi.fn(async () => ({committed: true, sha: 'commit-sha', attempts: 1})),
-      readMetadata: async (path: string) => {
-        if (path === 'metadata/allowlist.yaml') {
-          return {
-            version: 1,
-            approved_inviters: [{username: 'marcusrbrown', added: '2025-04-15', role: 'owner'}],
-          }
-        }
-
-        return {version: 1, repos: []}
-      },
+      readMetadata: readTestMetadata,
     }).catch((error: unknown) => error)
 
     // #then it surfaces a structured error with remediation
@@ -385,7 +901,7 @@ describe('handleInvitations', () => {
             id: 106,
             // GitHub returns inviter: null when the inviting user's account has been deleted.
             inviter: null as unknown as {login: string},
-            repository: {name: 'orphaned-repo', owner: {login: 'fro-bot'}},
+            repository: {name: 'orphaned-repo', node_id: 'R_kgDOORPHANED', private: false, owner: {login: 'fro-bot'}},
           },
         ],
       }),
@@ -403,16 +919,7 @@ describe('handleInvitations', () => {
       workflowRef: 'main',
       commitMetadata,
       bootstrapDataBranch: vi.fn(async () => ({})),
-      readMetadata: async (path: string) => {
-        if (path === 'metadata/allowlist.yaml') {
-          return {
-            version: 1,
-            approved_inviters: [{username: 'marcusrbrown', added: '2025-04-15', role: 'owner'}],
-          }
-        }
-
-        return {version: 1, repos: []}
-      },
+      readMetadata: readTestMetadata,
     })
 
     // #then it skips the invitation with inviter-unknown instead of throwing
@@ -446,20 +953,41 @@ describe('handleInvitations', () => {
       workflowFile: 'survey.yaml',
       workflowRef: 'main',
       commitMetadata,
-      readMetadata: async (path: string) => {
-        if (path === 'metadata/allowlist.yaml') {
-          return {
-            version: 1,
-            approved_inviters: [{username: 'marcusrbrown', added: '2025-04-15', role: 'owner'}],
-          }
-        }
-
-        return {version: 1, repos: []}
-      },
+      readMetadata: readTestMetadata,
     })
 
     // #then it becomes a no-op
     expect(result).toEqual({processed: []})
     expect(commitMetadata).not.toHaveBeenCalled()
+  })
+})
+
+describe('countPublicAcceptedInvitations', () => {
+  it('excludes private accepted invitations from public notification counts', () => {
+    expect(
+      countPublicAcceptedInvitations([
+        {invitationId: 1, inviter: 'marcusrbrown', owner: 'fro-bot', repo: 'public-repo', status: 'accepted'},
+        {invitationId: 2, inviter: 'marcusrbrown', owner: '[REDACTED]', repo: 'R_kgDOPRIVATE', status: 'accepted'},
+        {
+          invitationId: 3,
+          inviter: 'marcusrbrown',
+          owner: 'fro-bot',
+          repo: 'skipped-repo',
+          status: 'skipped',
+          reason: 'inviter-not-allowlisted',
+        },
+      ]),
+    ).toBe(1)
+  })
+})
+
+describe('formatInvitationGithubOutput', () => {
+  it('writes an explicit public invitation count output', () => {
+    expect(
+      formatInvitationGithubOutput([
+        {invitationId: 1, inviter: 'marcusrbrown', owner: 'fro-bot', repo: 'public-repo', status: 'accepted'},
+        {invitationId: 2, inviter: 'marcusrbrown', owner: '[REDACTED]', repo: 'R_kgDOPRIVATE', status: 'accepted'},
+      ]),
+    ).toBe('public_invitations_accepted=1\n')
   })
 })

--- a/scripts/handle-invitation.ts
+++ b/scripts/handle-invitation.ts
@@ -30,6 +30,8 @@ export interface RepositoryInvitation {
   } | null
   repository: {
     name: string
+    node_id?: unknown
+    private?: unknown
     owner: {
       login: string
     }
@@ -99,6 +101,8 @@ export type InvitationHandlingErrorCode =
   | 'RATE_LIMITED'
   | 'TRANSIENT_FAILURE'
   | 'API_ERROR'
+
+const REDACTED_OWNER = '[REDACTED]'
 
 export class InvitationHandlingError extends Error {
   readonly code: InvitationHandlingErrorCode
@@ -175,6 +179,8 @@ async function processInvitation(params: {
   const inviter = params.invitation.inviter?.login ?? null
   const repoOwner = params.invitation.repository.owner.login
   const repoName = params.invitation.repository.name
+  const repoPrivacy = invitationRepositoryPrivacy(params.invitation)
+  let displayTarget = invitationDisplayTarget(repoPrivacy, repoOwner, repoName)
 
   // Skip invitations where GitHub has nulled the inviter (deleted account). We can't allowlist-check
   // an unknown inviter, so treat it as a skip rather than failing the whole poll.
@@ -182,8 +188,8 @@ async function processInvitation(params: {
     return {
       invitationId: params.invitation.id,
       inviter: null,
-      owner: repoOwner,
-      repo: repoName,
+      owner: displayTarget.owner,
+      repo: displayTarget.repo,
       status: 'skipped',
       reason: 'inviter-unknown',
     }
@@ -193,51 +199,220 @@ async function processInvitation(params: {
     return {
       invitationId: params.invitation.id,
       inviter,
-      owner: repoOwner,
-      repo: repoName,
+      owner: displayTarget.owner,
+      repo: displayTarget.repo,
       status: 'skipped',
       reason: 'inviter-not-allowlisted',
     }
   }
 
   try {
+    if (repoPrivacy.kind === 'private-without-node') {
+      throw new Error('Private invitation is missing repository.node_id')
+    }
+    if (repoPrivacy.kind === 'malformed') {
+      throw new Error('Invitation repository.private must be boolean when present')
+    }
+    if (repoPrivacy.kind === 'missing-private') {
+      throw new Error('Invitation repository.private is required')
+    }
+    if (repoPrivacy.kind === 'missing-node') {
+      throw new Error('Invitation repository.node_id is required')
+    }
+    if (repoPrivacy.kind !== 'public' && repoPrivacy.kind !== 'private') {
+      throw new Error('Invitation repository privacy is not usable')
+    }
+
     await acceptInvitation(params.octokit, params.invitation.id)
+    const acceptedPrivacy = await acceptedInvitationRepositoryPrivacy(params.octokit, repoOwner, repoName, repoPrivacy)
+    displayTarget = invitationDisplayTarget(acceptedPrivacy, repoOwner, repoName)
     await params.octokit.rest.activity.starRepoForAuthenticatedUser({owner: repoOwner, repo: repoName})
+    const entryInput = {
+      owner: repoOwner,
+      repo: repoName,
+      now: params.now,
+      discovery_channel: 'collab' as const,
+      ...(acceptedPrivacy.kind === 'private'
+        ? {private: true, node_id: acceptedPrivacy.nodeId}
+        : {private: false, node_id: acceptedPrivacy.nodeId}),
+    }
     await params.commitMetadata({
       octokit: params.octokit,
       path: params.reposPath,
-      message: `chore(metadata): add ${repoOwner}/${repoName} from invitation polling`,
-      mutator: current =>
-        addRepoEntry(current, {owner: repoOwner, repo: repoName, now: params.now, discovery_channel: 'collab'}),
+      message: invitationCommitMessage(displayTarget),
+      mutator: current => addRepoEntry(current, entryInput),
     })
-    await params.octokit.rest.actions.createWorkflowDispatch({
-      owner: params.owner,
-      repo: params.repo,
-      workflow_id: params.workflowFile,
-      ref: params.workflowRef,
-      inputs: {owner: repoOwner, repo: repoName},
-    })
+    if (acceptedPrivacy.kind !== 'private') {
+      await params.octokit.rest.actions.createWorkflowDispatch({
+        owner: params.owner,
+        repo: params.repo,
+        workflow_id: params.workflowFile,
+        ref: params.workflowRef,
+        inputs: {owner: repoOwner, repo: repoName},
+      })
+    }
 
     return {
       invitationId: params.invitation.id,
       inviter,
-      owner: repoOwner,
-      repo: repoName,
+      owner: displayTarget.owner,
+      repo: displayTarget.repo,
       status: 'accepted',
     }
   } catch (error: unknown) {
     const normalized = normalizePerInvitationError(error)
+    const message =
+      displayTarget.owner === REDACTED_OWNER
+        ? sanitizePrivateInvitationError(normalized.message, displayTarget.repo)
+        : normalized.message
 
     return {
       invitationId: params.invitation.id,
       inviter,
-      owner: repoOwner,
-      repo: repoName,
+      owner: displayTarget.owner,
+      repo: displayTarget.repo,
       status: 'failed',
       errorCode: normalized.code,
-      message: normalized.message,
+      message,
     }
   }
+}
+
+async function acceptedInvitationRepositoryPrivacy(
+  octokit: OctokitClient,
+  owner: string,
+  repo: string,
+  invitationPrivacy: PublicInvitationRepositoryPrivacy | PrivateInvitationRepositoryPrivacy,
+): Promise<PublicInvitationRepositoryPrivacy | PrivateInvitationRepositoryPrivacy> {
+  if (invitationPrivacy.kind === 'private') {
+    return invitationPrivacy
+  }
+
+  try {
+    const response = await octokit.rest.repos.get({owner, repo})
+    const privateFlag = response.data.private
+    const nodeId =
+      typeof response.data.node_id === 'string' && response.data.node_id !== ''
+        ? response.data.node_id
+        : invitationPrivacy.nodeId
+
+    if (privateFlag === false) {
+      return {kind: 'public', nodeId: invitationPrivacy.nodeId}
+    }
+
+    return {kind: 'private', nodeId}
+  } catch {
+    return {kind: 'private', nodeId: invitationPrivacy.nodeId}
+  }
+}
+
+interface PublicInvitationRepositoryPrivacy {
+  kind: 'public'
+  nodeId: string
+}
+
+interface PrivateInvitationRepositoryPrivacy {
+  kind: 'private'
+  nodeId: string
+}
+
+interface PrivateWithoutNodeInvitationRepositoryPrivacy {
+  kind: 'private-without-node'
+}
+
+interface MissingNodeInvitationRepositoryPrivacy {
+  kind: 'missing-node'
+}
+
+type InvitationRepositoryPrivacy =
+  | PublicInvitationRepositoryPrivacy
+  | PrivateInvitationRepositoryPrivacy
+  | PrivateWithoutNodeInvitationRepositoryPrivacy
+  | MissingNodeInvitationRepositoryPrivacy
+
+interface MalformedInvitationRepositoryPrivacy {
+  kind: 'malformed' | 'missing-private'
+  nodeId?: string
+}
+
+function invitationRepositoryPrivacy(
+  invitation: RepositoryInvitation,
+): InvitationRepositoryPrivacy | MalformedInvitationRepositoryPrivacy {
+  if (invitation.repository.private !== undefined && typeof invitation.repository.private !== 'boolean') {
+    return {
+      kind: 'malformed',
+      ...(typeof invitation.repository.node_id === 'string' && invitation.repository.node_id !== ''
+        ? {nodeId: invitation.repository.node_id}
+        : {}),
+    }
+  }
+
+  if (invitation.repository.private === undefined) {
+    return {
+      kind: 'missing-private',
+      ...(typeof invitation.repository.node_id === 'string' && invitation.repository.node_id !== ''
+        ? {nodeId: invitation.repository.node_id}
+        : {}),
+    }
+  }
+
+  const nodeId = invitation.repository.node_id
+  if (typeof nodeId !== 'string' || nodeId === '') {
+    return invitation.repository.private === true ? {kind: 'private-without-node'} : {kind: 'missing-node'}
+  }
+
+  if (invitation.repository.private !== true) {
+    return {kind: 'public', nodeId}
+  }
+
+  return {kind: 'private', nodeId}
+}
+
+function invitationDisplayTarget(
+  privacy: InvitationRepositoryPrivacy | MalformedInvitationRepositoryPrivacy,
+  owner: string,
+  repo: string,
+): {owner: string; repo: string} {
+  if (privacy.kind === 'private') {
+    return {owner: REDACTED_OWNER, repo: privacy.nodeId}
+  }
+  if (privacy.kind === 'private-without-node' || privacy.kind === 'malformed' || privacy.kind === 'missing-private') {
+    return {
+      owner: REDACTED_OWNER,
+      repo:
+        (privacy.kind === 'malformed' || privacy.kind === 'missing-private') && privacy.nodeId !== undefined
+          ? privacy.nodeId
+          : REDACTED_OWNER,
+    }
+  }
+  return {owner, repo}
+}
+
+function invitationCommitMessage(target: {owner: string; repo: string}): string {
+  if (target.owner === REDACTED_OWNER) {
+    return `chore(metadata): accept invitation ${target.repo}`
+  }
+  return `chore(metadata): add ${target.owner}/${target.repo} from invitation polling`
+}
+
+export function countPublicAcceptedInvitations(processed: readonly InvitationProcessResult[]): number {
+  return processed.filter(result => result.status === 'accepted' && result.owner !== REDACTED_OWNER).length
+}
+
+export function formatInvitationGithubOutput(processed: readonly InvitationProcessResult[]): string {
+  return `public_invitations_accepted=${countPublicAcceptedInvitations(processed)}\n`
+}
+
+function sanitizePrivateInvitationError(message: string, nodeIdOrRedacted: string): string {
+  if (
+    message === 'Private invitation is missing repository.node_id' ||
+    message === 'Invitation repository.private must be boolean when present' ||
+    message === 'Invitation repository.private is required'
+  ) {
+    return message
+  }
+
+  return `Private invitation handling failed for ${nodeIdOrRedacted}`
 }
 
 async function pollInvitations(octokit: OctokitClient): Promise<RepositoryInvitation[]> {
@@ -404,10 +579,9 @@ async function main(): Promise<void> {
   const result = await handleInvitations()
   process.stdout.write(`${JSON.stringify(result)}\n`)
 
-  const accepted = result.processed.filter(p => p.status === 'accepted').length
   const githubOutput = process.env.GITHUB_OUTPUT
   if (githubOutput !== undefined && githubOutput !== '') {
-    appendFileSync(githubOutput, `invitations_accepted=${accepted}\n`)
+    appendFileSync(githubOutput, formatInvitationGithubOutput(result.processed))
   }
 }
 


### PR DESCRIPTION
## Summary

- Redacts private repository invitations before writing metadata, commit subjects, or workflow outputs.
- Rechecks repository visibility after accepting an invitation and treats anything not definitively public as private.
- Replaces the invitation notification output with `public_invitations_accepted` so private accepts do not trigger public social posts.
- Updates the private-repo handling plan status and adds regression coverage for privacy edge cases.

## Verification

- `pnpm test scripts/handle-invitation.test.ts scripts/record-survey-result.test.ts scripts/reset-survey-status.test.ts scripts/repos-metadata.test.ts`
- `pnpm bootstrap`
- `pnpm check-types`
- `pnpm lint`
- `pnpm test`
