### PR TITLE
feat(wiki-lint): JSON artifact contract and durable issue lifecycle

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -23,3 +23,14 @@ branches:
           - Review Dependencies
           - Test
           - Test Scripts Load
+
+labels:
+  - name: wiki-lint
+    color: '#5319e7'
+    description: Applied to every wiki-lint issue
+  - name: wiki-lint-finding
+    color: '#fbca04'
+    description: Deterministic wiki lint finding
+  - name: wiki-lint-failure
+    color: '#b60205'
+    description: Wiki lint execution failure

--- a/.github/workflows/wiki-lint.yaml
+++ b/.github/workflows/wiki-lint.yaml
@@ -34,6 +34,7 @@ jobs:
           if git ls-remote --exit-code origin data >/dev/null 2>&1; then
             git fetch --depth=1 origin data
             git restore --source FETCH_HEAD --worktree -- knowledge
+            echo "data_sha=$(git rev-parse FETCH_HEAD)" >> "$GITHUB_OUTPUT"
           else
             printf '%s\n' 'cannot lint wiki snapshot: origin/data is unavailable' >&2
             exit 1
@@ -43,12 +44,15 @@ jobs:
         if: steps.restore-wiki.outcome == 'success'
         env:
           WIKI_LINT_REPORT_PATH: wiki-lint-report.md
+          WIKI_LINT_JSON_PATH: wiki-lint-report.json
+          WIKI_LINT_SNAPSHOT_SHA: ${{ steps.restore-wiki.outputs.data_sha }}
         run: node scripts/wiki-lint.ts
 
       - name: Report restore failure
         if: steps.restore-wiki.outcome == 'failure'
         env:
           WIKI_LINT_REPORT_PATH: wiki-lint-report.md
+          WIKI_LINT_JSON_PATH: wiki-lint-report.json
           WIKI_LINT_FAILURE_MESSAGE: 'cannot lint wiki snapshot: origin/data is unavailable'
         run: node scripts/wiki-lint.ts
 
@@ -57,5 +61,45 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wiki-lint-report
-          path: wiki-lint-report.md
+          path: |
+            wiki-lint-report.md
+            wiki-lint-report.json
           retention-days: 7
+
+  wiki-lint-issue-sync:
+    name: Sync wiki lint issues
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: wiki-lint
+    if: always()
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: ⤵ Checkout Branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: 📦 Setup
+        uses: ./.github/actions/setup
+
+      - name: Download wiki lint artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: wiki-lint-report
+
+      - name: Mint App token
+        id: app-token
+        uses: actions/create-github-app-token@v3.1.1
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          permission-issues: write
+          permission-contents: read
+
+      - name: Sync wiki lint issues
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          WIKI_LINT_JSON_PATH: wiki-lint-report.json
+        run: node scripts/wiki-lint-issues.ts

--- a/.github/workflows/wiki-lint.yaml
+++ b/.github/workflows/wiki-lint.yaml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Mint App token
         id: app-token
-        uses: actions/create-github-app-token@v3.1.1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.APPLICATION_ID }}
           private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ coverage
 
 # Local agent artifacts
 .context/
+
+# Wiki lint local artifacts (CI uploads them to actions/upload-artifact; never tracked in git)
+wiki-lint-report.md
+wiki-lint-report.json

--- a/docs/plans/2026-05-02-001-feat-wiki-lint-followups-plan.md
+++ b/docs/plans/2026-05-02-001-feat-wiki-lint-followups-plan.md
@@ -1,7 +1,7 @@
 ---
 title: feat: Add post-v1 wiki-lint escalation and repair flows
 type: feat
-status: active
+status: complete
 date: 2026-05-02
 deepened: 2026-05-02
 ---
@@ -135,7 +135,7 @@ flowchart TB
 
 ## Implementation Units
 
-- [ ] **Unit 1: Add versioned `wiki-lint` JSON output and finding fingerprints**
+- [x] **Unit 1: Add versioned `wiki-lint` JSON output and finding fingerprints**
 
 **Goal:** Extend `wiki-lint`'s artifact contract so downstream automation can consume structured status, snapshot metadata, and stable finding fingerprints without scraping markdown.
 
@@ -181,7 +181,7 @@ flowchart TB
 
 ---
 
-- [ ] **Unit 2: Add durable issue lifecycle for deterministic findings and execution failures**
+- [x] **Unit 2: Add durable issue lifecycle for deterministic findings and execution failures**
 
 **Goal:** Turn `wiki-lint` findings into durable operator-facing issues that dedupe, reopen, update, and close automatically instead of forcing humans to poll artifacts manually.
 

