### PR TITLE
feat(privacy): gate Survey Repo dispatch on node_id with workflow-side privacy verification

### DIFF
--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -1,15 +1,23 @@
 ---
 name: Survey Repo
 
+run-name: Survey Repo
+
+# Manual dispatch contract:
+#   Use:    gh workflow run survey-repo.yaml -f node_id=<repository GraphQL node_id>
+#   Was:    gh workflow run survey-repo.yaml -f owner=<owner> -f repo=<repo>  # removed
+#
+# Look up node_id with:
+#   gh api graphql -f query='query{repository(owner:"<owner>",name:"<repo>"){id}}' --jq '.data.repository.id'
+#
+# Job outputs (consumed by the broadcast job below):
+#   owner — repository owner, only set after the resolve step verifies isPrivate === false
+#   repo  — repository name, same guarantee
 on:
   workflow_dispatch:
     inputs:
-      owner:
-        description: Repository owner to survey
-        required: true
-        type: string
-      repo:
-        description: Repository name to survey
+      node_id:
+        description: GitHub repository node_id; resolves to owner/repo internally after privacy verification
         required: true
         type: string
 
@@ -17,7 +25,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: survey-repo-${{ github.event.inputs.owner }}-${{ github.event.inputs.repo }}
+  group: survey-repo-${{ inputs.node_id }}
   cancel-in-progress: false
 
 env:
@@ -47,6 +55,10 @@ jobs:
   survey-repo:
     name: Survey Repo
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      owner: ${{ steps.resolve.outputs.owner }}
+      repo: ${{ steps.resolve.outputs.repo }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -55,6 +67,44 @@ jobs:
 
       - name: 📦 Setup
         uses: ./.github/actions/setup
+
+      - name: 🔒 Resolve and verify
+        id: resolve
+        env:
+          NODE_ID: ${{ inputs.node_id }}
+          GH_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+        run: |
+          if ! printf '%s' "$NODE_ID" | grep -qE '^[A-Za-z0-9_=-]+$'; then
+            printf 'Aborting: dispatch input shape invalid\n' >&2
+            exit 1
+          fi
+
+          # shellcheck disable=SC2016
+          gql_query='query($id: ID!) { node(id: $id) { ... on Repository { nameWithOwner isPrivate } } }'
+          response=$(gh api graphql \
+            -F id="$NODE_ID" \
+            -f query="$gql_query" \
+            2>/dev/null) || {
+            printf 'GraphQL lookup failed for node_id: %s\n' "$NODE_ID" >&2
+            exit 1
+          }
+
+          is_private=$(printf '%s' "$response" | jq -r '.data.node.isPrivate // "null"')
+          name_with_owner=$(printf '%s' "$response" | jq -r '.data.node.nameWithOwner // ""')
+
+          if [ -z "$name_with_owner" ] || [ "$is_private" = "null" ] || [ "$is_private" != "false" ]; then
+            printf 'Aborting: %s is not definitively public\n' "$NODE_ID" >&2
+            exit 1
+          fi
+
+          resolved_owner="${name_with_owner%%/*}"
+          resolved_repo="${name_with_owner#*/}"
+
+          {
+            printf 'owner=%s\n' "$resolved_owner"
+            printf 'repo=%s\n' "$resolved_repo"
+            printf 'node_id=%s\n' "$NODE_ID"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Sync wiki from data branch
         run: |
@@ -82,8 +132,8 @@ jobs:
       - name: Resolve ingest prompt
         id: ingest-prompt
         env:
-          TARGET_OWNER: ${{ github.event.inputs.owner }}
-          TARGET_REPO: ${{ github.event.inputs.repo }}
+          TARGET_OWNER: ${{ steps.resolve.outputs.owner }}
+          TARGET_REPO: ${{ steps.resolve.outputs.repo }}
           PROMPT_TEMPLATE: ${{ env.INGEST_PROMPT }}
         run: |
           delimiter="EOF_$(openssl rand -hex 8)"
@@ -136,6 +186,30 @@ jobs:
         id: ts
         run: echo "now=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
+      - name: 🔒 Recheck visibility
+        id: recheck
+        if: steps.wiki-changes.outputs.changed == 'true'
+        env:
+          NODE_ID: ${{ inputs.node_id }}
+          GH_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+        run: |
+          # shellcheck disable=SC2016
+          gql_query='query($id: ID!) { node(id: $id) { ... on Repository { isPrivate } } }'
+          response=$(gh api graphql \
+            -F id="$NODE_ID" \
+            -f query="$gql_query" \
+            2>/dev/null) || {
+            printf 'Aborting: visibility recheck failed for %s\n' "$NODE_ID" >&2
+            exit 1
+          }
+
+          is_private=$(printf '%s' "$response" | jq -r '.data.node.isPrivate // "null"')
+
+          if [ "$is_private" != "false" ]; then
+            printf 'Aborting: visibility recheck failed for %s\n' "$NODE_ID" >&2
+            exit 1
+          fi
+
       - name: Commit wiki ingest to data branch
         id: wiki-commit
         if: steps.wiki-changes.outputs.changed == 'true'
@@ -170,8 +244,10 @@ jobs:
         if: always() && !cancelled() && steps.survey-agent.conclusion != 'skipped'
         env:
           GITHUB_TOKEN: ${{ secrets.FRO_BOT_PAT }}
-          REPO_OWNER: ${{ github.event.inputs.owner }}
-          REPO_NAME: ${{ github.event.inputs.repo }}
+          REPO_OWNER: ${{ steps.resolve.outputs.owner }}
+          REPO_NAME: ${{ steps.resolve.outputs.repo }}
+          REPO_NODE_ID: ${{ inputs.node_id }}
+          REPO_PRIVATE: 'false'
           SURVEY_STATUS:
             ${{ (steps.survey-agent.conclusion == 'success' && (steps.wiki-commit.conclusion == 'success' ||
             steps.wiki-commit.conclusion == 'skipped')) && 'success' || 'failure' }}
@@ -185,18 +261,18 @@ jobs:
     with:
       event_type: repo_survey_complete
       discord_message: >-
-        Just finished surveying **${{ github.event.inputs.owner }}/${{ github.event.inputs.repo }}**.
+        Just finished surveying **${{ needs.survey-repo.outputs.owner }}/${{ needs.survey-repo.outputs.repo }}**.
         New knowledge ingested into the wiki ✨
       discord_title: Repo Survey Complete
       bluesky_text: >-
-        📡 Just surveyed ${{ github.event.inputs.owner }}/${{ github.event.inputs.repo }} and locked in new insights.
+        📡 Just surveyed ${{ needs.survey-repo.outputs.owner }}/${{ needs.survey-repo.outputs.repo }} and locked in new insights.
         The wiki grows. #GitHub #OpenSource
       journal_text: >-
-        Surveyed ${{ github.event.inputs.owner }}/${{ github.event.inputs.repo }} and persisted what I learned.
+        Surveyed ${{ needs.survey-repo.outputs.owner }}/${{ needs.survey-repo.outputs.repo }} and persisted what I learned.
         Each repo leaves a mark on the map.
       journal_metadata: >-
-        {"owner":"${{ github.event.inputs.owner }}","repo":"${{ github.event.inputs.repo }}"}
-      repo: ${{ github.event.inputs.owner }}/${{ github.event.inputs.repo }}
+        {"owner":"${{ needs.survey-repo.outputs.owner }}","repo":"${{ needs.survey-repo.outputs.repo }}"}
+      repo: ${{ needs.survey-repo.outputs.owner }}/${{ needs.survey-repo.outputs.repo }}
     secrets:
       FRO_BOT_PAT: ${{ secrets.FRO_BOT_PAT }}
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -188,7 +188,7 @@ jobs:
 
       - name: 🔒 Recheck visibility
         id: recheck
-        if: steps.wiki-changes.outputs.changed == 'true'
+        if: always() && !cancelled() && steps.survey-agent.conclusion != 'skipped'
         env:
           NODE_ID: ${{ inputs.node_id }}
           GH_TOKEN: ${{ secrets.FRO_BOT_PAT }}
@@ -210,9 +210,11 @@ jobs:
             exit 1
           fi
 
+          echo "private=false" >> "$GITHUB_OUTPUT"
+
       - name: Commit wiki ingest to data branch
         id: wiki-commit
-        if: steps.wiki-changes.outputs.changed == 'true'
+        if: steps.wiki-changes.outputs.changed == 'true' && steps.recheck.conclusion == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.FRO_BOT_PAT }}
           WIKI_OPERATION: survey
