### PR TITLE
fix(privacy): gate private survey dispatches

### DIFF
--- a/docs/plans/2026-05-05-002-feat-private-repo-handling-plan.md
+++ b/docs/plans/2026-05-05-002-feat-private-repo-handling-plan.md
@@ -506,9 +506,9 @@ persona/
 - Modify: `scripts/reconcile-repos.test.ts`
 
 **Approach:**
-- In `classifyTracked`: privacy gate runs FIRST. If `entry.private !== false`, skip and increment `summary.skippedPrivate`. The eligibility gate (cadence) runs only on entries that passed the privacy gate.
+- In `classifyTracked`: compute survey eligibility first, then skip and increment `summary.skippedPrivate` only when an otherwise-dispatchable repo is not definitively public in both stored metadata and the live access list.
 - Skipped entries do NOT update `last_survey_at` or `last_survey_status`
-- `summary.skippedPrivate` is exposed in JSON output; commit messages may include the count (`+N skipped private`) but never names
+- `summary.skippedPrivate` is exposed in JSON output only; public commit messages do not include skipped-private counts or names
 
 **Patterns to follow:**
 - Existing `summary.unchanged`, `summary.dispatched` counters
@@ -521,7 +521,7 @@ persona/
 - Edge case: 13 onboarded public repos + 1 private repo with cap=12 → 12 public dispatched; private skipped (proves no displacement)
 - Edge case: gate ordering — private repo with `next_survey_eligible_at` in the past (eligible) is still skipped (privacy first)
 - Happy path: all entries public → `summary.skippedPrivate: 0`; commit message omits the counter
-- Happy path: at least one private skip → commit message includes `+N skipped private`; no names
+- Edge case: at least one private skip → JSON output includes `summary.skippedPrivate`; commit message still omits the counter
 
 **Verification:**
 - New tests pass

--- a/docs/plans/2026-05-05-002-feat-private-repo-handling-plan.md
+++ b/docs/plans/2026-05-05-002-feat-private-repo-handling-plan.md
@@ -493,7 +493,7 @@ persona/
 
 ---
 
-- [ ] **Unit 5: Reconcile dispatch gate (defense in depth, ordered)**
+- [x] **Unit 5: Reconcile dispatch gate (defense in depth, ordered)**
 
 **Goal:** Reconcile skips Survey Repo dispatch for entries where `private !== false`. Skip happens inside `classifyTracked` BEFORE the eligibility gate (cadence Unit 2). `summary.skippedPrivate` aggregate counter; no per-repo names in any public surface.
 