--- a/scripts/wiki-lint-issues.test.ts
+++ b/scripts/wiki-lint-issues.test.ts
@@ -1,0 +1,540 @@
+import type {ExistingIssue, OctokitClient, PlanInput} from './wiki-lint-issues.ts'
+import type {WikiLintFindingKind, WikiLintJsonFinding, WikiLintJsonReport} from './wiki-lint.ts'
+
+import {readFileSync} from 'node:fs'
+import process from 'node:process'
+
+import {describe, expect, it, vi} from 'vitest'
+import {parse as parseYaml} from 'yaml'
+import {planIssueLifecycle, syncWikiLintIssues, validateWikiLintJsonReport} from './wiki-lint-issues.ts'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeReport(overrides: Partial<WikiLintJsonReport> = {}): WikiLintJsonReport {
+  return {
+    schema_version: 1,
+    fingerprint_version: 1,
+    status: 'clean',
+    scan_complete: true,
+    snapshot_sha: 'abc123',
+    generated_at: '2026-05-17T00:00:00Z',
+    failure_class: null,
+    repair_eligible: false,
+    findings: [],
+    freshness: [],
+    counts: {
+      findings_total: 0,
+      findings_deterministic: 0,
+      findings_advisory: 0,
+      pages_scanned: 0,
+      pages_stale: 0,
+    },
+    ...overrides,
+  }
+}
+
+function makeFinding(overrides: Partial<WikiLintJsonFinding> = {}): WikiLintJsonFinding {
+  return {
+    kind: 'broken-wikilink' as WikiLintFindingKind,
+    severity: 'deterministic',
+    path: 'knowledge/wiki/repos/foo.md',
+    target: null,
+    message: 'Broken wikilink [[bar]]',
+    fingerprint: 'deadbeef01234567',
+    ...overrides,
+  }
+}
+
+function makeOpenIssue(fingerprint: string, number = 1): ExistingIssue {
+  return {
+    number,
+    state: 'open',
+    body: `<!-- wiki-lint:subject:fingerprint=${fingerprint} -->\n\nSome body.`,
+  }
+}
+
+function makeClosedIssue(fingerprint: string, number = 2): ExistingIssue {
+  return {
+    number,
+    state: 'closed',
+    body: `<!-- wiki-lint:subject:fingerprint=${fingerprint} -->\n\nSome body.`,
+  }
+}
+
+function makeFailureOpenIssue(failureClass: string, number = 10): ExistingIssue {
+  return {
+    number,
+    state: 'open',
+    body: `<!-- wiki-lint:subject:failure-class=${failureClass} -->\n\nSome body.`,
+  }
+}
+
+function emptyInput(overrides: Partial<PlanInput> = {}): PlanInput {
+  return {
+    report: makeReport(),
+    openIssues: [],
+    recentlyClosedIssues: [],
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mock octokit factory
+// ---------------------------------------------------------------------------
+
+interface MockIssuesMethods {
+  create: ReturnType<typeof vi.fn>
+  createComment: ReturnType<typeof vi.fn>
+  update: ReturnType<typeof vi.fn>
+}
+
+interface MockOctokitShape {
+  rest: {
+    issues: MockIssuesMethods
+  }
+}
+
+function mockOctokit(
+  overrides: {
+    create?: ReturnType<typeof vi.fn>
+    createComment?: ReturnType<typeof vi.fn>
+    update?: ReturnType<typeof vi.fn>
+  } = {},
+): OctokitClient {
+  const shape: MockOctokitShape = {
+    rest: {
+      issues: {
+        create: overrides.create ?? vi.fn().mockResolvedValue({data: {number: 99}}),
+        createComment: overrides.createComment ?? vi.fn().mockResolvedValue({data: {id: 1}}),
+        update: overrides.update ?? vi.fn().mockResolvedValue({data: {number: 1}}),
+      },
+    },
+  }
+  return shape as unknown as OctokitClient
+}
+
+// ---------------------------------------------------------------------------
+// Pure-function tests: planIssueLifecycle
+// ---------------------------------------------------------------------------
+
+describe('planIssueLifecycle', () => {
+  it('1. new deterministic finding with no existing issue → toOpen with correct marker and labels', () => {
+    const finding = makeFinding()
+    const report = makeReport({
+      status: 'findings',
+      scan_complete: true,
+      findings: [finding],
+      counts: {findings_total: 1, findings_deterministic: 1, findings_advisory: 0, pages_scanned: 1, pages_stale: 0},
+    })
+    const plan = planIssueLifecycle(emptyInput({report}))
+
+    expect(plan.toOpen).toHaveLength(1)
+    expect(plan.toUpdate).toHaveLength(0)
+    expect(plan.toReopen).toHaveLength(0)
+    expect(plan.toClose).toHaveLength(0)
+
+    const [draft] = plan.toOpen
+    if (!draft) throw new Error('expected one toOpen entry')
+    expect(draft.body).toContain(`<!-- wiki-lint:subject:fingerprint=${finding.fingerprint} -->`)
+    expect(draft.labels).toContain('wiki-lint')
+    expect(draft.labels).toContain('wiki-lint-finding')
+    expect(draft.title).toContain('broken-wikilink')
+    expect(draft.title).toContain('knowledge/wiki/repos/foo.md')
+  })
+
+  it('2. deterministic finding matching an existing OPEN issue → toUpdate, NOT toOpen', () => {
+    const finding = makeFinding()
+    const report = makeReport({
+      status: 'findings',
+      scan_complete: true,
+      findings: [finding],
+    })
+    const openIssue = makeOpenIssue(finding.fingerprint, 42)
+    const plan = planIssueLifecycle(emptyInput({report, openIssues: [openIssue]}))
+
+    expect(plan.toOpen).toHaveLength(0)
+    expect(plan.toUpdate).toHaveLength(1)
+    expect(plan.toUpdate[0]?.issueNumber).toBe(42)
+    expect(plan.toReopen).toHaveLength(0)
+  })
+
+  it('3. deterministic finding matching a recently-closed issue → toReopen, NOT toOpen', () => {
+    const finding = makeFinding()
+    const report = makeReport({
+      status: 'findings',
+      scan_complete: true,
+      findings: [finding],
+    })
+    const closedIssue = makeClosedIssue(finding.fingerprint, 55)
+    const plan = planIssueLifecycle(emptyInput({report, recentlyClosedIssues: [closedIssue]}))
+
+    expect(plan.toOpen).toHaveLength(0)
+    expect(plan.toReopen).toHaveLength(1)
+    expect(plan.toReopen[0]?.issueNumber).toBe(55)
+    expect(plan.toUpdate).toHaveLength(0)
+  })
+
+  it('4. clean run with open finding issue not in current findings → toClose', () => {
+    const report = makeReport({status: 'clean', scan_complete: true, findings: []})
+    const openIssue = makeOpenIssue('aabbccdd11223344', 7)
+    const plan = planIssueLifecycle(emptyInput({report, openIssues: [openIssue]}))
+
+    expect(plan.toClose).toHaveLength(1)
+    expect(plan.toClose[0]?.issueNumber).toBe(7)
+    expect(plan.toOpen).toHaveLength(0)
+  })
+
+  it('5. execution-failure run with open finding issues → toClose is EMPTY, failure issue opened', () => {
+    const report = makeReport({
+      status: 'execution-failure',
+      scan_complete: false,
+      failure_class: 'snapshot-restore',
+      findings: [],
+    })
+    const openFindingIssue = makeOpenIssue('some-fingerprint', 3)
+    const plan = planIssueLifecycle(emptyInput({report, openIssues: [openFindingIssue]}))
+
+    expect(plan.toClose).toHaveLength(0)
+    expect(plan.toOpen).toHaveLength(1)
+    expect(plan.toOpen[0]?.labels).toContain('wiki-lint-failure')
+  })
+
+  it('6. execution-failure for snapshot-restore with no existing failure issue → toOpen failure draft', () => {
+    const report = makeReport({
+      status: 'execution-failure',
+      scan_complete: false,
+      failure_class: 'snapshot-restore',
+    })
+    const plan = planIssueLifecycle(emptyInput({report}))
+
+    expect(plan.toOpen).toHaveLength(1)
+    const [draft] = plan.toOpen
+    if (!draft) throw new Error('expected one toOpen entry')
+    expect(draft.body).toContain('<!-- wiki-lint:subject:failure-class=snapshot-restore -->')
+    expect(draft.labels).toContain('wiki-lint')
+    expect(draft.labels).toContain('wiki-lint-failure')
+    expect(draft.title).toContain('snapshot-restore')
+  })
+
+  it('7. execution-failure matching an existing OPEN failure-class issue → toUpdate', () => {
+    const report = makeReport({
+      status: 'execution-failure',
+      scan_complete: false,
+      failure_class: 'snapshot-restore',
+    })
+    const openFailureIssue = makeFailureOpenIssue('snapshot-restore', 20)
+    const plan = planIssueLifecycle(emptyInput({report, openIssues: [openFailureIssue]}))
+
+    expect(plan.toUpdate).toHaveLength(1)
+    expect(plan.toUpdate[0]?.issueNumber).toBe(20)
+    expect(plan.toOpen).toHaveLength(0)
+  })
+
+  it('8. findings run (scan_complete=true) with open issue NOT in current findings → toClose', () => {
+    const report = makeReport({
+      status: 'findings',
+      scan_complete: true,
+      findings: [makeFinding({fingerprint: 'aabbccdd11223344'})],
+    })
+    const staleOpenIssue = makeOpenIssue('deadbeef01234567', 9)
+    const plan = planIssueLifecycle(emptyInput({report, openIssues: [staleOpenIssue]}))
+
+    expect(plan.toClose).toHaveLength(1)
+    expect(plan.toClose[0]?.issueNumber).toBe(9)
+  })
+
+  it('9. findings run with scan_complete=false → toClose is empty (defensive)', () => {
+    const report = makeReport({
+      status: 'findings',
+      scan_complete: false,
+      findings: [],
+    })
+    const openIssue = makeOpenIssue('some-fp', 4)
+    const plan = planIssueLifecycle(emptyInput({report, openIssues: [openIssue]}))
+
+    expect(plan.toClose).toHaveLength(0)
+  })
+
+  it('10. advisory finding is IGNORED — no issue opened', () => {
+    const advisoryFinding = makeFinding({severity: 'advisory', fingerprint: 'advisory-fp'})
+    const report = makeReport({
+      status: 'findings',
+      scan_complete: true,
+      findings: [advisoryFinding],
+    })
+    const plan = planIssueLifecycle(emptyInput({report}))
+
+    expect(plan.toOpen).toHaveLength(0)
+    expect(plan.toUpdate).toHaveLength(0)
+    expect(plan.toReopen).toHaveLength(0)
+  })
+
+  it('20. deduplicates findings with the same fingerprint in a single report — only one toOpen entry', () => {
+    const fp = 'deadbeef01234567'
+    const finding1 = makeFinding({fingerprint: fp, path: 'knowledge/wiki/repos/foo.md'})
+    const finding2 = makeFinding({fingerprint: fp, path: 'knowledge/wiki/repos/bar.md'}) // same fingerprint, different path
+    const report = makeReport({
+      status: 'findings',
+      scan_complete: true,
+      findings: [finding1, finding2],
+    })
+    const plan = planIssueLifecycle(emptyInput({report}))
+
+    // Only one toOpen entry — the duplicate is skipped
+    expect(plan.toOpen).toHaveLength(1)
+    expect(plan.toUpdate).toHaveLength(0)
+    expect(plan.toReopen).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// I/O shell tests: syncWikiLintIssues
+// ---------------------------------------------------------------------------
+
+describe('syncWikiLintIssues', () => {
+  it('11. plan with 1 toOpen → issues.create called, counters.opened=1', async () => {
+    const createMock = vi.fn().mockResolvedValue({data: {number: 1}})
+    const octokit = mockOctokit({create: createMock})
+    const plan = {
+      toOpen: [{title: 'Wiki lint: broken-wikilink in foo.md', body: '<!-- marker -->', labels: ['wiki-lint']}],
+      toUpdate: [],
+      toReopen: [],
+      toClose: [],
+    }
+    const result = await syncWikiLintIssues({octokit, owner: 'fro-bot', repo: '.github', plan})
+
+    expect(createMock).toHaveBeenCalledOnce()
+    expect(createMock).toHaveBeenCalledWith(expect.objectContaining({title: 'Wiki lint: broken-wikilink in foo.md'}))
+    expect(result.counters.opened).toBe(1)
+    expect(result.errors).toHaveLength(0)
+  })
+
+  it('12. plan with 1 toUpdate → issues.createComment called, counters.updated=1', async () => {
+    const commentMock = vi.fn().mockResolvedValue({data: {id: 1}})
+    const octokit = mockOctokit({createComment: commentMock})
+    const plan = {
+      toOpen: [],
+      toUpdate: [{issueNumber: 42, comment: 'Recurrence detected.'}],
+      toReopen: [],
+      toClose: [],
+    }
+    const result = await syncWikiLintIssues({octokit, owner: 'fro-bot', repo: '.github', plan})
+
+    expect(commentMock).toHaveBeenCalledOnce()
+    expect(commentMock).toHaveBeenCalledWith(expect.objectContaining({issue_number: 42}))
+    expect(result.counters.updated).toBe(1)
+    expect(result.errors).toHaveLength(0)
+  })
+
+  it('13. plan with 1 toClose → issues.update with state=closed, counters.closed=1', async () => {
+    const updateMock = vi.fn().mockResolvedValue({data: {number: 7}})
+    const octokit = mockOctokit({update: updateMock})
+    const plan = {
+      toOpen: [],
+      toUpdate: [],
+      toReopen: [],
+      toClose: [{issueNumber: 7}],
+    }
+    const result = await syncWikiLintIssues({octokit, owner: 'fro-bot', repo: '.github', plan})
+
+    expect(updateMock).toHaveBeenCalledOnce()
+    expect(updateMock).toHaveBeenCalledWith(expect.objectContaining({state: 'closed', issue_number: 7}))
+    expect(result.counters.closed).toBe(1)
+    expect(result.errors).toHaveLength(0)
+  })
+
+  it('14. issues.create rejects → failed increments, errors has entry, other ops still execute', async () => {
+    const createMock = vi.fn().mockRejectedValue(new Error('API error'))
+    const commentMock = vi.fn().mockResolvedValue({data: {id: 1}})
+    const octokit = mockOctokit({create: createMock, createComment: commentMock})
+    const plan = {
+      toOpen: [{title: 'Failing issue', body: '<!-- marker -->', labels: ['wiki-lint']}],
+      toUpdate: [{issueNumber: 5, comment: 'Recurrence.'}],
+      toReopen: [],
+      toClose: [],
+    }
+    const result = await syncWikiLintIssues({octokit, owner: 'fro-bot', repo: '.github', plan})
+
+    expect(result.counters.failed).toBe(1)
+    expect(result.errors).toHaveLength(1)
+    expect(result.counters.updated).toBe(1) // other op still ran
+  })
+
+  it('15. issues.update rejects when closing → failed increments, errors has entry', async () => {
+    const updateMock = vi.fn().mockRejectedValue(new Error('Forbidden'))
+    const octokit = mockOctokit({update: updateMock})
+    const plan = {
+      toOpen: [],
+      toUpdate: [],
+      toReopen: [],
+      toClose: [{issueNumber: 3}],
+    }
+    const result = await syncWikiLintIssues({octokit, owner: 'fro-bot', repo: '.github', plan})
+
+    expect(result.counters.failed).toBe(1)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toContain('#3')
+  })
+
+  it('21. failure isolation — update fails, close still runs', async () => {
+    let updateCallCount = 0
+    const updateMock = vi.fn().mockImplementation(async () => {
+      updateCallCount++
+      if (updateCallCount === 1) {
+        throw new Error('update failed')
+      }
+      return {data: {number: 99}}
+    })
+    const octokit = mockOctokit({update: updateMock})
+    const plan = {
+      toOpen: [],
+      toUpdate: [],
+      toReopen: [{issueNumber: 10, comment: 'Recurrence.'}], // uses update internally
+      toClose: [{issueNumber: 20}],
+    }
+    const result = await syncWikiLintIssues({octokit, owner: 'fro-bot', repo: '.github', plan})
+
+    expect(result.counters.failed).toBe(1)
+    expect(result.counters.closed).toBe(1)
+  })
+
+  it('22. failure isolation — createComment fails, close still runs', async () => {
+    const commentMock = vi.fn().mockRejectedValue(new Error('comment failed'))
+    const updateMock = vi.fn().mockResolvedValue({data: {number: 1}})
+    const octokit = mockOctokit({createComment: commentMock, update: updateMock})
+    const plan = {
+      toOpen: [],
+      toUpdate: [{issueNumber: 5, comment: 'Recurrence.'}],
+      toReopen: [],
+      toClose: [{issueNumber: 7}],
+    }
+    const result = await syncWikiLintIssues({octokit, owner: 'fro-bot', repo: '.github', plan})
+
+    expect(result.counters.failed).toBe(1)
+    expect(result.counters.closed).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Shape validation tests: validateWikiLintJsonReport
+// ---------------------------------------------------------------------------
+
+describe('validateWikiLintJsonReport', () => {
+  it('23. valid report passes validation without throwing', () => {
+    const raw = makeReport()
+    expect(() => validateWikiLintJsonReport(raw)).not.toThrow()
+  })
+
+  it('24. execution-failure report with null failure_class is rejected as invalid', () => {
+    const raw = makeReport({status: 'execution-failure', failure_class: null})
+    // validateWikiLintJsonReport calls process.exit(1) — we need to intercept it
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number | string | null) => {
+      throw new Error('process.exit called')
+    })
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    try {
+      expect(() => validateWikiLintJsonReport(raw)).toThrow('process.exit called')
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('execution-failure report missing failure_class'))
+    } finally {
+      exitSpy.mockRestore()
+      stderrSpy.mockRestore()
+    }
+  })
+
+  it('25. report with invalid status is rejected', () => {
+    const raw = {...makeReport(), status: 'unknown-status'}
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number | string | null) => {
+      throw new Error('process.exit called')
+    })
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    try {
+      expect(() => validateWikiLintJsonReport(raw)).toThrow('process.exit called')
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('invalid report shape'))
+    } finally {
+      exitSpy.mockRestore()
+      stderrSpy.mockRestore()
+    }
+  })
+
+  it('26. report with non-array findings is rejected', () => {
+    const raw = {...makeReport(), findings: 'not-an-array'}
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number | string | null) => {
+      throw new Error('process.exit called')
+    })
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    try {
+      expect(() => validateWikiLintJsonReport(raw)).toThrow('process.exit called')
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('findings is not an array'))
+    } finally {
+      exitSpy.mockRestore()
+      stderrSpy.mockRestore()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// CLI main() tests (via temp file + GITHUB_OUTPUT)
+// ---------------------------------------------------------------------------
+
+describe('main() CLI via temp files', () => {
+  it.todo('schema_version mismatch → exit 1, no octokit calls (requires testable main() extraction)')
+  it.todo('fingerprint_version mismatch → exit 1, no octokit calls (requires testable main() extraction)')
+  it.todo('CLI main() counters output — GITHUB_OUTPUT contains opened=1 (requires testable main() extraction)')
+})
+
+// ---------------------------------------------------------------------------
+// Workflow YAML integration tests
+// ---------------------------------------------------------------------------
+
+const workflowPath = new URL('../.github/workflows/wiki-lint.yaml', import.meta.url).pathname
+
+describe('wiki-lint.yaml workflow', () => {
+  const workflowContent = readFileSync(workflowPath, 'utf8')
+  const workflow = parseYaml(workflowContent) as Record<string, unknown>
+  const jobs = workflow.jobs as Record<string, unknown>
+
+  it('16. workflow has wiki-lint-issue-sync job that depends on wiki-lint via needs', () => {
+    expect(jobs).toHaveProperty('wiki-lint-issue-sync')
+    const syncJob = jobs['wiki-lint-issue-sync'] as Record<string, unknown>
+    const needs = syncJob.needs
+    const needsArr = Array.isArray(needs) ? needs : [needs]
+    expect(needsArr).toContain('wiki-lint')
+  })
+
+  it('17. issue-sync job runs if: always()', () => {
+    const syncJob = jobs['wiki-lint-issue-sync'] as Record<string, unknown>
+    expect(syncJob.if).toBe('always()')
+  })
+
+  it('18. issue-sync job uses create-github-app-token and download-artifact', () => {
+    const syncJob = jobs['wiki-lint-issue-sync'] as Record<string, unknown>
+    const steps = syncJob.steps as Record<string, unknown>[]
+    const usesValues = steps.map(s => s.uses).filter(Boolean)
+    expect(usesValues.some(u => typeof u === 'string' && u.includes('create-github-app-token'))).toBe(true)
+    expect(usesValues.some(u => typeof u === 'string' && u.includes('download-artifact'))).toBe(true)
+  })
+
+  it('19. issue-sync job has permissions issues:write and contents:read', () => {
+    const syncJob = jobs['wiki-lint-issue-sync'] as Record<string, unknown>
+    const permissions = syncJob.permissions as Record<string, unknown>
+    expect(permissions).toBeDefined()
+    expect(permissions.issues).toBe('write')
+    expect(permissions.contents).toBe('read')
+  })
+
+  it('27. app-token step has permission-issues:write and permission-contents:read', () => {
+    const syncJob = jobs['wiki-lint-issue-sync'] as Record<string, unknown>
+    const steps = syncJob.steps as Record<string, unknown>[]
+    const appTokenStep = steps.find(s => typeof s.uses === 'string' && s.uses.includes('create-github-app-token'))
+    expect(appTokenStep).toBeDefined()
+    const withBlock = appTokenStep?.with as Record<string, unknown> | undefined
+    expect(withBlock).toBeDefined()
+    expect(withBlock?.['permission-issues']).toBe('write')
+    expect(withBlock?.['permission-contents']).toBe('read')
+  })
+})

--- a/scripts/wiki-lint-issues.ts
+++ b/scripts/wiki-lint-issues.ts
@@ -1,0 +1,558 @@
+import type {WikiLintJsonReport} from './wiki-lint.ts'
+import {appendFile, readFile} from 'node:fs/promises'
+import process from 'node:process'
+
+import {Octokit} from '@octokit/rest'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type OctokitClient = Octokit
+
+export interface ExistingIssue {
+  readonly number: number
+  readonly state: 'open' | 'closed'
+  readonly body: string | null | undefined
+}
+
+export interface IssueDraft {
+  readonly title: string
+  readonly body: string
+  readonly labels: readonly string[]
+}
+
+export interface IssueUpdate {
+  readonly issueNumber: number
+  readonly comment: string
+}
+
+export interface ReopenAction {
+  readonly issueNumber: number
+  readonly comment: string
+}
+
+export interface CloseAction {
+  readonly issueNumber: number
+}
+
+export interface IssueLifecyclePlan {
+  readonly toOpen: readonly IssueDraft[]
+  readonly toUpdate: readonly IssueUpdate[]
+  readonly toReopen: readonly ReopenAction[]
+  readonly toClose: readonly CloseAction[]
+}
+
+export interface PlanInput {
+  readonly report: WikiLintJsonReport
+  readonly openIssues: readonly ExistingIssue[]
+  readonly recentlyClosedIssues: readonly ExistingIssue[]
+}
+
+export interface SyncParams {
+  readonly octokit: OctokitClient
+  readonly owner: string
+  readonly repo: string
+  readonly plan: IssueLifecyclePlan
+}
+
+export interface SyncResult {
+  readonly counters: {
+    opened: number
+    updated: number
+    reopened: number
+    closed: number
+    failed: number
+  }
+  readonly errors: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Hidden marker patterns
+// ---------------------------------------------------------------------------
+
+const FINGERPRINT_MARKER_PATTERN = /<!-- wiki-lint:subject:fingerprint=([a-f0-9]+) -->/u
+const FAILURE_CLASS_MARKER_PATTERN = /<!-- wiki-lint:subject:failure-class=([\w-]+) -->/u
+
+function extractFingerprint(body: string | null | undefined): string | null {
+  if (body === null || body === undefined || body === '') return null
+  const match = FINGERPRINT_MARKER_PATTERN.exec(body)
+  return match === null ? null : (match[1] ?? null)
+}
+
+function extractFailureClass(body: string | null | undefined): string | null {
+  if (body === null || body === undefined || body === '') return null
+  const match = FAILURE_CLASS_MARKER_PATTERN.exec(body)
+  return match === null ? null : (match[1] ?? null)
+}
+
+// ---------------------------------------------------------------------------
+// Issue body builders
+// ---------------------------------------------------------------------------
+
+function buildFindingBody(
+  fingerprint: string,
+  kind: string,
+  path: string,
+  message: string,
+  generatedAt: string,
+  snapshotSha: string | null,
+): string {
+  const shaLine = snapshotSha === null ? '' : `\n**Snapshot SHA:** \`${snapshotSha}\``
+  return [
+    `<!-- wiki-lint:subject:fingerprint=${fingerprint} -->`,
+    '',
+    `**Kind:** \`${kind}\``,
+    `**Path:** \`${path}\``,
+    `**Message:** ${message}${shaLine}`,
+    '',
+    `First detected at \`${generatedAt}\`.`,
+  ].join('\n')
+}
+
+function buildFailureBody(failureClass: string, generatedAt: string): string {
+  return [
+    `<!-- wiki-lint:subject:failure-class=${failureClass} -->`,
+    '',
+    `**Failure class:** \`${failureClass}\``,
+    '',
+    `First detected at \`${generatedAt}\`.`,
+  ].join('\n')
+}
+
+function buildRecurrenceComment(generatedAt: string, snapshotSha: string | null): string {
+  const shaNote = snapshotSha === null ? '' : ` (snapshot: \`${snapshotSha}\`)`
+  return `Recurrence detected at \`${generatedAt}\`${shaNote}.`
+}
+
+// ---------------------------------------------------------------------------
+// Shape validation
+// ---------------------------------------------------------------------------
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string'
+}
+
+function isNumber(value: unknown): value is number {
+  return typeof value === 'number'
+}
+
+function isBoolean(value: unknown): value is boolean {
+  return typeof value === 'boolean'
+}
+
+function isNullOrString(value: unknown): value is string | null {
+  return value === null || isString(value)
+}
+
+function assertShape(condition: boolean, reason: string): asserts condition {
+  if (!condition) {
+    process.stderr.write(`wiki-lint-issues: invalid report shape: ${reason}\n`)
+    process.exit(1)
+  }
+}
+
+export function validateWikiLintJsonReport(raw: unknown): asserts raw is WikiLintJsonReport {
+  if (!isRecord(raw)) {
+    process.stderr.write('wiki-lint-issues: invalid report shape: root is not an object\n')
+    process.exit(1)
+  }
+
+  assertShape(isNumber(raw.schema_version), 'schema_version is not a number')
+  assertShape(isNumber(raw.fingerprint_version), 'fingerprint_version is not a number')
+  assertShape(
+    raw.status === 'clean' || raw.status === 'findings' || raw.status === 'execution-failure',
+    `status "${String(raw.status)}" is not valid`,
+  )
+  assertShape(isBoolean(raw.scan_complete), 'scan_complete is not a boolean')
+  assertShape(isNullOrString(raw.snapshot_sha), 'snapshot_sha is not string | null')
+  assertShape(isString(raw.generated_at), 'generated_at is not a string')
+  assertShape(
+    raw.failure_class === null || raw.failure_class === 'snapshot-restore' || raw.failure_class === 'lint-execution',
+    `failure_class "${String(raw.failure_class)}" is not valid`,
+  )
+  assertShape(isBoolean(raw.repair_eligible), 'repair_eligible is not a boolean')
+  assertShape(Array.isArray(raw.findings), 'findings is not an array')
+
+  for (const [i, finding] of (raw.findings as unknown[]).entries()) {
+    if (!isRecord(finding)) {
+      process.stderr.write(`wiki-lint-issues: invalid report shape: findings[${i}] is not an object\n`)
+      process.exit(1)
+    }
+    assertShape(isString(finding.kind), `findings[${i}].kind is not a string`)
+    assertShape(
+      finding.severity === 'deterministic' || finding.severity === 'advisory',
+      `findings[${i}].severity "${String(finding.severity)}" is not valid`,
+    )
+    assertShape(isString(finding.path), `findings[${i}].path is not a string`)
+    assertShape(isNullOrString(finding.target), `findings[${i}].target is not string | null`)
+    assertShape(isString(finding.message), `findings[${i}].message is not a string`)
+    assertShape(isString(finding.fingerprint), `findings[${i}].fingerprint is not a string`)
+  }
+
+  assertShape(Array.isArray(raw.freshness), 'freshness is not an array')
+
+  if (!isRecord(raw.counts)) {
+    process.stderr.write('wiki-lint-issues: invalid report shape: counts is not an object\n')
+    process.exit(1)
+  }
+
+  for (const field of [
+    'findings_total',
+    'findings_deterministic',
+    'findings_advisory',
+    'pages_scanned',
+    'pages_stale',
+  ] as const) {
+    assertShape(isNumber(raw.counts[field]), `counts.${field} is not a number`)
+  }
+
+  // Semantic constraint: execution-failure must have a non-null failure_class
+  if (raw.status === 'execution-failure' && raw.failure_class === null) {
+    process.stderr.write('wiki-lint-issues: execution-failure report missing failure_class\n')
+    process.exit(1)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure lifecycle planner
+// ---------------------------------------------------------------------------
+
+export function planIssueLifecycle(input: PlanInput): IssueLifecyclePlan {
+  const {report, openIssues, recentlyClosedIssues} = input
+
+  // Build lookup maps from existing issues
+  const openByFingerprint = new Map<string, ExistingIssue>()
+  const openByFailureClass = new Map<string, ExistingIssue>()
+  const closedByFingerprint = new Map<string, ExistingIssue>()
+  const closedByFailureClass = new Map<string, ExistingIssue>()
+
+  for (const issue of openIssues) {
+    const fp = extractFingerprint(issue.body)
+    if (fp !== null) {
+      openByFingerprint.set(fp, issue)
+      continue
+    }
+    const fc = extractFailureClass(issue.body)
+    if (fc !== null) openByFailureClass.set(fc, issue)
+  }
+
+  for (const issue of recentlyClosedIssues) {
+    const fp = extractFingerprint(issue.body)
+    if (fp !== null) {
+      closedByFingerprint.set(fp, issue)
+      continue
+    }
+    const fc = extractFailureClass(issue.body)
+    if (fc !== null) closedByFailureClass.set(fc, issue)
+  }
+
+  const toOpen: IssueDraft[] = []
+  const toUpdate: IssueUpdate[] = []
+  const toReopen: ReopenAction[] = []
+  const toClose: CloseAction[] = []
+
+  // Track which fingerprints are active in this report
+  const currentFingerprints = new Set<string>()
+
+  // Deduplicate findings by fingerprint within the same report
+  const seenFingerprintsInReport = new Set<string>()
+  let duplicateCount = 0
+
+  // Process deterministic findings only (advisory are ignored per spec)
+  for (const finding of report.findings) {
+    if (finding.severity !== 'deterministic') continue
+
+    const {fingerprint} = finding
+
+    // Deduplicate: skip if we've already processed this fingerprint in this report
+    if (seenFingerprintsInReport.has(fingerprint)) {
+      duplicateCount++
+      continue
+    }
+    seenFingerprintsInReport.add(fingerprint)
+
+    currentFingerprints.add(fingerprint)
+
+    const openIssue = openByFingerprint.get(fingerprint)
+    if (openIssue !== undefined) {
+      // Already open — add recurrence comment
+      toUpdate.push({
+        issueNumber: openIssue.number,
+        comment: buildRecurrenceComment(report.generated_at, report.snapshot_sha),
+      })
+      continue
+    }
+
+    const closedIssue = closedByFingerprint.get(fingerprint)
+    if (closedIssue !== undefined) {
+      // Was closed — reopen it
+      toReopen.push({
+        issueNumber: closedIssue.number,
+        comment: buildRecurrenceComment(report.generated_at, report.snapshot_sha),
+      })
+      continue
+    }
+
+    // New finding — open an issue
+    toOpen.push({
+      title: `Wiki lint: ${finding.kind} in ${finding.path}`,
+      body: buildFindingBody(
+        fingerprint,
+        finding.kind,
+        finding.path,
+        finding.message,
+        report.generated_at,
+        report.snapshot_sha,
+      ),
+      labels: ['wiki-lint', 'wiki-lint-finding'],
+    })
+  }
+
+  if (duplicateCount > 0) {
+    process.stderr.write(
+      `wiki-lint-issues: skipped ${duplicateCount} duplicate findings (fingerprint collision in same report)\n`,
+    )
+  }
+
+  // Process execution failure
+  if (report.status === 'execution-failure' && report.failure_class !== null) {
+    const fc = report.failure_class
+
+    const openFailureIssue = openByFailureClass.get(fc)
+    if (openFailureIssue === undefined) {
+      const closedFailureIssue = closedByFailureClass.get(fc)
+      if (closedFailureIssue === undefined) {
+        toOpen.push({
+          title: `Wiki lint failure: ${fc}`,
+          body: buildFailureBody(fc, report.generated_at),
+          labels: ['wiki-lint', 'wiki-lint-failure'],
+        })
+      } else {
+        toReopen.push({
+          issueNumber: closedFailureIssue.number,
+          comment: buildRecurrenceComment(report.generated_at, report.snapshot_sha),
+        })
+      }
+    } else {
+      toUpdate.push({
+        issueNumber: openFailureIssue.number,
+        comment: buildRecurrenceComment(report.generated_at, report.snapshot_sha),
+      })
+    }
+  }
+
+  // Close-on-clear: only when scan was complete and not an execution failure
+  const canClose = report.status !== 'execution-failure' && report.scan_complete
+
+  if (canClose) {
+    for (const [fp, issue] of openByFingerprint) {
+      if (!currentFingerprints.has(fp)) {
+        toClose.push({issueNumber: issue.number})
+      }
+    }
+
+    // Close failure-class issues when scan completed without that failure class
+    for (const [fc, issue] of openByFailureClass) {
+      if (report.failure_class !== fc) {
+        toClose.push({issueNumber: issue.number})
+      }
+    }
+  }
+
+  return {toOpen, toUpdate, toReopen, toClose}
+}
+
+// ---------------------------------------------------------------------------
+// I/O shell
+// ---------------------------------------------------------------------------
+
+export async function syncWikiLintIssues(params: SyncParams): Promise<SyncResult> {
+  const {octokit, owner, repo, plan} = params
+  const counters = {opened: 0, updated: 0, reopened: 0, closed: 0, failed: 0}
+  const errors: string[] = []
+
+  // Open new issues
+  for (const draft of plan.toOpen) {
+    try {
+      await octokit.rest.issues.create({owner, repo, title: draft.title, body: draft.body, labels: [...draft.labels]})
+      counters.opened++
+    } catch (error) {
+      counters.failed++
+      errors.push(`Failed to open issue "${draft.title}": ${String(error)}`)
+    }
+  }
+
+  // Update existing open issues (add recurrence comment)
+  for (const update of plan.toUpdate) {
+    try {
+      await octokit.rest.issues.createComment({owner, repo, issue_number: update.issueNumber, body: update.comment})
+      counters.updated++
+    } catch (error) {
+      counters.failed++
+      errors.push(`Failed to comment on issue #${update.issueNumber}: ${String(error)}`)
+    }
+  }
+
+  // Reopen closed issues
+  for (const reopen of plan.toReopen) {
+    try {
+      await octokit.rest.issues.update({owner, repo, issue_number: reopen.issueNumber, state: 'open'})
+      await octokit.rest.issues.createComment({owner, repo, issue_number: reopen.issueNumber, body: reopen.comment})
+      counters.reopened++
+    } catch (error) {
+      counters.failed++
+      errors.push(`Failed to reopen issue #${reopen.issueNumber}: ${String(error)}`)
+    }
+  }
+
+  // Close resolved issues
+  for (const close of plan.toClose) {
+    try {
+      await octokit.rest.issues.update({owner, repo, issue_number: close.issueNumber, state: 'closed'})
+      counters.closed++
+    } catch (error) {
+      counters.failed++
+      errors.push(`Failed to close issue #${close.issueNumber}: ${String(error)}`)
+    }
+  }
+
+  return {counters, errors}
+}
+
+// ---------------------------------------------------------------------------
+// CLI entrypoint
+// ---------------------------------------------------------------------------
+
+async function loadOctokit(): Promise<OctokitClient> {
+  const token = process.env.GITHUB_TOKEN
+  if (token === undefined || token === '') throw new Error('GITHUB_TOKEN is not set')
+  return new Octokit({auth: token})
+}
+
+const KNOWN_SCHEMA_VERSION = 1
+const KNOWN_FINGERPRINT_VERSION = 1
+
+async function main(): Promise<void> {
+  const jsonPath = process.env.WIKI_LINT_JSON_PATH ?? process.argv[2]
+  if (jsonPath === undefined || jsonPath === '') {
+    process.stderr.write('wiki-lint-issues: WIKI_LINT_JSON_PATH or first argument is required\n')
+    process.exit(1)
+  }
+
+  let rawReport: unknown
+  try {
+    const raw = await readFile(jsonPath, 'utf8')
+    rawReport = JSON.parse(raw)
+  } catch (error) {
+    process.stderr.write(`wiki-lint-issues: failed to read ${jsonPath}: ${String(error)}\n`)
+    process.exit(1)
+  }
+
+  // Validate shape before any version checks or network calls
+  validateWikiLintJsonReport(rawReport)
+
+  const report = rawReport
+
+  if (report.schema_version !== KNOWN_SCHEMA_VERSION) {
+    process.stderr.write(
+      `wiki-lint-issues: unknown schema_version ${report.schema_version}, expected ${KNOWN_SCHEMA_VERSION}\n`,
+    )
+    process.exit(1)
+  }
+
+  if (report.fingerprint_version !== KNOWN_FINGERPRINT_VERSION) {
+    process.stderr.write(
+      `wiki-lint-issues: unknown fingerprint_version ${report.fingerprint_version}, expected ${KNOWN_FINGERPRINT_VERSION}\n`,
+    )
+    process.exit(1)
+  }
+
+  const owner = process.env.GITHUB_REPOSITORY_OWNER ?? 'fro-bot'
+  const repo = (process.env.GITHUB_REPOSITORY ?? 'fro-bot/.github').split('/')[1] ?? '.github'
+
+  const octokit = await loadOctokit()
+
+  // Fetch open wiki-lint issues
+  const openIssues: ExistingIssue[] = []
+  const recentlyClosedIssues: ExistingIssue[] = []
+
+  for await (const response of octokit.paginate.iterator(octokit.rest.issues.listForRepo, {
+    owner,
+    repo,
+    labels: 'wiki-lint',
+    state: 'open',
+    per_page: 100,
+  })) {
+    for (const issue of response.data) {
+      openIssues.push({number: issue.number, state: 'open', body: issue.body})
+    }
+  }
+
+  // Fetch recently closed (last 100)
+  const closedResponse = await octokit.rest.issues.listForRepo({
+    owner,
+    repo,
+    labels: 'wiki-lint',
+    state: 'closed',
+    per_page: 100,
+    sort: 'updated',
+    direction: 'desc',
+  })
+  for (const issue of closedResponse.data) {
+    recentlyClosedIssues.push({number: issue.number, state: 'closed', body: issue.body})
+  }
+
+  const plan = planIssueLifecycle({report, openIssues, recentlyClosedIssues})
+  const result = await syncWikiLintIssues({octokit, owner, repo, plan})
+
+  // Write to GITHUB_STEP_SUMMARY
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY
+  if (summaryPath !== undefined && summaryPath !== '') {
+    const table = [
+      '## Wiki Lint Issue Sync',
+      '',
+      '| Action | Count |',
+      '|--------|-------|',
+      `| Opened | ${result.counters.opened} |`,
+      `| Updated | ${result.counters.updated} |`,
+      `| Reopened | ${result.counters.reopened} |`,
+      `| Closed | ${result.counters.closed} |`,
+      `| Failed | ${result.counters.failed} |`,
+      '',
+    ].join('\n')
+    await appendFile(summaryPath, table)
+  }
+
+  // Write to GITHUB_OUTPUT
+  const outputPath = process.env.GITHUB_OUTPUT
+  if (outputPath !== undefined && outputPath !== '') {
+    const lines = [
+      `opened=${result.counters.opened}`,
+      `updated=${result.counters.updated}`,
+      `reopened=${result.counters.reopened}`,
+      `closed=${result.counters.closed}`,
+      `failed=${result.counters.failed}`,
+      '',
+    ].join('\n')
+    await appendFile(outputPath, lines)
+  }
+
+  if (result.errors.length > 0) {
+    for (const error of result.errors) {
+      process.stderr.write(`wiki-lint-issues: ${error}\n`)
+    }
+    process.exit(1)
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(error => {
+    process.stderr.write(`wiki-lint-issues: unhandled error: ${String(error)}\n`)
+    process.exit(1)
+  })
+}

--- a/scripts/wiki-lint.test.ts
+++ b/scripts/wiki-lint.test.ts
@@ -6,12 +6,14 @@ import {describe, expect, it} from 'vitest'
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const wikiLintModulePromise: Promise<{
+  buildWikiLintJsonReport: typeof import('./wiki-lint.js').buildWikiLintJsonReport
   lintWikiSnapshot: typeof import('./wiki-lint.js').lintWikiSnapshot
   runWikiLint: typeof import('./wiki-lint.js').runWikiLint
   writeWikiLintFailureOutputs: typeof import('./wiki-lint.js').writeWikiLintFailureOutputs
   writeWikiLintOutputs: typeof import('./wiki-lint.js').writeWikiLintOutputs
 }> = import(`./wiki-lint${'.js'}`)
-const {lintWikiSnapshot, runWikiLint, writeWikiLintFailureOutputs, writeWikiLintOutputs} = await wikiLintModulePromise
+const {buildWikiLintJsonReport, lintWikiSnapshot, runWikiLint, writeWikiLintFailureOutputs, writeWikiLintOutputs} =
+  await wikiLintModulePromise
 
 function buildPage(params: {
   path: string
@@ -622,5 +624,427 @@ describe('lintWikiSnapshot', () => {
     expect(workflow).toContain("steps.restore-wiki.outcome == 'failure'")
     expect(workflow).toContain('if: always()')
     expect(workflow).toContain('actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a')
+  })
+})
+
+function buildCleanFiles() {
+  return Object.fromEntries([
+    [
+      'knowledge/index.md',
+      buildIndex([
+        '## Repos',
+        '',
+        '- [[fro-bot--github]] — Fro Bot .github',
+        '',
+        '## Topics',
+        '',
+        '- [[github-actions-ci]] — GitHub Actions CI',
+        '',
+        '## Entities',
+        '',
+        '_No entity pages yet._',
+        '',
+        '## Comparisons',
+        '',
+        '_No comparison pages yet._',
+      ]),
+    ],
+    buildPage({
+      path: 'knowledge/wiki/repos/fro-bot--github.md',
+      type: 'repo',
+      title: 'Fro Bot .github',
+      tags: ['automation'],
+      bodyLines: ['See [[github-actions-ci]] for workflow conventions.'],
+    }),
+    buildPage({
+      path: 'knowledge/wiki/topics/github-actions-ci.md',
+      type: 'topic',
+      title: 'GitHub Actions CI',
+      tags: ['ci', 'automation'],
+      bodyLines: ['See [[fro-bot--github]] for control-plane workflow patterns.'],
+    }),
+  ])
+}
+
+describe('buildWikiLintJsonReport', () => {
+  it('clean snapshot produces JSON with status clean, scan_complete true, repair_eligible false, empty findings, all-page freshness', () => {
+    const files = buildCleanFiles()
+    const result = lintWikiSnapshot({files, now: new Date('2026-05-02T00:00:00Z')})
+    const report = buildWikiLintJsonReport({
+      result,
+      status: 'clean',
+      scanComplete: true,
+      snapshotSha: 'abc123',
+      generatedAt: '2026-05-02T00:00:00.000Z',
+      failureClass: null,
+    })
+
+    expect(report.status).toBe('clean')
+    expect(report.scan_complete).toBe(true)
+    expect(report.repair_eligible).toBe(false)
+    expect(report.findings).toEqual([])
+    expect(report.freshness).toHaveLength(2)
+    expect(
+      report.freshness.every(f => 'path' in f && 'updated' in f && 'days_stale' in f && 'stale_threshold_days' in f),
+    ).toBe(true)
+    expect(report.snapshot_sha).toBe('abc123')
+  })
+
+  it('deterministic finding produces a stable fingerprint across two identical runs', () => {
+    const files = Object.fromEntries([
+      [
+        'knowledge/index.md',
+        buildIndex([
+          '## Repos',
+          '',
+          '- [[fro-bot--github]] — Fro Bot .github',
+          '',
+          '## Topics',
+          '',
+          '_No topic pages yet._',
+          '',
+          '## Entities',
+          '',
+          '_No entity pages yet._',
+          '',
+          '## Comparisons',
+          '',
+          '_No comparison pages yet._',
+        ]),
+      ],
+      [
+        'knowledge/wiki/repos/fro-bot--github.md',
+        [
+          '---',
+          'type: repo',
+          'created: 2026-04-16',
+          'updated: 2026-04-16',
+          '---',
+          '',
+          'See [[missing-topic]] for context.',
+          '',
+        ].join('\n'),
+      ],
+    ])
+    const result = lintWikiSnapshot({files, now: new Date('2026-05-02T00:00:00Z')})
+    const report1 = buildWikiLintJsonReport({
+      result,
+      status: 'findings',
+      scanComplete: true,
+      snapshotSha: null,
+      generatedAt: '2026-05-02T00:00:00.000Z',
+      failureClass: null,
+    })
+    const report2 = buildWikiLintJsonReport({
+      result,
+      status: 'findings',
+      scanComplete: true,
+      snapshotSha: null,
+      generatedAt: '2026-05-02T00:01:00.000Z',
+      failureClass: null,
+    })
+
+    expect(report1.findings.length).toBeGreaterThan(0)
+    expect(report1.findings.map(f => f.fingerprint)).toEqual(report2.findings.map(f => f.fingerprint))
+  })
+
+  it('different findings produce different fingerprints', () => {
+    const files1 = Object.fromEntries([
+      [
+        'knowledge/index.md',
+        buildIndex([
+          '## Repos',
+          '',
+          '- [[fro-bot--github]] — Fro Bot .github',
+          '',
+          '## Topics',
+          '',
+          '_No topic pages yet._',
+          '',
+          '## Entities',
+          '',
+          '_No entity pages yet._',
+          '',
+          '## Comparisons',
+          '',
+          '_No comparison pages yet._',
+        ]),
+      ],
+      [
+        'knowledge/wiki/repos/fro-bot--github.md',
+        [
+          '---',
+          'type: repo',
+          'created: 2026-04-16',
+          'updated: 2026-04-16',
+          '---',
+          '',
+          'See [[missing-topic-a]] for context.',
+          '',
+        ].join('\n'),
+      ],
+    ])
+    const files2 = Object.fromEntries([
+      [
+        'knowledge/index.md',
+        buildIndex([
+          '## Repos',
+          '',
+          '- [[fro-bot--github]] — Fro Bot .github',
+          '',
+          '## Topics',
+          '',
+          '_No topic pages yet._',
+          '',
+          '## Entities',
+          '',
+          '_No entity pages yet._',
+          '',
+          '## Comparisons',
+          '',
+          '_No comparison pages yet._',
+        ]),
+      ],
+      [
+        'knowledge/wiki/repos/fro-bot--github.md',
+        [
+          '---',
+          'type: repo',
+          'created: 2026-04-16',
+          'updated: 2026-04-16',
+          '---',
+          '',
+          'See [[missing-topic-b]] for context.',
+          '',
+        ].join('\n'),
+      ],
+    ])
+    const result1 = lintWikiSnapshot({files: files1, now: new Date('2026-05-02T00:00:00Z')})
+    const result2 = lintWikiSnapshot({files: files2, now: new Date('2026-05-02T00:00:00Z')})
+    const report1 = buildWikiLintJsonReport({
+      result: result1,
+      status: 'findings',
+      scanComplete: true,
+      snapshotSha: null,
+      generatedAt: '2026-05-02T00:00:00.000Z',
+      failureClass: null,
+    })
+    const report2 = buildWikiLintJsonReport({
+      result: result2,
+      status: 'findings',
+      scanComplete: true,
+      snapshotSha: null,
+      generatedAt: '2026-05-02T00:00:00.000Z',
+      failureClass: null,
+    })
+
+    const fps1 = report1.findings.map(f => f.fingerprint)
+    const fps2 = report2.findings.map(f => f.fingerprint)
+    expect(fps1).not.toEqual(fps2)
+  })
+
+  it('JSON includes freshness telemetry for every page including non-stale pages', () => {
+    const files = buildCleanFiles()
+    const result = lintWikiSnapshot({files, now: new Date('2026-05-02T00:00:00Z')})
+    const report = buildWikiLintJsonReport({
+      result,
+      status: 'clean',
+      scanComplete: true,
+      snapshotSha: null,
+      generatedAt: '2026-05-02T00:00:00.000Z',
+      failureClass: null,
+    })
+
+    // Both pages are fresh (updated 2026-04-16, now 2026-05-02 = ~16 days)
+    expect(report.freshness).toHaveLength(2)
+    expect(report.freshness.every(f => f.days_stale !== null && f.days_stale < 90)).toBe(true)
+    expect(report.counts.pages_scanned).toBe(2)
+    expect(report.counts.pages_stale).toBe(0)
+  })
+
+  it('snapshot_sha is null when not provided, populated when provided', () => {
+    const files = buildCleanFiles()
+    const result = lintWikiSnapshot({files, now: new Date('2026-05-02T00:00:00Z')})
+
+    const withSha = buildWikiLintJsonReport({
+      result,
+      status: 'clean',
+      scanComplete: true,
+      snapshotSha: 'deadbeef1234',
+      generatedAt: '2026-05-02T00:00:00.000Z',
+      failureClass: null,
+    })
+    const withoutSha = buildWikiLintJsonReport({
+      result,
+      status: 'clean',
+      scanComplete: true,
+      snapshotSha: null,
+      generatedAt: '2026-05-02T00:00:00.000Z',
+      failureClass: null,
+    })
+
+    expect(withSha.snapshot_sha).toBe('deadbeef1234')
+    expect(withoutSha.snapshot_sha).toBeNull()
+  })
+
+  it('repair_eligible is true only when status is findings and scan_complete is true', () => {
+    const files = buildCleanFiles()
+    const result = lintWikiSnapshot({files, now: new Date('2026-05-02T00:00:00Z')})
+
+    const cleanReport = buildWikiLintJsonReport({
+      result,
+      status: 'clean',
+      scanComplete: true,
+      snapshotSha: null,
+      generatedAt: '2026-05-02T00:00:00.000Z',
+      failureClass: null,
+    })
+    const findingsReport = buildWikiLintJsonReport({
+      result,
+      status: 'findings',
+      scanComplete: true,
+      snapshotSha: null,
+      generatedAt: '2026-05-02T00:00:00.000Z',
+      failureClass: null,
+    })
+    const failureReport = buildWikiLintJsonReport({
+      result,
+      status: 'execution-failure',
+      scanComplete: false,
+      snapshotSha: null,
+      generatedAt: '2026-05-02T00:00:00.000Z',
+      failureClass: 'snapshot-restore',
+    })
+
+    expect(cleanReport.repair_eligible).toBe(false)
+    expect(findingsReport.repair_eligible).toBe(true)
+    expect(failureReport.repair_eligible).toBe(false)
+  })
+
+  it('schema_version and fingerprint_version are present and integers', () => {
+    const files = buildCleanFiles()
+    const result = lintWikiSnapshot({files, now: new Date('2026-05-02T00:00:00Z')})
+    const report = buildWikiLintJsonReport({
+      result,
+      status: 'clean',
+      scanComplete: true,
+      snapshotSha: null,
+      generatedAt: '2026-05-02T00:00:00.000Z',
+      failureClass: null,
+    })
+
+    expect(typeof report.schema_version).toBe('number')
+    expect(Number.isInteger(report.schema_version)).toBe(true)
+    expect(typeof report.fingerprint_version).toBe('number')
+    expect(Number.isInteger(report.fingerprint_version)).toBe(true)
+  })
+
+  it('failure outputs JSON with status execution-failure, scan_complete false, failure_class set, repair_eligible false', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'wiki-lint-failure-json-'))
+    const reportPath = join(tempDir, 'wiki-lint-report.md')
+    const jsonPath = join(tempDir, 'wiki-lint-report.json')
+
+    const writeResult = await writeWikiLintFailureOutputs({
+      message: 'cannot lint wiki snapshot: origin/data is unavailable',
+      reportPath,
+      jsonPath,
+      failureClass: 'snapshot-restore',
+    })
+
+    expect(writeResult.status).toBe('execution-failure')
+    expect(writeResult.jsonPath).toBe(jsonPath)
+    const json = JSON.parse(await readFile(jsonPath, 'utf8')) as {
+      status: string
+      scan_complete: boolean
+      failure_class: string
+      repair_eligible: boolean
+    }
+    expect(json.status).toBe('execution-failure')
+    expect(json.scan_complete).toBe(false)
+    expect(json.failure_class).toBe('snapshot-restore')
+    expect(json.repair_eligible).toBe(false)
+  })
+
+  it('failure outputs write both markdown and JSON', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'wiki-lint-failure-both-'))
+    const reportPath = join(tempDir, 'wiki-lint-report.md')
+    const jsonPath = join(tempDir, 'wiki-lint-report.json')
+
+    await writeWikiLintFailureOutputs({
+      message: 'lint execution error',
+      reportPath,
+      jsonPath,
+      failureClass: 'lint-execution',
+    })
+
+    await expect(readFile(reportPath, 'utf8')).resolves.toContain('## Execution failure')
+    await expect(readFile(jsonPath, 'utf8')).resolves.toContain('"execution-failure"')
+  })
+
+  it('runWikiLint writes both markdown and JSON on success', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'wiki-lint-run-json-'))
+    const reportPath = join(tempDir, 'wiki-lint-report.md')
+    const jsonPath = join(tempDir, 'wiki-lint-report.json')
+    const wikiDir = join(tempDir, 'knowledge', 'wiki', 'repos')
+    await mkdir(wikiDir, {recursive: true})
+    await writeFile(
+      join(tempDir, 'knowledge', 'index.md'),
+      buildIndex([
+        '## Repos',
+        '',
+        '- [[fro-bot--github]] — Fro Bot .github',
+        '',
+        '## Topics',
+        '',
+        '_No topic pages yet._',
+        '',
+        '## Entities',
+        '',
+        '_No entity pages yet._',
+        '',
+        '## Comparisons',
+        '',
+        '_No comparison pages yet._',
+      ]),
+    )
+    await writeFile(
+      join(wikiDir, 'fro-bot--github.md'),
+      [
+        '---',
+        'type: repo',
+        'title: Fro Bot .github',
+        'created: 2026-04-16',
+        'updated: 2026-04-16',
+        '---',
+        '',
+        'See [[fro-bot--github]] for workflow conventions.',
+        '',
+      ].join('\n'),
+    )
+
+    const result = await runWikiLint({
+      rootDir: tempDir,
+      reportPath,
+      jsonPath,
+      now: new Date('2026-05-02T00:00:00Z'),
+    })
+
+    expect(result.jsonPath).toBe(jsonPath)
+    await expect(readFile(reportPath, 'utf8')).resolves.toContain('# Wiki Lint Report')
+    const json = JSON.parse(await readFile(jsonPath, 'utf8')) as {status: string; scan_complete: boolean}
+    expect(json.scan_complete).toBe(true)
+  })
+
+  it('workflow YAML uploads both markdown and JSON artifacts', async () => {
+    const workflow = await readFile('.github/workflows/wiki-lint.yaml', 'utf8')
+
+    expect(workflow).toContain('wiki-lint-report.md')
+    expect(workflow).toContain('wiki-lint-report.json')
+  })
+
+  it('workflow YAML passes WIKI_LINT_SNAPSHOT_SHA env to the lint step on success', async () => {
+    const workflow = await readFile('.github/workflows/wiki-lint.yaml', 'utf8')
+
+    expect(workflow).toContain('WIKI_LINT_SNAPSHOT_SHA')
   })
 })

