### PR TITLE
chore(plans): reconcile plan status against shipped reality

### DIFF
--- a/docs/plans/2025-04-15-001-feat-frobot-control-plane-plan.md
+++ b/docs/plans/2025-04-15-001-feat-frobot-control-plane-plan.md
@@ -1,8 +1,9 @@
 ---
 title: "feat: Fro Bot Autonomous Control Plane"
 type: feat
-status: active
+status: complete
 date: 2026-04-15
+completed: 2026-04-28
 origin: docs/brainstorms/2025-04-15-frobot-control-plane-requirements.md
 deepened: 2025-04-15
 ---
@@ -625,7 +626,7 @@ Renovate dispatch, metadata refresh, and wiki lint. Scheduled autonomy ships onl
 
 ### Phase 3: Social Voice + Journal
 
-- [ ] **Unit 11: Discord Notification Script**
+- [x] **Unit 11: Discord Notification Script**
 
 **Goal:** Provide a reusable TypeScript module for posting rich Discord embeds from any workflow.
 
@@ -661,7 +662,7 @@ Renovate dispatch, metadata refresh, and wiki lint. Scheduled autonomy ships onl
 
 ---
 
-- [ ] **Unit 12: BlueSky Post Script**
+- [x] **Unit 12: BlueSky Post Script**
 
 **Goal:** Provide a reusable TypeScript module for BlueSky posting.
 
@@ -700,7 +701,7 @@ Renovate dispatch, metadata refresh, and wiki lint. Scheduled autonomy ships onl
 
 ---
 
-- [ ] **Unit 13: Journal System**
+- [x] **Unit 13: Journal System**
 
 **Goal:** Maintain a running in-character activity journal in GitHub Issues.
 
@@ -740,7 +741,7 @@ Renovate dispatch, metadata refresh, and wiki lint. Scheduled autonomy ships onl
 
 ---
 
-- [ ] **Unit 14: Social Broadcast Integration**
+- [x] **Unit 14: Social Broadcast Integration**
 
 **Goal:** Wire Discord and BlueSky posting into the control plane with hybrid curation.
 
@@ -786,7 +787,7 @@ Renovate dispatch, metadata refresh, and wiki lint. Scheduled autonomy ships onl
 
 ### Phase 4: Scheduled Autonomy
 
-- [ ] **Unit 15: Renovate Smart Dispatch**
+- [x] **Unit 15: Renovate Smart Dispatch**
 
 **Goal:** Dispatch Renovate across tracked repos with deduplication and no unnecessary approval gate.
 
@@ -826,7 +827,7 @@ Renovate dispatch, metadata refresh, and wiki lint. Scheduled autonomy ships onl
 
 ---
 
-- [ ] **Unit 16: Metadata Update Workflow**
+- [x] **Unit 16: Metadata Update Workflow**
 
 **Goal:** Periodically scan collaborator repos and refresh metadata state.
 
@@ -867,7 +868,7 @@ Renovate dispatch, metadata refresh, and wiki lint. Scheduled autonomy ships onl
 
 ---
 
-- [ ] **Unit 17: Wiki Lint Weekly**
+- [x] **Unit 17: Wiki Lint Weekly**
 
 **Goal:** Perform a weekly detect/report health check of the authoritative wiki state on `data`.
 

--- a/docs/plans/2026-04-17-001-feat-repo-reconciliation-plan.md
+++ b/docs/plans/2026-04-17-001-feat-repo-reconciliation-plan.md
@@ -1,8 +1,9 @@
 ---
 title: Repo Reconciliation
 type: feat
-status: active
+status: complete
 date: 2026-04-17
+completed: 2026-04-17
 deepened: 2026-04-17
 origin: docs/brainstorms/2026-04-17-repo-reconciliation-requirements.md
 ---
@@ -135,7 +136,7 @@ Per-repo classification decision table:
 
 ## Implementation Units
 
-- [ ] **Unit 1: Extend schema and extract shared `addRepoEntry` helper**
+- [x] **Unit 1: Extend schema and extract shared `addRepoEntry` helper**
 
 **Goal:** Land the two prerequisites reconcile needs before Unit 2: (a) extend `OnboardingStatus` enum + guard to include `lost-access` and `pending-review`; (b) lift `addRepoEntry` from `scripts/handle-invitation.ts` into a shared module so reconcile can produce entries with the exact same shape.
 
@@ -181,7 +182,7 @@ Per-repo classification decision table:
 
 ---
 
-- [ ] **Unit 2: Pure reconciliation engine (`reconcileRepos`)**
+- [x] **Unit 2: Pure reconciliation engine (`reconcileRepos`)**
 
 **Goal:** Implement `reconcileRepos(inputs) → changePlan` as a pure function with exhaustive tests covering every entry in the classification decision table.
 
@@ -239,7 +240,7 @@ Per-repo classification decision table:
 
 ---
 
-- [ ] **Unit 3: I/O shell — Octokit wiring, `commitMetadata` integration, dispatch + issue loop**
+- [x] **Unit 3: I/O shell — Octokit wiring, `commitMetadata` integration, dispatch + issue loop**
 
 **Goal:** Implement the outer layer that fetches inputs, invokes `reconcileRepos`, commits via `commitMetadata`, then walks the dispatch and issue queues sequentially with non-blocking failure. Expose a CLI entrypoint (`if (import.meta.url === …) { await main() }`) mirroring other scripts.
 