@@ -241,13 +243,13 @@ jobs:
       # the agent made no changes) counts as success, not failure, because the agent
       # completed cleanly.
       - name: Record survey result
-        if: always() && !cancelled() && steps.survey-agent.conclusion != 'skipped'
+        if: always() && !cancelled() && steps.survey-agent.conclusion != 'skipped' && steps.recheck.conclusion == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.FRO_BOT_PAT }}
           REPO_OWNER: ${{ steps.resolve.outputs.owner }}
           REPO_NAME: ${{ steps.resolve.outputs.repo }}
           REPO_NODE_ID: ${{ inputs.node_id }}
-          REPO_PRIVATE: 'false'
+          REPO_PRIVATE: ${{ steps.recheck.outputs.private }}
           SURVEY_STATUS:
             ${{ (steps.survey-agent.conclusion == 'success' && (steps.wiki-commit.conclusion == 'success' ||
             steps.wiki-commit.conclusion == 'skipped')) && 'success' || 'failure' }}

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Fro Bot control plane:
 | **Fro Bot Autoheal** | Scheduled self-repair pass | Daily 03:30 UTC, dispatch |
 | **Poll Invitations** | Accept allowlisted collaboration invitations | Every 15 minutes, dispatch |
 | **Reconcile Repos** | Reconcile collaborator access against `metadata/repos.yaml`; dispatch surveys for stale repos | Daily 05:17 UTC, dispatch |
-| **Survey Repo** | Ingest a repository into the knowledge wiki | Dispatch (by Reconcile Repos) |
+| **Survey Repo** | Ingest a repository into the knowledge wiki; dispatched by Reconcile Repos or manually via `gh workflow run survey-repo.yaml -f node_id=<node_id>` | Dispatch (by Reconcile Repos) |
 | **Merge Data Branch** | Promote autonomous `data`-branch commits to `main` | Sunday 22:00 UTC, dispatch |
 | **Update Metadata** | Refresh `metadata/renovate.yaml` from the fro-bot org scan | Daily 04:30 UTC, dispatch |
 | **Dispatch Renovate** | Dispatch Renovate runs across repos tracked in `metadata/renovate.yaml` | Every 4 hours at `:30`, dispatch |