--- a/scripts/wiki-lint.ts
+++ b/scripts/wiki-lint.ts
@@ -1,3 +1,4 @@
+import {createHash} from 'node:crypto'
 import {appendFile, readdir, readFile, writeFile} from 'node:fs/promises'
 import {join} from 'node:path'
 import process from 'node:process'
@@ -32,6 +33,59 @@ export interface WikiLintResult {
   readonly advisoryFindings: readonly WikiLintFinding[]
   readonly summary: string
   readonly report: string
+  readonly pages: readonly WikiLintPageInfo[]
+}
+
+export interface WikiLintPageInfo {
+  readonly path: string
+  readonly updated: string | null
+}
+
+export interface WikiLintJsonFinding {
+  readonly kind: WikiLintFindingKind
+  readonly severity: 'deterministic' | 'advisory'
+  readonly path: string
+  readonly target: string | null
+  readonly message: string
+  readonly fingerprint: string
+}
+
+export interface WikiLintFreshnessEntry {
+  readonly path: string
+  readonly updated: string | null
+  readonly days_stale: number | null
+  readonly stale_threshold_days: number
+}
+
+export interface WikiLintCounts {
+  readonly findings_total: number
+  readonly findings_deterministic: number
+  readonly findings_advisory: number
+  readonly pages_scanned: number
+  readonly pages_stale: number
+}
+
+export interface WikiLintJsonReport {
+  readonly schema_version: number
+  readonly fingerprint_version: number
+  readonly status: 'clean' | 'findings' | 'execution-failure'
+  readonly scan_complete: boolean
+  readonly snapshot_sha: string | null
+  readonly generated_at: string
+  readonly failure_class: 'snapshot-restore' | 'lint-execution' | null
+  readonly repair_eligible: boolean
+  readonly findings: readonly WikiLintJsonFinding[]
+  readonly freshness: readonly WikiLintFreshnessEntry[]
+  readonly counts: WikiLintCounts
+}
+
+export interface BuildWikiLintJsonReportParams {
+  readonly result: WikiLintResult
+  readonly status: 'clean' | 'findings' | 'execution-failure'
+  readonly scanComplete: boolean
+  readonly snapshotSha: string | null
+  readonly generatedAt: string
+  readonly failureClass: 'snapshot-restore' | 'lint-execution' | null
 }
 
 export interface LintWikiSnapshotParams {
@@ -42,6 +96,9 @@ export interface LintWikiSnapshotParams {
 export interface WriteWikiLintOutputsParams {
   readonly result: WikiLintResult
   readonly reportPath: string
+  readonly jsonPath?: string
+  readonly snapshotSha?: string | null
+  readonly generatedAt?: string
   readonly githubStepSummaryPath?: string
   readonly githubOutputPath?: string
 }
@@ -49,11 +106,14 @@ export interface WriteWikiLintOutputsParams {
 export interface WriteWikiLintOutputsResult {
   readonly status: 'clean' | 'findings'
   readonly reportPath: string
+  readonly jsonPath: string
 }
 
 export interface WriteWikiLintFailureOutputsParams {
   readonly message: string
   readonly reportPath: string
+  readonly jsonPath?: string
+  readonly failureClass?: 'snapshot-restore' | 'lint-execution'
   readonly githubStepSummaryPath?: string
   readonly githubOutputPath?: string
 }
@@ -61,11 +121,14 @@ export interface WriteWikiLintFailureOutputsParams {
 export interface WriteWikiLintFailureOutputsResult {
   readonly status: 'execution-failure'
   readonly reportPath: string
+  readonly jsonPath: string
 }
 
 export interface RunWikiLintParams {
   readonly rootDir?: string
   readonly reportPath: string
+  readonly jsonPath?: string
+  readonly snapshotSha?: string | null
   readonly githubStepSummaryPath?: string
   readonly githubOutputPath?: string
   readonly now?: Date
@@ -82,6 +145,80 @@ interface ParsedPage {
   readonly body: string
   readonly frontmatter: Record<string, unknown>
   readonly frontmatterError?: string
+}
+
+export function buildWikiLintJsonReport(params: BuildWikiLintJsonReportParams): WikiLintJsonReport {
+  const {result, status, scanComplete, snapshotSha, generatedAt, failureClass} = params
+
+  const deterministicFindings: WikiLintJsonFinding[] = result.deterministicFindings.map(f => ({
+    kind: f.kind,
+    severity: 'deterministic' as const,
+    path: f.path,
+    target: f.target ?? null,
+    message: f.message,
+    fingerprint: computeFingerprint(f.kind, f.path, f.target ?? null),
+  }))
+
+  const advisoryFindings: WikiLintJsonFinding[] = result.advisoryFindings.map(f => ({
+    kind: f.kind,
+    severity: 'advisory' as const,
+    path: f.path,
+    target: f.target ?? null,
+    message: f.message,
+    fingerprint: computeFingerprint(f.kind, f.path, f.target ?? null),
+  }))
+
+  const allFindings = [...deterministicFindings, ...advisoryFindings]
+
+  const freshnessNow = new Date(generatedAt)
+  const freshness: WikiLintFreshnessEntry[] = result.pages.map(page => {
+    const daysStale = computeDaysStale(page.updated, freshnessNow)
+    return {
+      path: page.path,
+      updated: page.updated,
+      days_stale: daysStale,
+      stale_threshold_days: STALE_DAYS,
+    }
+  })
+
+  const pagesStale = freshness.filter(f => f.days_stale !== null && f.days_stale >= STALE_DAYS).length
+
+  return {
+    schema_version: 1,
+    fingerprint_version: 1,
+    status,
+    scan_complete: scanComplete,
+    snapshot_sha: snapshotSha,
+    generated_at: generatedAt,
+    failure_class: failureClass,
+    repair_eligible: scanComplete && status === 'findings',
+    findings: allFindings,
+    freshness,
+    counts: {
+      findings_total: allFindings.length,
+      findings_deterministic: deterministicFindings.length,
+      findings_advisory: advisoryFindings.length,
+      pages_scanned: result.pages.length,
+      pages_stale: pagesStale,
+    },
+  }
+}
+
+function computeFingerprint(kind: string, path: string, target: string | null): string {
+  const input = `${kind}\u0000${path}\u0000${target ?? ''}`
+  return createHash('sha256').update(input).digest('hex').slice(0, 16)
+}
+
+function computeDaysStale(updated: string | null, now: Date): number | null {
+  if (updated === null || updated === '') {
+    return null
+  }
+  const updatedDate = new Date(`${updated}T00:00:00Z`)
+  if (Number.isNaN(updatedDate.getTime())) {
+    return null
+  }
+  const ageMs = now.getTime() - updatedDate.getTime()
+  return Math.floor(ageMs / (24 * 60 * 60 * 1000))
 }
 
 export function lintWikiSnapshot(params: LintWikiSnapshotParams): WikiLintResult {
@@ -194,12 +331,18 @@ export function lintWikiSnapshot(params: LintWikiSnapshotParams): WikiLintResult
 
   const report = reportSections.join('\n')
 
+  const pageInfos: WikiLintPageInfo[] = pages.map(page => ({
+    path: page.path,
+    updated: hasNonEmptyString(page.frontmatter.updated) ? String(page.frontmatter.updated) : null,
+  }))
+
   return {
     ok: deterministicFindings.length === 0,
     deterministicFindings,
     advisoryFindings,
     summary,
     report,
+    pages: pageInfos,
   }
 }
 
@@ -211,6 +354,20 @@ export async function writeWikiLintOutputs(params: WriteWikiLintOutputsParams): 
 
   await writeFile(params.reportPath, `${params.result.report}\n`, 'utf8')
 
+  const resolvedJsonPath = params.jsonPath ?? process.env.WIKI_LINT_JSON_PATH ?? 'wiki-lint-report.json'
+  const generatedAt = params.generatedAt ?? new Date().toISOString()
+  const snapshotSha = params.snapshotSha ?? null
+
+  const jsonReport = buildWikiLintJsonReport({
+    result: params.result,
+    status,
+    scanComplete: true,
+    snapshotSha,
+    generatedAt,
+    failureClass: null,
+  })
+  await writeFile(resolvedJsonPath, `${JSON.stringify(jsonReport, null, 2)}\n`, 'utf8')
+
   if (params.githubStepSummaryPath !== undefined && params.githubStepSummaryPath !== '') {
     await appendFile(params.githubStepSummaryPath, `${params.result.summary}\n`, 'utf8')
   }
@@ -220,7 +377,7 @@ export async function writeWikiLintOutputs(params: WriteWikiLintOutputsParams): 
     await appendFile(params.githubOutputPath, `${lines.join('\n')}\n`, 'utf8')
   }
 
-  return {status, reportPath: params.reportPath}
+  return {status, reportPath: params.reportPath, jsonPath: resolvedJsonPath}
 }
 
 export async function writeWikiLintFailureOutputs(
@@ -231,6 +388,28 @@ export async function writeWikiLintFailureOutputs(
 
   await writeFile(params.reportPath, `${report}\n`, 'utf8')
 
+  const resolvedJsonPath = params.jsonPath ?? process.env.WIKI_LINT_JSON_PATH ?? 'wiki-lint-report.json'
+  const failureClass = params.failureClass ?? 'lint-execution'
+
+  const emptyResult: WikiLintResult = {
+    ok: false,
+    deterministicFindings: [],
+    advisoryFindings: [],
+    summary: '',
+    report: '',
+    pages: [],
+  }
+
+  const jsonReport = buildWikiLintJsonReport({
+    result: emptyResult,
+    status: 'execution-failure',
+    scanComplete: false,
+    snapshotSha: null,
+    generatedAt: new Date().toISOString(),
+    failureClass,
+  })
+  await writeFile(resolvedJsonPath, `${JSON.stringify(jsonReport, null, 2)}\n`, 'utf8')
+
   if (params.githubStepSummaryPath !== undefined && params.githubStepSummaryPath !== '') {
     await appendFile(params.githubStepSummaryPath, `${summary}\n`, 'utf8')
   }
@@ -240,7 +419,7 @@ export async function writeWikiLintFailureOutputs(
     await appendFile(params.githubOutputPath, `${lines.join('\n')}\n`, 'utf8')
   }
 
-  return {status: 'execution-failure', reportPath: params.reportPath}
+  return {status: 'execution-failure', reportPath: params.reportPath, jsonPath: resolvedJsonPath}
 }
 
 export async function runWikiLint(params: RunWikiLintParams): Promise<RunWikiLintResult> {
@@ -250,6 +429,8 @@ export async function runWikiLint(params: RunWikiLintParams): Promise<RunWikiLin
   const outputs = await writeWikiLintOutputs({
     result,
     reportPath: params.reportPath,
+    jsonPath: params.jsonPath,
+    snapshotSha: params.snapshotSha,
     githubStepSummaryPath: params.githubStepSummaryPath,
     githubOutputPath: params.githubOutputPath,
   })
@@ -407,12 +588,16 @@ function isStale(updated: unknown, now: Date): boolean {
 
 async function main(): Promise<void> {
   const reportPath = process.env.WIKI_LINT_REPORT_PATH ?? 'wiki-lint-report.md'
+  const jsonPath = process.env.WIKI_LINT_JSON_PATH ?? 'wiki-lint-report.json'
   const failureMessage = process.env.WIKI_LINT_FAILURE_MESSAGE
+  const snapshotSha = process.env.WIKI_LINT_SNAPSHOT_SHA ?? null
 
   if (failureMessage !== undefined && failureMessage !== '') {
     await writeWikiLintFailureOutputs({
       message: failureMessage,
       reportPath,
+      jsonPath,
+      failureClass: 'snapshot-restore',
       githubStepSummaryPath: process.env.GITHUB_STEP_SUMMARY,
       githubOutputPath: process.env.GITHUB_OUTPUT,
     })
@@ -423,6 +608,8 @@ async function main(): Promise<void> {
   try {
     const result = await runWikiLint({
       reportPath,
+      jsonPath,
+      snapshotSha,
       githubStepSummaryPath: process.env.GITHUB_STEP_SUMMARY,
       githubOutputPath: process.env.GITHUB_OUTPUT,
     })
@@ -433,6 +620,8 @@ async function main(): Promise<void> {
     await writeWikiLintFailureOutputs({
       message,
       reportPath,
+      jsonPath,
+      failureClass: 'lint-execution',
       githubStepSummaryPath: process.env.GITHUB_STEP_SUMMARY,
       githubOutputPath: process.env.GITHUB_OUTPUT,
     })


### PR DESCRIPTION
Wiki-lint now emits a versioned JSON artifact alongside the existing markdown report, and a follow-on workflow job reconciles GitHub Issues from those artifacts. Operators stop polling weekly artifacts to learn what the linter found — issues with stable identity track findings across runs, reopen when a finding recurs, and close when an authoritative scan no longer sees them.

## The contract

`wiki-lint-report.json` is a versioned control-plane contract that downstream automation can read without scraping markdown:

- `schema_version` and `fingerprint_version` are explicit so consumers can fail closed on unknown payloads instead of inferring behavior from ad-hoc fields. The issue-sync job validates the shape and exits non-zero before touching the GitHub API.
- Findings carry stable SHA-256 fingerprints derived from `kind + path + (target ?? '')`. The same finding produces the same identity across runs of the same snapshot — that's how issues dedupe.
- Per-page freshness telemetry (`updated`, `days_stale`, `stale_threshold_days`) is emitted for every scanned page, not just stale ones. A later stale-threshold plan can analyze observed data without retrofitting the schema.
- `scan_complete`, `failure_class`, and `repair_eligible` give the issue-sync job explicit signals about whether close-on-clear is safe to apply.

Both `wiki-lint-report.md` and `wiki-lint-report.json` are uploaded on every path: `clean`, `findings`, and `execution-failure`.

## The lifecycle

`scripts/wiki-lint-issues.ts` is a pure decision engine plus a thin GitHub I/O shell. The pure `planIssueLifecycle()` takes the JSON artifact plus the current set of open and recently-closed `wiki-lint` issues and produces an action plan: `{ toOpen, toUpdate, toReopen, toClose }`. The async shell executes each action independently — one GitHub API failure does not abort the rest of the plan, but the job fails when any required operation fails so escalation can never report green silently.

Hidden markers — `<!-- wiki-lint:subject:fingerprint=... -->` and `<!-- wiki-lint:subject:failure-class=... -->` — dedupe issues across runs without relying on titles. Close-on-clear runs only on a complete authoritative scan; an execution-failure run never closes existing finding issues because the absence of a finding could just mean the scan didn't complete. Lifecycle counters (`opened`, `updated`, `reopened`, `closed`, `failed`) write to `GITHUB_OUTPUT` and `GITHUB_STEP_SUMMARY` so future rollout decisions rely on evidence rather than eyeballing the issues tab.

The new `wiki-lint-issue-sync` job in `.github/workflows/wiki-lint.yaml` runs `if: always()` so close-on-clear works on clean runs and issue creation works on lint-failure runs. It mints a narrowed App installation token (`permission-issues: write`, `permission-contents: read`) and times out at 10 minutes.

## Three repo-local labels

`wiki-lint`, `wiki-lint-finding`, and `wiki-lint-failure` are declared in `.github/settings.yml` so they live in the same settings contract as branch protection. Every wiki-lint issue gets the base `wiki-lint` label plus exactly one of the finding/failure variants.

## What's deferred

This PR ships the foundation. Stale-threshold tuning waits for six weekly runs of freshness telemetry to justify any page-type-specific thresholds. Repair-proposal automation waits for issue-sync to stay stable across three consecutive scheduled runs. Both follow-ons are documented in the plan's Phased Delivery section.

A few smaller follow-ups surfaced during review that are worth filing as separate work after this lands:

- Retry/backoff on transient 429/5xx GitHub API errors (current behavior is fail-fast).
- Paginate the closed-issue lookup beyond the first 100 results so older recurrences don't open duplicates.
- A per-run budget for issue mutations so a 1000-finding fire-drill doesn't flood the issues tab on the first scheduled run after the foundation lands.
- An anchor-block design for the hidden markers so a human accidentally editing an issue body can't make the next run lose the finding identity.

## Verification

- `pnpm check-types` ✅
- `pnpm lint` ✅ (0 errors, 0 warnings)
- `pnpm test` ✅ — 603 passing + 3 `it.todo` (+8 from baseline 595 before this branch's review fixes, +39 from main's 564)
- `actionlint .github/workflows/wiki-lint.yaml` ✅