@@ -312,7 +313,7 @@ Per-repo classification decision table:
 
 ---
 
-- [ ] **Unit 4: Scheduled workflow (`reconcile-repos.yaml`)**
+- [x] **Unit 4: Scheduled workflow (`reconcile-repos.yaml`)**
 
 **Goal:** Ship the scheduled cron + manual dispatch workflow that mints the app token, runs `scripts/reconcile-repos.ts` with both credentials available, and reports the JSON summary in the run log.
 

--- a/docs/plans/2026-04-19-001-feat-wiki-authority-ci-guard-plan.md
+++ b/docs/plans/2026-04-19-001-feat-wiki-authority-ci-guard-plan.md
@@ -1,8 +1,9 @@
 ---
 title: 'feat: Wiki authority CI guard'
 type: feat
-status: active
+status: complete
 date: 2026-04-19
+completed: 2026-04-19
 ---
 
 # feat: Wiki authority CI guard
@@ -94,7 +95,7 @@ Not required. This is a well-patterned CI guard, and the codebase has two direct
 
 ## Implementation Units
 
-- [ ] **Unit 1: Pure guard function + CLI script**
+- [x] **Unit 1: Pure guard function + CLI script**
 
 **Goal:** Implement the wiki-authority decision function and a thin CLI that wires it to PR event context.
 
@@ -149,7 +150,7 @@ Not required. This is a well-patterned CI guard, and the codebase has two direct
 - `pnpm lint` and `pnpm check-types` clean on the new file.
 - Smoke-test the CLI locally by invoking it with a synthetic `GITHUB_EVENT_PATH` JSON and observing exit status + message.
 
-- [ ] **Unit 2: Wire guard into CI + required status check**
+- [x] **Unit 2: Wire guard into CI + required status check**
 
 **Goal:** Add the `check-wiki-authority` job to `main.yaml` and register it in `settings.yml` so branch protection enforces it.
 
@@ -180,7 +181,7 @@ Test expectation: none — this unit is YAML config with no behavioral logic to 
 - On the Unit 2 PR itself, the new `check-wiki-authority` job runs, evaluates `{author: <user>, files: ['.github/workflows/main.yaml', '.github/settings.yml']}`, and passes (neither file is guarded).
 - After merge, `Update Repo Settings` workflow applies the new required check to branch protection. A subsequent test PR touching `metadata/repos.yaml` under a non-Fro-Bot author must fail the check and block merge.
 
-- [ ] **Unit 3: Document operator workflow**
+- [x] **Unit 3: Document operator workflow**
 
 **Goal:** Document the policy so future operators know the correct workflow for one-off wiki or metadata edits.
 

--- a/docs/plans/2026-05-05-001-feat-survey-cadence-and-multi-channel-discovery-plan.md
+++ b/docs/plans/2026-05-05-001-feat-survey-cadence-and-multi-channel-discovery-plan.md
@@ -1,8 +1,9 @@
 ---
 title: 'feat: Survey cadence + multi-channel discovery'
 type: feat
-status: active
+status: complete
 date: 2026-05-05
+completed: 2026-05-06
 origin: docs/brainstorms/2026-05-04-survey-cadence-and-multi-channel-discovery-requirements.md
 deepened: 2026-05-05
 ---


### PR DESCRIPTION
Four plans had stale checkboxes and active status despite all units shipping. Flip checkboxes and frontmatter so `docs/plans/` reflects what's actually on `main`.

## Why

A quick audit found three plans whose Implementation Units were still all `- [ ]` despite the underlying scripts, workflows, and tests being merged months ago. That makes `docs/plans/` an unreliable source for "what's done" versus "what's still on the roadmap" — both for me and for any future contributor or agent reading the repo cold.

## What changed

| Plan | Before | After |
|---|---|---|
| Fro Bot Autonomous Control Plane | active, 10/17 units checked | **complete**, 17/17 (Units 11–17 were already shipped as `scripts/discord-notify.ts`, `scripts/bluesky-post.ts`, `scripts/journal-entry.ts`, `.github/workflows/social-broadcast.yaml`, `scripts/dispatch-renovate.ts`, `scripts/update-metadata.ts`, `scripts/wiki-lint.ts`) |
| Repo Reconciliation | active, 0/4 | **complete**, 4/4 (`scripts/reconcile-repos.ts` + `.github/workflows/reconcile-repos.yaml` shipped April 2026) |
| Wiki Authority CI Guard | active, 0/3 | **complete**, 3/3 (`scripts/check-wiki-authority.ts` + `main.yaml` job + `settings.yml` required check + metadata/knowledge docs all shipped) |
| Survey Cadence + Multi-Channel Discovery | active, 5/5 checked | **complete** (frontmatter flip only) |

Two plans intentionally stay `status: active`:

- **Private-repo handling** — 7/13 units shipped (Units 0–6); Units 7–12 are next.
- **Wiki-lint followups** — 0/2 shipped; versioned JSON output + durable issue lifecycle still to do.

## Scope

Documentation-only. No behavior change, no scripts touched, no workflows touched.

## Verification

`pnpm lint` clean (markdownlint applied to docs/plans/).