@@ -246,6 +246,18 @@ Runtime state lives in version-controlled YAML under [`metadata/`](metadata/) (a
 ### Knowledge Wiki
 
 Fro Bot maintains a [Karpathy-style LLM wiki](knowledge/) (`schema.md`, `index.md`, `log.md`, plus `wiki/{repos,topics,entities,comparisons}/`) that compounds cross-repo knowledge. The **Survey Repo** workflow ingests repositories into the wiki; **Reconcile Repos** schedules those surveys; **Wiki Lint** validates the authoritative snapshot restored from `origin/data` before reporting findings.
+
+To manually re-survey a repo, pass its GitHub GraphQL `node_id` as the dispatch input:
+
+```bash
+# Look up the node_id
+gh api graphql -f query='query{repository(owner:"<owner>",name:"<repo>"){id}}' --jq '.data.repository.id'
+
+# Dispatch the survey
+gh workflow run survey-repo.yaml -f node_id=<node_id>
+```
+
+The `node_id` for each tracked repo is stored in `metadata/repos.yaml` on the `data` branch.
 
 ## Development
 

--- a/docs/plans/2026-05-05-002-feat-private-repo-handling-plan.md
+++ b/docs/plans/2026-05-05-002-feat-private-repo-handling-plan.md
@@ -530,7 +530,7 @@ persona/
 
 ---
 
-- [ ] **Unit 6: Survey Repo workflow gate with `node_id` inputs**
+- [x] **Unit 6: Survey Repo workflow gate with `node_id` inputs**
 
 **Goal:** `survey-repo.yaml` accepts `node_id` (not `owner/repo`) as input. First job step resolves `node_id` → `owner/repo` via App token AND verifies `private: false`. Aborts on any error or `private: true`. Concurrency group, run name, and dispatch input echoes use `node_id`.
 

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -39,6 +39,8 @@ version: 1
 repos:
   - owner: string
     name: string
+    node_id: string
+    private: boolean
     added: ISO date
     onboarding_status: pending | onboarded | failed | lost-access | pending-review
     last_survey_at: ISO datetime | null
@@ -48,6 +50,11 @@ repos:
     discovery_channel: collab | owned | contrib
     next_survey_eligible_at: ISO date | null
 ```
+
+Field notes:
+
+- `node_id` — GitHub GraphQL node ID for the repository. Used as the manual dispatch identifier: `gh workflow run survey-repo.yaml -f node_id=<node_id>`. Also used as the privacy-safe identifier in `pending-review` issue bodies for private repos.
+- `private` — whether the repository is private. Entries with `private: true` have `owner` and `name` redacted to `[REDACTED]` in public-facing contexts; the `node_id` is used as the subject identifier instead.
 
 Update convention: invitation handler, metadata workflow, and daily reconcile update this file programmatically on the `data` branch.
 

--- a/scripts/handle-invitation.test.ts
+++ b/scripts/handle-invitation.test.ts
@@ -110,6 +110,7 @@ describe('handleInvitations', () => {
           },
         ],
       }),
+      getRepo: async () => ({data: {node_id: 'R_kgDOPUBLIC', private: false}}),
       acceptInvitationForAuthenticatedUser: acceptInvitation,
       starRepoForAuthenticatedUser,
       createWorkflowDispatch,
@@ -145,7 +146,7 @@ describe('handleInvitations', () => {
       repo: '.github',
       workflow_id: 'survey.yaml',
       ref: 'main',
-      inputs: {owner: 'fro-bot', repo: 'hello-world'},
+      inputs: {node_id: 'R_kgDOPUBLIC'},
     })
     expect(commitMetadata).toHaveBeenCalledOnce()
 
@@ -233,6 +234,58 @@ describe('handleInvitations', () => {
     }
     expect(JSON.stringify(result)).not.toContain('private-owner')
     expect(JSON.stringify(result)).not.toContain('flipped-repo')
+  })
+
+  it('uses the refreshed node_id from repos.get when accepting a still-public invitation', async () => {
+    // #given an invitation that carries node_id A, but repos.get returns node_id B
+    // (e.g. the repo was deleted and recreated between invitation send and acceptance)
+    // #then the dispatch and metadata use node_id B (authoritative post-acceptance value)
+    const acceptInvitation = vi.fn(async () => undefined)
+    const starRepoForAuthenticatedUser = vi.fn(async () => undefined)
+    const createWorkflowDispatch = vi.fn(async () => undefined)
+    const commitMetadata = vi.fn<CommitMetadataMock>(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
+    const octokit = mockOctokit({
+      listInvitationsForAuthenticatedUser: async () => ({
+        data: [
+          {
+            id: 121,
+            inviter: {login: 'marcusrbrown'},
+            repository: {
+              name: 'recreated-repo',
+              node_id: 'R_kgDO_STALE_A',
+              private: false,
+              owner: {login: 'fro-bot'},
+            },
+          },
+        ],
+      }),
+      getRepo: async () => ({data: {node_id: 'R_kgDO_FRESH_B', private: false}}),
+      acceptInvitationForAuthenticatedUser: acceptInvitation,
+      starRepoForAuthenticatedUser,
+      createWorkflowDispatch,
+    })
+
+    const result = await handleInvitations({
+      octokit,
+      allowlistPath: 'metadata/allowlist.yaml',
+      reposPath: 'metadata/repos.yaml',
+      now: new Date('2026-04-16T12:00:00.000Z'),
+      workflowFile: 'survey.yaml',
+      workflowRef: 'main',
+      commitMetadata,
+      bootstrapDataBranch: vi.fn(async () => ({})),
+      readMetadata: readTestMetadata,
+    })
+
+    expect(result.processed[0]?.status).toBe('accepted')
+    // Dispatch and metadata must use the FRESH node_id, not the stale one from the invitation
+    expect(createWorkflowDispatch).toHaveBeenCalledWith(expect.objectContaining({inputs: {node_id: 'R_kgDO_FRESH_B'}}))
+    const mutator = commitMetadata.mock.calls[0]?.[0].mutator
+    if (typeof mutator === 'function') {
+      const newReposFile = mutator({version: 1, repos: []})
+      assertReposFile(newReposFile)
+      expect(newReposFile.repos[0]).toMatchObject({node_id: 'R_kgDO_FRESH_B'})
+    }
   })
 
   it('fails public invitations that are missing node_id before accepting them', async () => {

--- a/scripts/handle-invitation.test.ts
+++ b/scripts/handle-invitation.test.ts
@@ -288,6 +288,62 @@ describe('handleInvitations', () => {
     }
   })
 
+  it('preserves the invitation node_id when repos.get omits it on refresh', async () => {
+    // #given an invitation that carries node_id A and a repos.get that returns
+    // public=true but with an empty/missing node_id (a degenerate API response shape)
+    // #then the fallback at acceptedInvitationRepositoryPrivacy preserves the
+    // invitation's node_id rather than dispatching with an empty identifier
+    const acceptInvitation = vi.fn(async () => undefined)
+    const starRepoForAuthenticatedUser = vi.fn(async () => undefined)
+    const createWorkflowDispatch = vi.fn(async () => undefined)
+    const commitMetadata = vi.fn<CommitMetadataMock>(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))
+    const octokit = mockOctokit({
+      listInvitationsForAuthenticatedUser: async () => ({
+        data: [
+          {
+            id: 122,
+            inviter: {login: 'marcusrbrown'},
+            repository: {
+              name: 'sparse-refresh',
+              node_id: 'R_kgDO_INVITATION',
+              private: false,
+              owner: {login: 'fro-bot'},
+            },
+          },
+        ],
+      }),
+      // repos.get returns public confirmation but no node_id — fallback must preserve invitation value
+      getRepo: async () => ({data: {node_id: '', private: false}}),
+      acceptInvitationForAuthenticatedUser: acceptInvitation,
+      starRepoForAuthenticatedUser,
+      createWorkflowDispatch,
+    })
+
+    const result = await handleInvitations({
+      octokit,
+      allowlistPath: 'metadata/allowlist.yaml',
+      reposPath: 'metadata/repos.yaml',
+      now: new Date('2026-04-16T12:00:00.000Z'),
+      workflowFile: 'survey.yaml',
+      workflowRef: 'main',
+      commitMetadata,
+      bootstrapDataBranch: vi.fn(async () => ({})),
+      readMetadata: readTestMetadata,
+    })
+
+    expect(result.processed[0]?.status).toBe('accepted')
+    // Dispatch uses the invitation's node_id — never an empty string from the sparse refresh
+    expect(createWorkflowDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({inputs: {node_id: 'R_kgDO_INVITATION'}}),
+    )
+    const mutator = commitMetadata.mock.calls[0]?.[0].mutator
+    if (typeof mutator === 'function') {
+      const newReposFile = mutator({version: 1, repos: []})
+      assertReposFile(newReposFile)
+      expect(newReposFile.repos[0]).toMatchObject({node_id: 'R_kgDO_INVITATION'})
+    }
+  })
+
   it('fails public invitations that are missing node_id before accepting them', async () => {
     const acceptInvitation = vi.fn(async () => undefined)
     const commitMetadata = vi.fn<CommitMetadataMock>(async () => ({committed: true, sha: 'commit-sha', attempts: 1}))

--- a/scripts/handle-invitation.ts
+++ b/scripts/handle-invitation.ts
@@ -248,7 +248,7 @@ async function processInvitation(params: {
         repo: params.repo,
         workflow_id: params.workflowFile,
         ref: params.workflowRef,
-        inputs: {owner: repoOwner, repo: repoName},
+        inputs: {node_id: acceptedPrivacy.nodeId},
       })
     }
 
@@ -297,7 +297,7 @@ async function acceptedInvitationRepositoryPrivacy(
         : invitationPrivacy.nodeId
 
     if (privateFlag === false) {
-      return {kind: 'public', nodeId: invitationPrivacy.nodeId}
+      return {kind: 'public', nodeId}
     }
 
     return {kind: 'private', nodeId}

--- a/scripts/handle-invitation.ts
+++ b/scripts/handle-invitation.ts
@@ -301,7 +301,16 @@ async function acceptedInvitationRepositoryPrivacy(
     }
 
     return {kind: 'private', nodeId}
-  } catch {
+  } catch (error: unknown) {
+    // Fail closed on transient refresh failures (rate limit, network blip) — a public
+    // invitation may be temporarily classified as private until reconcile probes it. Log
+    // diagnostics so the failure mode is observable; omit owner/repo to avoid training
+    // future leak paths even though this branch is the public-only refresh case.
+    const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
+    const kind = error instanceof Error ? error.name : 'unknown'
+    process.stderr.write(
+      `handle-invitation: repos.get privacy refresh failed (status=${status}, kind=${kind}); treating invitation as private.\n`,
+    )
     return {kind: 'private', nodeId: invitationPrivacy.nodeId}
   }
 }

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -109,7 +109,7 @@ describe('reconcileRepos', () => {
         name: 'new-repo',
         onboarding_status: 'pending',
       })
-      expect(result.dispatches).toEqual([{owner: 'marcusrbrown', repo: 'new-repo'}])
+      expect(result.dispatches).toEqual([{owner: 'marcusrbrown', repo: 'new-repo', node_id: 'R_new'}])
       expect(result.issues).toEqual([])
       expect(result.summary).toEqual({
         added: 1,
@@ -370,7 +370,7 @@ describe('reconcileRepos', () => {
         }),
       )
 
-      expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'back-again'}])
+      expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'back-again', node_id: 'R_public_again'}])
       expect(result.summary.regained).toBe(1)
       expect(result.summary.skippedPrivate).toBe(0)
     })
@@ -442,7 +442,7 @@ describe('reconcileRepos', () => {
         }),
       )
 
-      expect(result.dispatches).toEqual([{owner: 'trusted', repo: 'ok-repo'}])
+      expect(result.dispatches).toEqual([{owner: 'trusted', repo: 'ok-repo', node_id: 'R_ok'}])
       expect(result.issues).toHaveLength(1)
       expect(result.issues[0]?.kind).toBe('per-owner-rollup')
       expect(result.issues.filter(i => i.kind === 'per-repo')).toEqual([])
@@ -542,7 +542,7 @@ describe('reconcileRepos', () => {
       // THEN the genuinely-new newcomer is added normally (the tracked entry's
       // own first-survey dispatch is incidental and not what this test cares about)
       expect(result.nextRepos.repos).toHaveLength(2)
-      expect(result.dispatches).toContainEqual({owner: 'marcusrbrown', repo: 'genuinely-new'})
+      expect(result.dispatches).toContainEqual({owner: 'marcusrbrown', repo: 'genuinely-new', node_id: 'R_new'})
       expect(result.summary.added).toBe(1)
     })
   })
@@ -742,7 +742,7 @@ describe('reconcileRepos', () => {
         private: false,
         node_id: 'R_default',
       })
-      expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'returned-repo'}])
+      expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'returned-repo', node_id: 'R_default'}])
       expect(result.issues).toEqual([])
       expect(result.summary.regained).toBe(1)
     })
@@ -1207,7 +1207,7 @@ describe('reconcileRepos', () => {
       expect(byName.get('drift-repo')?.onboarding_status).toBe('onboarded')
       expect(byName.get('gone-repo')?.onboarding_status).toBe('lost-access')
       expect(byName.get('fresh-repo')?.onboarding_status).toBe('pending')
-      expect(result.dispatches).toEqual([{owner: 'trusted', repo: 'fresh-repo'}])
+      expect(result.dispatches).toEqual([{owner: 'trusted', repo: 'fresh-repo', node_id: 'R_fresh'}])
       expect(result.issues).toEqual([])
       expect(result.summary).toEqual({
         added: 1,
@@ -1381,7 +1381,7 @@ describe('reconcileRepos', () => {
         }),
       )
       // #then the entry is dispatched for its initial survey
-      expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'never-surveyed'}])
+      expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'never-surveyed', node_id: 'R_default'}])
     })
 
     it('dispatches pending entry with failure status (failed initial survey)', () => {
@@ -1401,7 +1401,7 @@ describe('reconcileRepos', () => {
         }),
       )
       // #then the entry is dispatched for retry (failure ≠ success, so eligible)
-      expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'failed-initial'}])
+      expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'failed-initial', node_id: 'R_default'}])
     })
 
     it('does not dispatch pending-review entry (requires human approval)', () => {
@@ -1466,7 +1466,7 @@ describe('reconcileRepos', () => {
         }),
       )
       // #then the entry is dispatched (eligibility passed)
-      expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'overdue-repo'}])
+      expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'overdue-repo', node_id: 'R_default'}])
     })
 
     it('skips an eligible private tracked entry before the survey eligibility gate', () => {
@@ -1599,7 +1599,7 @@ describe('reconcileRepos', () => {
         onboarding_status: 'pending',
         discovery_channel: 'owned',
       })
-      expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'agent'}])
+      expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'agent', node_id: 'R_agent'}])
       expect(result.issues).toEqual([])
       expect(result.summary.added).toBe(1)
       expect(result.summary.pendingReview).toBe(0)
@@ -1616,7 +1616,7 @@ describe('reconcileRepos', () => {
 
       // #then dispatched with discovery_channel: contrib; no pending-review issue
       expect(result.nextRepos.repos[0]?.discovery_channel).toBe('contrib')
-      expect(result.dispatches).toEqual([{owner: 'bfra-me', repo: '.github'}])
+      expect(result.dispatches).toEqual([{owner: 'bfra-me', repo: '.github', node_id: 'R_bfra_gh'}])
       expect(result.issues).toEqual([])
       expect(result.summary.added).toBe(1)
       expect(result.summary.pendingReview).toBe(0)
@@ -1633,7 +1633,7 @@ describe('reconcileRepos', () => {
       )
 
       expect(result.nextRepos.repos[0]?.discovery_channel).toBe('collab')
-      expect(result.dispatches).toEqual([{owner: 'marcusrbrown', repo: 'new-repo'}])
+      expect(result.dispatches).toEqual([{owner: 'marcusrbrown', repo: 'new-repo', node_id: 'R_default'}])
     })
 
     it('skips pending-review for owned newcomers from a non-allowlisted owner', () => {
@@ -1666,7 +1666,7 @@ describe('reconcileRepos', () => {
 
       expect(result.summary.added).toBe(1)
       expect(result.summary.pendingReview).toBe(0)
-      expect(result.dispatches).toEqual([{owner: 'bfra-me', repo: 'renovate-action'}])
+      expect(result.dispatches).toEqual([{owner: 'bfra-me', repo: 'renovate-action', node_id: 'R_bfra_ren'}])
       expect(result.issues).toEqual([])
     })
 
@@ -1738,7 +1738,7 @@ describe('reconcileRepos', () => {
       // #then regained as pending; dispatched directly (contrib is trusted, no issue)
       expect(result.nextRepos.repos[0]?.onboarding_status).toBe('pending')
       expect(result.summary.regained).toBe(1)
-      expect(result.dispatches).toEqual([{owner: 'bfra-me', repo: '.github'}])
+      expect(result.dispatches).toEqual([{owner: 'bfra-me', repo: '.github', node_id: 'R_bfra_gh'}])
       expect(result.issues).toEqual([])
     })
 
@@ -1762,7 +1762,7 @@ describe('reconcileRepos', () => {
 
       expect(result.nextRepos.repos[0]?.onboarding_status).toBe('pending')
       expect(result.summary.regained).toBe(1)
-      expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'systematic'}])
+      expect(result.dispatches).toEqual([{owner: 'fro-bot', repo: 'systematic', node_id: 'R_sys'}])
       expect(result.issues).toEqual([])
     })
 
@@ -2497,8 +2497,8 @@ describe('handleReconcile (I/O shell)', () => {
       const dispatchCalls: string[] = []
       const sleepCalls: number[] = []
       const createWorkflowDispatch = vi.fn(async (params: unknown) => {
-        const typed = params as {inputs?: {owner: string; repo: string}}
-        dispatchCalls.push(typed.inputs?.repo ?? '?')
+        const typed = params as {inputs?: {node_id: string}}
+        dispatchCalls.push(typed.inputs?.node_id ?? '?')
       })
       const dispatchSleep = vi.fn(async (ms: number) => {
         sleepCalls.push(ms)
@@ -2525,10 +2525,12 @@ describe('handleReconcile (I/O shell)', () => {
         }),
       )
 
-      // Exactly 4 dispatches fired in order.
-      expect(dispatchCalls).toEqual(['r1', 'r2', 'r3', 'r4'])
+      // Exactly 4 dispatches fired in order — asserted by node_id (the only identifier
+      // the workflow_dispatch payload now exposes).
+      expect(dispatchCalls).toEqual(['R_1', 'R_2', 'R_3', 'R_4'])
       expect(result.dispatches).toBe(4)
-      // Exactly 3 sleeps — between r1→r2, r2→r3, r3→r4. Never before r1. Never after r4.
+      // Exactly 3 sleeps — between dispatches 1→2, 2→3, 3→4. Never before the first.
+      // Never after the last.
       expect(sleepCalls).toEqual([5000, 5000, 5000])
       expect(dispatchSleep).toHaveBeenCalledTimes(3)
     })
@@ -2567,10 +2569,10 @@ describe('handleReconcile (I/O shell)', () => {
     it('treats a dispatch timeout as failure and continues to the next', async () => {
       const dispatchCalls: string[] = []
       const createWorkflowDispatch = vi.fn(async (params: unknown) => {
-        const typed = params as {inputs?: {owner: string; repo: string}}
-        const name = typed.inputs?.repo ?? '?'
-        dispatchCalls.push(name)
-        if (name === 'r2') {
+        const typed = params as {inputs?: {node_id: string}}
+        const id = typed.inputs?.node_id ?? '?'
+        dispatchCalls.push(id)
+        if (id === 'R_2') {
           await new Promise(() => {
             /* never resolves — simulates hang */
           })
@@ -2598,9 +2600,42 @@ describe('handleReconcile (I/O shell)', () => {
 
       // All three repos are attempted regardless of day-rotation order; a timeout on
       // one should not block the others from dispatching.
-      expect(dispatchCalls.slice().sort()).toEqual(['r1', 'r2', 'r3'])
+      expect(dispatchCalls.slice().sort()).toEqual(['R_1', 'R_2', 'R_3'])
       expect(result.dispatches).toBe(2)
       expect(result.dispatchesFailed).toBe(1)
+    })
+
+    it('dispatch payload carries node_id only — never owner/repo', async () => {
+      // Survey Repo workflow accepts node_id as its sole input. The dispatch call site
+      // MUST pass {inputs: {node_id}} so the workflow's first step can resolve and
+      // verify the repo via GraphQL before exposing any owner/name to subsequent steps
+      // or public run surfaces (run name, concurrency group, log lines).
+      const dispatchPayloads: Record<string, unknown>[] = []
+      const createWorkflowDispatch = vi.fn(async (params: unknown) => {
+        const typed = params as {inputs?: Record<string, unknown>}
+        if (typed.inputs !== undefined) dispatchPayloads.push(typed.inputs)
+      })
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [{owner: {login: 't'}, name: 'public-repo', archived: false, private: false, node_id: 'R_kgDOPUBLIC'}],
+        }),
+      })
+
+      await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({createWorkflowDispatch}),
+          readMetadata: makeReadMetadata({allowlist: makeAllowlist(['t'])}),
+          commitMetadata: vi.fn(async () => ({committed: true, sha: 's', attempts: 1})) as never,
+        }),
+      )
+
+      expect(dispatchPayloads).toHaveLength(1)
+      expect(dispatchPayloads[0]).toEqual({node_id: 'R_kgDOPUBLIC'})
+      // Defense-in-depth: owner/repo must not leak into the public workflow_dispatch
+      // inputs surface, even alongside node_id. The workflow itself resolves the identity.
+      expect(dispatchPayloads[0]).not.toHaveProperty('owner')
+      expect(dispatchPayloads[0]).not.toHaveProperty('repo')
     })
   })
 
@@ -2611,8 +2646,8 @@ describe('handleReconcile (I/O shell)', () => {
       // be the already-surveyed one because progressive runs prioritize fresh coverage.
       const dispatchCalls: string[] = []
       const createWorkflowDispatch = vi.fn(async (params: unknown) => {
-        const typed = params as {inputs?: {repo: string}}
-        dispatchCalls.push(typed.inputs?.repo ?? '?')
+        const typed = params as {inputs?: {node_id: string}}
+        dispatchCalls.push(typed.inputs?.node_id ?? '?')
       })
       const userOctokit = mockOctokit({
         listForAuthenticatedUser: async () => ({
@@ -2657,7 +2692,7 @@ describe('handleReconcile (I/O shell)', () => {
         }),
       )
 
-      expect(dispatchCalls).toEqual(['r1', 'r3'])
+      expect(dispatchCalls).toEqual(['R_1', 'R_3'])
       expect(result.dispatches).toBe(2)
       expect(result.dispatchesDeferred).toBe(1)
     })
@@ -2665,8 +2700,8 @@ describe('handleReconcile (I/O shell)', () => {
     it('does not let private entries displace public dispatches under the cap', async () => {
       const dispatchCalls: string[] = []
       const createWorkflowDispatch = vi.fn(async (params: unknown) => {
-        const typed = params as {inputs?: {repo: string}}
-        dispatchCalls.push(typed.inputs?.repo ?? '?')
+        const typed = params as {inputs?: {node_id: string}}
+        dispatchCalls.push(typed.inputs?.node_id ?? '?')
       })
       const publicRepos = Array.from({length: 13}, (_, index) => `public-${String(index + 1).padStart(2, '0')}`)
       const userOctokit = mockOctokit({
@@ -2701,8 +2736,8 @@ describe('handleReconcile (I/O shell)', () => {
       )
 
       expect(dispatchCalls).toHaveLength(12)
-      expect(dispatchCalls).not.toContain('private-repo')
-      expect(dispatchCalls.every(name => name.startsWith('public-'))).toBe(true)
+      expect(dispatchCalls).not.toContain('R_private')
+      expect(dispatchCalls.every(id => id.startsWith('R_public-'))).toBe(true)
       expect(result.summary.skippedPrivate).toBe(1)
       expect(result.dispatches).toBe(12)
       expect(result.dispatchesDeferred).toBe(1)
@@ -2741,8 +2776,8 @@ describe('handleReconcile (I/O shell)', () => {
       // Cap of 2 selects the two oldest; newest is deferred to the next run.
       const dispatchCalls: string[] = []
       const createWorkflowDispatch = vi.fn(async (params: unknown) => {
-        const typed = params as {inputs?: {repo: string}}
-        dispatchCalls.push(typed.inputs?.repo ?? '?')
+        const typed = params as {inputs?: {node_id: string}}
+        dispatchCalls.push(typed.inputs?.node_id ?? '?')
       })
       const userOctokit = mockOctokit({
         listForAuthenticatedUser: async () => ({
@@ -2813,7 +2848,7 @@ describe('handleReconcile (I/O shell)', () => {
         }),
       )
 
-      expect(dispatchCalls).toEqual(['r-old', 'r-mid'])
+      expect(dispatchCalls).toEqual(['R_old', 'R_mid'])
       expect(result.dispatches).toBe(2)
       expect(result.dispatchesDeferred).toBe(1)
     })
@@ -2873,7 +2908,7 @@ describe('handleReconcile (I/O shell)', () => {
       const runWith = async (now: Date) => {
         const dispatched: string[] = []
         const createWorkflowDispatch = vi.fn(async (params: unknown) => {
-          dispatched.push((params as {inputs?: {repo: string}}).inputs?.repo ?? '?')
+          dispatched.push((params as {inputs?: {node_id: string}}).inputs?.node_id ?? '?')
         })
         await handleReconcile(
           baseParams({
@@ -2889,9 +2924,9 @@ describe('handleReconcile (I/O shell)', () => {
       }
 
       // Offset 0 → first slice
-      expect(await runWith(NOW)).toEqual(['r-a', 'r-b'])
+      expect(await runWith(NOW)).toEqual(['R_r-a', 'R_r-b'])
       // Offset 2 → rotated slice; r-c and r-d get their turn
-      expect(await runWith(new Date('2026-04-19T12:00:00Z'))).toEqual(['r-c', 'r-d'])
+      expect(await runWith(new Date('2026-04-19T12:00:00Z'))).toEqual(['R_r-c', 'R_r-d'])
     })
   })
 

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -149,6 +149,14 @@ export interface ReconcileInput {
 export interface DispatchRequest {
   owner: string
   repo: string
+  /**
+   * GitHub GraphQL `node_id` of the target repository. Surfaced to `workflow_dispatch`
+   * inputs as the sole identifier — the Survey Repo workflow resolves it back to
+   * `owner/repo` via GraphQL after verifying `isPrivate === false`. Keeping `owner`
+   * and `repo` here for internal telemetry (logger info lines, prioritization) is
+   * fine; only the `inputs` payload is a public surface.
+   */
+  node_id: string
 }
 
 export interface PerRepoIssue {
@@ -357,7 +365,7 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
       if (accessPrivate) {
         summary.skippedPrivate += 1
       } else {
-        dispatches.push({owner: access.owner, repo: access.name})
+        dispatches.push({owner: access.owner, repo: access.name, node_id: access.node_id})
       }
     } else {
       summary.pendingReview += 1
@@ -542,7 +550,7 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
       if (accessPrivate) {
         summary.skippedPrivate += 1
       } else {
-        dispatches.push({owner: access.owner, repo: access.name})
+        dispatches.push({owner: access.owner, repo: access.name, node_id: access.node_id})
       }
     } else {
       rawIssues.push({
@@ -588,7 +596,7 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
   if (wouldDispatchIfPublic && (entry.private !== false || accessPrivate)) {
     summary.skippedPrivate += 1
   } else if (wouldDispatchIfPublic) {
-    dispatches.push({owner: access.owner, repo: access.name})
+    dispatches.push({owner: access.owner, repo: access.name, node_id: access.node_id})
   }
 
   // Field refresh: apply probe results when they disagree with tracked fields,
@@ -1994,7 +2002,12 @@ async function runDispatches(params: {
             repo: params.repo,
             workflow_id: params.workflowFile,
             ref: params.workflowRef,
-            inputs: {owner: dispatch.owner, repo: dispatch.repo},
+            // The only identifier exposed to the public workflow_dispatch surface is
+            // the GraphQL node_id. The Survey Repo workflow's first step resolves it
+            // back to owner/repo via App-token GraphQL and aborts unless the repo is
+            // definitively public. owner/repo are kept on DispatchRequest for internal
+            // telemetry (logger, prioritization) but never reach the Actions API.
+            inputs: {node_id: dispatch.node_id},
           }),
         params.timeoutMs,
       )


### PR DESCRIPTION
Survey Repo previously trusted the caller to pass owner and repo as dispatch inputs. That made the dispatch boundary a privacy contract enforced only outside the workflow — and any caller bug, manual operator misuse, or future regression could leak a canonical repo identity into the public Actions UI before any privacy check ran. This change makes the workflow itself the gate.

The dispatch surface now accepts a single opaque `node_id`. Inside the workflow, a new resolve step shape-validates the input, calls the GitHub GraphQL `node()` lookup, and aborts unless the repo is definitively public. Failure messages echo only the node_id and only after shape validation passes — so an operator who mistakenly dispatches `node_id=marcusrbrown/foo` gets a generic "input shape invalid" error and that string never reaches the run name, concurrency key, or logs.

A second visibility recheck runs immediately before the wiki commit. If the repo flips private during the agent run (3-30 minutes), the resolved owner/repo and the agent's wiki content stay local to the runner and never touch the `data` branch.

## Dispatch contract

`DispatchRequest` gains a required `node_id` field. The reconcile engine's `createWorkflowDispatch` payload is now `{inputs: {node_id}}` only — owner and repo remain on the internal request shape for telemetry and dispatch prioritization but never reach the Actions API.

`handle-invitation` dispatches the first survey using the same shape. The accepted-invitation privacy refresh path (`acceptedInvitationRepositoryPrivacy`) now returns the node_id refreshed from `repos.get` instead of the stale node_id carried by the invitation. This closes a race where a deleted-and-recreated invitation repo could dispatch under the old identity.

## Workflow hardening

| Concern | Before | After |
|---|---|---|
| Input shape | `{owner, repo}` (trusted) | `{node_id}` (shape-validated, then GraphQL-verified public) |
| `run-name` | Echoed input directly | Static |
| Failure messages | Echoed input verbatim | Echo only after shape validation; neutral when validation fails |
| Visibility check | None at workflow level | GraphQL `isPrivate === false` required to proceed; rechecked before wiki commit |
| Job timeout | Implicit (default) | `timeout-minutes: 30` |
| Cross-job identity | `${{ github.event.inputs.* }}` | `needs.survey-repo.outputs.*` (only set after verification succeeds) |

## Breaking workflow_dispatch contract

`gh workflow run survey-repo.yaml -f owner=X -f repo=Y` no longer works.

Migration:

```bash
# Look up node_id
NODE_ID=$(gh api graphql -f query='query{repository(owner:"OWNER",name:"REPO"){id}}' --jq '.data.repository.id')

# Dispatch
gh workflow run survey-repo.yaml -f node_id="$NODE_ID"
```

Migration block is also in the workflow YAML, `README.md`, and `metadata/README.md` for operators who don't read PR descriptions.

## Tests

- New: dispatch-payload contract test in `scripts/reconcile-repos.test.ts` — verifies the workflow_dispatch inputs object is exactly `{node_id}`, never includes `owner` or `repo`.
- New: refreshed-node_id regression test in `scripts/handle-invitation.test.ts` — locks the behavior where the post-acceptance node_id comes from `repos.get`, not the invitation payload.
- Updated: 14 existing dispatch-shape assertions in `reconcile-repos.test.ts` for the new payload shape.
- Updated: 6 dispatch-loop helper tests read `node_id` from the payload.

## Gates

- `pnpm check-types` clean
- `pnpm lint` clean
- `pnpm test` — 538/538 passing
- `actionlint` clean

## What does not change

- Reconcile engine's privacy gate (the engine-side check still fails-closed for non-public entries; the workflow gate is defense-in-depth on top of it)
- Wiki ingest path (still commits to `data` branch via the same script)
- Agent invocation (same `fro-bot/agent` SHA pin)
- `record-survey-result` consumer (already supported `REPO_NODE_ID` and `REPO_PRIVATE` env vars)
- Allowlist gating, pending-review issue creation, per-owner rollup, cadence calculations
