### PR TITLE
fix(reconcile): suppress self-heal rollup duplicates from same-run race

### DIFF
--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -3258,6 +3258,56 @@ describe('handleReconcile (I/O shell)', () => {
       expect(params?.labels).toContain('reconcile:rollup-pending-review')
     })
 
+    it('regression: does not duplicate rollup when listForRepo lags behind same-run create', async () => {
+      // Reproduces the 2026-05-18 race (run 26023380395, issues #3307 + #3308):
+      //
+      // Setup: bfra-me grants access to 2 repos in this run (NOT pre-existing in metadata).
+      // Pass 1 of reconcileRepos adds both as `pending-review` + pushes 2 rawIssues.
+      // buildIssueQueue groups them into a single `per-owner-rollup` for bfra-me.
+      // plan.issues therefore contains that rollup → currentRunRollupOwners = {'bfra-me'}.
+      //
+      // runIssueQueue (step 10) creates the rollup via issuesCreate.
+      // issuesListForRepo returns [] — simulating eventual-consistency lag.
+      // selfHealRollups (step 12) sees empty existingRollupOwners from the API, but the fix
+      // unions currentRunRollupOwners in, so bfra-me is already "known" → no second create.
+      //
+      // Without the fix, selfHealRollups would see bfra-me has 2 pending-review entries and
+      // no existing rollup, and would call issuesCreate a second time.
+
+      // currentRepos starts EMPTY — bfra-me grants are new this run.
+      const issuesCreate = vi.fn(async () => ({data: {number: 99}}))
+      // Simulate eventual-consistency lag: listForRepo returns empty even though step 10 just created a rollup.
+      const issuesListForRepo = vi.fn(async () => ({data: []}))
+
+      const userOctokit = mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {owner: {login: 'bfra-me'}, name: '.github', archived: false, private: false, node_id: 'R_bfra_1'},
+            {
+              owner: {login: 'bfra-me'},
+              name: 'ha-addon-repository',
+              archived: false,
+              private: false,
+              node_id: 'R_bfra_2',
+            },
+          ],
+        }),
+      })
+
+      await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit: mockOctokit({issuesCreate, issuesListForRepo}),
+          // Empty repos + no bfra-me in allowlist → both repos classified as unsolicited-new
+          readMetadata: makeReadMetadata({repos: {version: 1, repos: []}, allowlist: makeAllowlist([])}),
+          commitMetadata: vi.fn(async () => ({committed: false, attempts: 1})) as never,
+        }),
+      )
+
+      // runIssueQueue (step 10) creates exactly 1 rollup; selfHealRollups (step 12) must NOT
+      // create a second one even though listForRepo returned empty.
+      expect(issuesCreate).toHaveBeenCalledOnce()
+    })
     it('does not file a new rollup when an open rollup issue already exists for that owner', async () => {
       const existing: ReposFile = {
         version: 1,

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -1429,6 +1429,14 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
   })
 
   // 12. Self-healing rollup re-file.
+  // Build the set of rollup owners attempted by runIssueQueue this run. We use "attempted"
+  // (not "succeeded") so that even a transient create failure suppresses self-heal for this
+  // run — a failed create is safer to retry on the next cron than to risk a duplicate now.
+  // The GitHub Issues listing API has eventual-consistency lag: a rollup POSTed in step 10
+  // may not appear in a subsequent listForRepo call, causing selfHealRollups to re-create it.
+  const currentRunRollupOwners = new Set(
+    plan.issues.filter(issue => issue.kind === 'per-owner-rollup').map(issue => issue.owner),
+  )
   const healedRollups = await selfHealRollups({
     appOctokit,
     owner,
@@ -1437,6 +1445,7 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
     accessList,
     allowlist,
     logger,
+    currentRunRollupOwners,
   })
 
   return {
@@ -2450,6 +2459,7 @@ async function selfHealRollups(params: {
   accessList: AccessListEntry[]
   allowlist: AllowlistFile
   logger: ReconcileLogger
+  currentRunRollupOwners: ReadonlySet<string>
 }): Promise<number> {
   const allowlistedOwners = new Set(params.allowlist.approved_inviters.map(i => i.username))
   const pendingReviewByOwner = new Map<string, RepoEntry[]>()
@@ -2479,6 +2489,12 @@ async function selfHealRollups(params: {
       const body = issue.body ?? ''
       const match = ROLLUP_OWNER_MARKER_PATTERN.exec(body)
       if (match?.[1] !== undefined) existingRollupOwners.add(match[1])
+    }
+    // Union with owners whose rollups were attempted in this same reconcile run.
+    // The GitHub Issues listing API has eventual-consistency lag: a rollup created
+    // in step 10 may not appear in this listing, causing a duplicate to be filed here.
+    for (const owner of params.currentRunRollupOwners) {
+      existingRollupOwners.add(owner)
     }
   } catch (error: unknown) {
     const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'


### PR DESCRIPTION
Suppresses a same-run race in `scripts/reconcile-repos.ts` that creates duplicate per-owner rollup issues when `runIssueQueue` POSTs a rollup and `selfHealRollups` lists open rollups before GitHub's `issues.listForRepo` reflects the new issue.

## Why

GitHub's Issues listing API lags behind issue creation by several seconds. In a single reconcile run:

1. `runIssueQueue` (step 10) successfully creates a rollup for an owner.
2. `selfHealRollups` (step 12) calls `issues.listForRepo` to enumerate open rollups — gets stale data without the just-created rollup.
3. The owner still has qualifying `pending-review` entries, so self-heal creates a *second* rollup.

Live recurrence confirms the bug:

- 2026-05-18: issues #3307 and #3308 — both opened at `08:54:50Z` with identical body and marker, same reconcile run.
- 2026-05-19: issues #3316 and #3317 — same pattern after the `bfra-me` allowlist merge.

## What changed

`selfHealRollups` accepts a new `currentRunRollupOwners: ReadonlySet<string>` built from `plan.issues` (filtered to `kind: 'per-owner-rollup'`). After fetching the API-listed set, the function unions `currentRunRollupOwners` into `existingRollupOwners` before the create-guard.

**"Attempted" semantics** — the set is derived from `plan.issues`, not from successful creates. Rationale: a transient create failure can recover on the next cron (24h max delay); a duplicate has no automatic recovery. Trading rare missed-rollup latency for guaranteed dedup.

## Verification

- Regression test reshaped so it actually exercises the race-guard threading: empty `currentRepos`, 2 fresh `bfra-me` repos arriving via `listForAuthenticatedUser`, empty allowlist. `buildIssueQueue` produces a per-owner-rollup, `runIssueQueue` creates it, `issuesListForRepo` returns `[]`, self-heal correctly skips. Asserts `issuesCreate` is called exactly once.
- Verified the test **fails without the fix** (two creates) and **passes with the fix** (one create) by temporarily reverting and restoring the union block.
- `pnpm check-types`, `pnpm lint`, `pnpm test` all clean. 604 passed + 3 todo.

## Follow-ups (deferred)

Tracked as separate issues from review:

- #3319 — race-suppression is not observable in `ReconcileSummary` or logs
- #3320 — cross-run idempotency gap (a manual rerun within ~60s of a scheduled run can still hit the race)

Closes: race surfaced by #3307/#3308 and #3316/#3317
