### PR TITLE
feat(privacy): gate social-broadcast external posts on private input

### DIFF
--- a/.github/workflows/social-broadcast.yaml
+++ b/.github/workflows/social-broadcast.yaml
@@ -37,6 +37,11 @@ on:
         required: false
         type: string
         default: ''
+      private:
+        description: Whether the broadcast concerns a private repo (skips external Discord and Bluesky posts when true; journal still fires)
+        required: false
+        type: boolean
+        default: true
     secrets:
       FRO_BOT_PAT:
         required: true
@@ -63,7 +68,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: 📣 Notify Discord
-        if: inputs.discord_message != ''
+        if: inputs.discord_message != '' && inputs.private != true
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           DISCORD_MESSAGE: ${{ inputs.discord_message }}
@@ -74,7 +79,7 @@ jobs:
             --title "$DISCORD_TITLE"
 
       - name: 🦋 Post to Bluesky
-        if: inputs.bluesky_text != ''
+        if: inputs.bluesky_text != '' && inputs.private != true
         env:
           BLUESKY_HANDLE: ${{ secrets.BLUESKY_HANDLE }}
           BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}

--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -277,6 +277,9 @@ jobs:
       journal_metadata: >-
         {"owner":"${{ needs.survey-repo.outputs.owner }}","repo":"${{ needs.survey-repo.outputs.repo }}"}
       repo: ${{ needs.survey-repo.outputs.owner }}/${{ needs.survey-repo.outputs.repo }}
+      # The resolve-and-verify gate has already proven this repo is public
+      # before survey-repo succeeds, so external posts are safe to send.
+      private: false
     secrets:
       FRO_BOT_PAT: ${{ secrets.FRO_BOT_PAT }}
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
Gates external social posts (Discord, Bluesky) on a new `private` input to `social-broadcast.yaml`. The journal step always runs — it's in-repo and inherits visibility — but Discord and Bluesky now require an explicit `private: false` from the caller.

## Why

Fro Bot's privacy posture is "no information about a private repo's existence, contents, or activity appears in any public artifact." `social-broadcast.yaml` is one of several public-egress chokepoints. Until now it had no awareness of repo visibility; any caller passing message text into the Discord or Bluesky inputs would have fired those posts unconditionally.

## What changed

`.github/workflows/social-broadcast.yaml`

- New input `private: boolean`, `required: false`, `default: true`.
- Discord step `if:` extended to `inputs.discord_message != '' && inputs.private != true`.
- Bluesky step `if:` extended to `inputs.bluesky_text != '' && inputs.private != true`.
- Journal step untouched.

`.github/workflows/survey-repo.yaml`

- The `broadcast:` job now passes `private: false` explicitly. The resolve-and-verify gate has already proven `isPrivate == false` via GraphQL before `survey-repo` succeeds and triggers the broadcast, so the literal is safe.

## Default-true rationale (fail-safe)

The default is `true`, not `false`. A future caller that forgets to pass `private` gets no external posts — that's the safer failure mode. In-flight workflow runs that captured the old `social-broadcast.yaml` continue to succeed under the new contract; external posts they expected to fire are skipped, and the operator can re-trigger if needed.

## Verification

- `actionlint` clean on both files.
- `pnpm check-types`, `pnpm lint`, `pnpm test` — all green. 604 tests + 3 todo (no test count change; the plan keeps Unit 7's verification as workflow integration plus actionlint).
- Caller audit: `social-broadcast.yaml` has only one caller in this repo (`survey-repo.yaml`); no other plumb-through needed.

## Out of scope

- No changes to the journal pipeline (in-repo, inherits visibility).
- No tightening of `private` from optional to required — that's a follow-up after all callers are confirmed to pass the flag.

Loose-then-tight: tightening to `required: true` is deferred to a separate PR once we've watched the default-true behavior in production for a cycle.