--- a/docs/solutions/security-issues/private-repo-dispatch-visibility-gate-2026-05-08.md
+++ b/docs/solutions/security-issues/private-repo-dispatch-visibility-gate-2026-05-08.md
@@ -1,0 +1,134 @@
+---
+title: Private repo dispatch requires definitive public visibility
+category: security-issues
+problem_type: security_issue
+component: tooling
+root_cause: missing_validation
+resolution_type: code_fix
+severity: high
+date: 2026-05-08
+last_updated: 2026-05-08
+module: scripts/reconcile-repos.ts
+related_components:
+  - development_workflow
+  - testing_framework
+tags:
+  - privacy
+  - private-repos
+  - workflow-dispatch
+  - reconcile
+  - redaction
+  - node-id
+  - fail-closed
+verified: true
+symptoms:
+  - Survey dispatch planning could include canonical owner/name for private, unknown, or visibility-conflicting repos.
+  - Duplicate access-list rows sharing a node_id could allow a public-looking alias to dispatch before private visibility was considered.
+  - Stored-public/live-private entries needed redaction and dispatch suppression in the same reconcile pass.
+  - Internal skipped-private counters risked becoming a public commit-message side channel.
+---
+
+## Problem
+
+Survey dispatch planning needs the same privacy boundary as metadata storage: private repo identities must never appear in public workflow inputs, commit subjects, issues, or logs.
+
+The dangerous shape is a repo that looks public in one source but private or unknown in another. If dispatch planning trusts the public-looking source, it can send canonical `owner`/`repo` values through `workflow_dispatch` before redaction catches up.
+
+## Symptoms
+
+- Private access-list entries are redacted in metadata, but edge dispatch paths can still use canonical `owner`/`repo`.
+- Missing or malformed `private` fields can be treated as public by boolean coercion.
+- Duplicate access-list rows with the same `node_id` can make dispatch behavior depend on row ordering.
+- Stored-public entries that become live-private can dispatch before the field-refresh path redacts them.
+- Aggregate private-skip counts are safe in internal JSON, but unsafe in public commit subjects.
+
+## What Didn't Work
+
+- **Checking only `access.private === true`** fails open for `undefined`, `null`, malformed, or conflicting privacy data.
+- **Trusting stored metadata alone** misses same-run visibility flips from public to private.
+- **Trusting one access-list row at a time** misses duplicate aliases for the same GitHub repo identity.
+- **Counting all private tracked repos as skipped dispatches** makes operational summaries noisy; only repos that would otherwise dispatch should increment the counter.
+- **Putting aggregate private counts in public commit messages** creates a side channel about private repo activity.
+
+## Solution
+
+Make dispatch opt-in to public visibility. A repo can dispatch only when stored metadata and the live access-list state are both definitively public.
+
+The reconcile engine now builds a node-level privacy index across the whole access list:
+
+```ts
+const accessNodePrivacy = indexAccessNodePrivacy(accessList)
+```
+
+The index treats anything not explicitly public as non-public, and duplicate `node_id` rows as unsafe:
+
+```ts
+function accessPrivateForStorage(access: AccessListEntry, accessNodePrivacy: Map<string, AccessNodePrivacy>): boolean {
+  const nodePrivacy = accessNodePrivacy.get(access.node_id)
+  return access.private !== false || nodePrivacy?.hasNonPublic === true || (nodePrivacy?.count ?? 0) > 1
+}
+```
+
+Newcomers and regained entries use that derived privacy state before writing metadata or queueing dispatches:
+
+```ts
+const accessPrivate = accessPrivateForStorage(access, accessNodePrivacy)
+
+next = addRepoEntry(next, {
+  owner: access.owner,
+  repo: access.name,
+  private: accessPrivate,
+  node_id: access.node_id,
+  now,
+})
+
+if (accessPrivate) {
+  summary.skippedPrivate += 1
+} else {
+  dispatches.push({owner: access.owner, repo: access.name})
+}
+```
+
+Tracked entries compute survey eligibility separately, then apply the privacy gate only to repos that would otherwise dispatch:
+
+```ts
+const wouldDispatchIfPublic =
+  (entry.onboarding_status === 'onboarded' && isEligibleForSurvey(entry.next_survey_eligible_at, params.now)) ||
+  (entry.onboarding_status === 'pending' &&
+    (entry.last_survey_status !== 'success' || isEligibleForSurvey(entry.next_survey_eligible_at, params.now)))
+
+if (wouldDispatchIfPublic && (entry.private !== false || accessPrivate)) {
+  summary.skippedPrivate += 1
+} else if (wouldDispatchIfPublic) {
+  dispatches.push({owner: access.owner, repo: access.name})
+}
+```
+
+`summary.skippedPrivate` remains available in internal JSON output, but `formatCommitMessage` intentionally omits it so public commit subjects do not reveal private activity.
+
+## Why This Works
+
+The invariant changes from “dispatch unless known private” to “dispatch only when definitively public.” That closes the leak window for missing data, stale stored metadata, duplicate aliases, and same-run visibility flips.
+
+The `node_id` privacy index makes privacy a property of the GitHub repository identity, not whichever access-list row happens to be processed first. Requiring both stored and live public visibility prevents canonical dispatch inputs from racing ahead of redaction.
+
+## Prevention
+
+Keep these regressions in place around any future reconcile dispatch changes:
+
+- Duplicate `node_id` aliases in both row orders must not dispatch if any alias is non-public.
+- Missing `private` on an access-list entry must fail closed.
+- Stored-public/live-private entries must redact and skip in the same pass.
+- Regained lost-access entries dispatch only when live visibility is explicitly public.
+- Private entries that are not survey-eligible must not inflate `summary.skippedPrivate`.
+- Public commit subjects must not include private-skip counts.
+
+Review any future `workflow_dispatch` inputs as public artifacts. If an input would be unsafe in a GitHub Actions run page, it must be redacted or replaced with an opaque identifier before dispatch.
+
+## Related Issues
+
+- PR: https://github.com/fro-bot/.github/pull/3265
+- Related: `docs/solutions/best-practices/loose-then-tight-schema-migration-pattern-2026-05-05.md`
+- Related: `docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md`
+- Related: `docs/solutions/integration-issues/wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md`
+- Related: `docs/solutions/workflow-issues/github-actions-step-output-interpolation-2026-04-21.md`

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -120,6 +120,7 @@ describe('reconcileRepos', () => {
         migrated: 0,
         transient: 0,
         malformed: 0,
+        skippedPrivate: 0,
         unchanged: 0,
         // dispatched/deferred populated by the I/O shell, not the engine
         byChannel: {
@@ -180,6 +181,82 @@ describe('reconcileRepos', () => {
       expect(JSON.stringify(result.nextRepos)).not.toContain('secret-repo')
       expect(result.dispatches).toEqual([])
       expect(result.summary.added).toBe(1)
+    })
+
+    it('does not dispatch a duplicate public alias for a private node_id seen earlier in the same pass', () => {
+      const result = reconcileRepos(
+        makeInput({
+          accessList: [
+            makeAccess({owner: 'private-owner', name: 'secret-repo', node_id: 'R_duplicate_private', private: true}),
+            makeAccess({owner: 'marcusrbrown', name: 'public-alias', node_id: 'R_duplicate_private', private: false}),
+          ],
+          allowlist: makeAllowlist(['private-owner', 'marcusrbrown']),
+        }),
+      )
+
+      expect(result.dispatches).toEqual([])
+      expect(result.summary.added).toBe(1)
+      expect(result.summary.skippedPrivate).toBe(1)
+      expect(result.nextRepos.repos).toEqual([
+        expect.objectContaining({
+          owner: '[REDACTED]',
+          name: 'R_duplicate_private',
+          private: true,
+          node_id: 'R_duplicate_private',
+        }),
+      ])
+    })
+
+    it('does not dispatch a duplicate public alias before a later private row for the same node_id', () => {
+      const result = reconcileRepos(
+        makeInput({
+          accessList: [
+            makeAccess({owner: 'marcusrbrown', name: 'public-alias', node_id: 'R_public_first', private: false}),
+            makeAccess({owner: 'private-owner', name: 'secret-repo', node_id: 'R_public_first', private: true}),
+          ],
+          allowlist: makeAllowlist(['marcusrbrown', 'private-owner']),
+        }),
+      )
+
+      expect(result.dispatches).toEqual([])
+      expect(result.summary.added).toBe(1)
+      expect(result.summary.skippedPrivate).toBe(1)
+      expect(result.nextRepos.repos).toEqual([
+        expect.objectContaining({
+          owner: '[REDACTED]',
+          name: 'R_public_first',
+          private: true,
+          node_id: 'R_public_first',
+        }),
+      ])
+    })
+
+    it('treats a newcomer with missing privacy as private before dispatching', () => {
+      const access = {
+        owner: 'marcusrbrown',
+        name: 'unknown-privacy',
+        archived: false,
+        node_id: 'R_missing_private',
+      } as unknown as AccessListEntry
+
+      const result = reconcileRepos(
+        makeInput({
+          accessList: [access],
+          allowlist: makeAllowlist(['marcusrbrown']),
+        }),
+      )
+
+      expect(result.dispatches).toEqual([])
+      expect(result.summary.added).toBe(1)
+      expect(result.summary.skippedPrivate).toBe(1)
+      expect(result.nextRepos.repos).toEqual([
+        expect.objectContaining({
+          owner: '[REDACTED]',
+          name: 'R_missing_private',
+          private: true,
+          node_id: 'R_missing_private',
+        }),
+      ])
     })
 
     it('redacts an existing canonical entry when access-list visibility flips private', () => {
@@ -272,6 +349,30 @@ describe('reconcileRepos', () => {
       })
       expect(result.dispatches).toEqual([])
       expect(result.summary.regained).toBe(1)
+      expect(result.summary.skippedPrivate).toBe(1)
+    })
+
+    it('dispatches a regained repo when the live access list proves it is public again', () => {
+      const tracked = makeEntry({
+        owner: 'fro-bot',
+        name: 'back-again',
+        private: true,
+        node_id: 'R_public_again',
+        onboarding_status: 'lost-access',
+      })
+
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [tracked]},
+          accessList: [makeAccess({name: 'back-again', node_id: 'R_public_again', private: false})],
+          allowlist: makeAllowlist(['fro-bot']),
+          accessChannelByKey: new Map([['fro-bot/back-again', 'owned']]),
+        }),
+      )
+
+      expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'back-again'}])
+      expect(result.summary.regained).toBe(1)
+      expect(result.summary.skippedPrivate).toBe(0)
     })
 
     it('fail-closes a redacted private tracked entry missing from the access list', () => {
@@ -618,6 +719,8 @@ describe('reconcileRepos', () => {
       const entry = makeEntry({
         name: 'returned-repo',
         onboarding_status: 'lost-access',
+        private: false,
+        node_id: 'R_default',
         last_survey_at: '2026-01-10',
         last_survey_status: 'success',
         has_fro_bot_workflow: true,
@@ -1070,6 +1173,8 @@ describe('reconcileRepos', () => {
       const drift = makeEntry({
         name: 'drift-repo',
         onboarding_status: 'onboarded',
+        private: false,
+        node_id: 'R_default',
         has_renovate: false,
         last_survey_at: '2026-04-10',
         last_survey_status: 'success',
@@ -1113,6 +1218,7 @@ describe('reconcileRepos', () => {
         migrated: 0,
         transient: 0,
         malformed: 0,
+        skippedPrivate: 0,
         unchanged: 0,
         // dispatched/deferred populated by the I/O shell, not the engine
         byChannel: {
@@ -1153,6 +1259,7 @@ describe('reconcileRepos', () => {
         migrated: 0,
         transient: 0,
         malformed: 0,
+        skippedPrivate: 0,
         unchanged: 1,
         byChannel: {
           collab: {tracked: 1, dispatched: 0, deferred: 0, lostAccess: 0},
@@ -1177,6 +1284,7 @@ describe('reconcileRepos', () => {
         migrated: 0,
         transient: 0,
         malformed: 0,
+        skippedPrivate: 0,
         unchanged: 0,
         byChannel: emptyChannelStats(),
       })
@@ -1261,6 +1369,8 @@ describe('reconcileRepos', () => {
       const entry = makeEntry({
         name: 'never-surveyed',
         onboarding_status: 'pending',
+        private: false,
+        node_id: 'R_default',
         last_survey_at: null,
         last_survey_status: null,
       })
@@ -1279,6 +1389,8 @@ describe('reconcileRepos', () => {
       const entry = makeEntry({
         name: 'failed-initial',
         onboarding_status: 'pending',
+        private: false,
+        node_id: 'R_default',
         last_survey_at: '2026-04-19',
         last_survey_status: 'failure',
       })
@@ -1341,6 +1453,8 @@ describe('reconcileRepos', () => {
       const entry = makeEntry({
         name: 'overdue-repo',
         onboarding_status: 'onboarded',
+        private: false,
+        node_id: 'R_default',
         last_survey_at: '2026-03-01',
         last_survey_status: 'success',
         next_survey_eligible_at: '2026-04-03',
@@ -1353,6 +1467,113 @@ describe('reconcileRepos', () => {
       )
       // #then the entry is dispatched (eligibility passed)
       expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'overdue-repo'}])
+    })
+
+    it('skips an eligible private tracked entry before the survey eligibility gate', () => {
+      const entry = makeEntry({
+        owner: '[REDACTED]',
+        name: 'R_private',
+        private: true,
+        node_id: 'R_private',
+        onboarding_status: 'onboarded',
+        last_survey_at: '2026-02-01',
+        last_survey_status: 'success',
+        next_survey_eligible_at: '2026-04-01',
+      })
+
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({owner: 'private-owner', name: 'secret-repo', node_id: 'R_private', private: true})],
+        }),
+      )
+
+      expect(result.dispatches).toEqual([])
+      expect(result.summary.skippedPrivate).toBe(1)
+      expect(result.nextRepos.repos[0]).toMatchObject({
+        last_survey_at: '2026-02-01',
+        last_survey_status: 'success',
+      })
+      expect(JSON.stringify(result)).not.toContain('private-owner')
+      expect(JSON.stringify(result)).not.toContain('secret-repo')
+    })
+
+    it('skips an eligible stored-public entry when the live access list reports private', () => {
+      const entry = makeEntry({
+        name: 'visibility-flipped',
+        private: false,
+        node_id: 'R_visibility_flipped',
+        onboarding_status: 'onboarded',
+        last_survey_at: '2026-02-01',
+        last_survey_status: 'success',
+        next_survey_eligible_at: '2026-04-01',
+      })
+
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({name: 'visibility-flipped', node_id: 'R_visibility_flipped', private: true})],
+        }),
+      )
+
+      expect(result.dispatches).toEqual([])
+      expect(result.summary.skippedPrivate).toBe(1)
+      expect(result.nextRepos.repos[0]).toMatchObject({
+        owner: '[REDACTED]',
+        name: 'R_visibility_flipped',
+        private: true,
+        node_id: 'R_visibility_flipped',
+      })
+    })
+
+    it('does not count private tracked entries that are not survey-eligible as skipped dispatches', () => {
+      const entry = makeEntry({
+        owner: '[REDACTED]',
+        name: 'R_private_fresh',
+        private: true,
+        node_id: 'R_private_fresh',
+        onboarding_status: 'onboarded',
+        last_survey_at: '2026-04-01',
+        last_survey_status: 'success',
+        next_survey_eligible_at: '2026-05-01',
+      })
+
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [
+            makeAccess({owner: 'private-owner', name: 'secret-repo', node_id: 'R_private_fresh', private: true}),
+          ],
+        }),
+      )
+
+      expect(result.dispatches).toEqual([])
+      expect(result.summary.skippedPrivate).toBe(0)
+    })
+
+    it('skips an entry with unknown privacy before refreshing it to public', () => {
+      const entry = makeEntry({
+        name: 'legacy-repo',
+        onboarding_status: 'pending',
+        last_survey_at: null,
+        last_survey_status: null,
+      })
+
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({name: 'legacy-repo', private: false, node_id: 'R_legacy'})],
+        }),
+      )
+
+      expect(result.dispatches).toEqual([])
+      expect(result.summary.skippedPrivate).toBe(1)
+      expect(result.summary.refreshed).toBe(1)
+      expect(result.nextRepos.repos[0]).toMatchObject({
+        name: 'legacy-repo',
+        private: false,
+        node_id: 'R_legacy',
+      })
     })
   })
 
@@ -1503,6 +1724,8 @@ describe('reconcileRepos', () => {
         name: '.github',
         onboarding_status: 'lost-access',
         discovery_channel: 'contrib',
+        private: false,
+        node_id: 'R_bfra_gh',
       })
       const result = reconcileRepos(
         makeInput({
@@ -1525,6 +1748,8 @@ describe('reconcileRepos', () => {
         name: 'systematic',
         onboarding_status: 'lost-access',
         discovery_channel: 'owned',
+        private: false,
+        node_id: 'R_sys',
       })
       const result = reconcileRepos(
         makeInput({
@@ -2420,6 +2645,8 @@ describe('handleReconcile (I/O shell)', () => {
                   has_fro_bot_workflow: false,
                   has_renovate: false,
                   discovery_channel: 'collab',
+                  private: false,
+                  node_id: 'R_2',
                   next_survey_eligible_at: null,
                 },
               ],
@@ -2433,6 +2660,80 @@ describe('handleReconcile (I/O shell)', () => {
       expect(dispatchCalls).toEqual(['r1', 'r3'])
       expect(result.dispatches).toBe(2)
       expect(result.dispatchesDeferred).toBe(1)
+    })
+
+    it('does not let private entries displace public dispatches under the cap', async () => {
+      const dispatchCalls: string[] = []
+      const createWorkflowDispatch = vi.fn(async (params: unknown) => {
+        const typed = params as {inputs?: {repo: string}}
+        dispatchCalls.push(typed.inputs?.repo ?? '?')
+      })
+      const publicRepos = Array.from({length: 13}, (_, index) => `public-${String(index + 1).padStart(2, '0')}`)
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [
+            ...publicRepos.map(name => ({
+              owner: {login: 'trusted'},
+              name,
+              archived: false,
+              private: false,
+              node_id: `R_${name}`,
+            })),
+            {
+              owner: {login: 'trusted'},
+              name: 'private-repo',
+              archived: false,
+              private: true,
+              node_id: 'R_private',
+            },
+          ],
+        }),
+      })
+
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({createWorkflowDispatch}),
+          readMetadata: makeReadMetadata({allowlist: makeAllowlist(['trusted'])}),
+          commitMetadata: vi.fn(async () => ({committed: true, sha: 's', attempts: 1})) as never,
+          maxDispatchesPerRun: 12,
+        }),
+      )
+
+      expect(dispatchCalls).toHaveLength(12)
+      expect(dispatchCalls).not.toContain('private-repo')
+      expect(dispatchCalls.every(name => name.startsWith('public-'))).toBe(true)
+      expect(result.summary.skippedPrivate).toBe(1)
+      expect(result.dispatches).toBe(12)
+      expect(result.dispatchesDeferred).toBe(1)
+    })
+
+    it('treats access-list entries with missing private as private and skips dispatch', async () => {
+      const createWorkflowDispatch = vi.fn(async () => undefined)
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {
+              owner: {login: 'trusted'},
+              name: 'unknown-privacy',
+              archived: false,
+              node_id: 'R_unknown_privacy',
+            } as unknown as AccessListApiEntry,
+          ],
+        }),
+      })
+
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({createWorkflowDispatch}),
+          readMetadata: makeReadMetadata({allowlist: makeAllowlist(['trusted'])}),
+          commitMetadata: vi.fn(async () => ({committed: true, sha: 's', attempts: 1})) as never,
+        }),
+      )
+
+      expect(createWorkflowDispatch).not.toHaveBeenCalled()
+      expect(result.summary.skippedPrivate).toBe(1)
     })
 
     it('among repos with non-null last_survey_at, dispatches oldest first', async () => {
@@ -2472,6 +2773,8 @@ describe('handleReconcile (I/O shell)', () => {
                   has_fro_bot_workflow: false,
                   has_renovate: false,
                   discovery_channel: 'collab',
+                  private: false,
+                  node_id: 'R_old',
                   next_survey_eligible_at: null,
                 },
                 {
@@ -2484,6 +2787,8 @@ describe('handleReconcile (I/O shell)', () => {
                   has_fro_bot_workflow: false,
                   has_renovate: false,
                   discovery_channel: 'collab',
+                  private: false,
+                  node_id: 'R_mid',
                   next_survey_eligible_at: null,
                 },
                 {
@@ -2496,6 +2801,8 @@ describe('handleReconcile (I/O shell)', () => {
                   has_fro_bot_workflow: false,
                   has_renovate: false,
                   discovery_channel: 'collab',
+                  private: false,
+                  node_id: 'R_new',
                   next_survey_eligible_at: null,
                 },
               ],
@@ -3550,6 +3857,8 @@ jobs:
         has_fro_bot_workflow: true,
         has_renovate: false,
         discovery_channel: 'owned',
+        private: false,
+        node_id: 'R_a',
         next_survey_eligible_at: null,
       }
       const userOctokit = mockOctokit({
@@ -3642,6 +3951,8 @@ jobs:
         has_fro_bot_workflow: false,
         has_renovate: false,
         discovery_channel: 'collab',
+        private: false,
+        node_id: `R_${name}`,
         next_survey_eligible_at: null,
       }))
       const userOctokit = mockOctokit({
@@ -3857,6 +4168,7 @@ describe('formatCommitMessage', () => {
         migrated: 0,
         transient: 0,
         malformed: 0,
+        skippedPrivate: 0,
         unchanged: 0,
         byChannel: emptyChannelStats(),
       }),
@@ -3874,10 +4186,29 @@ describe('formatCommitMessage', () => {
         migrated: 18,
         transient: 0,
         malformed: 0,
+        skippedPrivate: 0,
         unchanged: 0,
         byChannel: emptyChannelStats(),
       }),
     ).toBe('chore(reconcile): +0 new, 0 pending-review, 0 lost-access, 0 refreshes, +18 migrated')
+  })
+
+  it('keeps skipped-private counts out of public commit messages', () => {
+    expect(
+      formatCommitMessage({
+        added: 0,
+        pendingReview: 0,
+        regained: 0,
+        lostAccess: 0,
+        refreshed: 1,
+        migrated: 0,
+        transient: 0,
+        malformed: 0,
+        skippedPrivate: 2,
+        unchanged: 0,
+        byChannel: emptyChannelStats(),
+      }),
+    ).toBe('chore(reconcile): +0 new, 0 pending-review, 0 lost-access, 1 refreshes')
   })
 
   it('includes the migrated suffix alongside other non-zero counters', () => {
@@ -3891,6 +4222,7 @@ describe('formatCommitMessage', () => {
         migrated: 18,
         transient: 0,
         malformed: 0,
+        skippedPrivate: 0,
         unchanged: 0,
         byChannel: emptyChannelStats(),
       }),

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -95,6 +95,11 @@ export interface AccessListEntry {
   node_id: string
 }
 
+interface AccessNodePrivacy {
+  count: number
+  hasNonPublic: boolean
+}
+
 /**
  * Result of probing a single tracked repo's status via `GET /repos/{owner}/{name}`.
  *
@@ -218,6 +223,12 @@ export interface ReconcileSummary {
    */
   malformed: number
   /**
+   * Number of dispatch-capable entries skipped before survey eligibility because their
+   * stored or live privacy state was not definitively public. Operational counter only:
+   * it does not imply a metadata change by itself.
+   */
+  skippedPrivate: number
+  /**
    * Per-channel activity breakdown. See {@link ChannelStats} for field semantics. The
    * engine populates `tracked` and `lostAccess`; the shell populates `dispatched` and
    * `deferred` after cap selection.
@@ -247,6 +258,7 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
 
   const accessByKey = indexAccessList(accessList)
   const accessByNodeId = indexAccessListByNodeId(accessList)
+  const accessNodePrivacy = indexAccessNodePrivacy(accessList)
   const allowlistedOwners = new Set(allowlist.approved_inviters.map(i => i.username))
 
   const summary: ReconcileSummary = {
@@ -259,6 +271,7 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
     unchanged: 0,
     transient: 0,
     malformed: 0,
+    skippedPrivate: 0,
     byChannel: {
       collab: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
       owned: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
@@ -278,6 +291,7 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
       key,
       accessByKey,
       accessByNodeId,
+      accessNodePrivacy,
       accessChannelByKey,
       perRepoStatus,
       fieldProbes,
@@ -325,28 +339,33 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
     const channel = accessChannelByKey.get(key) ?? 'collab'
     const trusted = isTrustedChannel(channel, access.owner, allowlistedOwners)
     const status: OnboardingStatus = trusted ? 'pending' : 'pending-review'
+    const accessPrivate = accessPrivateForStorage(access, accessNodePrivacy)
 
     next = addRepoEntry(next, {
       owner: access.owner,
       repo: access.name,
       now,
-      private: access.private,
+      private: accessPrivate,
       node_id: access.node_id,
       onboarding_status: status,
       discovery_channel: channel,
     })
+    knownNodeIds.add(access.node_id)
 
     if (trusted) {
       summary.added += 1
-      if (access.private) continue
-      dispatches.push({owner: access.owner, repo: access.name})
+      if (accessPrivate) {
+        summary.skippedPrivate += 1
+      } else {
+        dispatches.push({owner: access.owner, repo: access.name})
+      }
     } else {
       summary.pendingReview += 1
       rawIssues.push({
         owner: access.owner,
         repo: access.name,
         reason: 'unsolicited-new',
-        private: access.private,
+        private: accessPrivate,
         node_id: access.node_id,
       })
     }
@@ -376,6 +395,7 @@ interface ClassifyTrackedParams {
   key: string
   accessByKey: Map<string, AccessListEntry>
   accessByNodeId: Map<string, AccessListEntry>
+  accessNodePrivacy: Map<string, AccessNodePrivacy>
   accessChannelByKey: Map<string, DiscoveryChannel>
   perRepoStatus: Map<string, RepoStatusProbe>
   fieldProbes: Map<string, FieldProbe>
@@ -396,6 +416,7 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
   const {
     accessByKey,
     accessByNodeId,
+    accessNodePrivacy,
     perRepoStatus,
     fieldProbes,
     allowlistedOwners,
@@ -506,21 +527,6 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
     }
   }
 
-  if (access.private && entry.onboarding_status !== 'lost-access') {
-    const normalized = normalizeRepoEntryForStorage(entry, {
-      owner: access.owner,
-      repo: access.name,
-      private: true,
-      node_id: access.node_id,
-    })
-    if (normalized === entry) {
-      summary.unchanged += 1
-      return entry
-    }
-    summary.refreshed += 1
-    return normalized
-  }
-
   if (entry.onboarding_status === 'lost-access') {
     // Regain: entry was lost-access and is now back in the access list. Trust path
     // mirrors Pass 2's newcomer logic via `isTrustedChannel`. Channel resolution
@@ -530,9 +536,12 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
     const channel = entry.discovery_channel ?? params.accessChannelByKey.get(accessKey) ?? 'collab'
     const trusted = isTrustedChannel(channel, access.owner, allowlistedOwners)
     const nextStatus: OnboardingStatus = trusted ? 'pending' : 'pending-review'
+    const accessPrivate = accessPrivateForStorage(access, accessNodePrivacy)
     summary.regained += 1
     if (trusted) {
-      if (!access.private) {
+      if (accessPrivate) {
+        summary.skippedPrivate += 1
+      } else {
         dispatches.push({owner: access.owner, repo: access.name})
       }
     } else {
@@ -540,7 +549,7 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
         owner: access.owner,
         repo: access.name,
         reason: 'unsolicited-regain',
-        private: access.private,
+        private: accessPrivate,
         node_id: access.node_id,
       })
     }
@@ -548,7 +557,7 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
       ...normalizeRepoEntryForStorage(entry, {
         owner: access.owner,
         repo: access.name,
-        private: access.private,
+        private: accessPrivate,
         node_id: access.node_id,
       }),
       onboarding_status: nextStatus,
@@ -569,19 +578,22 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
   // The actual dispatch may still be deferred by the per-run cap; entries that are
   // genuinely fresh never become candidates so they don't compete for dispatch slots.
   // `pending-review` entries are excluded — they require human approval first.
-  if (entry.onboarding_status === 'onboarded' && isEligibleForSurvey(entry.next_survey_eligible_at, params.now)) {
-    dispatches.push({owner: access.owner, repo: access.name})
-  } else if (
-    entry.onboarding_status === 'pending' &&
-    (entry.last_survey_status !== 'success' || isEligibleForSurvey(entry.next_survey_eligible_at, params.now))
-  ) {
+  const wouldDispatchIfPublic =
+    (entry.onboarding_status === 'onboarded' && isEligibleForSurvey(entry.next_survey_eligible_at, params.now)) ||
+    (entry.onboarding_status === 'pending' &&
+      (entry.last_survey_status !== 'success' || isEligibleForSurvey(entry.next_survey_eligible_at, params.now)))
+
+  const accessPrivate = accessPrivateForStorage(access, accessNodePrivacy)
+
+  if (wouldDispatchIfPublic && (entry.private !== false || accessPrivate)) {
+    summary.skippedPrivate += 1
+  } else if (wouldDispatchIfPublic) {
     dispatches.push({owner: access.owner, repo: access.name})
   }
 
   // Field refresh: apply probe results when they disagree with tracked fields,
   // and write live private/node_id from the access list when they differ.
   const probe = fieldProbes.get(key) ?? fieldProbes.get(accessKey)
-  const accessPrivate = access.private
   const accessNodeId = access.node_id
   const storageInput = {owner: access.owner, repo: access.name, private: accessPrivate, node_id: accessNodeId}
 
@@ -772,6 +784,23 @@ function indexAccessListByNodeId(accessList: AccessListEntry[]): Map<string, Acc
     map.set(entry.node_id, entry)
   }
   return map
+}
+
+function indexAccessNodePrivacy(accessList: AccessListEntry[]): Map<string, AccessNodePrivacy> {
+  const map = new Map<string, AccessNodePrivacy>()
+  for (const entry of accessList) {
+    const current = map.get(entry.node_id) ?? {count: 0, hasNonPublic: false}
+    map.set(entry.node_id, {
+      count: current.count + 1,
+      hasNonPublic: current.hasNonPublic || entry.private !== false,
+    })
+  }
+  return map
+}
+
+function accessPrivateForStorage(access: AccessListEntry, accessNodePrivacy: Map<string, AccessNodePrivacy>): boolean {
+  const nodePrivacy = accessNodePrivacy.get(access.node_id)
+  return access.private !== false || nodePrivacy?.hasNonPublic === true || (nodePrivacy?.count ?? 0) > 1
 }
 
 function storedRepoNodeId(entry: RepoEntry): string | undefined {
@@ -1304,7 +1333,10 @@ function planHasChanges(plan: ReconcileResult): boolean {
  */
 export function formatCommitMessage(summary: ReconcileSummary): string {
   const base = `chore(reconcile): +${summary.added} new, ${summary.pendingReview} pending-review, ${summary.lostAccess} lost-access, ${summary.refreshed} refreshes`
-  return summary.migrated > 0 ? `${base}, +${summary.migrated} migrated` : base
+  const suffixes = [summary.migrated > 0 ? `+${summary.migrated} migrated` : undefined].filter(
+    (suffix): suffix is string => suffix !== undefined,
+  )
+  return suffixes.length > 0 ? `${base}, ${suffixes.join(', ')}` : base
 }
 
 async function loadAllowlist(readMetadata: (path: string) => Promise<unknown>, path: string): Promise<AllowlistFile> {
@@ -1363,7 +1395,7 @@ async function fetchAccessList(userOctokit: OctokitClient): Promise<AccessListEn
         owner: r.owner.login,
         name: r.name,
         archived: r.archived === true,
-        private: r.private === true,
+        private: r.private !== false,
         node_id: r.node_id,
       })
     }

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -798,6 +798,11 @@ function indexAccessNodePrivacy(accessList: AccessListEntry[]): Map<string, Acce
   return map
 }
 
+/**
+ * Fails closed for privacy and dispatch planning. Duplicate node_id rows are
+ * treated as private even when every row reports public visibility because the
+ * canonical owner/repo identity is ambiguous.
+ */
 function accessPrivateForStorage(access: AccessListEntry, accessNodePrivacy: Map<string, AccessNodePrivacy>): boolean {
   const nodePrivacy = accessNodePrivacy.get(access.node_id)
   return access.private !== false || nodePrivacy?.hasNonPublic === true || (nodePrivacy?.count ?? 0) > 1


### PR DESCRIPTION
## Summary

- Gate Survey Repo dispatches behind both stored and live public visibility.
- Treat unknown or conflicting access-list privacy as private before dispatch planning.
- Keep private-skip counts out of public commit messages while preserving internal summary counters.
- Add regression coverage for visibility flips, duplicate node IDs, malformed privacy data, regain paths, and dispatch-cap behavior.

## Testing

- `pnpm bootstrap`
- `pnpm check-types`
- `pnpm lint`
- `pnpm test`