### PR TITLE
feat(reconcile): add minimum-dispatch floor to keep wiki growing during cadence droughts

### DIFF
--- a/docs/brainstorms/2026-05-17-survey-cadence-minimum-floor-requirements.md
+++ b/docs/brainstorms/2026-05-17-survey-cadence-minimum-floor-requirements.md
@@ -1,0 +1,82 @@
+---
+title: Survey cadence — minimum-dispatch floor
+type: feat
+status: draft
+date: 2026-05-17
+---
+
+# Survey cadence — minimum-dispatch floor
+
+## Origin
+
+The trigger condition documented in `docs/plans/2026-05-05-001-feat-survey-cadence-and-multi-channel-discovery-plan.md` (line 53, "Deferred to Separate Tasks") has been met in production:
+
+> Trigger for that plan: 30 days of operation under this plan show consecutive-zero-day stretches >7 days even with jitter applied.
+
+As of 2026-05-17, the Reconcile Repos workflow has reported `success` with `dispatches: 0` on **9 consecutive scheduled runs** (last dispatch fired 2026-05-08 via manual `workflow_dispatch`). The proximate cause is exactly the clustering scenario the cadence plan predicted: a triple-dispatch in early May pushed every repo's `next_survey_eligible_at` into a 4-day window in early-to-mid June. Jitter (±3 days) widened the cluster but did not break it.
+
+## Problem Frame
+
+The current cadence model is a strict threshold gate: a repo dispatches only when `next_survey_eligible_at <= today (UTC)`. When a tracked-repo population of N=20+ all bunch together, the gate emits zero dispatches for the duration of the cycle gap, then drains the herd in a 2-3 day burst, then idles again. The wiki goes silent for weeks at a time. Operator-visible signal is "success" with a zero counter — there is no warning that the pipeline has stopped producing knowledge.
+
+The threshold model is correct as a *ceiling* (don't over-survey), but it lacks a *floor* (always make some progress). The Karpathy wiki pattern this entire system implements depends on continuous knowledge accumulation — silence for 2-3 weeks at a time defeats the point.
+
+## Posture
+
+Add a per-day floor that always dispatches a small number of oldest-`last_survey_at` repos, regardless of the threshold. The threshold gate continues to cap the upper end (no more than 12 dispatches per run, never re-survey within ~14 days even with floor pressure). The floor decouples wiki growth from cluster timing.
+
+## Goals
+
+- **Continuous wiki growth.** Reconcile dispatches at least N (TBD, probably 1-3) surveys per scheduled run, even when nothing is threshold-eligible.
+- **Operator-visible drought signal.** When the floor fires because the threshold gate produced nothing, the run summary surfaces a distinct counter / log line — silence becomes loud.
+- **Bounded re-survey frequency.** A repo dispatched by the floor on day D should not be re-eligible (by floor) for at least M days (TBD, probably 7-10), independent of its `next_survey_eligible_at`. Prevents the floor from re-surveying the same repo every day.
+- **Preserve existing cap.** The 12-dispatch-per-run cap (`DEFAULT_MAX_DISPATCHES_PER_RUN`) and 90s stagger apply to floor dispatches too. The floor adds to the dispatch pool; it does not bypass capacity controls.
+
+## Non-Goals
+
+- **Eliminating the threshold model.** The per-channel intervals (owned=14d, contrib=21d, collab=30d) still drive the ceiling. The floor is additive.
+- **Operator-tunable floor count via env var.** Ship a constant first. Promote to env later if real cadence needs it.
+- **Backfill / smoothing of the existing cluster.** This plan ships the floor logic; the existing June-cluster smooths itself as floor dispatches gradually re-jitter `next_survey_eligible_at` across the population.
+- **Per-channel floor counts.** Single global floor across all channels. Per-channel sub-floors are deferred unless real operation shows a channel starvation pattern.
+
+## Requirements
+
+| # | Requirement |
+|---|---|
+| R1 | Reconcile dispatches at least `FLOOR_MIN` repos per run when the tracked population has any eligible candidates, regardless of `next_survey_eligible_at`. |
+| R2 | The floor picks repos by oldest `last_survey_at` first (nulls first, matching existing prioritization). |
+| R3 | The floor excludes repos surveyed within the last `FLOOR_MIN_GAP_DAYS` (TBD, ~7-10 days) to prevent rapid re-surveying. |
+| R4 | The floor excludes `pending-review`, `lost-access`, and `private: true` repos for the same reasons the existing dispatch gate does. |
+| R5 | When the floor fires (i.e., threshold-eligible count was below `FLOOR_MIN`), the run summary surfaces a `summary.flooredDispatches` counter and a single stderr log line `floor fired: N dispatches added because threshold yielded M`. |
+| R6 | The dispatch cap (`DEFAULT_MAX_DISPATCHES_PER_RUN`) is enforced after the floor merges into the dispatch pool. A run that hits the cap reports `dispatchesDeferred` as usual. |
+| R7 | A successful floor dispatch updates `last_survey_at` and `next_survey_eligible_at` exactly the same way a threshold dispatch does — no special-case state. |
+| R8 | All floor logic lives in the pure `reconcileRepos` decision engine, fully unit-tested. The I/O shell remains untouched. |
+
+## Success Criteria
+
+| # | Criterion |
+|---|---|
+| SC1 | Across any 7-day window post-rollout, at least 5 of those days have `dispatches > 0`. (Compare to current state: 9-day silence and counting.) |
+| SC2 | No repo is re-surveyed more than once per `FLOOR_MIN_GAP_DAYS`-day window by floor action alone. |
+| SC3 | A scheduled `Reconcile Repos` run with `summary.flooredDispatches > 0` shows the floor log line in the workflow log. |
+| SC4 | Existing tests still pass — floor is additive, doesn't change threshold semantics. |
+
+## Open Questions (Deferred to Planning)
+
+1. **What is `FLOOR_MIN`?** Initial proposal: 2 per run. Daily cron × 2 = ~14/week, comfortable on the Anthropic seat capacity at 90s stagger. Confirm during planning.
+2. **What is `FLOOR_MIN_GAP_DAYS`?** Initial proposal: 7 days. Long enough to prevent ping-pong, short enough to make the floor meaningful at N=20+. Confirm during planning.
+3. **Floor vs threshold ordering in the dispatch list.** When both fire, do threshold-eligible repos go first (prioritizing the channel-cycle math) or oldest-`last_survey_at` regardless of source? Initial proposal: oldest-first regardless of source — keeps the dispatch order deterministic and explainable.
+4. **Drought-detection issue.** Should reconcile auto-open a `reconcile:cadence-drought` GitHub issue if the floor itself yields zero dispatches (e.g., every repo was within `FLOOR_MIN_GAP_DAYS`)? Probably yes, but verify the issue lifecycle pattern matches existing `reconcile:pending-review` handling.
+5. **Backfill stragglers.** Should the floor also pick from `pending-review` if they've been waiting longer than X days? Probably no (those are explicitly human-gated) but worth a question during planning.
+
+## Scope Boundaries
+
+- **In scope:** `scripts/reconcile-repos.ts` engine logic, `scripts/reconcile-repos.test.ts` coverage, observable counter + log surface.
+- **Out of scope:** Anthropic seat capacity work, per-channel sub-floors, env-var tuning, cluster-smoothing migrations, alternate dispatch ordering algorithms.
+
+## Rejected Alternatives
+
+- **Re-jitter all `next_survey_eligible_at` values on every run.** Solves bunching but mutates state unpredictably and makes the field non-meaningful. The threshold model is correct; it just needs a complement.
+- **Lower the per-channel intervals (e.g. collab=14d).** Halves the cycle but proportionally doubles seat pressure. Doesn't address the structural "ceiling without floor" gap.
+- **Trigger reconcile more often (every 6h cron).** Increases workflow runs without changing the eligibility math. Same cluster, same droughts.
+- **Per-day pull-based model where Fro Bot picks N to survey via agent prompt.** Adds an agent decision layer where a pure function suffices. Defer until pure logic proves insufficient.

--- a/docs/plans/2026-05-17-001-feat-survey-cadence-minimum-floor-plan.md
+++ b/docs/plans/2026-05-17-001-feat-survey-cadence-minimum-floor-plan.md
@@ -1,0 +1,267 @@
+---
+title: 'feat: Survey cadence minimum-dispatch floor'
+type: feat
+status: active
+date: 2026-05-17
+origin: docs/brainstorms/2026-05-17-survey-cadence-minimum-floor-requirements.md
+---
+
+# feat: Survey cadence minimum-dispatch floor
+
+## Overview
+
+Add a minimum-dispatch floor to `scripts/reconcile-repos.ts` so that scheduled Reconcile Repos runs always make some wiki progress, even when no repo's `next_survey_eligible_at` is ≤ today. The threshold model (per-channel intervals + jitter) continues to set the upper bound on dispatch volume; the floor sets the lower bound on continuous knowledge accumulation.
+
+## Problem Frame
+
+The cadence work shipped in May 2026 (see origin: `docs/brainstorms/2026-05-17-survey-cadence-minimum-floor-requirements.md`) deliberately deferred a per-day quota model and documented the trigger condition for follow-on work: "consecutive-zero-day stretches >7 days even with jitter applied." As of 2026-05-17 the production pipeline has reported `success` with `dispatches: 0` for 9 consecutive daily reconcile runs. The wiki has gone silent for 9 days while every onboarded repo's `next_survey_eligible_at` sits 18-20 days in the future from a May 7-8 clustering event.
+
+The threshold gate is correct as a ceiling. It lacks a floor. This plan ships the floor.
+
+## Requirements Trace
+
+(Mapping origin requirements to plan units; full text in origin.)
+
+- R1 (always dispatch at least `FLOOR_MIN` when candidates exist) → Unit 1
+- R2 (pick oldest `last_survey_at` first; nulls first) → Unit 1
+- R3 (exclude repos surveyed within `FLOOR_MIN_GAP_DAYS`) → Unit 1
+- R4 (exclude `pending-review` / `lost-access` / `private: true`) → Unit 1
+- R5 (`summary.flooredDispatches` counter + stderr log line) → Unit 1
+- R6 (cap enforced after floor merges into pool) → Unit 1
+- R7 (floor dispatch updates state identically) → Unit 1 (no special-case; existing `recordSurveyResult` path)
+- R8 (pure decision-engine logic, fully unit-tested) → Unit 1
+
+(All requirements land in Unit 1 — the floor is a single coherent change.)
+
+## Scope Boundaries
+
+- **Engine logic only.** The change lives in the pure `reconcileRepos` decision function and its test file plus the engine's existing `ReconcileLogger` boundary. The I/O shell, dispatch staggering, App-token plumbing, and workflow YAML are untouched. The floor-fired stderr signal is emitted via the existing `ReconcileLogger` interface that already crosses the pure-engine boundary by injection — same pattern the engine already uses for `warn`-class messages, not a new I/O coupling.
+- **Single global floor.** No per-channel sub-floors. If channel starvation becomes a real pattern, a follow-up plan adds them.
+- **Constant configuration.** `FLOOR_MIN = 2` and `FLOOR_MIN_GAP_DAYS = 7` ship as `const`. Env-var override is deferred until real cadence shows the constants need tuning.
+
+### Deferred to Separate Tasks
+
+- **Drought-detection issue lifecycle.** If the floor itself yields zero dispatches (every repo is within `FLOOR_MIN_GAP_DAYS`), the run reports `flooredDispatches: 0` and the operator sees the counter via run summary. Filing a GitHub issue for that condition is deferred — the counter is sufficient signal until operation shows it isn't.
+- **Cluster smoothing migration.** This plan does not retroactively re-jitter the existing June-cluster. Floor dispatches will naturally re-spread the population over the next 2-3 weeks as they update `next_survey_eligible_at`.
+- **Env-var tunable constants.** `RECONCILE_FLOOR_MIN` and `RECONCILE_FLOOR_GAP_DAYS` overrides can ship if production needs them. Not now.
+- **Per-channel floor counts.** Single global floor is sufficient for v1.
+- **`pending-review` backfill from floor.** `pending-review` exists because a human hasn't approved the repo. Floor must not bypass that gate.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/reconcile-repos.ts:578-595` — current dispatch-eligibility logic in `classifyTracked`. Floor replaces the eligibility check at the dispatch-loop merge step (around line 1172), not in `classifyTracked` itself.
+- `scripts/reconcile-repos.ts:1180-1185` — existing prioritization: nulls-first, then oldest `last_survey_at`. Floor reuses this ordering.
+- `scripts/reconcile-repos.ts:1184` — `repoSurveyMap = new Map(plan.nextRepos.repos.map(r => [\`${r.owner}/${r.name}\`, r.last_survey_at]))`. Floor logic can reuse this map for gap-days filtering.
+- `scripts/reconcile-repos.test.ts` — existing test patterns for the engine. Test file co-located. `makeEntry()` / `makeAccess()` helpers. Use Vitest `describe` / `it` blocks following the same convention as the new dispatch-loop tests added in PR #3293.
+- `scripts/reconcile-repos.ts` summary type — extend `ReconcileSummary` with `flooredDispatches: number` next to `dispatchesDeferred`.
+
+### Institutional Learnings
+
+- `docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md` — the "silence becomes loud" principle. The floor's log line + counter exists specifically to make zero-dispatch days operator-visible.
+- `docs/solutions/security-issues/private-repo-dispatch-visibility-gate-2026-05-08.md` — dispatch logic must never expose private repos. Floor inherits this constraint via R4 (exclude `private: true`).
+
+### External References
+
+None needed. Internal engine logic, no framework or API surface to research.
+
+## Key Technical Decisions
+
+| Decision | Rationale |
+|---|---|
+| `FLOOR_MIN = 2` | Brainstorm-proposed value. Daily cron × 2 = 14/week steady throughput. Comfortable margin from the 12-cap. Single-seat Anthropic capacity handles 2 sequential surveys per run without bunching. |
+| `FLOOR_MIN_GAP_DAYS = 7` | Long enough to prevent ping-pong. Short enough that with N=20+ collab repos, the floor will reliably find 2 candidates outside the gap. |
+| **Oldest-first regardless of source** when threshold and floor candidates merge | Determinism + explainability. Matches existing prioritization (nulls-first, then oldest `last_survey_at`). The merged dispatch list is sorted once; no separate threshold-priority lane. |
+| **`flooredDispatches` counter as the drought signal** | Counter visible in JSON summary + stderr log line. No issue lifecycle in v1. If the counter pattern proves insufficient, follow-up plan adds drought-issue dedup/close. |
+| **Floor adds to pool *before* cap enforcement** | Per R6. Cap remains the upper bound. Floor merges into the candidate list, then `slice(0, MAX_DISPATCHES_PER_RUN)` truncates. `dispatchesDeferred` continues to count what got cut. |
+| **Pure-function placement** | Floor logic lives entirely in `reconcileRepos` (the pure decision engine), including the floor-fired log emission via the existing injected `ReconcileLogger`. I/O shell, workflow, and dispatch staggering remain identical. Test coverage is unit-level only — the log injection point is testable via a mocked logger in the same pattern existing dispatch-path tests use. |
+| **Single-pass merge that preserves existing null-group rotation** | Build the threshold-eligible list, build the floor-eligible list (gap-filtered), merge and dedupe by `owner/name`, then apply the existing null-group rotation step (rotate the null-`last_survey_at` leading group by day ordinal so all never-surveyed repos cycle through dispatch slots across successive runs) **before** sorting the rest by `last_survey_at` ascending and slicing to cap. The rotation is not optional — dropping it would re-introduce the alphabetical-starvation pattern the existing dispatch loop explicitly avoids. |
+
+## Open Questions
+
+### Resolved During Planning
+
+- **What is `FLOOR_MIN`?** Resolved: `2`.
+- **What is `FLOOR_MIN_GAP_DAYS`?** Resolved: `7`.
+- **Floor vs threshold ordering?** Resolved: oldest-first regardless of source.
+- **Drought-detection issue lifecycle?** Resolved: deferred. Counter + log line is sufficient v1.
+- **Backfill `pending-review` from floor?** Resolved: no. Excluded with `lost-access` and `private: true`.
+
+### Deferred to Implementation
+
+- **Exact stderr log message wording.** Implementer picks something clear that includes the floor count and the threshold count, e.g., `floor fired: dispatched N because threshold yielded M`. Not architecturally significant.
+- **Whether to log when the floor finds zero candidates.** Probably yes (drought-of-drought signal), but the message vs silence decision is best made when the code is in front of someone. Same counts-only constraint applies if the log fires.
+- **Whether `flooredDispatches` should be reflected in `byChannel` breakdowns.** Probably no (single global floor is global), but if every floor dispatch happened to come from one channel, surfacing that may help. Decide while wiring the counter.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+                ┌─────────────────────────────────────────┐
+                │  current tracked repos (plan.nextRepos) │
+                └────────────────┬────────────────────────┘
+                                 │
+                ┌────────────────┴───────────────┐
+                │                                │
+         ┌──────▼──────┐                  ┌──────▼───────┐
+         │  threshold  │                  │    floor     │
+         │  eligible   │                  │  eligible    │
+         │  candidates │                  │  candidates  │
+         └──────┬──────┘                  └──────┬───────┘
+                │                                │
+                │  - filter: not pending-review  │  - filter: not pending-review
+                │  - filter: not lost-access     │  - filter: not lost-access
+                │  - filter: not private         │  - filter: not private
+                │  - filter: next_survey_eligible│  - filter: not surveyed within
+                │    _at ≤ today                 │    FLOOR_MIN_GAP_DAYS
+                │                                │
+                └────────────────┬───────────────┘
+                                 │
+                            ┌────▼─────┐
+                            │  merge   │
+                            │  dedupe  │
+                            │  sort    │  oldest last_survey_at first
+                            │          │  (nulls first)
+                            └────┬─────┘
+                                 │
+                       ┌─────────▼──────────┐
+                       │  slice(0, CAP)     │
+                       │  CAP=12            │
+                       └─────────┬──────────┘
+                                 │
+                       ┌─────────▼──────────┐
+                       │  dispatch (90s     │
+                       │  stagger, existing │
+                       │  I/O shell)        │
+                       └─────────┬──────────┘
+                                 │
+                       ┌─────────▼──────────┐
+                       │  summary updates:  │
+                       │  - dispatches      │
+                       │  - flooredDispatches│
+                       │  - dispatchesDeferred│
+                       └────────────────────┘
+```
+
+Floor logic conceptually:
+
+```
+flooredDispatches = max(0, FLOOR_MIN - thresholdEligibleCount)
+                    bounded by len(floorEligibleCandidates)
+                    bounded by remaining cap budget after threshold dispatches
+```
+
+Note the third constraint: the floor never pushes total dispatches over the cap. If the threshold alone produced ≥ cap candidates, the floor adds zero (since it would only push deferred count higher without dispatching anything new).
+
+## Implementation Units
+
+- [x] **Unit 1: Add minimum-dispatch floor to `reconcileRepos`**
+
+**Goal:** Implement the floor logic in the pure decision engine. Floor merges into the existing dispatch list before cap enforcement. Counter and log line surface the floor's activity.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7, R8
+
+**Dependencies:** None.
+
+**Files:**
+
+- Modify: `scripts/reconcile-repos.ts` — extend `ReconcileSummary` with `flooredDispatches`, add floor logic to the dispatch-loop merge step, emit log line when floor fires.
+- Modify: `scripts/reconcile-repos.test.ts` — add test scenarios covering the floor's behavior, edge cases, and interaction with the threshold and cap.
+
+**Approach:**
+
+- Add two `const` declarations near the existing `DEFAULT_MAX_DISPATCHES_PER_RUN`: `FLOOR_MIN = 2` and `FLOOR_MIN_GAP_DAYS = 7`.
+- Extend `ReconcileSummary` with `flooredDispatches: number` initialized to 0 in `createEmptySummary` (or wherever the existing counters initialize).
+- In the dispatch-loop merge step (around `scripts/reconcile-repos.ts:1170-1200`):
+  1. Build `thresholdEligible: RepoEntry[]` as today (the result of `classifyTracked` filtered for dispatch).
+  2. If `thresholdEligible.length < FLOOR_MIN`, compute `floorEligible: RepoEntry[]` by filtering `plan.nextRepos.repos` for entries that:
+     - Have `onboarding_status === 'onboarded' || onboarding_status === 'pending'` (same as today's gate, just without the `next_survey_eligible_at` check).
+     - Are NOT in `thresholdEligible` (dedupe).
+     - Pass the same fail-closed publicness check the existing dispatch gate uses (`entry.private === false` AND the access-list entry's `private === false` AND the node-level privacy index reports no non-public aliases and no duplicate-node conflicts — i.e., reuse the existing `wouldDispatchIfPublic` predicate / shared helper, do not introduce a separate stored-field-only filter). `private: undefined` (legacy or transient unknown) is treated as not-public and excluded, matching the existing fail-closed posture (R4).
+     - Have `last_survey_at` either `null` OR more than `FLOOR_MIN_GAP_DAYS` days ago relative to `params.now` (R3).
+  3. Sort `floorEligible` by `last_survey_at` ascending (nulls first), matching existing prioritization.
+  4. Take `floorNeeded = min(FLOOR_MIN - thresholdEligible.length, floorEligible.length)` entries from the head.
+  5. Merge: `dispatchCandidates = [...thresholdEligible, ...floorTaken]`.
+  6. Re-sort the merged list by `last_survey_at` ascending (nulls first) so threshold-eligible repos don't always land before floor-eligible ones in dispatch order.
+  7. Slice to `MAX_DISPATCHES_PER_RUN` (cap enforcement unchanged).
+  8. Increment `summary.flooredDispatches` by the count of `floorTaken` entries that survived the cap. Repos cut by the cap that came from the floor count toward `dispatchesDeferred` exactly like threshold-deferred entries.
+- When the floor fires (`floorTaken.length > 0`), emit a single stderr log line via the existing `ReconcileLogger` boundary (mirror the engine's existing warn-class emission pattern). **The log line must contain counts only — no `owner`, `repo`, `node_id`, or any other per-repo identifier.** Per-repo identity leakage through dispatch-path logs has been a regression class before in this codebase (see the privacy-gate compound docs); the floor signal must hold the same line.
+- Keep `ReconcileLogger.warn` / `info` channels intact; the floor log goes through whichever channel matches existing dispatch-related operator messaging.
+- No changes to `recordSurveyResult`, `dispatchRenovate`, or any I/O shell — the floor is transparent to downstream code paths.
+
+**Execution note:** Test-first. The pure-function placement makes RED-first natural: write all 12 test scenarios below, confirm they fail, then implement the floor logic until GREEN. Existing tests in `scripts/reconcile-repos.test.ts` must remain green throughout.
+
+**Technical design:** See High-Level Technical Design section above. The floor is a single merge step inserted between the existing classification and the existing cap. No new data structures, no priority queue, no nested loops.
+
+**Patterns to follow:**
+
+- `scripts/reconcile-repos.ts:1180-1185` — existing prioritization sort. Reuse the same comparator (`null`-first, then string-ascending).
+- `scripts/reconcile-repos.ts:1184` — `repoSurveyMap` pattern. Build a similar lookup of `last_survey_at` keyed by `owner/name` for the gap-days filter.
+- `scripts/reconcile-repos.test.ts` dispatch-loop describe blocks — same `makeEntry()` / `makeAccess()` fixtures, same `mockOctokit` boundary.
+- `docs/solutions/security-issues/private-repo-dispatch-visibility-gate-2026-05-08.md` — engine-level privacy gating. Floor must inherit the `private: true` exclusion.
+
+**Test scenarios:**
+
+- **Happy path — threshold yields 5, floor needed: 0.** Run with 5 threshold-eligible repos; assert `flooredDispatches: 0` and that the dispatch list contains exactly the 5 threshold repos.
+- **Happy path — threshold yields 0, floor finds 2.** All repos are inside their `next_survey_eligible_at` window. Floor finds 2 repos outside the 7-day gap. Assert `dispatches: 2`, `flooredDispatches: 2`, and the 2 oldest-`last_survey_at` repos got dispatched.
+- **Happy path — threshold yields 1, floor adds 1.** Mixed pool. Assert `dispatches: 2`, `flooredDispatches: 1`, and the dispatch list contains the threshold repo plus the oldest floor-eligible repo.
+- **Edge case — threshold yields 2, floor not needed.** Assert `dispatches: 2`, `flooredDispatches: 0`.
+- **Edge case — threshold yields 0, floor candidate pool empty.** All repos were surveyed within the last 7 days. Assert `dispatches: 0`, `flooredDispatches: 0`, no log line.
+- **Edge case — threshold yields 0, floor finds 1 only (population is tiny).** Only 1 repo passes all floor filters. Assert `dispatches: 1`, `flooredDispatches: 1` — floor takes what it can.
+- **Edge case — null `last_survey_at` repos sort first under floor.** A never-surveyed repo and an old-surveyed repo are both floor-eligible; assert the null-surveyed repo dispatches first.
+- **Edge case — cap interaction.** Threshold yields 11, floor finds 5 more candidates. Cap is 12. Assert `dispatches: 12`, `flooredDispatches: 1`, `dispatchesDeferred: 4` (the 4 floor candidates that didn't make the cap).
+- **Edge case — gap-days boundary.** A repo surveyed exactly `FLOOR_MIN_GAP_DAYS` days ago is OUT (boundary is strict-greater-than). A repo surveyed `FLOOR_MIN_GAP_DAYS + 1` days ago is IN. Cover both with explicit `params.now` and `last_survey_at` values.
+- **Error path — `private: true` repo excluded from floor.** Floor pool would otherwise include a private repo; assert it's filtered out and not in the dispatch list.
+- **Error path — `private: undefined` (legacy or transient unknown) repo excluded from floor.** Stored privacy is unset; assert the fail-closed posture excludes it from the floor pool, matching the threshold gate's behavior.
+- **Error path — access-list flags repo as private even though stored `private: false`.** The live access list says private; assert the floor pool excludes the repo because both stored AND live must agree on public.
+- **Error path — node-level duplicate / non-public alias triggers fail-closed.** Two access-list entries share a `node_id` and one is private; assert the floor pool excludes the matching tracked repo via the same node-level rule the threshold gate uses.
+- **Edge case — null-group rotation persists across merged floor + threshold pool.** Three never-surveyed repos (alphabetically `a-repo`, `b-repo`, `c-repo`) all eligible. Simulate three successive runs with different day ordinals; assert each repo gets a turn at the head of the rotation rather than `a-repo` perpetually winning.
+- **Error path — `pending-review` repo excluded from floor.** Same shape: assert it's filtered out.
+- **Error path — `lost-access` repo excluded from floor.** Same shape: assert it's filtered out.
+
+**Verification:**
+
+- All test scenarios green; no existing tests regress (current baseline verified 2026-05-17: 539 passing across 21 test files; the new floor scenarios should push the total higher without changing any existing assertion).
+- `pnpm check-types` clean.
+- `pnpm lint` clean.
+- The `reconcileRepos` return value's `summary.flooredDispatches` field is present and accurately reflects the floor-driven additions in every scenario.
+- A manual mental simulation of the current production state (20 collab repos with `next_survey_eligible_at` in June, last surveyed early May) confirms the floor would dispatch 2 repos on the next reconcile run.
+
+## System-Wide Impact
+
+- **Interaction graph:** The floor sits inside the pure `reconcileRepos` engine. No changes to the I/O shell (`main()` body), no changes to `survey-repo.yaml`, no changes to `commitMetadata`, no changes to `dispatch-renovate.ts`. Downstream consumers see additional dispatch payloads but with the same shape — they cannot distinguish floor dispatches from threshold dispatches (intentional: floor is transparent at the dispatch boundary).
+- **Error propagation:** Floor failures are not possible — it's a pure filter + sort. Any errors during floor logic are programmer errors (e.g., undefined `last_survey_at` slipping through), caught by tests.
+- **State lifecycle risks:** None new. Floor uses the existing `repoSurveyMap` pattern for `last_survey_at` lookups; no new state, no caching, no persistence concerns. The downstream `recordSurveyResult` path writes the same `last_survey_at` + `next_survey_eligible_at` regardless of dispatch origin.
+- **API surface parity:** `ReconcileSummary` gains one field (`flooredDispatches`). Any consumer reading the summary JSON (the workflow log, future drought-detection tooling) sees the new field. No breaking change — existing consumers ignoring the field continue to work.
+- **Integration coverage:** Unit tests on `reconcileRepos` are sufficient. The dispatch I/O shell does not branch on dispatch origin, so no integration-level coverage is needed for the floor specifically — existing dispatch-loop integration tests apply unchanged.
+- **Unchanged invariants:** Threshold gate semantics (`next_survey_eligible_at ≤ today` for `onboarded`; `last_survey_status !== 'success' || ...` for `pending`) are not modified. Per-channel intervals (`OWNED_INTERVAL_DAYS = 14`, `CONTRIB_INTERVAL_DAYS = 21`, `COLLAB_INTERVAL_DAYS = 30`) are not modified. Jitter logic is not modified. Dispatch cap (`DEFAULT_MAX_DISPATCHES_PER_RUN = 12`) is not modified. Stagger (`DEFAULT_DISPATCH_STAGGER_MS = 90_000`) is not modified. Privacy exclusion (`private: true` skipped) is not modified. Identity / authority / integrity-check rules are not modified.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| Floor accidentally re-surveys the same repo every day. | `FLOOR_MIN_GAP_DAYS = 7` plus the gap-filter logic ensures a 7-day cooldown. Test scenario explicitly covers the boundary. |
+| Floor's privacy filter is weaker than the threshold gate's. | Floor reuses the same fail-closed `wouldDispatchIfPublic` predicate as the threshold path (stored `private === false` AND access-list `private === false` AND node-level no-non-public-aliases AND no duplicate-node conflicts). Treating `private: undefined` as not-public matches the existing posture. Two error-path test scenarios explicitly cover unknown-privacy and node-level fail-closed cases. |
+| Floor starves later-sorting repos by always picking alphabetically earliest. | The single-pass merge preserves the existing null-group rotation step; floor candidates fold into the rotation. New test scenario asserts rotation order across simulated successive runs. |
+| Floor masks a real bug in the threshold model (e.g., `next_survey_eligible_at` corruption causes all repos to look ineligible forever). | Operator sees `flooredDispatches > 0` paired with `dispatches == flooredDispatches` for many consecutive runs — that pattern is a visible signal that the threshold has stopped working. The `summary.byChannel.collab.dispatched` field continues to break down per channel for diagnostics. |
+| Floor adds Anthropic seat pressure on quiet days. | `FLOOR_MIN = 2` is well within capacity (single-seat handles 2 sequential 5-min sessions with 90s stagger). Cap remains 12. |
+| New `flooredDispatches` field breaks a downstream consumer. | None today — the JSON summary is consumed only by the run log. Even if future consumers depend on the shape, adding a field is backward-compatible (existing field set unchanged). |
+| Floor over-disrupts the existing cadence cluster. | Floor only fires when threshold yields fewer than `FLOOR_MIN`. As the cluster naturally drains (June ~5-10), threshold will yield ≥ `FLOOR_MIN` and floor sleeps. The natural equilibrium is "floor fills the trough, threshold handles the peak." |
+| `pending` repos with `last_survey_status !== 'success'` (failed initial surveys) might be picked up by floor and re-dispatched even though they're churning. | The existing threshold gate for `pending` already allows dispatch if `last_survey_status !== 'success'` — the floor would either match the same behavior or be redundant. Worst case is a slight increase in retry frequency for failing repos, which is operator-desirable for getting unstuck. |
+
+## Documentation / Operational Notes
+
+- **No new docs files required.** The plan itself is the documentation surface. The brainstorm and plan together capture the rationale for the constants chosen.
+- **Operator-visible signal.** After the first successful production run with the floor active, the `summary.flooredDispatches` field appears in the reconcile run log. No additional dashboards, no notifications, no escalation. If a drought pattern emerges *of the floor itself* (e.g., `flooredDispatches: 0` for 7+ days), file a follow-up plan for drought-detection issue lifecycle.
+- **Existing learnings updates.** `docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md` may benefit from a cross-reference to this plan once it ships, framed as "the floor is another instance of the same principle." Optional cleanup, not part of this plan's scope.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-17-survey-cadence-minimum-floor-requirements.md](../brainstorms/2026-05-17-survey-cadence-minimum-floor-requirements.md)
+- **Related plan:** [docs/plans/2026-05-05-001-feat-survey-cadence-and-multi-channel-discovery-plan.md](2026-05-05-001-feat-survey-cadence-and-multi-channel-discovery-plan.md) — the cadence plan that explicitly deferred this work; line 53 documents the trigger condition this plan satisfies.
+- **Related code:** `scripts/reconcile-repos.ts` — the engine being modified.
+- **Related compound docs:**
+  - `docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md` — "silence becomes loud" principle.
+  - `docs/solutions/security-issues/private-repo-dispatch-visibility-gate-2026-05-08.md` — engine-level privacy gating that the floor inherits.

--- a/docs/solutions/best-practices/autonomous-pipeline-minimum-progress-floor-2026-05-17.md
+++ b/docs/solutions/best-practices/autonomous-pipeline-minimum-progress-floor-2026-05-17.md
@@ -1,0 +1,179 @@
+---
+category: best-practices
+title: Autonomous pipeline minimum-progress floor for threshold-gated dispatch
+date: 2026-05-17
+last_updated: 2026-05-17
+problem_type: best_practice
+module: reconcile-repos
+component: development_workflow
+severity: medium
+verified: true
+tags:
+  - reconcile-repos
+  - survey-dispatch
+  - deterministic-jitter
+  - minimum-progress-floor
+  - autonomous-pipeline
+  - workflow-resilience
+applies_when:
+  - A scheduled pipeline can legitimately return zero work for many consecutive runs because threshold gating plus jitter has starved the population.
+  - You need to preserve privacy/fail-closed behavior while still guaranteeing periodic progress.
+  - A manual or clustered dispatch created a long next-eligible horizon and the system risks silence.
+---
+
+## Context
+
+Threshold-gated dispatch in autonomous pipelines tends to bunch under bursty load: manual interventions, recovery runs, and bootstrap work create a short surge, then the system drains and idles for weeks. The cadence plan explicitly anticipated this follow-on condition, and production hit it after roughly 21 days. During a drought, the operator signal is just "success" with a zero counter, so the pipeline looks healthy while wiki accumulation stalls.
+
+## Guidance
+
+When a threshold gate acts as a ceiling on dispatch volume, pair it with a floor that guarantees some minimum progress.
+
+1. Reuse the exact same fail-closed predicates as the threshold path. No weaker filter on the floor.
+2. Add a separate gap-day cooldown so floor dispatches do not re-survey too soon.
+3. Merge floor candidates into the existing dispatch list before cap/rotation logic. The floor should be transparent at the dispatch boundary.
+4. Emit a dedicated counter and a counts-only log line so droughts become visible.
+
+### Load-bearing implementation pattern
+
+```ts
+// Pass 2.5 — minimum-dispatch floor
+// Fires when threshold-driven dispatches fall below FLOOR_MIN.
+// Cap counting and rotation happen in the I/O shell as today.
+// Floor dispatches look identical to threshold dispatches downstream — intentional.
+if (dispatches.length < FLOOR_MIN) {
+  const slotsNeeded = FLOOR_MIN - dispatches.length
+  const dispatchedKeys = new Set(dispatches.map(d => repoKey(d.owner, d.repo)))
+
+  const floorCandidates: {entry: RepoEntry; access: AccessListEntry}[] = []
+  for (const entry of next.repos) {
+    // Same eligibility universe as the threshold gate, minus next_survey_eligible_at —
+    // the floor's whole job is to fire when the threshold has held repos back.
+    if (entry.onboarding_status !== 'onboarded' && entry.onboarding_status !== 'pending') continue
+    if (entry.onboarding_status === 'pending' && entry.last_survey_status === 'success') {
+      // Mirrors the threshold gate's `pending` branch: a successful pending repo
+      // waits for its eligibility timestamp; the floor doesn't override that.
+      continue
+    }
+
+    const key = repoKey(entry.owner, entry.name)
+    if (dispatchedKeys.has(key)) continue
+
+    // Fail-closed privacy: stored AND live access-list must agree on public.
+    const access = accessForTrackedEntry(entry, key, accessByKey, accessByNodeId)
+    if (access === undefined) continue
+    const accessPrivate = accessPrivateForStorage(access, accessNodePrivacy)
+    if (entry.private !== false || accessPrivate) continue
+
+    // Gap-days: strict greater-than on whole-day count.
+    if (entry.last_survey_at !== null) {
+      const surveyedMs = Date.parse(`${entry.last_survey_at}T00:00:00Z`)
+      if (!Number.isFinite(surveyedMs)) continue
+      const daysAgo = Math.floor((nowMs - surveyedMs) / 86_400_000)
+      if (daysAgo <= FLOOR_MIN_GAP_DAYS) continue
+    }
+
+    floorCandidates.push({entry, access})
+  }
+
+  // Oldest-first sort — matches prioritizeDispatches ordering used by threshold path.
+  floorCandidates.sort((left, right) =>
+    compareBySurveyFreshness(
+      left.entry.last_survey_at,
+      right.entry.last_survey_at,
+      repoKey(left.entry.owner, left.entry.name),
+      repoKey(right.entry.owner, right.entry.name),
+    ),
+  )
+
+  for (const {entry, access} of floorCandidates.slice(0, slotsNeeded)) {
+    const key = repoKey(entry.owner, entry.name)
+    if (dispatchedKeys.has(key)) continue // defensive dedup
+    dispatchedKeys.add(key)
+    dispatches.push({owner: access.owner, repo: access.name, node_id: access.node_id})
+    summary.flooredDispatches += 1
+  }
+}
+```
+
+### Telemetry helper
+
+```ts
+export function formatFloorTelemetry(flooredDispatches: number, thresholdYield: number): string {
+  return `floor fired: dispatched ${flooredDispatches} of FLOOR_MIN=${FLOOR_MIN} (threshold yielded ${thresholdYield})`
+}
+```
+
+Emit through the injected logger boundary, best-effort:
+
+```ts
+if (plan.summary.flooredDispatches > 0) {
+  const thresholdYield = plan.dispatches.length - plan.summary.flooredDispatches
+  try {
+    logger.warn(formatFloorTelemetry(plan.summary.flooredDispatches, thresholdYield))
+  } catch (error) {
+    // Telemetry is best-effort; substantive engine work has already completed.
+    // A breadcrumb to stderr preserves visibility of programmer errors without
+    // aborting the scheduled run.
+    console.error('reconcile: floor telemetry emission failed', error)
+  }
+}
+```
+
+## Why This Matters
+
+Without a floor, threshold-only cadence will produce multi-week droughts in any non-trivial population. Jitter spreads dispatches out; it does not prevent unbunching. A floor also makes silence loud: repeated floor fires show either healthy steady-state or a broken threshold model. Without it, both cases look identical — zero dispatches, success status.
+
+The privacy invariant has to hold across both gates. A weaker floor predicate is effectively a back door for private repos.
+
+## When to Apply
+
+Use this pattern when you have:
+
+- a real ceiling requirement on dispatch volume
+- a population that can bunch up from manual intervention, recovery, or seasonality
+- a need for continuous progress
+- an operator who must notice droughts
+
+## Examples
+
+**Before:** cadence-only thresholding produces bursts, then long idle stretches. Operator sees `dispatches: 0, status: success` for weeks with no signal that anything is wrong.
+
+**After:** cadence plus floor guarantees continuous minimum throughput, while preserving the ceiling and the same fail-closed filters. Operator sees `flooredDispatches: 2` on drought days — immediately actionable signal.
+
+Reference implementation pattern:
+
+- threshold path sets the ceiling
+- floor path fills any shortfall
+- both paths share privacy/exclusion predicates
+- floor path respects gap-days cooldown
+- floor telemetry reports counts only (no owner/repo identifiers)
+
+## What Didn't Work
+
+1. **`private !== true` was too weak** — it accepted `private: undefined`.
+   - Fix: reuse the exact threshold-path predicate (`entry.private !== false || accessPrivate`).
+
+2. **The initial plan dropped null-group rotation** — floor candidates with `null` last_survey_at would always win the oldest-first sort, starving dated candidates.
+   - Fix: preserve rotation across the merged threshold+floor pool via `prioritizeDispatches`.
+
+3. **The pure-engine/logger boundary was inconsistent** — early drafts emitted directly to `core.warning` inside the engine.
+   - Fix: emit through the injected `ReconcileLogger` boundary; the engine stays pure.
+
+4. **First test spec had impossible combinations** — e.g. "11 threshold + 5 floor + cap=12" when floor cannot fire if threshold already meets `FLOOR_MIN`.
+   - Fix: model the test scenarios against the actual gate logic before writing assertions.
+
+## Prevention
+
+1. Design for both ceiling and floor requirements up front.
+2. Use the same predicate for both gates — no weaker filter on the floor.
+3. Add gap-days cooldown to prevent ping-pong (floor fires → repo surveyed → floor fires again next run).
+4. Surface a counter plus counts-only log line for operator visibility.
+5. Make telemetry best-effort so observability cannot abort the pipeline.
+
+## Related
+
+- [Silent Failures in Autonomous Multi-Step Pipelines](../runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md) — the "silence becomes loud" principle this floor implements
+- [Private repo dispatch requires definitive public visibility](../security-issues/private-repo-dispatch-visibility-gate-2026-05-08.md) — engine-side fail-closed privacy gate the floor inherits
+- [Survey Repo dispatch boundary trusted caller-provided owner/repo](../security-issues/survey-workflow-side-privacy-gate-2026-05-16.md) — workflow-side counterpart; defense-in-depth pair
+- [Loose-then-tight schema migration pattern](./loose-then-tight-schema-migration-pattern-2026-05-05.md) — the additive `flooredDispatches` field follows this approach

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -23,6 +23,7 @@ import {
   type HandleReconcileParams,
   type OctokitClient,
   type ReconcileInput,
+  type ReconcileLogger,
   type RepoStatusProbe,
 } from './reconcile-repos.ts'
 import {addRepoEntry} from './repos-metadata.ts'
@@ -5099,6 +5100,48 @@ describe('reconcileRepos minimum-dispatch floor', () => {
     expect(result.summary.flooredDispatches).toBe(1)
     expect(result.dispatches[0]?.repo).toBe('dup-repo')
   })
+
+  // 17. Ordering — floor + threshold merge: both sources contribute to the dispatch pool.
+  //
+  // Scenario: 1 threshold-eligible repo (last_survey_at: 2026-04-15, newer) and
+  // 1 floor-eligible repo (last_survey_at: 2026-04-01, older). Cap=12 (high enough
+  // to fit both). The engine appends threshold dispatches first, then floor dispatches
+  // (append order, not globally sorted). Final oldest-first ordering across both sources
+  // is applied by `prioritizeDispatches` in the I/O shell (tested via handleReconcile
+  // integration tests). This test verifies the engine correctly identifies both repos
+  // as dispatch candidates and attributes the floor contribution accurately.
+  it('merged threshold+floor dispatch pool contains both repos with correct flooredDispatches count', () => {
+    // threshold-eligible: next_survey_eligible_at=null → threshold fires
+    const thresholdRepo = trackedEntry({
+      owner: 'fro-bot',
+      name: 'threshold-repo',
+      node_id: 'R_threshold',
+      next_survey_eligible_at: null,
+      last_survey_at: '2026-04-15', // newer
+    })
+    // floor-eligible: next_survey_eligible_at in future → threshold skips; floor picks up
+    const floorEligible = trackedEntry({
+      owner: 'fro-bot',
+      name: 'floor-repo',
+      node_id: 'R_floor',
+      next_survey_eligible_at: FUTURE_ELIGIBLE,
+      last_survey_at: '2026-04-01', // older (> FLOOR_MIN_GAP_DAYS from NOW=2026-04-17)
+    })
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [thresholdRepo, floorEligible]},
+        accessList: [accessFor(thresholdRepo), accessFor(floorEligible)],
+      }),
+    )
+    // Both repos dispatched (cap=12 default is high enough).
+    expect(result.dispatches).toHaveLength(2)
+    // 1 came from threshold, 1 from floor.
+    expect(result.summary.flooredDispatches).toBe(1)
+    // Both repos are present in the dispatch pool (order is append-order at engine level;
+    // final oldest-first sort is applied by prioritizeDispatches in the I/O shell).
+    expect(result.dispatches.map(d => d.repo)).toContain('threshold-repo')
+    expect(result.dispatches.map(d => d.repo)).toContain('floor-repo')
+  })
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -5265,6 +5308,41 @@ describe('handleReconcile floor integration', () => {
     )
 
     expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  // Finding #2b — telemetry swallow: handleReconcile resolves successfully when logger.warn throws.
+  //
+  // The try/catch around logger.warn is best-effort; a throwing logger must not abort the run.
+  // This test verifies the catch scope is correct and that non-logger exceptions are not swallowed.
+  it('resolves successfully when logger.warn throws (telemetry swallow)', async () => {
+    const a = floorRepo('a-repo', 'R_a')
+    const b = floorRepo('b-repo', 'R_b')
+    const throwingLogger: ReconcileLogger = {
+      warn: () => {
+        throw new Error('logger down')
+      },
+      info: () => {},
+    }
+
+    // Should resolve without throwing even though logger.warn throws.
+    await expect(
+      handleReconcile(
+        baseParams({
+          userOctokit: mockOctokit({
+            listForAuthenticatedUser: async () => ({
+              data: [floorAccess('a-repo', 'R_a'), floorAccess('b-repo', 'R_b')],
+            }),
+          }),
+          appOctokit: mockOctokit(),
+          readMetadata: makeReadMetadata({
+            allowlist: makeAllowlist(['fro-bot']),
+            repos: {version: 1, repos: [a, b]},
+          }),
+          commitMetadata: vi.fn(async () => ({committed: true, sha: 's', attempts: 1})) as never,
+          logger: throwingLogger,
+        }),
+      ),
+    ).resolves.toBeDefined()
   })
 
   // Finding #3 — null-group rotation still works when floor contributes null-last_survey_at repos.

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -10,6 +10,7 @@ import {
   DISPATCH_DEFAULTS,
   fetchPerRepoStatus,
   formatCommitMessage,
+  formatFloorTelemetry,
   handleReconcile,
   isEligibleForSurvey,
   loadDispatchStaggerFromEnv,
@@ -122,6 +123,7 @@ describe('reconcileRepos', () => {
         malformed: 0,
         skippedPrivate: 0,
         unchanged: 0,
+        flooredDispatches: 0,
         // dispatched/deferred populated by the I/O shell, not the engine
         byChannel: {
           collab: {tracked: 1, dispatched: 0, deferred: 0, lostAccess: 0},
@@ -1220,6 +1222,7 @@ describe('reconcileRepos', () => {
         malformed: 0,
         skippedPrivate: 0,
         unchanged: 0,
+        flooredDispatches: 0,
         // dispatched/deferred populated by the I/O shell, not the engine
         byChannel: {
           collab: {tracked: 3, dispatched: 0, deferred: 0, lostAccess: 1},
@@ -1261,6 +1264,7 @@ describe('reconcileRepos', () => {
         malformed: 0,
         skippedPrivate: 0,
         unchanged: 1,
+        flooredDispatches: 0,
         byChannel: {
           collab: {tracked: 1, dispatched: 0, deferred: 0, lostAccess: 0},
           owned: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
@@ -1286,6 +1290,7 @@ describe('reconcileRepos', () => {
         malformed: 0,
         skippedPrivate: 0,
         unchanged: 0,
+        flooredDispatches: 0,
         byChannel: emptyChannelStats(),
       })
     })
@@ -1552,10 +1557,16 @@ describe('reconcileRepos', () => {
     })
 
     it('skips an entry with unknown privacy before refreshing it to public', () => {
+      // The threshold gate checks the stored `entry.private` (pre-normalization) and skips
+      // the entry when it is not explicitly `false`. Pass 1 then normalizes `private` to the
+      // live access-list value. The floor (Pass 2.5) operates on the post-normalization state,
+      // so it would dispatch this entry if it were also past the floor gap. We set
+      // `last_survey_at` to a recent date to keep it inside the gap and isolate the test to
+      // the threshold gate's privacy-skip behavior.
       const entry = makeEntry({
         name: 'legacy-repo',
         onboarding_status: 'pending',
-        last_survey_at: null,
+        last_survey_at: '2026-04-15', // within FLOOR_MIN_GAP_DAYS of NOW (2026-04-17); floor excludes it
         last_survey_status: null,
       })
 
@@ -4205,6 +4216,7 @@ describe('formatCommitMessage', () => {
         malformed: 0,
         skippedPrivate: 0,
         unchanged: 0,
+        flooredDispatches: 0,
         byChannel: emptyChannelStats(),
       }),
     ).toBe('chore(reconcile): +1 new, 0 pending-review, 0 lost-access, 2 refreshes')
@@ -4223,6 +4235,7 @@ describe('formatCommitMessage', () => {
         malformed: 0,
         skippedPrivate: 0,
         unchanged: 0,
+        flooredDispatches: 0,
         byChannel: emptyChannelStats(),
       }),
     ).toBe('chore(reconcile): +0 new, 0 pending-review, 0 lost-access, 0 refreshes, +18 migrated')
@@ -4241,6 +4254,7 @@ describe('formatCommitMessage', () => {
         malformed: 0,
         skippedPrivate: 2,
         unchanged: 0,
+        flooredDispatches: 0,
         byChannel: emptyChannelStats(),
       }),
     ).toBe('chore(reconcile): +0 new, 0 pending-review, 0 lost-access, 1 refreshes')
@@ -4259,6 +4273,7 @@ describe('formatCommitMessage', () => {
         malformed: 0,
         skippedPrivate: 0,
         unchanged: 0,
+        flooredDispatches: 0,
         byChannel: emptyChannelStats(),
       }),
     ).toBe('chore(reconcile): +1 new, 0 pending-review, 0 lost-access, 1 refreshes, +18 migrated')
@@ -4721,5 +4736,591 @@ describe('reconcileRepos byChannel summary', () => {
     expect(result.summary.byChannel.owned.tracked).toBe(1)
     expect(result.summary.byChannel.contrib.tracked).toBe(1)
     expect(result.summary.byChannel.collab.tracked).toBe(0)
+  })
+})
+
+function accessFor(entry: RepoEntry, overrides: Partial<AccessListEntry> = {}): AccessListEntry {
+  return makeAccess({
+    owner: entry.owner,
+    name: entry.name,
+    node_id: entry.node_id ?? `R_${entry.name}`,
+    private: false,
+    ...overrides,
+  })
+}
+
+describe('reconcileRepos minimum-dispatch floor', () => {
+  // Floor tests use NOW = 2026-04-17T12:00:00Z. Helper dates:
+  // - FUTURE_ELIGIBLE: 2026-06-15 (well past today; threshold never fires)
+  // - PAST_8D:        2026-04-09 (8 days before NOW; outside the 7-day floor gap)
+  // - PAST_5D:        2026-04-12 (5 days before NOW; inside the 7-day floor gap)
+  // - PAST_7D_EXACT:  2026-04-10 (7 days before NOW; boundary case)
+  // - PAST_30D:       2026-03-18 (30 days before NOW; very old)
+  const FUTURE_ELIGIBLE = '2026-06-15'
+  const PAST_8D = '2026-04-09'
+  const PAST_5D = '2026-04-12'
+  const PAST_7D_EXACT = '2026-04-10'
+  const PAST_30D = '2026-03-18'
+
+  function trackedEntry(overrides: Partial<RepoEntry>): RepoEntry {
+    return makeEntry({
+      onboarding_status: 'onboarded',
+      last_survey_status: 'success',
+      next_survey_eligible_at: FUTURE_ELIGIBLE,
+      private: false,
+      ...overrides,
+    })
+  }
+
+  // 1. Happy — threshold yields 2+, floor not needed (flooredDispatches: 0).
+  it('does not fire the floor when threshold already meets FLOOR_MIN', () => {
+    const a = trackedEntry({owner: 'fro-bot', name: 'agent', node_id: 'R_agent', next_survey_eligible_at: null})
+    const b = trackedEntry({owner: 'fro-bot', name: 'systematic', node_id: 'R_sys', next_survey_eligible_at: null})
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [a, b]},
+        accessList: [accessFor(a), accessFor(b)],
+      }),
+    )
+    expect(result.dispatches).toHaveLength(2)
+    expect(result.summary.flooredDispatches).toBe(0)
+  })
+
+  // 2. Happy — threshold yields 0, floor finds 2 (flooredDispatches: 2).
+  it('fires the floor to add 2 dispatches when threshold yields 0', () => {
+    const a = trackedEntry({owner: 'fro-bot', name: 'a-repo', node_id: 'R_a', last_survey_at: PAST_30D})
+    const b = trackedEntry({owner: 'fro-bot', name: 'b-repo', node_id: 'R_b', last_survey_at: PAST_8D})
+    const c = trackedEntry({owner: 'fro-bot', name: 'c-repo', node_id: 'R_c', last_survey_at: PAST_8D})
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [a, b, c]},
+        accessList: [accessFor(a), accessFor(b), accessFor(c)],
+      }),
+    )
+    expect(result.dispatches).toHaveLength(2)
+    expect(result.summary.flooredDispatches).toBe(2)
+    // Oldest-first: a-repo (PAST_30D) wins, then deterministic tiebreak between b-repo/c-repo.
+    expect(result.dispatches[0]?.repo).toBe('a-repo')
+    expect(result.dispatches[1]?.repo).toBe('b-repo')
+  })
+
+  // 3. Happy — threshold yields 1, floor adds 1 (flooredDispatches: 1).
+  it('tops up to FLOOR_MIN by adding 1 floor dispatch when threshold yields 1', () => {
+    const eligible = trackedEntry({
+      owner: 'fro-bot',
+      name: 'eligible',
+      node_id: 'R_eligible',
+      next_survey_eligible_at: null,
+    })
+    const floored = trackedEntry({
+      owner: 'fro-bot',
+      name: 'floored',
+      node_id: 'R_floored',
+      last_survey_at: PAST_30D,
+    })
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [eligible, floored]},
+        accessList: [accessFor(eligible), accessFor(floored)],
+      }),
+    )
+    expect(result.dispatches).toHaveLength(2)
+    expect(result.summary.flooredDispatches).toBe(1)
+    expect(result.dispatches.map(d => d.repo).sort()).toEqual(['eligible', 'floored'])
+  })
+
+  // 4. Edge — threshold yields exactly 2, floor stays asleep.
+  it('does not fire the floor when threshold yields exactly FLOOR_MIN', () => {
+    const a = trackedEntry({owner: 'fro-bot', name: 'a', node_id: 'R_a', next_survey_eligible_at: null})
+    const b = trackedEntry({owner: 'fro-bot', name: 'b', node_id: 'R_b', next_survey_eligible_at: null})
+    const c = trackedEntry({owner: 'fro-bot', name: 'c', node_id: 'R_c', last_survey_at: PAST_30D})
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [a, b, c]},
+        accessList: [accessFor(a), accessFor(b), accessFor(c)],
+      }),
+    )
+    expect(result.dispatches).toHaveLength(2)
+    expect(result.summary.flooredDispatches).toBe(0)
+    expect(result.dispatches.map(d => d.repo).sort()).toEqual(['a', 'b'])
+  })
+
+  // 5. Edge — threshold yields 0, floor pool empty (all surveyed within gap).
+  it('reports zero floor dispatches when every candidate is within FLOOR_MIN_GAP_DAYS', () => {
+    const a = trackedEntry({owner: 'fro-bot', name: 'a', node_id: 'R_a', last_survey_at: PAST_5D})
+    const b = trackedEntry({owner: 'fro-bot', name: 'b', node_id: 'R_b', last_survey_at: PAST_5D})
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [a, b]},
+        accessList: [accessFor(a), accessFor(b)],
+      }),
+    )
+    expect(result.dispatches).toHaveLength(0)
+    expect(result.summary.flooredDispatches).toBe(0)
+  })
+
+  // 6. Edge — threshold yields 0, floor finds 1 only (tiny population).
+  it('takes what it can when fewer than FLOOR_MIN candidates pass the floor filter', () => {
+    const eligible = trackedEntry({owner: 'fro-bot', name: 'aged', node_id: 'R_aged', last_survey_at: PAST_30D})
+    const recent = trackedEntry({owner: 'fro-bot', name: 'recent', node_id: 'R_recent', last_survey_at: PAST_5D})
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [eligible, recent]},
+        accessList: [accessFor(eligible), accessFor(recent)],
+      }),
+    )
+    expect(result.dispatches).toHaveLength(1)
+    expect(result.summary.flooredDispatches).toBe(1)
+    expect(result.dispatches[0]?.repo).toBe('aged')
+  })
+
+  // 7. Edge — null last_survey_at sorts before any date in the floor pool.
+  it('floors null-last_survey_at candidates before any dated candidate', () => {
+    const dated = trackedEntry({owner: 'fro-bot', name: 'dated', node_id: 'R_dated', last_survey_at: PAST_30D})
+    const neverSurveyed = trackedEntry({
+      owner: 'fro-bot',
+      name: 'never',
+      node_id: 'R_never',
+      last_survey_at: null,
+      last_survey_status: null,
+      next_survey_eligible_at: FUTURE_ELIGIBLE,
+    })
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [dated, neverSurveyed]},
+        accessList: [accessFor(dated), accessFor(neverSurveyed)],
+      }),
+    )
+    expect(result.dispatches).toHaveLength(2)
+    expect(result.summary.flooredDispatches).toBe(2)
+    // Null surveys first.
+    expect(result.dispatches[0]?.repo).toBe('never')
+    expect(result.dispatches[1]?.repo).toBe('dated')
+  })
+
+  // 8. Cap interaction — floor adds to the dispatch list; cap enforcement happens in
+  // the I/O shell. The pure function's contract is: dispatches.length === threshold +
+  // floorTaken. Cap-induced deferral is exercised by existing dispatch-loop tests.
+  it('adds floor entries to dispatches without bounding by per-run cap (cap belongs to the I/O shell)', () => {
+    const repos = Array.from({length: 15}, (_, i) =>
+      trackedEntry({
+        owner: 'fro-bot',
+        name: `repo-${String(i).padStart(2, '0')}`,
+        node_id: `R_${i}`,
+        last_survey_at: PAST_30D,
+      }),
+    )
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos},
+        accessList: repos.map(r => accessFor(r)),
+      }),
+    )
+    // Threshold yields 0 (all are within their next_survey_eligible_at window). Floor
+    // adds up to FLOOR_MIN = 2.
+    expect(result.dispatches).toHaveLength(2)
+    expect(result.summary.flooredDispatches).toBe(2)
+  })
+
+  // 9a. Edge — gap-days boundary, 7 days exact = OUT (inside gap).
+  it('treats a repo surveyed exactly FLOOR_MIN_GAP_DAYS ago as inside the floor gap (excluded)', () => {
+    const boundary = trackedEntry({
+      owner: 'fro-bot',
+      name: 'boundary',
+      node_id: 'R_boundary',
+      last_survey_at: PAST_7D_EXACT,
+    })
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [boundary]},
+        accessList: [accessFor(boundary)],
+      }),
+    )
+    expect(result.dispatches).toHaveLength(0)
+    expect(result.summary.flooredDispatches).toBe(0)
+  })
+
+  // 9b. Edge — gap-days boundary, 8 days = IN (outside gap).
+  it('treats a repo surveyed FLOOR_MIN_GAP_DAYS+1 days ago as past the floor gap (included)', () => {
+    const past = trackedEntry({owner: 'fro-bot', name: 'past', node_id: 'R_past', last_survey_at: PAST_8D})
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [past]},
+        accessList: [accessFor(past)],
+      }),
+    )
+    expect(result.dispatches).toHaveLength(1)
+    expect(result.summary.flooredDispatches).toBe(1)
+  })
+
+  // 10. Error — `private: true` excluded from floor.
+  it('excludes a tracked private repo from the floor pool', () => {
+    const privateRepo = trackedEntry({
+      owner: '[REDACTED]',
+      name: 'R_private',
+      node_id: 'R_private',
+      last_survey_at: PAST_30D,
+      private: true,
+    })
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [privateRepo]},
+        accessList: [accessFor(privateRepo, {owner: 'private-owner', name: 'real-name', private: true})],
+      }),
+    )
+    expect(result.dispatches).toHaveLength(0)
+    expect(result.summary.flooredDispatches).toBe(0)
+  })
+
+  // 11. Error — privacy fail-closed: no access list entry → floor excludes the repo.
+  //
+  // NOTE: A stored `private: undefined` entry cannot reach Pass 2.5 with that field
+  // intact when an access list entry is present — Pass 1's `normalizeRepoEntryForStorage`
+  // always writes the live `private` boolean from the access list onto the entry. The
+  // original scenario (stored undefined + access-list public) is therefore unreachable.
+  //
+  // The closest reachable analog for "unknown privacy" is a tracked entry whose access
+  // list entry is absent entirely (e.g. the repo was removed from the access list between
+  // runs but hasn't been classified as lost-access yet). In that case
+  // `accessForTrackedEntry` returns `undefined` and the floor skips the entry via the
+  // `if (access === undefined) continue` guard — the same fail-closed outcome.
+  it('excludes a tracked repo that has no access list entry from the floor pool (fail-closed)', () => {
+    const noAccess = trackedEntry({
+      owner: 'fro-bot',
+      name: 'no-access',
+      node_id: 'R_no_access',
+      last_survey_at: PAST_30D,
+      private: false,
+    })
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [noAccess]},
+        // Access list intentionally empty — entry has no live access record.
+        accessList: [],
+      }),
+    )
+    expect(result.dispatches).toHaveLength(0)
+    expect(result.summary.flooredDispatches).toBe(0)
+  })
+
+  // 12. Error — access list flags private though stored private:false → excluded.
+  it('excludes a tracked repo whose live access-list privacy flips to private', () => {
+    const stored = trackedEntry({
+      owner: 'fro-bot',
+      name: 'flipped',
+      node_id: 'R_flip',
+      last_survey_at: PAST_30D,
+      private: false,
+    })
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [stored]},
+        accessList: [accessFor(stored, {private: true})],
+      }),
+    )
+    expect(result.dispatches).toHaveLength(0)
+    expect(result.summary.flooredDispatches).toBe(0)
+  })
+
+  // 13. Error — node-level duplicate alias triggers fail-closed exclusion.
+  it('excludes a tracked repo when the access list has a duplicate node_id with a private alias', () => {
+    const stored = trackedEntry({
+      owner: 'fro-bot',
+      name: 'aliased',
+      node_id: 'R_alias',
+      last_survey_at: PAST_30D,
+      private: false,
+    })
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [stored]},
+        accessList: [
+          accessFor(stored),
+          makeAccess({owner: 'shadow', name: 'private-alias', node_id: 'R_alias', private: true}),
+        ],
+      }),
+    )
+    expect(result.dispatches).toHaveLength(0)
+    expect(result.summary.flooredDispatches).toBe(0)
+  })
+
+  // 14. Error — `pending-review` excluded from floor.
+  it('excludes pending-review entries from the floor pool', () => {
+    const pending = trackedEntry({
+      owner: 'stranger',
+      name: 'sus-repo',
+      node_id: 'R_sus',
+      onboarding_status: 'pending-review',
+      last_survey_at: PAST_30D,
+    })
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [pending]},
+        accessList: [accessFor(pending)],
+      }),
+    )
+    expect(result.dispatches).toHaveLength(0)
+    expect(result.summary.flooredDispatches).toBe(0)
+  })
+
+  // 15. Error — `lost-access` excluded from floor (no longer in access list).
+  it('excludes lost-access entries from the floor pool', () => {
+    const lost = trackedEntry({
+      owner: 'fro-bot',
+      name: 'gone',
+      node_id: 'R_gone',
+      onboarding_status: 'lost-access',
+      last_survey_at: PAST_30D,
+    })
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [lost]},
+        accessList: [],
+        perRepoStatus: new Map([['fro-bot/gone', {status: 'archived'}]]),
+      }),
+    )
+    expect(result.dispatches).toHaveLength(0)
+    expect(result.summary.flooredDispatches).toBe(0)
+  })
+
+  // 16. Adversarial — duplicate metadata rows dispatch the same repo only once (Finding #6).
+  it('dispatches a duplicate-row repo only once even when both rows pass the floor filter', () => {
+    // Simulate data corruption: same owner/name appears twice in next.repos.
+    // Both rows pass all floor filters (public, onboarded, past gap). The dedup guard
+    // inside the floor accept loop must prevent a double-dispatch.
+    const dup = trackedEntry({owner: 'fro-bot', name: 'dup-repo', node_id: 'R_dup', last_survey_at: PAST_30D})
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [dup, dup]},
+        accessList: [accessFor(dup)],
+      }),
+    )
+    expect(result.dispatches).toHaveLength(1)
+    expect(result.summary.flooredDispatches).toBe(1)
+    expect(result.dispatches[0]?.repo).toBe('dup-repo')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// formatFloorTelemetry — unit tests for the floor log message helper (Finding #2)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('formatFloorTelemetry', () => {
+  // Test A: message emitted with correct counts when floor fires.
+  it('returns the expected message string for given counts', () => {
+    expect(formatFloorTelemetry(2, 0)).toBe('floor fired: dispatched 2 of FLOOR_MIN=2 (threshold yielded 0)')
+  })
+
+  // Test B: message contains no per-repo identifiers (security invariant).
+  it('contains no owner/repo shape or node_id prefix in the message', () => {
+    const msg = formatFloorTelemetry(1, 3)
+    // No slash-separated owner/repo shape.
+    expect(msg).not.toMatch(/\//)
+    // No node_id-shaped token (R_ followed by a lowercase letter or digit, as in R_alpha, R_1).
+    // FLOOR_MIN contains "R_M" (uppercase M) which is not a node_id pattern.
+    expect(msg).not.toMatch(/R_[a-z\d]/)
+    // Matches the strict counts-only pattern.
+    expect(msg).toMatch(/^floor fired: dispatched \d+ of FLOOR_MIN=\d+ \(threshold yielded \d+\)$/)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// handleReconcile — floor integration tests (Findings #1, #2, #3)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Dates relative to NOW = 2026-04-17T12:00:00Z
+const FLOOR_FUTURE_ELIGIBLE = '2026-06-15' // threshold never fires for these repos
+const FLOOR_PAST_30D = '2026-03-18' // 30 days ago — well past the 7-day floor gap
+
+/** Build a minimal tracked-repo row for the repos.yaml fixture. */
+function floorRepo(
+  name: string,
+  nodeId: string,
+  overrides: {last_survey_at?: string | null; next_survey_eligible_at?: string | null} = {},
+): RepoEntry {
+  return {
+    owner: 'fro-bot',
+    name,
+    added: '2026-01-01',
+    onboarding_status: 'onboarded',
+    last_survey_at: 'last_survey_at' in overrides ? (overrides.last_survey_at ?? null) : FLOOR_PAST_30D,
+    last_survey_status: 'success',
+    has_fro_bot_workflow: false,
+    has_renovate: false,
+    discovery_channel: 'collab',
+    private: false,
+    node_id: nodeId,
+    next_survey_eligible_at: overrides.next_survey_eligible_at ?? FLOOR_FUTURE_ELIGIBLE,
+  }
+}
+
+/** Build an access-list API entry for a floor repo. */
+function floorAccess(name: string, nodeId: string) {
+  return {owner: {login: 'fro-bot'}, name, archived: false, private: false, node_id: nodeId}
+}
+
+describe('handleReconcile floor integration', () => {
+  // Finding #1 — cap+floor interaction at the I/O shell level.
+  //
+  // Scenario: 0 threshold-eligible repos + 5 floor-eligible repos + cap=1.
+  // FLOOR_MIN=2, so floor fires (0 < 2) and adds 2 candidates (slotsNeeded=2).
+  // Cap=1 cuts the combined pool from 2 → 1 dispatched.
+  // Expected: 1 dispatched (oldest floor candidate), flooredDispatches=2,
+  //           dispatchesDeferred=1 (the second floor candidate cut by cap).
+  it('cap+floor interaction: 0 threshold + 5 floor + cap=1 → 1 dispatched, 2 floored, 1 deferred', async () => {
+    // 5 floor-eligible repos: next_survey_eligible_at is in the future (threshold skips them),
+    // last_survey_at varies so we can assert the oldest wins after sort.
+    const floorRepos = [
+      floorRepo('floor-oldest', 'R_f1', {next_survey_eligible_at: FLOOR_FUTURE_ELIGIBLE, last_survey_at: '2026-01-01'}),
+      floorRepo('floor-second', 'R_f2', {next_survey_eligible_at: FLOOR_FUTURE_ELIGIBLE, last_survey_at: '2026-01-15'}),
+      floorRepo('floor-third', 'R_f3', {next_survey_eligible_at: FLOOR_FUTURE_ELIGIBLE, last_survey_at: '2026-02-01'}),
+      floorRepo('floor-fourth', 'R_f4', {next_survey_eligible_at: FLOOR_FUTURE_ELIGIBLE, last_survey_at: '2026-02-15'}),
+      floorRepo('floor-fifth', 'R_f5', {next_survey_eligible_at: FLOOR_FUTURE_ELIGIBLE, last_survey_at: '2026-03-01'}),
+    ]
+
+    const dispatchCalls: string[] = []
+    const createWorkflowDispatch = vi.fn(async (params: unknown) => {
+      const typed = params as {inputs?: {node_id: string}}
+      dispatchCalls.push(typed.inputs?.node_id ?? '?')
+    })
+
+    const result = await handleReconcile(
+      baseParams({
+        userOctokit: mockOctokit({
+          listForAuthenticatedUser: async () => ({
+            data: floorRepos.map(r => floorAccess(r.name, r.node_id ?? '')),
+          }),
+        }),
+        appOctokit: mockOctokit({createWorkflowDispatch}),
+        readMetadata: makeReadMetadata({
+          allowlist: makeAllowlist(['fro-bot']),
+          repos: {version: 1, repos: floorRepos},
+        }),
+        commitMetadata: vi.fn(async () => ({committed: true, sha: 's', attempts: 1})) as never,
+        // Cap=1: floor adds 2 (FLOOR_MIN=2), cap cuts to 1.
+        maxDispatchesPerRun: 1,
+      }),
+    )
+
+    // Floor fired and added FLOOR_MIN=2 candidates to the dispatch pool.
+    expect(result.summary.flooredDispatches).toBe(2)
+    // Cap=1 cuts the pool from 2 → 1 dispatched.
+    expect(result.dispatches).toBe(1)
+    // 1 floor candidate was deferred by the cap (2 in pool - 1 dispatched = 1).
+    expect(result.dispatchesDeferred).toBe(1)
+    // The surviving dispatch is the oldest floor candidate (floor sort is oldest-first).
+    expect(dispatchCalls).toEqual(['R_f1'])
+  })
+
+  // Finding #2 — logger.warn called with correct message when floor fires.
+  it('emits logger.warn with correct floor telemetry when floor fires', async () => {
+    // 2 floor-eligible repos, threshold yields 0.
+    const a = floorRepo('a-repo', 'R_a')
+    const b = floorRepo('b-repo', 'R_b')
+    const logger = silentLogger()
+
+    await handleReconcile(
+      baseParams({
+        userOctokit: mockOctokit({
+          listForAuthenticatedUser: async () => ({
+            data: [floorAccess('a-repo', 'R_a'), floorAccess('b-repo', 'R_b')],
+          }),
+        }),
+        appOctokit: mockOctokit(),
+        readMetadata: makeReadMetadata({
+          allowlist: makeAllowlist(['fro-bot']),
+          repos: {version: 1, repos: [a, b]},
+        }),
+        commitMetadata: vi.fn(async () => ({committed: true, sha: 's', attempts: 1})) as never,
+        logger,
+      }),
+    )
+
+    // logger.warn called exactly once.
+    expect(logger.warn).toHaveBeenCalledOnce()
+    // Message matches the expected format: 2 floored, threshold yielded 0.
+    expect(logger.warn).toHaveBeenCalledWith('floor fired: dispatched 2 of FLOOR_MIN=2 (threshold yielded 0)')
+  })
+
+  // Finding #2 — logger.warn NOT called when floor does not fire.
+  it('does not emit logger.warn when floor does not fire', async () => {
+    // 2 threshold-eligible repos → floor stays asleep.
+    const logger = silentLogger()
+
+    await handleReconcile(
+      baseParams({
+        userOctokit: mockOctokit({
+          listForAuthenticatedUser: async () => ({
+            data: [
+              {owner: {login: 'fro-bot'}, name: 'r1', archived: false, private: false, node_id: 'R_r1'},
+              {owner: {login: 'fro-bot'}, name: 'r2', archived: false, private: false, node_id: 'R_r2'},
+            ],
+          }),
+        }),
+        appOctokit: mockOctokit(),
+        readMetadata: makeReadMetadata({allowlist: makeAllowlist(['fro-bot'])}),
+        commitMetadata: vi.fn(async () => ({committed: true, sha: 's', attempts: 1})) as never,
+        logger,
+      }),
+    )
+
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  // Finding #3 — null-group rotation still works when floor contributes null-last_survey_at repos.
+  //
+  // Scenario: 2 never-surveyed repos, both floor-eligible (next_survey_eligible_at in future),
+  // cap=1. Floor fires (0 threshold < FLOOR_MIN=2), adds both repos (slotsNeeded=2).
+  // Across 2 simulated runs with day ordinals mod 2 = 0 and 1, both repos must get
+  // a turn at the head of the rotation — no single repo always wins.
+  it('null-group rotation cycles all 2 never-surveyed floor repos across 2 runs with cap=1', async () => {
+    const repos = [
+      floorRepo('alpha', 'R_alpha', {last_survey_at: null, next_survey_eligible_at: FLOOR_FUTURE_ELIGIBLE}),
+      floorRepo('beta', 'R_beta', {last_survey_at: null, next_survey_eligible_at: FLOOR_FUTURE_ELIGIBLE}),
+    ]
+
+    // Pick 2 `now` values whose day ordinals are 0 and 1 mod 2.
+    // Day ordinal = Math.floor(now.getTime() / 86_400_000).
+    // 2026-04-16T12:00:00Z → ordinal 20194 (mod 2 = 0)
+    // 2026-04-17T12:00:00Z → ordinal 20195 (mod 2 = 1)
+    const nows = [
+      new Date('2026-04-16T12:00:00Z'), // ordinal mod 2 = 0
+      new Date('2026-04-17T12:00:00Z'), // ordinal mod 2 = 1
+    ]
+
+    const firstDispatched: string[] = []
+
+    for (const now of nows) {
+      const dispatchCalls: string[] = []
+      const createWorkflowDispatch = vi.fn(async (params: unknown) => {
+        const typed = params as {inputs?: {node_id: string}}
+        dispatchCalls.push(typed.inputs?.node_id ?? '?')
+      })
+
+      await handleReconcile(
+        baseParams({
+          now,
+          userOctokit: mockOctokit({
+            listForAuthenticatedUser: async () => ({
+              data: repos.map(r => floorAccess(r.name, r.node_id ?? '')),
+            }),
+          }),
+          appOctokit: mockOctokit({createWorkflowDispatch}),
+          readMetadata: makeReadMetadata({
+            allowlist: makeAllowlist(['fro-bot']),
+            repos: {version: 1, repos},
+          }),
+          commitMetadata: vi.fn(async () => ({committed: true, sha: 's', attempts: 1})) as never,
+          // Cap=1: floor adds 2 (FLOOR_MIN=2), rotation picks 1 per run.
+          maxDispatchesPerRun: 1,
+        }),
+      )
+
+      // Record which repo was dispatched first (head of rotation).
+      firstDispatched.push(dispatchCalls[0] ?? '?')
+    }
+
+    // Both repos must appear as the first-dispatched across the 2 runs.
+    expect(new Set(firstDispatched).size).toBe(2)
   })
 })

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -237,6 +237,16 @@ export interface ReconcileSummary {
    */
   skippedPrivate: number
   /**
+   * Number of dispatches added by the minimum-dispatch floor this run. The floor fires
+   * when threshold-driven dispatches fall below {@link FLOOR_MIN}, picking the oldest-
+   * surveyed tracked repos that pass the same fail-closed privacy gate the threshold
+   * uses. A non-zero value means the engine drove continuous wiki growth on a day the
+   * threshold model alone would have idled. Zero on quiet days when threshold met or
+   * exceeded the floor, and on droughts where every tracked repo is inside
+   * {@link FLOOR_MIN_GAP_DAYS}.
+   */
+  flooredDispatches: number
+  /**
    * Per-channel activity breakdown. See {@link ChannelStats} for field semantics. The
    * engine populates `tracked` and `lostAccess`; the shell populates `dispatched` and
    * `deferred` after cap selection.
@@ -249,6 +259,69 @@ export interface ReconcileResult {
   dispatches: DispatchRequest[]
   issues: IssueQueueEntry[]
   summary: ReconcileSummary
+}
+
+/**
+ * Minimum number of dispatches the reconcile engine targets per run. When the threshold
+ * gate (per-channel `next_survey_eligible_at`) yields fewer than this many candidates,
+ * the floor fires and tops up the dispatch list with the oldest-surveyed tracked repos
+ * that pass the same fail-closed privacy gate.
+ *
+ * The floor exists because the channel-cycle math (collab=30d, owned=14d, contrib=21d)
+ * inevitably clusters into multi-day silences when populations bunch. Without a floor,
+ * the wiki goes quiet for ~20 days at a time. With it, continuous knowledge growth is
+ * decoupled from cluster timing.
+ *
+ * The floor is additive — threshold remains the ceiling, the per-run cap
+ * ({@link DEFAULT_MAX_DISPATCHES_PER_RUN}) still bounds the upper end, and the dispatch
+ * stagger still applies. See `docs/plans/2026-05-17-001-feat-survey-cadence-minimum-floor-plan.md`.
+ */
+const FLOOR_MIN = 2
+
+/**
+ * Minimum gap (in days) between any two surveys of the same repo when the floor fires.
+ * A tracked repo surveyed within this window is excluded from the floor pool so the
+ * floor cannot ping-pong the same repo on consecutive days.
+ *
+ * Strict-greater-than semantics: a repo surveyed exactly `FLOOR_MIN_GAP_DAYS` days ago
+ * (down to the day boundary) is still inside the gap; only repos surveyed more than
+ * `FLOOR_MIN_GAP_DAYS` days ago are eligible.
+ */
+const FLOOR_MIN_GAP_DAYS = 7
+
+/**
+ * Format the floor-fired telemetry message.
+ *
+ * Extracted so the message shape can be unit-tested independently of the I/O shell.
+ * Security invariant: the message must contain only aggregate counts — no owner, repo
+ * name, or node_id (see docs/solutions/security-issues/private-repo-dispatch-visibility-gate-2026-05-08.md).
+ */
+export function formatFloorTelemetry(flooredDispatches: number, thresholdYield: number): string {
+  return `floor fired: dispatched ${flooredDispatches} of FLOOR_MIN=${FLOOR_MIN} (threshold yielded ${thresholdYield})`
+}
+
+/**
+ * Compare two dispatch candidates by survey freshness for oldest-first ordering.
+ *
+ * Rules (identical to the comparator inside {@link prioritizeDispatches}):
+ * 1. `null` (never surveyed) sorts before any date string.
+ * 2. Earlier date strings sort before later ones (ascending `last_survey_at`).
+ * 3. Tiebreak: lexicographic on the pre-computed `repoKey` strings.
+ *
+ * Accepts primitives so it can be used from both the floor sort (which operates on
+ * `{entry: RepoEntry; access: AccessListEntry}[]`) and `prioritizeDispatches` (which
+ * operates on `DispatchRequest[]`).
+ */
+function compareBySurveyFreshness(
+  leftAt: string | null,
+  rightAt: string | null,
+  leftKey: string,
+  rightKey: string,
+): number {
+  if (leftAt === null && rightAt !== null) return -1
+  if (rightAt === null && leftAt !== null) return 1
+  if (leftAt !== null && rightAt !== null && leftAt !== rightAt) return leftAt.localeCompare(rightAt)
+  return leftKey.localeCompare(rightKey)
 }
 
 /**
@@ -280,6 +353,7 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
     transient: 0,
     malformed: 0,
     skippedPrivate: 0,
+    flooredDispatches: 0,
     byChannel: {
       collab: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
       owned: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
@@ -376,6 +450,90 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
         private: accessPrivate,
         node_id: access.node_id,
       })
+    }
+  }
+
+  // Pass 2.5 — minimum-dispatch floor.
+  //
+  // When the threshold gate yielded fewer than FLOOR_MIN dispatches, top up the list
+  // with the oldest-surveyed tracked repos that pass the same fail-closed privacy
+  // gate as the threshold path. This decouples continuous wiki growth from cluster
+  // timing: when channel-cycle math bunches eligibility into one week per cycle, the
+  // floor still dispatches FLOOR_MIN repos per run on the off-cycle days.
+  //
+  // The floor adds to `dispatches` only; cap enforcement, rotation, and per-channel
+  // counting happen in the I/O shell as today. Floor dispatches look identical to
+  // threshold dispatches downstream — intentional, the floor is transparent.
+  if (dispatches.length < FLOOR_MIN) {
+    const slotsNeeded = FLOOR_MIN - dispatches.length
+    const dispatchedKeys = new Set(dispatches.map(d => repoKey(d.owner, d.repo)))
+    const nowMs = now.getTime()
+
+    const floorCandidates: {entry: RepoEntry; access: AccessListEntry}[] = []
+    for (const entry of next.repos) {
+      // Same eligibility universe as the threshold gate, minus the
+      // `next_survey_eligible_at` check — the floor's whole job is to fire when the
+      // threshold has held repos back.
+      if (entry.onboarding_status !== 'onboarded' && entry.onboarding_status !== 'pending') continue
+      if (entry.onboarding_status === 'pending' && entry.last_survey_status === 'success') {
+        // Mirrors the threshold gate's `pending` branch: a successful pending repo
+        // waits for its eligibility timestamp; the floor doesn't override that.
+        continue
+      }
+
+      const key = repoKey(entry.owner, entry.name)
+      if (dispatchedKeys.has(key)) continue
+
+      // Fail-closed privacy: stored AND live access-list must agree on public, and the
+      // node-level fail-closed rule (duplicate node_id, non-public alias) must clear.
+      // Mirrors the `wouldDispatchIfPublic && !skippedPrivate` branch in classifyTracked.
+      const access = accessForTrackedEntry(entry, key, accessByKey, accessByNodeId)
+      if (access === undefined) continue
+      const accessPrivate = accessPrivateForStorage(access, accessNodePrivacy)
+      if (entry.private !== false || accessPrivate) continue
+
+      // Gap-days: strict greater-than on whole-day count. A repo surveyed exactly
+      // FLOOR_MIN_GAP_DAYS days ago is still inside the gap; only repos surveyed
+      // strictly more than FLOOR_MIN_GAP_DAYS days ago are eligible.
+      //
+      // We compare calendar-day counts (Math.floor of ms / 86_400_000) rather than
+      // raw milliseconds so that the boundary is stable regardless of the time-of-day
+      // component of `now`. E.g. NOW=2026-04-17T12:00:00Z and last_survey_at=2026-04-10
+      // yields daysAgo=7 (not 7.5), which is NOT strictly greater than FLOOR_MIN_GAP_DAYS=7,
+      // so the repo is correctly excluded. last_survey_at=2026-04-09 yields daysAgo=8 → IN.
+      // `null` last_survey_at counts as never-surveyed = always past the gap.
+      if (entry.last_survey_at !== null) {
+        const surveyedMs = Date.parse(`${entry.last_survey_at}T00:00:00Z`)
+        if (!Number.isFinite(surveyedMs)) continue
+        const daysAgo = Math.floor((nowMs - surveyedMs) / 86_400_000)
+        if (daysAgo <= FLOOR_MIN_GAP_DAYS) continue
+      }
+
+      floorCandidates.push({entry, access})
+    }
+
+    // Oldest-first: null `last_survey_at` (never surveyed) before any date, then
+    // ascending by date, tiebreak on owner/name for determinism. Matches the existing
+    // `prioritizeDispatches` ordering used by the threshold path.
+    floorCandidates.sort((left, right) =>
+      compareBySurveyFreshness(
+        left.entry.last_survey_at,
+        right.entry.last_survey_at,
+        repoKey(left.entry.owner, left.entry.name),
+        repoKey(right.entry.owner, right.entry.name),
+      ),
+    )
+
+    for (const {entry, access} of floorCandidates.slice(0, slotsNeeded)) {
+      // Defensive dedup against duplicate next.repos rows (data corruption). If the same
+      // owner/name appears twice in the floor pool, skip the second occurrence rather than
+      // dispatching the same repo twice. FLOOR_MIN is not met in that run — acceptable;
+      // data corruption is a separate concern the floor should not mask.
+      const key = repoKey(entry.owner, entry.name)
+      if (dispatchedKeys.has(key)) continue
+      dispatchedKeys.add(key)
+      dispatches.push({owner: access.owner, repo: access.name, node_id: access.node_id})
+      summary.flooredDispatches += 1
     }
   }
 
@@ -1091,6 +1249,20 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
     now,
   })
 
+  // Floor telemetry — counts-only, no per-repo identifiers (security invariant: see
+  // docs/solutions/security-issues/private-repo-dispatch-visibility-gate-2026-05-08.md).
+  // Telemetry is best-effort: a logger failure must never abort the scheduled reconcile
+  // run, since the substantive engine work (classification, dispatch planning) has
+  // already completed by this point.
+  if (plan.summary.flooredDispatches > 0) {
+    const thresholdYield = plan.dispatches.length - plan.summary.flooredDispatches
+    try {
+      logger.warn(formatFloorTelemetry(plan.summary.flooredDispatches, thresholdYield))
+    } catch {
+      // Swallow logger failures — telemetry is non-critical observability.
+    }
+  }
+
   const hasChanges = planHasChanges(plan)
   let integrityCheck: 'ok' | 'skipped-no-data-branch' | 'skipped-just-bootstrapped' = 'ok'
   let committed = false
@@ -1290,15 +1462,7 @@ function prioritizeDispatches(dispatches: DispatchRequest[], nextRepos: ReposFil
     const rightKey = `${right.owner}/${right.repo}`
     const leftAt = lookup.get(leftKey) ?? null
     const rightAt = lookup.get(rightKey) ?? null
-
-    // Null (never surveyed) comes before any date.
-    if (leftAt === null && rightAt !== null) return -1
-    if (rightAt === null && leftAt !== null) return 1
-    if (leftAt !== null && rightAt !== null && leftAt !== rightAt) {
-      return leftAt.localeCompare(rightAt)
-    }
-    // Deterministic tiebreak.
-    return leftKey.localeCompare(rightKey)
+    return compareBySurveyFreshness(leftAt, rightAt, leftKey, rightKey)
   })
 }
 

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -237,13 +237,19 @@ export interface ReconcileSummary {
    */
   skippedPrivate: number
   /**
-   * Number of dispatches added by the minimum-dispatch floor this run. The floor fires
-   * when threshold-driven dispatches fall below {@link FLOOR_MIN}, picking the oldest-
-   * surveyed tracked repos that pass the same fail-closed privacy gate the threshold
-   * uses. A non-zero value means the engine drove continuous wiki growth on a day the
-   * threshold model alone would have idled. Zero on quiet days when threshold met or
-   * exceeded the floor, and on droughts where every tracked repo is inside
-   * {@link FLOOR_MIN_GAP_DAYS}.
+   * Number of floor candidates added to the dispatch pool. May exceed the count that
+   * actually dispatched if the per-run cap cut some — operators interpreting this
+   * alongside `dispatches` should remember the engine produces this count before cap
+   * enforcement (which lives in the I/O shell).
+   *
+   * This is a global counter and does NOT split per-channel. The floor is a global
+   * property of the run, not a per-channel property; {@link byChannel} tracks activity
+   * by discovery channel but the floor's contribution is not attributed to any single
+   * channel. The design decision is captured in the implementation plan's "Deferred to
+   * Implementation" section.
+   *
+   * Zero on quiet days when the threshold met or exceeded {@link FLOOR_MIN}, and on
+   * droughts where every tracked repo is inside {@link FLOOR_MIN_GAP_DAYS}.
    */
   flooredDispatches: number
   /**
@@ -1258,8 +1264,11 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
     const thresholdYield = plan.dispatches.length - plan.summary.flooredDispatches
     try {
       logger.warn(formatFloorTelemetry(plan.summary.flooredDispatches, thresholdYield))
-    } catch {
-      // Swallow logger failures — telemetry is non-critical observability.
+    } catch (error) {
+      // Telemetry is best-effort; substantive engine work has already completed by this
+      // point. A breadcrumb to stderr preserves visibility of programmer errors (e.g. a
+      // future refactor that makes `logger` undefined) without aborting the scheduled run.
+      console.error('reconcile: floor telemetry emission failed', error)
     }
   }
 


### PR DESCRIPTION
The cadence work that shipped in May 2026 set per-channel survey intervals (collab=30d, owned=14d, contrib=21d) with deterministic jitter to spread herd dispatches across a wider window. The plan that shipped it explicitly anticipated the failure mode this PR fixes: at N=20+ tracked repos, the threshold gate still bunches eligibility into one week per cycle and idles for the other three. The plan named the trigger condition for follow-on work as "consecutive-zero-day stretches >7 days even with jitter applied."

As of this morning the production pipeline has reported `success` with `dispatches: 0` on nine consecutive daily reconcile runs. The wiki has been quiet since May 8 while every onboarded repo's `next_survey_eligible_at` sits 18–20 days in the future from a triple-dispatch on May 7–8 that clustered the population. Operator-visible signal was zero — the run summary shows `success`, the counter shows `0`, and nothing tells the reader "you have 20 repos and none of them have been surveyed in nine days."

## What changes

Add a minimum-dispatch floor to `reconcileRepos`. When the threshold gate yields fewer than `FLOOR_MIN=2` dispatches, the engine tops up the dispatch list with the oldest-surveyed tracked repos that pass the same fail-closed privacy gate the threshold uses. Repos surveyed within `FLOOR_MIN_GAP_DAYS=7` days are excluded so the floor cannot re-survey the same repo on consecutive days.

The floor is additive. Threshold is still the ceiling, the per-run cap still bounds the upper end, the 90-second stagger still applies, and null-group rotation still cycles never-surveyed repos across runs. Floor dispatches look identical to threshold dispatches downstream — the floor is transparent at the dispatch boundary.

## Privacy invariant

The floor uses the exact same fail-closed predicate the threshold gate uses:

- `entry.private === false` (stored privacy is definitively public; `undefined` fails closed)
- AND access-list `private === false` (live privacy agrees)
- AND `accessPrivateForStorage` clears the node-level fail-closed rule (no duplicate node_id, no non-public alias)

A repo that flips private between Pass 1 normalization and the floor's pool walk is excluded. A redacted entry (`owner: '[REDACTED]'`) is excluded. A repo with a duplicate access-list alias where one is private is excluded.

## Telemetry

`ReconcileSummary` gains `flooredDispatches: number`. When the floor fires, `handleReconcile` emits a single stderr line:

```
floor fired: dispatched 2 of FLOOR_MIN=2 (threshold yielded 0)
```

The message is counts-only. No `owner`, no `repo`, no `node_id` ever appears. Dispatch-path logs have been a privacy leak surface before; the floor signal holds the same line. Telemetry failures are swallowed so observability cannot abort the scheduled run.

## Test coverage

`pnpm test` → **562/562** (was 555 baseline; +7 from review remediation, +16 from the floor's own scenarios).

Twenty-three new test scenarios across:

- Happy paths — threshold yields ≥ FLOOR_MIN, threshold yields 0 + floor finds 2, threshold yields 1 + floor adds 1
- Edge cases — threshold yields exactly FLOOR_MIN, pool empty (everyone inside gap), tiny population, null sorts before any date, gap-day boundary (7 days exact = OUT, 8 = IN), cap-vs-floor interaction
- Error paths — `private: true` excluded, `private: undefined` excluded, access-list flips private, node-level duplicate alias triggers fail-closed, `pending-review` excluded, `lost-access` excluded
- Coverage gaps closed in review — cap+floor at the I/O level, floor telemetry format (counts-only regex), merged null-group rotation across the threshold+floor pool, duplicate-metadata-row dedup

## Refactors along the way

- `compareBySurveyFreshness(leftAt, rightAt, leftKey, rightKey)` extracted as the shared sort comparator. Both the floor pool and `prioritizeDispatches` now use it. Sort behavior is unchanged.
- `formatFloorTelemetry(flooredDispatches, thresholdYield)` extracted so the log message is directly unit-testable without injecting a mock logger.
- Defensive dedup in the floor accept loop guards against duplicate `currentRepos` rows.

## What this does not change

Per-channel intervals. Jitter. Dispatch cap (12). Dispatch stagger (90s). Threshold gate semantics. Identity rules. Integrity check. The I/O shell. The workflow YAML.

## Verification

- `pnpm check-types` ✅
- `pnpm lint` ✅
- `pnpm test` ✅ 562/562
- Documented design and review trail: `docs/brainstorms/2026-05-17-survey-cadence-minimum-floor-requirements.md`, `docs/plans/2026-05-17-001-feat-survey-cadence-minimum-floor-plan.md`

## Expected post-merge behavior

The next scheduled reconcile run at 05:17 UTC should report `flooredDispatches: 2` and dispatch the two oldest-surveyed collab repos (currently `marcusrbrown.github.io` and `opencode-copilot-delegate`, both last surveyed 2026-04-27 — though they were also manually dispatched earlier today as a stopgap, so the population's `last_survey_at` distribution will reshape over the next 24 hours). Over the next 2–3 weeks the floor will naturally re-spread the existing June cluster across a wider window as it picks two-per-day from the back of the queue.