### PR TITLE
diag: ephemeral FRO_BOT_PAT GraphQL resolution probe

### DIFF
--- a/.github/workflows/diag-pat-resolution.yaml
+++ b/.github/workflows/diag-pat-resolution.yaml
@@ -1,0 +1,100 @@
+---
+name: Diag — FRO_BOT_PAT resolution
+
+run-name: Diag — FRO_BOT_PAT resolution
+
+# Single-purpose diagnostic. Captures everything the survey-repo gate hides:
+# - PAT scopes via /user header inspection
+# - GraphQL node() response for a known-public repo node_id (stderr included)
+# - GraphQL repository(owner,name) for the same repo
+# - REST /repos/{owner}/{repo} for comparison
+#
+# Remove this workflow after diagnosis.
+
+on:
+  workflow_dispatch:
+    inputs:
+      node_id:
+        description: Public repo node_id to test
+        required: true
+        type: string
+        default: R_kgDOR4g8TA
+      owner:
+        description: Repo owner (for the alphanumeric GraphQL lookup)
+        required: true
+        type: string
+        default: marcusrbrown
+      repo:
+        description: Repo name (for the alphanumeric GraphQL lookup)
+        required: true
+        type: string
+        default: infra
+
+permissions:
+  contents: read
+
+jobs:
+  diag:
+    name: Diag
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: PAT scopes
+        env:
+          GH_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+        run: |
+          set +e
+          printf '=== /user with -i (headers) ===\n'
+          gh api -i /user 2>&1 | head -40
+          printf '\n=== Token scopes header (raw curl, mask body) ===\n'
+          curl -sI -H "Authorization: token $GH_TOKEN" https://api.github.com/user | grep -iE '^x-oauth|^x-accepted|^x-github|^x-ratelimit-remaining'
+
+      - name: GraphQL node(id) — opaque ID path
+        env:
+          GH_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+          NODE_ID: ${{ inputs.node_id }}
+        run: |
+          set +e
+          printf '=== gh api graphql node(id) — full stderr+stdout ===\n'
+          # shellcheck disable=SC2016
+          gh api graphql \
+            -F id="$NODE_ID" \
+            -f query='query($id: ID!) { node(id: $id) { __typename ... on Repository { nameWithOwner isPrivate viewerPermission } } }' \
+            2>&1
+          printf '\n--- exit: %s ---\n' "$?"
+
+      - name: GraphQL repository(owner,name) — alphanumeric path
+        env:
+          GH_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+          OWNER: ${{ inputs.owner }}
+          REPO: ${{ inputs.repo }}
+        run: |
+          set +e
+          printf '=== gh api graphql repository(owner,name) ===\n'
+          # shellcheck disable=SC2016
+          gh api graphql \
+            -F owner="$OWNER" \
+            -F name="$REPO" \
+            -f query='query($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { id nameWithOwner isPrivate viewerPermission } }' \
+            2>&1
+          printf '\n--- exit: %s ---\n' "$?"
+
+      - name: REST /repos/{owner}/{repo}
+        env:
+          GH_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+          OWNER: ${{ inputs.owner }}
+          REPO: ${{ inputs.repo }}
+        run: |
+          set +e
+          printf '=== gh api /repos/{owner}/{repo} -i (headers + body) ===\n'
+          gh api "-H" "Accept: application/vnd.github+json" -i "/repos/$OWNER/$REPO" 2>&1 | head -60
+          printf '\n--- exit: %s ---\n' "$?"
+
+      - name: GraphQL viewer self-check
+        env:
+          GH_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+        run: |
+          set +e
+          printf '=== viewer { login, repositoriesContributedTo first 5 } ===\n'
+          gh api graphql -f query='query { viewer { login databaseId } }' 2>&1
+          printf '\n--- exit: %s ---\n' "$?"


### PR DESCRIPTION
Ephemeral diagnostic workflow to investigate why \`survey-repo.yaml\`'s resolve gate aborts with \"is not definitively public\" on known-public repos.

## What's failing

PR #3296 shipped the cadence minimum-dispatch floor. The earlier manual survey dispatches for `marcusrbrown/marcusrbrown`, `marcusrbrown/vbs`, and `marcusrbrown/infra` (all public) failed at the resolve gate with:

```
Aborting: <node_id> is not definitively public
```

Direct GraphQL queries with my classic PAT return `isPrivate: false` cleanly for all three. The workflow runs the same query under `secrets.FRO_BOT_PAT` and aborts deterministically (confirmed by re-dispatching `R_kgDOR4g8TA` 10+ minutes later — same failure shape).

## What `survey-repo.yaml` hides

The resolve step at line 87 pipes errors away:

```yaml
gh api graphql -F id=\"$NODE_ID\" -f query=... 2>/dev/null
```

When the GraphQL call fails (auth, scope, visibility, rate limit), the script can't distinguish error-response from valid-private response — they all collapse to \"is not definitively public.\"

## What this diagnostic captures

- PAT scopes via `/user` response headers
- Full GraphQL `node(id)` response with stderr included
- GraphQL `repository(owner, name)` alphanumeric path for comparison
- REST `/repos/{owner}/{repo}` for cross-check
- `viewer { login, databaseId }` self-check to confirm the PAT identity

## Plan

1. Merge this PR (or land it via a low-stakes squash)
2. Dispatch the diag workflow with the failing node_id
3. Read the actual GraphQL response and PAT scopes
4. Diagnose the root cause
5. Open a follow-up PR removing this workflow

This is the only way to see the real PAT behavior under the workflow environment — the API-dispatch path requires the workflow file on the default branch.