### PR TITLE
fix(data): bootstrap data before autonomous writes

### DIFF
--- a/docs/solutions/integration-issues/bootstrap-data-branch-before-autonomous-writes-2026-05-09.md
+++ b/docs/solutions/integration-issues/bootstrap-data-branch-before-autonomous-writes-2026-05-09.md
@@ -1,0 +1,174 @@
+---
+title: Bootstrap data branch before autonomous writes
+date: 2026-05-09
+category: integration-issues
+module: data-branch-bootstrap
+problem_type: integration_issue
+component: tooling
+severity: high
+last_updated: 2026-05-09
+verified: true
+symptoms:
+  - GitHub deleted the data source branch after a data-to-main promotion PR was squash-merged.
+  - Autonomous metadata and wiki writers could not safely write to the missing data branch.
+  - Manual branch restoration risked creating a human-authored data tip that failed integrity checks.
+  - Concurrent writer startup could race while recreating the same missing data ref.
+root_cause: missing_workflow_step
+resolution_type: code_fix
+related_components:
+  - development_workflow
+  - testing_framework
+tags:
+  - data-branch
+  - bootstrap
+  - autonomous-writes
+  - branch-protection
+  - commit-metadata
+  - wiki-ingest
+  - github-branches
+  - integrity-guard
+---
+
+# Bootstrap data branch before autonomous writes
+
+## Problem
+
+Autonomous writers in this repository use the unprotected `data` branch as their durable write
+target, then promote safe changes to `main` through a PR. After a data-to-main promotion PR was
+squash-merged, GitHub deleted the `data` source branch. The next metadata or wiki write then had no
+safe branch to target.
+
+Recreating `data` directly from `main` is not enough. If the restored tip is authored by a human, the
+data-branch integrity guard can reject it even when the tree contents are correct.
+
+## Symptoms
+
+- A data-to-main promotion PR succeeded, but the `data` source branch was deleted afterward.
+- Metadata and wiki writers could fail before reading or updating their target files.
+- Restoring `data` manually risked a wrong-author branch tip.
+- Multiple autonomous writers could concurrently observe missing `data` and race on `createRef`.
+- A writer could bootstrap `data`, then see a `404` if the branch disappeared again before a
+  follow-on content or ref read.
+
+## What Didn't Work
+
+- **Relying on the promotion workflow to preserve `data`.** GitHub can delete the source branch after
+  merge, so writers need their own safe bootstrap path.
+- **Restoring `data` as a human actor.** That fixes branch existence but violates the author model
+  enforced by the integrity guard.
+- **Treating every GitHub `422` as benign.** For ref creation, `422` only means the create failed. It
+  is safe to continue only after re-reading the branch and confirming it exists.
+- **Bootstrapping every target branch.** Non-`data` branches are explicit test or maintenance targets;
+  surprising bootstrap side effects there would hide configuration mistakes.
+- **Checking wiki branch safety after creating Git objects.** Protected targets should fail before
+  blobs, trees, commits, or ref updates are created.
+
+## Solution
+
+Centralize missing-`data` recovery in the shared writer path.
+
+### Restore `data` with a Fro Bot-authored same-tree commit
+
+`bootstrapDataBranch()` now no-ops when `data` exists. When `data` is missing, it reads `main`, uses
+the `main` tree, and creates a new restore commit with Fro Bot bot author and committer metadata:
+
+```ts
+const restoreCommit = await octokit.rest.git.createCommit({
+  owner,
+  repo,
+  message: 'chore(data): restore data branch',
+  tree: baseCommit.data.tree.sha,
+  parents: [main.data.commit.sha],
+  author: FRO_BOT_BOT_AUTHOR,
+  committer: FRO_BOT_BOT_AUTHOR,
+})
+```
+
+The resulting `data` tree matches `main`, but the branch tip is valid for the autonomous integrity
+model.
+
+### Recover only safe `createRef` races
+
+When creating `refs/heads/data` returns `422`, the bootstrapper re-reads `data`. If the branch exists,
+the race is safe and the observed tip is returned. If the branch still does not exist, the bootstrapper
+raises a structured API error.
+
+This handles both concurrent restore and “another writer already advanced `data`” races without
+requiring the current process to own the exact restore SHA.
+
+### Bootstrap and retry metadata writes
+
+`commitMetadata()` now bootstraps only for the canonical `data` branch before checking branch safety
+or reading file contents:
+
+```ts
+const shouldBootstrapDataBranch = branch === DEFAULT_BRANCH
+
+if (shouldBootstrapDataBranch) {
+  await bootstrapDataBranch()
+}
+```
+
+It rejects `main` and protected branches, and it retries after re-bootstrapping when recoverable
+missing-branch signals happen during the write loop:
+
+```ts
+if (shouldBootstrapDataBranch && isRecoverableDataBranchMissingError(error) && attempt < maxRetries) {
+  await bootstrapDataBranch()
+  continue
+}
+```
+
+### Bootstrap and guard wiki ingest writes
+
+`commitWikiChanges()` now follows the same data-branch bootstrap pattern. It rejects literal `main`
+before bootstrap, and it checks branch protection before creating wiki blobs, trees, commits, or ref
+updates:
+
+```ts
+function rejectProtectedWikiBranchName(branch: string): void {
+  if (branch === 'main') {
+    throw new WikiIngestError({
+      code: 'PROTECTED_BRANCH',
+      message: 'wiki ingest refuses to write to main; use the data branch',
+      remediation: 'Target the data branch. Promotions to main must go through the data-branch merge PR.',
+    })
+  }
+}
+```
+
+It retries when `data` disappears before reading the wiki head ref.
+
+## Why This Works
+
+- The restored branch has the same tree as `main`, so bootstrap does not introduce content drift.
+- The restore commit is authored and committed by `fro-bot[bot]`, preserving the data-branch
+  integrity contract.
+- The bootstrap path is idempotent: existing `data` is a no-op; missing `data` is restored;
+  concurrent creation is accepted only after the branch exists.
+- Shared writers recover from post-bootstrap `404` races instead of assuming the first bootstrap call
+  made the rest of the write atomic.
+- Branch-protection checks run before writes, so accidental `main` or protected-branch targets fail
+  closed.
+- Non-`data` branches keep explicit behavior and do not get hidden bootstrap side effects.
+
+## Prevention
+
+- Put missing-branch recovery in shared writer utilities, not individual workflow call sites.
+- Treat ref-creation `422` responses as recoverable only after verifying the ref exists afterward.
+- Restore `data` through `bootstrapDataBranch()` rather than manually recreating the branch.
+- Check both GitHub branch protection shapes before writing:
+  - `response.data.protected`
+  - `response.data.protection?.enabled`
+- Test writer behavior at the GitHub boundary: missing branch, branch deleted between steps,
+  concurrent `createRef`, protected targets, and non-`data` branch bypass.
+
+## Related Issues
+
+- PR: [#3272 — Bootstrap data before autonomous writes](https://github.com/fro-bot/.github/pull/3272)
+- Related promotion: [#3271 — Merge data into main](https://github.com/fro-bot/.github/pull/3271)
+- Related alert: [#3256 — Reconcile integrity alert](https://github.com/fro-bot/.github/issues/3256)
+- Related doc: [Data Merge PR recovery must distinguish GitHub 422s and mergeability races](merge-data-pr-github-422-race-recovery-2026-05-02.md)
+- Related doc: [Silent failures in autonomous multi-step pipelines](../runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md)
+- Related doc: [Normalize redacted metadata YAML quoting before data promotion](normalize-redacted-yaml-quotes-2026-05-09.md)
+- Related doc: [Wiki lint must report against authoritative data snapshots](wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md)

--- a/scripts/commit-metadata.test.ts
+++ b/scripts/commit-metadata.test.ts
@@ -39,7 +39,9 @@ function mockOctokit(overrides?: MockOverrides): OctokitClient {
       repos: {
         getBranch:
           overrides?.getBranch ??
-          (async () => ({data: {name: 'data', protected: false, protection: {enabled: false}}})),
+          (async ({branch}: {branch: string}) => ({
+            data: {name: branch, protected: false, protection: {enabled: false}, commit: {sha: `${branch}-sha`}},
+          })),
         getContent:
           overrides?.getContent ??
           (async () => ({
@@ -225,7 +227,7 @@ describe('commitMetadata API', () => {
 
   it('refuses protected: true branches (PROTECTED_BRANCH)', async () => {
     const octokit = mockOctokit({
-      getBranch: async () => ({data: {name: 'data', protected: true}}),
+      getBranch: async () => ({data: {name: 'data', protected: true, commit: {sha: 'data-sha'}}}),
     })
     const error = await commitMetadata({
       path: 'metadata/repos.yaml',
@@ -239,7 +241,9 @@ describe('commitMetadata API', () => {
 
   it('refuses protection.enabled branches (PROTECTED_BRANCH)', async () => {
     const octokit = mockOctokit({
-      getBranch: async () => ({data: {name: 'data', protected: false, protection: {enabled: true}}}),
+      getBranch: async () => ({
+        data: {name: 'data', protected: false, protection: {enabled: true}, commit: {sha: 'data-sha'}},
+      }),
     })
     const error = await commitMetadata({
       path: 'metadata/repos.yaml',
@@ -345,6 +349,164 @@ describe('commitMetadata API', () => {
     expect(result.sha).toBe('commit-sha-789')
     expect(result.attempts).toBe(1)
     expect(createSpy).toHaveBeenCalledOnce()
+  })
+
+  it('bootstraps the data branch before reading metadata', async () => {
+    const calls: string[] = []
+    const createSpy = vi.fn(async () => ({data: {commit: {sha: 'commit-sha-789'}}}))
+    const bootstrapDataBranch = vi.fn(async () => {
+      calls.push('bootstrap')
+      return {created: false, ref: 'refs/heads/data', sha: 'data-sha'}
+    })
+    const octokit = mockOctokit({
+      getBranch: async ({branch}: {branch: string}) => {
+        calls.push(`getBranch:${branch}`)
+        return {data: {name: branch, protected: false, protection: {enabled: false}}}
+      },
+      getContent: async () => {
+        calls.push('getContent')
+        return {data: {type: 'file' as const, sha: 'abc123', content: encode({version: 1}), encoding: 'base64'}}
+      },
+      createOrUpdateFileContents: createSpy,
+    })
+
+    await commitMetadata({
+      path: 'metadata/repos.yaml',
+      message: 'update version',
+      mutator: () => ({version: 2}),
+      octokit,
+      bootstrapDataBranch,
+    })
+
+    expect(bootstrapDataBranch).toHaveBeenCalledWith({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      dataBranch: 'data',
+    })
+    expect(calls).toEqual(['bootstrap', 'getBranch:data', 'getContent'])
+    expect(createSpy).toHaveBeenCalledOnce()
+  })
+
+  it('does not bootstrap when writing to an explicitly allowed non-data branch', async () => {
+    const bootstrapDataBranch = vi.fn(async () => {
+      throw new Error('bootstrap should not run')
+    })
+    const createSpy = vi.fn(async () => ({data: {commit: {sha: 'commit-sha-789'}}}))
+    const octokit = mockOctokit({createOrUpdateFileContents: createSpy})
+
+    const result = await commitMetadata({
+      path: 'metadata/repos.yaml',
+      branch: 'test-branch',
+      allowUnsafeBranch: true,
+      message: 'update version',
+      mutator: () => ({version: 2}),
+      octokit,
+      bootstrapDataBranch,
+    })
+
+    expect(result.committed).toBe(true)
+    expect(bootstrapDataBranch).not.toHaveBeenCalled()
+    expect(createSpy).toHaveBeenCalledOnce()
+  })
+
+  it('rebootstraps and retries when data disappears after the initial bootstrap', async () => {
+    const calls: string[] = []
+    const bootstrapDataBranch = vi.fn(async () => {
+      calls.push('bootstrap')
+      return {created: false, ref: 'refs/heads/data', sha: 'data-sha'}
+    })
+    const createSpy = vi.fn(async () => ({data: {commit: {sha: 'commit-sha-789'}}}))
+    const octokit = mockOctokit({
+      getBranch: vi
+        .fn<NonNullable<MockOverrides['getBranch']>>()
+        .mockRejectedValueOnce(Object.assign(new Error('Not Found'), {status: 404}))
+        .mockResolvedValue({
+          data: {name: 'data', protected: false, protection: {enabled: false}, commit: {sha: 'data-sha'}},
+        }),
+      createOrUpdateFileContents: createSpy,
+    })
+
+    const result = await commitMetadata({
+      path: 'metadata/repos.yaml',
+      message: 'update version',
+      maxRetries: 2,
+      mutator: () => ({version: 2}),
+      octokit,
+      bootstrapDataBranch,
+    })
+
+    expect(result.committed).toBe(true)
+    expect(bootstrapDataBranch).toHaveBeenCalledTimes(2)
+    expect(calls).toEqual(['bootstrap', 'bootstrap'])
+    expect(createSpy).toHaveBeenCalledOnce()
+  })
+
+  it('rebootstraps and retries when data disappears before reading metadata content', async () => {
+    const calls: string[] = []
+    const bootstrapDataBranch = vi.fn(async () => {
+      calls.push('bootstrap')
+      return {created: false, ref: 'refs/heads/data', sha: 'data-sha'}
+    })
+    const createSpy = vi.fn(async () => ({data: {commit: {sha: 'commit-sha-789'}}}))
+    const getBranch = vi
+      .fn<NonNullable<MockOverrides['getBranch']>>()
+      .mockResolvedValueOnce({
+        data: {name: 'data', protected: false, protection: {enabled: false}, commit: {sha: 'data-sha'}},
+      })
+      .mockResolvedValue({
+        data: {name: 'data', protected: false, protection: {enabled: false}, commit: {sha: 'data-sha'}},
+      })
+    const getContent = vi
+      .fn<NonNullable<MockOverrides['getContent']>>()
+      .mockRejectedValueOnce(Object.assign(new Error('Not Found'), {status: 404}))
+      .mockResolvedValue({
+        data: {type: 'file' as const, sha: 'abc123', content: encode({version: 1}), encoding: 'base64'},
+      })
+    const octokit = mockOctokit({
+      getBranch,
+      getContent,
+      createOrUpdateFileContents: createSpy,
+    })
+
+    const result = await commitMetadata({
+      path: 'metadata/repos.yaml',
+      message: 'update version',
+      maxRetries: 2,
+      mutator: () => ({version: 2}),
+      octokit,
+      bootstrapDataBranch,
+    })
+
+    expect(result.committed).toBe(true)
+    expect(bootstrapDataBranch).toHaveBeenCalledTimes(2)
+    expect(getBranch).toHaveBeenCalledTimes(2)
+    expect(getContent).toHaveBeenCalledTimes(2)
+    expect(createSpy).toHaveBeenCalledOnce()
+  })
+
+  it('stops before metadata reads and writes when bootstrap fails', async () => {
+    const bootstrapDataBranch = vi.fn(async () => {
+      throw new Error('bootstrap failed')
+    })
+    const getBranch = vi.fn<NonNullable<MockOverrides['getBranch']>>()
+    const getContent = vi.fn<NonNullable<MockOverrides['getContent']>>()
+    const createSpy = vi.fn<NonNullable<MockOverrides['createOrUpdateFileContents']>>()
+    const octokit = mockOctokit({getBranch, getContent, createOrUpdateFileContents: createSpy})
+
+    await expect(
+      commitMetadata({
+        path: 'metadata/repos.yaml',
+        message: 'update version',
+        mutator: () => ({version: 2}),
+        octokit,
+        bootstrapDataBranch,
+      }),
+    ).rejects.toThrow('bootstrap failed')
+
+    expect(getBranch).not.toHaveBeenCalled()
+    expect(getContent).not.toHaveBeenCalled()
+    expect(createSpy).not.toHaveBeenCalled()
   })
 
   it('serializes redacted metadata values in Prettier-compatible single quotes', async () => {

--- a/scripts/commit-metadata.ts
+++ b/scripts/commit-metadata.ts
@@ -3,6 +3,11 @@ import {Buffer} from 'node:buffer'
 import process from 'node:process'
 
 import {parse, stringify} from 'yaml'
+import {
+  bootstrapDataBranch as defaultBootstrapDataBranch,
+  type DataBranchBootstrapParams,
+  type DataBranchBootstrapResult,
+} from './data-branch-bootstrap.ts'
 
 const DEFAULT_OWNER = 'fro-bot'
 const DEFAULT_REPO = '.github'
@@ -67,6 +72,12 @@ export interface CommitMetadataParams {
    * Production callers should always use the data branch.
    */
   allowUnsafeBranch?: boolean
+  /**
+   * Idempotent data-branch bootstrap. Called before data-branch writes so
+   * shared metadata writers recover when GitHub deletes the `data` source ref
+   * after a promotion PR is merged.
+   */
+  bootstrapDataBranch?: (params: DataBranchBootstrapParams) => Promise<DataBranchBootstrapResult>
 }
 
 export interface CommitMetadataResult {
@@ -158,29 +169,39 @@ export async function commitMetadata(params: CommitMetadataParams): Promise<Comm
 
   const octokit = params.octokit ?? (await createOctokitFromEnv())
 
-  await assertWritableBranch(octokit, owner, repo, branch)
+  const shouldBootstrapDataBranch = branch === DEFAULT_BRANCH
+  const bootstrap = params.bootstrapDataBranch ?? defaultBootstrapDataBranch
+  const bootstrapDataBranch = async (): Promise<void> => {
+    await bootstrap({octokit, owner, repo, dataBranch: branch})
+  }
+
+  if (shouldBootstrapDataBranch) {
+    await bootstrapDataBranch()
+  }
 
   for (let attempt = 1; attempt <= maxRetries; attempt += 1) {
-    const current = await readExistingMetadataFile({
-      octokit,
-      owner,
-      repo,
-      branch,
-      path: params.path,
-    })
-
-    const next = await params.mutator(current.parsed)
-    const nextSerialized = serializeYaml(next)
-
-    // Authoritative unchanged-content check: compare serialized text, not
-    // deep-equal on objects. This catches (a) in-place mutations that return
-    // the same reference, (b) key-order or whitespace changes that would
-    // otherwise commit identical data.
-    if (nextSerialized === current.serialized) {
-      return {committed: false, attempts: attempt}
-    }
-
     try {
+      await assertWritableBranch(octokit, owner, repo, branch)
+
+      const current = await readExistingMetadataFile({
+        octokit,
+        owner,
+        repo,
+        branch,
+        path: params.path,
+      })
+
+      const next = await params.mutator(current.parsed)
+      const nextSerialized = serializeYaml(next)
+
+      // Authoritative unchanged-content check: compare serialized text, not
+      // deep-equal on objects. This catches (a) in-place mutations that return
+      // the same reference, (b) key-order or whitespace changes that would
+      // otherwise commit identical data.
+      if (nextSerialized === current.serialized) {
+        return {committed: false, attempts: attempt}
+      }
+
       const response = await octokit.rest.repos.createOrUpdateFileContents({
         owner,
         repo,
@@ -197,6 +218,11 @@ export async function commitMetadata(params: CommitMetadataParams): Promise<Comm
         attempts: attempt,
       }
     } catch (error: unknown) {
+      if (shouldBootstrapDataBranch && isRecoverableDataBranchMissingError(error) && attempt < maxRetries) {
+        await bootstrapDataBranch()
+        continue
+      }
+
       if (isConflictError(error) && attempt < maxRetries) {
         continue
       }
@@ -407,6 +433,14 @@ function serializeYaml(value: unknown): string {
 
 function isConflictError(error: unknown): boolean {
   return isRecord(error) && typeof error.status === 'number' && error.status === 409
+}
+
+function isApiErrorStatus(error: unknown, status: number): boolean {
+  return isRecord(error) && typeof error.status === 'number' && error.status === status
+}
+
+function isRecoverableDataBranchMissingError(error: unknown): boolean {
+  return isApiErrorStatus(error, 404) || (error instanceof CommitMetadataError && error.code === 'MISSING_FILE')
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/scripts/data-branch-bootstrap.test.ts
+++ b/scripts/data-branch-bootstrap.test.ts
@@ -4,6 +4,16 @@ import {bootstrapDataBranch, DataBranchBootstrapError} from './data-branch-boots
 
 interface MockOverrides {
   getBranch?: (params: {owner: string; repo: string; branch: string}) => Promise<unknown>
+  getCommit?: (params: {owner: string; repo: string; commit_sha: string}) => Promise<unknown>
+  createCommit?: (params: {
+    owner: string
+    repo: string
+    message: string
+    tree: string
+    parents: string[]
+    author: {name: string; email: string}
+    committer: {name: string; email: string}
+  }) => Promise<unknown>
   createRef?: (params: {owner: string; repo: string; ref: string; sha: string}) => Promise<unknown>
 }
 
@@ -21,6 +31,12 @@ function mockOctokit(overrides?: MockOverrides): OctokitClient {
           })),
       },
       git: {
+        getCommit:
+          overrides?.getCommit ??
+          (async (params: {commit_sha: string}) => ({
+            data: {sha: params.commit_sha, tree: {sha: `${params.commit_sha}-tree`}},
+          })),
+        createCommit: overrides?.createCommit ?? (async () => ({data: {sha: 'data-bootstrap-sha'}})),
         createRef: overrides?.createRef ?? (async () => ({data: {ref: 'refs/heads/data'}})),
       },
     },
@@ -28,7 +44,8 @@ function mockOctokit(overrides?: MockOverrides): OctokitClient {
 }
 
 describe('bootstrapDataBranch', () => {
-  it('creates data branch from main HEAD SHA when branch does not exist', async () => {
+  it('creates data branch from a Fro Bot-authored same-tree commit when branch does not exist', async () => {
+    const createCommit = vi.fn(async () => ({data: {sha: 'data-restore-sha'}}))
     const createRef = vi.fn(async () => ({data: {ref: 'refs/heads/data'}}))
     const octokit = mockOctokit({
       getBranch: async ({branch}: {branch: string}) => {
@@ -39,22 +56,145 @@ describe('bootstrapDataBranch', () => {
 
         return {data: {name: 'main', commit: {sha: 'main-head-sha'}}}
       },
+      getCommit: async () => ({data: {sha: 'main-head-sha', tree: {sha: 'main-tree-sha'}}}),
+      createCommit,
       createRef,
     })
 
     // #when the bootstrap runs
     const result = await bootstrapDataBranch({octokit})
 
-    // #then it creates data from main HEAD
+    // #then it creates data from a same-tree commit attributed to the Fro Bot bot identity
     expect(result.created).toBe(true)
     expect(result.ref).toBe('refs/heads/data')
-    expect(result.sha).toBe('main-head-sha')
+    expect(result.sha).toBe('data-restore-sha')
+    expect(createCommit).toHaveBeenCalledWith({
+      owner: 'fro-bot',
+      repo: '.github',
+      message: 'chore(data): restore data branch',
+      tree: 'main-tree-sha',
+      parents: ['main-head-sha'],
+      author: {
+        name: 'fro-bot[bot]',
+        email: '109017866+fro-bot[bot]@users.noreply.github.com',
+      },
+      committer: {
+        name: 'fro-bot[bot]',
+        email: '109017866+fro-bot[bot]@users.noreply.github.com',
+      },
+    })
     expect(createRef).toHaveBeenCalledWith({
       owner: 'fro-bot',
       repo: '.github',
       ref: 'refs/heads/data',
-      sha: 'main-head-sha',
+      sha: 'data-restore-sha',
     })
+  })
+
+  it('treats a concurrent createRef race as success when data exists afterward', async () => {
+    let dataLookups = 0
+    const createRef = vi.fn(async () => {
+      throw Object.assign(new Error('Reference already exists'), {status: 422})
+    })
+    const octokit = mockOctokit({
+      getBranch: async ({branch}: {branch: string}) => {
+        if (branch === 'data') {
+          dataLookups += 1
+          if (dataLookups === 1) {
+            throw Object.assign(new Error('Not Found'), {status: 404})
+          }
+          return {data: {name: 'data', commit: {sha: 'concurrent-data-sha'}}}
+        }
+
+        return {data: {name: 'main', commit: {sha: 'main-head-sha'}}}
+      },
+      getCommit: async (params: {commit_sha: string}) => ({
+        data: {
+          sha: params.commit_sha,
+          tree: {sha: 'main-tree-sha'},
+          message: 'chore(data): restore data branch',
+          author: {
+            name: 'fro-bot[bot]',
+            email: '109017866+fro-bot[bot]@users.noreply.github.com',
+          },
+          committer: {
+            name: 'fro-bot[bot]',
+            email: '109017866+fro-bot[bot]@users.noreply.github.com',
+          },
+          parents: params.commit_sha === 'concurrent-data-sha' ? [{sha: 'main-head-sha'}] : [],
+        },
+      }),
+      createCommit: async () => ({data: {sha: 'data-restore-sha'}}),
+      createRef,
+    })
+
+    const result = await bootstrapDataBranch({octokit})
+
+    expect(result).toEqual({created: false, ref: 'refs/heads/data', sha: 'concurrent-data-sha'})
+    expect(createRef).toHaveBeenCalledOnce()
+  })
+
+  it('treats a concurrent createRef race as success when another writer already advanced data', async () => {
+    let dataLookups = 0
+    const getCommit = vi.fn(async (params: {commit_sha: string}) => ({
+      data: {
+        sha: params.commit_sha,
+        tree: {sha: params.commit_sha === 'main-head-sha' ? 'main-tree-sha' : 'writer-tree-sha'},
+        message: params.commit_sha === 'main-head-sha' ? 'main commit' : 'chore(reconcile): update metadata',
+        parents: params.commit_sha === 'writer-commit-sha' ? [{sha: 'data-restore-sha'}] : [],
+      },
+    }))
+    const createRef = vi.fn(async () => {
+      throw Object.assign(new Error('Reference already exists'), {status: 422})
+    })
+    const octokit = mockOctokit({
+      getBranch: async ({branch}: {branch: string}) => {
+        if (branch === 'data') {
+          dataLookups += 1
+          if (dataLookups === 1) {
+            throw Object.assign(new Error('Not Found'), {status: 404})
+          }
+
+          return {data: {name: 'data', commit: {sha: 'writer-commit-sha'}}}
+        }
+
+        return {data: {name: 'main', commit: {sha: 'main-head-sha'}}}
+      },
+      getCommit,
+      createCommit: async () => ({data: {sha: 'data-restore-sha'}}),
+      createRef,
+    })
+
+    const result = await bootstrapDataBranch({octokit})
+
+    expect(result).toEqual({created: false, ref: 'refs/heads/data', sha: 'writer-commit-sha'})
+    expect(getCommit).toHaveBeenCalledOnce()
+    expect(getCommit).toHaveBeenCalledWith({owner: 'fro-bot', repo: '.github', commit_sha: 'main-head-sha'})
+    expect(createRef).toHaveBeenCalledOnce()
+  })
+
+  it('throws a structured error when createRef returns 422 but data still does not exist', async () => {
+    const createRef = vi.fn(async () => {
+      throw Object.assign(new Error('Reference already exists'), {status: 422})
+    })
+    const octokit = mockOctokit({
+      getBranch: async ({branch}: {branch: string}) => {
+        if (branch === 'data') {
+          throw Object.assign(new Error('Not Found'), {status: 404})
+        }
+
+        return {data: {name: 'main', commit: {sha: 'main-head-sha'}}}
+      },
+      getCommit: async () => ({data: {sha: 'main-head-sha', tree: {sha: 'main-tree-sha'}, parents: []}}),
+      createCommit: async () => ({data: {sha: 'data-restore-sha'}}),
+      createRef,
+    })
+
+    const error = await bootstrapDataBranch({octokit}).catch((error: unknown) => error)
+
+    expect(error).toBeInstanceOf(DataBranchBootstrapError)
+    expect((error as DataBranchBootstrapError).code).toBe('API_ERROR')
+    expect((error as DataBranchBootstrapError).message).toContain('creating data from main')
   })
 
   it('is a no-op when data branch already exists', async () => {

--- a/scripts/data-branch-bootstrap.ts
+++ b/scripts/data-branch-bootstrap.ts
@@ -5,6 +5,11 @@ const DEFAULT_OWNER = 'fro-bot'
 const DEFAULT_REPO = '.github'
 const DEFAULT_MAIN_BRANCH = 'main'
 const DEFAULT_DATA_BRANCH = 'data'
+const DEFAULT_RESTORE_MESSAGE = 'chore(data): restore data branch'
+const FRO_BOT_BOT_AUTHOR = {
+  name: 'fro-bot[bot]',
+  email: '109017866+fro-bot[bot]@users.noreply.github.com',
+}
 
 type OctokitConstructor = new (params: {auth: string}) => OctokitClient
 
@@ -82,20 +87,57 @@ export async function bootstrapDataBranch(params: DataBranchBootstrapParams = {}
     throw toBootstrapApiError(error, `reading ${mainBranch} branch head`)
   }
 
+  let baseCommit: Awaited<ReturnType<OctokitClient['rest']['git']['getCommit']>>
+  try {
+    baseCommit = await octokit.rest.git.getCommit({owner, repo, commit_sha: main.data.commit.sha})
+  } catch (error: unknown) {
+    throw toBootstrapApiError(error, `reading ${mainBranch} commit tree`)
+  }
+
+  let restoreCommit: Awaited<ReturnType<OctokitClient['rest']['git']['createCommit']>>
+  try {
+    restoreCommit = await octokit.rest.git.createCommit({
+      owner,
+      repo,
+      message: DEFAULT_RESTORE_MESSAGE,
+      tree: baseCommit.data.tree.sha,
+      parents: [main.data.commit.sha],
+      author: FRO_BOT_BOT_AUTHOR,
+      committer: FRO_BOT_BOT_AUTHOR,
+    })
+  } catch (error: unknown) {
+    throw toBootstrapApiError(error, `creating ${dataBranch} restore commit`)
+  }
+
   try {
     const response = await octokit.rest.git.createRef({
       owner,
       repo,
       ref: `refs/heads/${dataBranch}`,
-      sha: main.data.commit.sha,
+      sha: restoreCommit.data.sha,
     })
 
     return {
       created: true,
       ref: response.data.ref,
-      sha: main.data.commit.sha,
+      sha: restoreCommit.data.sha,
     }
   } catch (error: unknown) {
+    if (isApiErrorStatus(error, 422)) {
+      let existing: Awaited<ReturnType<OctokitClient['rest']['repos']['getBranch']>>
+      try {
+        existing = await octokit.rest.repos.getBranch({owner, repo, branch: dataBranch})
+      } catch (raceLookupError: unknown) {
+        throw toBootstrapApiError(raceLookupError, `creating ${dataBranch} from ${mainBranch}`)
+      }
+
+      return {
+        created: false,
+        ref: `refs/heads/${existing.data.name}`,
+        sha: existing.data.commit.sha,
+      }
+    }
+
     throw toBootstrapApiError(error, `creating ${dataBranch} from ${mainBranch}`)
   }
 }

--- a/scripts/wiki-ingest.test.ts
+++ b/scripts/wiki-ingest.test.ts
@@ -13,6 +13,7 @@ const wikiIngestModulePromise: Promise<{
 const {buildWikiIngestChanges, commitWikiChanges, parsePorcelainPaths, WikiIngestError} = await wikiIngestModulePromise
 
 interface MockOverrides {
+  getBranch?: (params: {owner: string; repo: string; branch: string}) => Promise<unknown>
   getRef?: (params: {owner: string; repo: string; ref: string}) => Promise<unknown>
   getCommit?: (params: {owner: string; repo: string; commit_sha: string}) => Promise<unknown>
   createBlob?: (params: {owner: string; repo: string; content: string; encoding: 'utf-8'}) => Promise<unknown>
@@ -35,6 +36,11 @@ interface MockOverrides {
 function createOctokitMock(overrides?: MockOverrides): OctokitClient {
   return {
     rest: {
+      repos: {
+        getBranch:
+          overrides?.getBranch ??
+          (async ({branch}: {branch: string}) => ({data: {name: branch, commit: {sha: `${branch}-sha`}}})),
+      },
       git: {
         getRef: overrides?.getRef ?? (async () => ({data: {object: {sha: 'head-sha'}}})),
         getCommit:
@@ -502,6 +508,191 @@ describe('commitWikiChanges', () => {
     expect(createTree).toHaveBeenCalledTimes(2)
     expect(createCommit).toHaveBeenCalledTimes(2)
     expect(updateRef).toHaveBeenCalledTimes(2)
+  })
+
+  it('bootstraps the data branch before reading the wiki head ref', async () => {
+    const calls: string[] = []
+    const bootstrapDataBranch = vi.fn(async () => {
+      calls.push('bootstrap')
+      return {created: false, ref: 'refs/heads/data', sha: 'data-sha'}
+    })
+    const octokit = createOctokitMock({
+      getRef: async () => {
+        calls.push('getRef')
+        return {data: {object: {sha: 'head-sha'}}}
+      },
+    })
+
+    await commitWikiChanges({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      branch: 'data',
+      message: 'feat(knowledge): ingest survey for fro-bot/agent',
+      files: {'knowledge/index.md': '# Wiki Index\n'},
+      bootstrapDataBranch,
+    })
+
+    expect(bootstrapDataBranch).toHaveBeenCalledWith({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      dataBranch: 'data',
+    })
+    expect(calls.slice(0, 2)).toEqual(['bootstrap', 'getRef'])
+  })
+
+  it('does not bootstrap when writing to a non-data branch', async () => {
+    const bootstrapDataBranch = vi.fn(async () => {
+      throw new Error('bootstrap should not run')
+    })
+
+    const result = await commitWikiChanges({
+      octokit: createOctokitMock(),
+      owner: 'fro-bot',
+      repo: '.github',
+      branch: 'test-branch',
+      message: 'feat(knowledge): write to test branch',
+      files: {'knowledge/index.md': '# Wiki Index\n'},
+      bootstrapDataBranch,
+    })
+
+    expect(result.committed).toBe(true)
+    expect(bootstrapDataBranch).not.toHaveBeenCalled()
+  })
+
+  it('rejects main before creating wiki git objects', async () => {
+    const createBlob = vi.fn<NonNullable<MockOverrides['createBlob']>>()
+    const createTree = vi.fn<NonNullable<MockOverrides['createTree']>>()
+    const createCommit = vi.fn<NonNullable<MockOverrides['createCommit']>>()
+    const updateRef = vi.fn<NonNullable<MockOverrides['updateRef']>>()
+
+    const error = await commitWikiChanges({
+      octokit: createOctokitMock({createBlob, createTree, createCommit, updateRef}),
+      owner: 'fro-bot',
+      repo: '.github',
+      branch: 'main',
+      message: 'feat(knowledge): reject protected target',
+      files: {'knowledge/index.md': '# Wiki Index\n'},
+    }).catch((error: unknown) => error)
+
+    expect(error).toBeInstanceOf(WikiIngestError)
+    expect((error as InstanceType<typeof WikiIngestError>).code).toBe('PROTECTED_BRANCH')
+    expect(createBlob).not.toHaveBeenCalled()
+    expect(createTree).not.toHaveBeenCalled()
+    expect(createCommit).not.toHaveBeenCalled()
+    expect(updateRef).not.toHaveBeenCalled()
+  })
+
+  it('rejects a protected wiki target before creating git objects', async () => {
+    const createBlob = vi.fn<NonNullable<MockOverrides['createBlob']>>()
+    const createTree = vi.fn<NonNullable<MockOverrides['createTree']>>()
+    const createCommit = vi.fn<NonNullable<MockOverrides['createCommit']>>()
+    const updateRef = vi.fn<NonNullable<MockOverrides['updateRef']>>()
+
+    const error = await commitWikiChanges({
+      octokit: createOctokitMock({
+        getBranch: async () => ({data: {name: 'protected-data', protected: true, protection: {enabled: false}}}),
+        createBlob,
+        createTree,
+        createCommit,
+        updateRef,
+      }),
+      owner: 'fro-bot',
+      repo: '.github',
+      branch: 'protected-data',
+      message: 'feat(knowledge): reject protected target',
+      files: {'knowledge/index.md': '# Wiki Index\n'},
+    }).catch((error: unknown) => error)
+
+    expect(error).toBeInstanceOf(WikiIngestError)
+    expect((error as InstanceType<typeof WikiIngestError>).code).toBe('PROTECTED_BRANCH')
+    expect(createBlob).not.toHaveBeenCalled()
+    expect(createTree).not.toHaveBeenCalled()
+    expect(createCommit).not.toHaveBeenCalled()
+    expect(updateRef).not.toHaveBeenCalled()
+  })
+
+  it('rejects a wiki target with enabled branch protection before creating git objects', async () => {
+    const createBlob = vi.fn<NonNullable<MockOverrides['createBlob']>>()
+    const createTree = vi.fn<NonNullable<MockOverrides['createTree']>>()
+    const createCommit = vi.fn<NonNullable<MockOverrides['createCommit']>>()
+    const updateRef = vi.fn<NonNullable<MockOverrides['updateRef']>>()
+
+    const error = await commitWikiChanges({
+      octokit: createOctokitMock({
+        getBranch: async () => ({data: {name: 'protected-data', protected: false, protection: {enabled: true}}}),
+        createBlob,
+        createTree,
+        createCommit,
+        updateRef,
+      }),
+      owner: 'fro-bot',
+      repo: '.github',
+      branch: 'protected-data',
+      message: 'feat(knowledge): reject protected target',
+      files: {'knowledge/index.md': '# Wiki Index\n'},
+    }).catch((error: unknown) => error)
+
+    expect(error).toBeInstanceOf(WikiIngestError)
+    expect((error as InstanceType<typeof WikiIngestError>).code).toBe('PROTECTED_BRANCH')
+    expect(createBlob).not.toHaveBeenCalled()
+    expect(createTree).not.toHaveBeenCalled()
+    expect(createCommit).not.toHaveBeenCalled()
+    expect(updateRef).not.toHaveBeenCalled()
+  })
+
+  it('stops before wiki ref reads and writes when bootstrap fails', async () => {
+    const bootstrapDataBranch = vi.fn(async () => {
+      throw new Error('bootstrap failed')
+    })
+    const getRef = vi.fn<NonNullable<MockOverrides['getRef']>>()
+    const createBlob = vi.fn<NonNullable<MockOverrides['createBlob']>>()
+    const updateRef = vi.fn<NonNullable<MockOverrides['updateRef']>>()
+
+    await expect(
+      commitWikiChanges({
+        octokit: createOctokitMock({getRef, createBlob, updateRef}),
+        owner: 'fro-bot',
+        repo: '.github',
+        branch: 'data',
+        message: 'feat(knowledge): stop on bootstrap failure',
+        files: {'knowledge/index.md': '# Wiki Index\n'},
+        bootstrapDataBranch,
+      }),
+    ).rejects.toThrow('bootstrap failed')
+
+    expect(getRef).not.toHaveBeenCalled()
+    expect(createBlob).not.toHaveBeenCalled()
+    expect(updateRef).not.toHaveBeenCalled()
+  })
+
+  it('rebootstraps and retries when data disappears before reading the wiki head ref', async () => {
+    const calls: string[] = []
+    const bootstrapDataBranch = vi.fn(async () => {
+      calls.push('bootstrap')
+      return {created: false, ref: 'refs/heads/data', sha: 'data-sha'}
+    })
+    const getRef = vi
+      .fn<NonNullable<MockOverrides['getRef']>>()
+      .mockRejectedValueOnce(Object.assign(new Error('Not Found'), {status: 404}))
+      .mockResolvedValue({data: {object: {sha: 'head-sha'}}})
+
+    const result = await commitWikiChanges({
+      octokit: createOctokitMock({getRef}),
+      owner: 'fro-bot',
+      repo: '.github',
+      branch: 'data',
+      message: 'feat(knowledge): retry after missing data branch',
+      files: {'knowledge/index.md': '# Wiki Index\n'},
+      maxRetries: 2,
+      bootstrapDataBranch,
+    })
+
+    expect(result.committed).toBe(true)
+    expect(result.attempts).toBe(2)
+    expect(bootstrapDataBranch).toHaveBeenCalledTimes(2)
+    expect(calls).toEqual(['bootstrap', 'bootstrap'])
   })
 
   it('backs off exponentially before retrying a 409 ref conflict', async () => {

--- a/scripts/wiki-ingest.ts
+++ b/scripts/wiki-ingest.ts
@@ -7,6 +7,11 @@ import process from 'node:process'
 import {promisify} from 'node:util'
 
 import {parse} from 'yaml'
+import {
+  bootstrapDataBranch as defaultBootstrapDataBranch,
+  type DataBranchBootstrapParams,
+  type DataBranchBootstrapResult,
+} from './data-branch-bootstrap.ts'
 
 const DEFAULT_OWNER = 'fro-bot'
 const DEFAULT_REPO = '.github'
@@ -58,6 +63,11 @@ export interface CommitWikiChangesParams {
   files: Record<string, string>
   octokit?: OctokitClient
   maxRetries?: number
+  /**
+   * Idempotent data-branch bootstrap. Called before data-branch writes so wiki
+   * ingest recovers when GitHub deletes the `data` source ref after promotion.
+   */
+  bootstrapDataBranch?: (params: DataBranchBootstrapParams) => Promise<DataBranchBootstrapResult>
 }
 
 export interface CommitWikiChangesResult {
@@ -78,6 +88,7 @@ export type WikiIngestErrorCode =
   | 'INVALID_FRONTMATTER'
   | 'INVALID_WIKILINK'
   | 'INVALID_RETRIES'
+  | 'PROTECTED_BRANCH'
   | 'MISSING_TOKEN'
   | 'OCTOKIT_LOAD_FAILED'
   | 'CONFLICT_EXHAUSTED'
@@ -172,9 +183,22 @@ export async function commitWikiChanges(params: CommitWikiChangesParams): Promis
   }
 
   const octokit = params.octokit ?? (await createOctokitFromEnv())
+  rejectProtectedWikiBranchName(branch)
+
+  const shouldBootstrapDataBranch = branch === DEFAULT_BRANCH
+  const bootstrap = params.bootstrapDataBranch ?? defaultBootstrapDataBranch
+  const bootstrapDataBranch = async (): Promise<void> => {
+    await bootstrap({octokit, owner, repo, dataBranch: branch})
+  }
+
+  if (shouldBootstrapDataBranch) {
+    await bootstrapDataBranch()
+  }
 
   for (let attempt = 1; attempt <= maxRetries; attempt += 1) {
     try {
+      await assertWritableWikiBranch(octokit, owner, repo, branch)
+
       const head = await octokit.rest.git.getRef({owner, repo, ref: `heads/${branch}`})
       const commit = await octokit.rest.git.getCommit({owner, repo, commit_sha: head.data.object.sha})
 
@@ -214,6 +238,11 @@ export async function commitWikiChanges(params: CommitWikiChangesParams): Promis
 
       return {committed: true, commitSha: createdCommit.data.sha, attempts: attempt}
     } catch (error: unknown) {
+      if (shouldBootstrapDataBranch && isApiErrorStatus(error, 404) && attempt < maxRetries) {
+        await bootstrapDataBranch()
+        continue
+      }
+
       if (isConflictError(error) && attempt < maxRetries) {
         await delayConflictRetry(attempt)
         continue
@@ -233,6 +262,34 @@ export async function commitWikiChanges(params: CommitWikiChangesParams): Promis
   }
 
   throw new Error('wiki ingest reached an unreachable retry state')
+}
+
+function rejectProtectedWikiBranchName(branch: string): void {
+  if (branch === 'main') {
+    throw new WikiIngestError({
+      code: 'PROTECTED_BRANCH',
+      message: 'wiki ingest refuses to write to main; use the data branch',
+      remediation: 'Target the data branch. Promotions to main must go through the data-branch merge PR.',
+    })
+  }
+}
+
+async function assertWritableWikiBranch(
+  octokit: OctokitClient,
+  owner: string,
+  repo: string,
+  branch: string,
+): Promise<void> {
+  const response = await octokit.rest.repos.getBranch({owner, repo, branch})
+
+  if (response.data.protected === true || response.data.protection?.enabled === true) {
+    throw new WikiIngestError({
+      code: 'PROTECTED_BRANCH',
+      message: `wiki ingest refuses to write to protected branch "${branch}"`,
+      remediation:
+        'Autonomous wiki writes must land on an unprotected branch. Review the ruleset or target the data branch.',
+    })
+  }
 }
 
 async function createOctokitFromEnv(): Promise<OctokitClient> {
@@ -613,6 +670,10 @@ function isWikiPageType(value: unknown): value is WikiPageType {
 
 function isConflictError(error: unknown): boolean {
   return isRecord(error) && error.status === 409
+}
+
+function isApiErrorStatus(error: unknown, status: number): boolean {
+  return isRecord(error) && error.status === status
 }
 
 async function delayConflictRetry(attempt: number): Promise<void> {


### PR DESCRIPTION
## Summary

- Bootstraps the `data` branch before shared metadata and wiki writes.
- Restores missing `data` as a same-tree Fro Bot-authored commit instead of relying on workflow-specific setup.
- Retries metadata/wiki writes when `data` disappears mid-write, while refusing protected wiki targets such as `main`.
- Covers concurrent branch-creation races, protected-branch guards, and non-`data` branch bypass behavior.

## Verification

- `pnpm bootstrap`
- `pnpm check-types`
- `pnpm lint`
- `pnpm test` — 536 passed
