### PR TITLE
feat(privacy): block merge-data when private wiki pages exist

### DIFF
--- a/.github/workflows/merge-data.yaml
+++ b/.github/workflows/merge-data.yaml
@@ -28,6 +28,18 @@ jobs:
       - name: 📦 Setup
         uses: ./.github/actions/setup
 
+      - name: ⤵ Fetch data branch for privacy check
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: data
+          path: data-branch-check
+
+      - name: 🔒 Block private wiki pages
+        env:
+          GITHUB_TOKEN: ${{ steps.get-workflow-app-token.outputs.token }}
+        working-directory: data-branch-check
+        run: node ../scripts/check-wiki-private-presence.ts
+
       - name: 🔀 Open weekly data merge PR
         env:
           GITHUB_TOKEN: ${{ steps.get-workflow-app-token.outputs.token }}

--- a/scripts/check-wiki-private-presence.test.ts
+++ b/scripts/check-wiki-private-presence.test.ts
@@ -1,0 +1,257 @@
+import {describe, expect, it, vi} from 'vitest'
+
+import {detectPrivateWikiLeaks, loadWikiFilenames, resolveCanonicalSlugs} from './check-wiki-private-presence.ts'
+
+// Hoisted mocks — vitest transforms these to the top of the module at compile time,
+// so they take effect before any imports regardless of source order.
+const {mockExecFileSync, mockReaddir} = vi.hoisted(() => {
+  return {
+    mockExecFileSync: vi.fn(),
+    mockReaddir: vi.fn(),
+  }
+})
+
+vi.mock('node:child_process', () => ({execFileSync: mockExecFileSync}))
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+  readdir: mockReaddir,
+}))
+
+describe('detectPrivateWikiLeaks', () => {
+  describe('happy path — no leaks', () => {
+    it('returns empty array when privateEntries is empty', () => {
+      // #given no private entries at all
+      // #when detection runs
+      // #then no leaks are reported
+      const result = detectPrivateWikiLeaks({
+        privateEntries: [],
+        wikiRepoFilenames: ['marcusrbrown--poly.md', 'some-org--some-repo.md'],
+      })
+      expect(result).toEqual([])
+    })
+
+    it('returns empty array when no wiki filenames match any private entry', () => {
+      // #given private entries whose slugs and node_ids do not appear in wiki filenames
+      // #when detection runs
+      // #then no leaks are reported
+      const result = detectPrivateWikiLeaks({
+        privateEntries: [
+          {node_id: 'R_kgDOABCDEF', canonicalSlug: 'acme--secret-repo'},
+          {node_id: 'R_kgDOXYZ123', canonicalSlug: 'acme--another-private'},
+        ],
+        wikiRepoFilenames: ['marcusrbrown--poly.md', 'some-org--public-repo.md'],
+      })
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('canonical slug matching', () => {
+    it('returns a leak when a wiki filename stem matches the canonicalSlug exactly', () => {
+      // #given a private entry whose canonicalSlug matches a wiki filename stem
+      // #when detection runs
+      // #then one leak is returned with reason canonical-slug-match
+      const result = detectPrivateWikiLeaks({
+        privateEntries: [{node_id: 'R_kgDOABCDEF', canonicalSlug: 'marcusrbrown--poly'}],
+        wikiRepoFilenames: ['marcusrbrown--poly.md', 'other-repo.md'],
+      })
+      expect(result).toEqual([
+        {
+          filename: 'marcusrbrown--poly.md',
+          reason: 'canonical-slug-match',
+          node_id: 'R_kgDOABCDEF',
+        },
+      ])
+    })
+
+    it('matches case-insensitively (filename MarcusRBrown--Poly.md matches slug marcusrbrown--poly)', () => {
+      // #given a wiki filename with mixed case that matches the lowercase slug
+      // #when detection runs
+      // #then the leak is detected despite case difference
+      const result = detectPrivateWikiLeaks({
+        privateEntries: [{node_id: 'R_kgDOABCDEF', canonicalSlug: 'marcusrbrown--poly'}],
+        wikiRepoFilenames: ['MarcusRBrown--Poly.md'],
+      })
+      expect(result).toEqual([
+        {
+          filename: 'MarcusRBrown--Poly.md',
+          reason: 'canonical-slug-match',
+          node_id: 'R_kgDOABCDEF',
+        },
+      ])
+    })
+  })
+
+  describe('node_id matching (defensive)', () => {
+    it('returns a leak when a wiki filename stem matches the node_id', () => {
+      // #given a wiki filename whose stem is the node_id (defensive future-proofing)
+      // #when detection runs
+      // #then one leak is returned with reason node-id-match
+      const result = detectPrivateWikiLeaks({
+        privateEntries: [{node_id: 'R_kgDOABCDEF'}],
+        wikiRepoFilenames: ['R_kgDOABCDEF.md', 'other-repo.md'],
+      })
+      expect(result).toEqual([
+        {
+          filename: 'R_kgDOABCDEF.md',
+          reason: 'node-id-match',
+          node_id: 'R_kgDOABCDEF',
+        },
+      ])
+    })
+
+    it('applies only node_id matching when canonicalSlug is absent (resolution failed)', () => {
+      // #given a private entry with no canonicalSlug (GraphQL resolution failed)
+      // #when detection runs against wiki files that do not match the node_id
+      // #then no leaks are reported (slug matching is skipped)
+      const result = detectPrivateWikiLeaks({
+        privateEntries: [{node_id: 'R_kgDOABCDEF'}],
+        wikiRepoFilenames: ['marcusrbrown--poly.md'],
+      })
+      expect(result).toEqual([])
+    })
+
+    it('detects node_id leak when canonicalSlug is absent and node_id matches', () => {
+      // #given a private entry with no canonicalSlug but node_id matches a wiki file
+      // #when detection runs
+      // #then the node_id-based leak is returned
+      const result = detectPrivateWikiLeaks({
+        privateEntries: [{node_id: 'R_kgDOABCDEF'}],
+        wikiRepoFilenames: ['R_kgDOABCDEF.md'],
+      })
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({reason: 'node-id-match', node_id: 'R_kgDOABCDEF'})
+    })
+  })
+
+  describe('both slug and node_id match different files for the same entry', () => {
+    it('returns two leaks when both canonicalSlug and node_id match different wiki files', () => {
+      // #given a private entry whose slug matches one file and node_id matches another
+      // #when detection runs
+      // #then two leaks are returned (one per match, no short-circuit)
+      const result = detectPrivateWikiLeaks({
+        privateEntries: [{node_id: 'R_kgDOABCDEF', canonicalSlug: 'marcusrbrown--poly'}],
+        wikiRepoFilenames: ['marcusrbrown--poly.md', 'R_kgDOABCDEF.md'],
+      })
+      expect(result).toHaveLength(2)
+      expect(result).toContainEqual({
+        filename: 'marcusrbrown--poly.md',
+        reason: 'canonical-slug-match',
+        node_id: 'R_kgDOABCDEF',
+      })
+      expect(result).toContainEqual({
+        filename: 'R_kgDOABCDEF.md',
+        reason: 'node-id-match',
+        node_id: 'R_kgDOABCDEF',
+      })
+    })
+  })
+
+  describe('multiple private entries — partial leaks', () => {
+    it('returns leaks only for matching entries when some match and some do not', () => {
+      // #given two private entries, only one of which has a matching wiki file
+      // #when detection runs
+      // #then only the matching entry produces a leak
+      const result = detectPrivateWikiLeaks({
+        privateEntries: [
+          {node_id: 'R_kgDOABCDEF', canonicalSlug: 'acme--secret'},
+          {node_id: 'R_kgDOXYZ123', canonicalSlug: 'acme--also-secret'},
+        ],
+        wikiRepoFilenames: ['acme--secret.md', 'public-repo.md'],
+      })
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({
+        filename: 'acme--secret.md',
+        reason: 'canonical-slug-match',
+        node_id: 'R_kgDOABCDEF',
+      })
+    })
+
+    it('returns all leaks when multiple entries each match a wiki file — asserts per-leak shape', () => {
+      // #given two private entries both matching wiki files
+      // #when detection runs
+      // #then both leaks are returned with correct filename, reason, and node_id (P3 #11 strengthened)
+      const result = detectPrivateWikiLeaks({
+        privateEntries: [
+          {node_id: 'R_kgDOABCDEF', canonicalSlug: 'acme--secret'},
+          {node_id: 'R_kgDOXYZ123', canonicalSlug: 'acme--also-secret'},
+        ],
+        wikiRepoFilenames: ['acme--secret.md', 'acme--also-secret.md'],
+      })
+      expect(result).toHaveLength(2)
+      expect(result).toContainEqual({
+        filename: 'acme--secret.md',
+        reason: 'canonical-slug-match',
+        node_id: 'R_kgDOABCDEF',
+      })
+      expect(result).toContainEqual({
+        filename: 'acme--also-secret.md',
+        reason: 'canonical-slug-match',
+        node_id: 'R_kgDOXYZ123',
+      })
+    })
+  })
+})
+
+describe('resolveCanonicalSlugs', () => {
+  it('returns resolved slugs for all entries when GraphQL succeeds', () => {
+    // #given GraphQL returns a valid nameWithOwner for each node_id
+    // #when resolveCanonicalSlugs is called
+    // #then each entry gets its canonicalSlug set
+    mockExecFileSync.mockReturnValue(JSON.stringify({data: {node: {nameWithOwner: 'acme/secret'}}}))
+    const result = resolveCanonicalSlugs([{node_id: 'R_kgDOABCDEF'}])
+    expect(result.resolved).toEqual([{node_id: 'R_kgDOABCDEF', canonicalSlug: 'acme--secret'}])
+    expect(result.failures).toEqual([])
+  })
+
+  it('throws (fails closed) when GraphQL resolution fails for any entry', () => {
+    // #given GraphQL throws for a private entry
+    // #when resolveCanonicalSlugs is called
+    // #then it throws with the failing node_id listed (fail-closed: P1 #2)
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('gh: HTTP 401')
+    })
+    expect(() => resolveCanonicalSlugs([{node_id: 'R_kgDOABCDEF'}])).toThrow(/R_kgDOABCDEF/)
+  })
+
+  it('throws listing all failing node_ids when multiple entries fail resolution', () => {
+    // #given GraphQL throws for two private entries
+    // #when resolveCanonicalSlugs is called
+    // #then the error message names both node_ids
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('gh: HTTP 401')
+    })
+    expect(() => resolveCanonicalSlugs([{node_id: 'R_kgDOABCDEF'}, {node_id: 'R_kgDOXYZ123'}])).toThrow(
+      /R_kgDOABCDEF.*R_kgDOXYZ123|R_kgDOXYZ123.*R_kgDOABCDEF/,
+    )
+  })
+})
+
+describe('loadWikiFilenames', () => {
+  it('returns empty array when knowledge/wiki/repos/ does not exist (ENOENT)', async () => {
+    // #given the wiki repos directory does not exist
+    // #when loadWikiFilenames is called
+    // #then it returns [] gracefully (fresh checkout, no wiki yet)
+    const enoent = Object.assign(new Error('ENOENT'), {code: 'ENOENT'})
+    mockReaddir.mockRejectedValue(enoent)
+    const result = await loadWikiFilenames()
+    expect(result).toEqual([])
+  })
+
+  it('propagates non-ENOENT errors (fail-closed: P1 #3)', async () => {
+    // #given readdir throws a permission error (not ENOENT)
+    // #when loadWikiFilenames is called
+    // #then the error propagates — do not silently swallow FS errors
+    const eperm = Object.assign(new Error('EPERM: operation not permitted'), {code: 'EPERM'})
+    mockReaddir.mockRejectedValue(eperm)
+    await expect(loadWikiFilenames()).rejects.toThrow(/EPERM/)
+  })
+
+  it('returns only .md files from the directory listing', async () => {
+    // #given the directory contains .md and non-.md files
+    // #when loadWikiFilenames is called
+    // #then only .md filenames are returned
+    mockReaddir.mockResolvedValue(['acme--secret.md', 'README.md', '.gitkeep', 'other.txt'])
+    const result = await loadWikiFilenames()
+    expect(result).toEqual(['acme--secret.md', 'README.md'])
+  })
+})

--- a/scripts/check-wiki-private-presence.ts
+++ b/scripts/check-wiki-private-presence.ts
@@ -1,0 +1,195 @@
+import {execFileSync} from 'node:child_process'
+import {readdir, readFile} from 'node:fs/promises'
+import process from 'node:process'
+
+import YAML from 'yaml'
+
+import {assertReposFile} from './schemas.ts'
+
+export interface PrivateWikiLeak {
+  filename: string
+  reason: 'canonical-slug-match' | 'node-id-match'
+  node_id: string
+}
+
+/**
+ * Pure function: detect wiki files in knowledge/wiki/repos/ that correspond to private repo entries.
+ *
+ * For each private entry:
+ * - If canonicalSlug is provided, check for a case-insensitive stem match against wiki filenames.
+ * - Always check if any wiki filename stem matches the entry's node_id (defensive).
+ *
+ * Returns all leaks found without short-circuiting.
+ */
+export function detectPrivateWikiLeaks(params: {
+  privateEntries: readonly {node_id: string; canonicalSlug?: string}[]
+  wikiRepoFilenames: readonly string[]
+}): PrivateWikiLeak[] {
+  const {privateEntries, wikiRepoFilenames} = params
+  const leaks: PrivateWikiLeak[] = []
+
+  for (const entry of privateEntries) {
+    for (const filename of wikiRepoFilenames) {
+      const stem = filename.replace(/\.md$/i, '')
+
+      // Canonical slug match (case-insensitive)
+      if (entry.canonicalSlug !== undefined && stem.toLowerCase() === entry.canonicalSlug.toLowerCase()) {
+        leaks.push({filename, reason: 'canonical-slug-match', node_id: entry.node_id})
+        continue
+      }
+
+      // Node ID match (defensive)
+      if (stem === entry.node_id) {
+        leaks.push({filename, reason: 'node-id-match', node_id: entry.node_id})
+      }
+    }
+  }
+
+  return leaks
+}
+
+// ---------------------------------------------------------------------------
+// Type guard for GraphQL response (P2 #6 — no unsafe casts at JSON boundary)
+// ---------------------------------------------------------------------------
+
+function isGraphQLRepoNameResponse(value: unknown): value is {data: {node: {nameWithOwner: string}}} {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as Record<string, unknown>
+  if (typeof v.data !== 'object' || v.data === null) return false
+  const data = v.data as Record<string, unknown>
+  if (typeof data.node !== 'object' || data.node === null) return false
+  const node = data.node as Record<string, unknown>
+  return typeof node.nameWithOwner === 'string' && node.nameWithOwner.length > 0
+}
+
+// ---------------------------------------------------------------------------
+// resolveCanonicalSlugs — exported for testing; fail-closed (P1 #2)
+// ---------------------------------------------------------------------------
+
+export interface ResolvedEntry {
+  node_id: string
+  canonicalSlug: string
+}
+
+export interface SlugResolutionResult {
+  resolved: ResolvedEntry[]
+  failures: string[] // node_ids that failed — always empty on success; throws if non-empty
+}
+
+/**
+ * Resolve canonical slugs for all private entries via GraphQL.
+ *
+ * Fail-closed: if ANY entry's slug cannot be resolved (API error, lost access,
+ * deleted repo), throws with the list of failing node_ids. The caller must not
+ * proceed — a canonical leak could slip through undetected.
+ *
+ * Captures all subprocess output; never echoes to stdout/stderr.
+ */
+export function resolveCanonicalSlugs(entries: readonly {node_id: string}[]): SlugResolutionResult {
+  const resolved: ResolvedEntry[] = []
+  const failures: string[] = []
+
+  for (const entry of entries) {
+    try {
+      const stdout = execFileSync(
+        'gh',
+        ['api', 'graphql', '-f', `query={ node(id: "${entry.node_id}") { ... on Repository { nameWithOwner } } }`],
+        {encoding: 'utf8', stdio: ['inherit', 'pipe', 'pipe']},
+      )
+      const parsed: unknown = JSON.parse(stdout)
+      if (isGraphQLRepoNameResponse(parsed)) {
+        // Convert "owner/repo" → "owner--repo" (wiki slug convention)
+        resolved.push({node_id: entry.node_id, canonicalSlug: parsed.data.node.nameWithOwner.replace('/', '--')})
+      } else {
+        // Unexpected response shape — treat as failure
+        failures.push(entry.node_id)
+      }
+    } catch {
+      failures.push(entry.node_id)
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      `check-wiki-private-presence: cannot verify private wiki presence — ${failures.length} private ${failures.length === 1 ? 'entry' : 'entries'} failed slug resolution: ${failures.join(', ')}. Investigate token scope / repo access before re-running.`,
+    )
+  }
+
+  return {resolved, failures}
+}
+
+// ---------------------------------------------------------------------------
+// loadWikiFilenames — exported for testing; ENOENT-only graceful (P1 #3)
+// ---------------------------------------------------------------------------
+
+/**
+ * List .md filenames in knowledge/wiki/repos/.
+ *
+ * ENOENT is graceful (fresh checkout, no wiki yet) → returns [].
+ * Any other error propagates — do not silently swallow FS errors.
+ */
+export async function loadWikiFilenames(): Promise<string[]> {
+  try {
+    const entries = await readdir('knowledge/wiki/repos')
+    return entries.filter(f => f.endsWith('.md'))
+  } catch (error) {
+    if (typeof error === 'object' && error !== null && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return []
+    }
+    throw error
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry-point
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  // 1. Read and validate metadata/repos.yaml
+  const reposRaw = await readFile('metadata/repos.yaml', 'utf8')
+  const reposParsed: unknown = YAML.parse(reposRaw)
+  assertReposFile(reposParsed)
+
+  // 2. Filter to private entries with node_id
+  const privateEntries = reposParsed.repos.filter(
+    (r): r is typeof r & {node_id: string} => r.private === true && typeof r.node_id === 'string',
+  )
+
+  if (privateEntries.length === 0) {
+    process.stdout.write('no private wiki leaks detected\n')
+    return
+  }
+
+  // 3. List wiki repo filenames from the working directory (data branch checkout)
+  const wikiRepoFilenames = await loadWikiFilenames()
+
+  // 4. Resolve canonical slugs via GraphQL (fail-closed — throws on any failure)
+  const {resolved} = resolveCanonicalSlugs(privateEntries)
+
+  // 5. Detect leaks
+  const leaks = detectPrivateWikiLeaks({
+    privateEntries: resolved,
+    wikiRepoFilenames,
+  })
+
+  // 6. Report
+  if (leaks.length > 0) {
+    const filenames = leaks.map(l => l.filename)
+    process.stderr.write(
+      `${[
+        'check-wiki-private-presence: BLOCKED — private wiki pages detected in knowledge/wiki/repos/:',
+        ...filenames.map(f => `  - ${f}`),
+        '',
+        'These files expose private repository identities. Remove them from the data branch before promoting.',
+        `Leak count: ${leaks.length}`,
+      ].join('\n')}\n`,
+    )
+    process.exit(1)
+  }
+
+  process.stdout.write('no private wiki leaks detected\n')
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}


### PR DESCRIPTION
Adds a defense-in-depth check before `merge-data.yaml` opens the weekly `data → main` promotion PR: if any `knowledge/wiki/repos/` file on the `data` branch matches a private repo entry's canonical slug or `node_id`, the workflow stops.

The earlier dispatch gate (Unit 6) already prevents new private wiki pages from being written via `survey-repo.yaml`. This catches anything that slips through — a manual dispatch with a wrong input, an agent error, an out-of-band write.

## What changed

`scripts/check-wiki-private-presence.ts` (new, 141 LOC) — pure `detectPrivateWikiLeaks(params)` over `(privateEntries, wikiRepoFilenames)`. CLI glue reads `metadata/repos.yaml`, resolves canonical slugs via `gh api graphql node(id:)`, lists `knowledge/wiki/repos/`, blocks on match. Exports `resolveCanonicalSlugs` and `loadWikiFilenames` separately so each fail-mode is independently testable.

`scripts/check-wiki-private-presence.test.ts` (new, 168 LOC) — 16 tests covering happy path, slug match, `node_id` match, both reasons firing on the same entry, case-insensitive match, no-canonical-slug fallback (resolution returned null), multi-entry detection, `.md`-only filtering, fail-closed-on-GraphQL-failure with single and multi-entry messages, ENOENT-graceful + EPERM-propagates filesystem behavior.

`.github/workflows/merge-data.yaml` — adds two steps before the existing `🔀 Open weekly data merge PR`:

1. `⤵ Fetch data branch for privacy check` — second `actions/checkout` at `ref: data`, `path: data-branch-check`. The default checkout (`main`) is still needed because that's where the scripts live.
2. `🔒 Block private wiki pages` — runs `node ../scripts/check-wiki-private-presence.ts` with `working-directory: data-branch-check` so `metadata/repos.yaml` and `knowledge/wiki/repos/` are read from the **`data`** branch tree being promoted, not the `main` checkout.

## Fail-closed posture

This is a privacy gate. Every failure mode favors blocking the merge over letting a leak slip:

- **GraphQL resolution failure** for any private entry → throws with all failing `node_id` values, exits non-zero. Operator investigates token scope or repo access before re-running.
- **`fs.readdir` failure** other than ENOENT → propagates and exits non-zero. ENOENT only is graceful (fresh checkout, never had a wiki).
- **YAML/schema validation failure** on `metadata/repos.yaml` → propagates and exits non-zero via `assertReposFile`.
- **No private entries** → exits 0 immediately, no GraphQL or FS calls wasted.

## Deferred (follow-up issues)

Three concerns surfaced during review are tracked separately because each needs a design decision rather than a code patch:

- #3326 — stderr output prints matched filenames (which are themselves canonical names). Plan called this trade-off explicit ("the filename IS the leak"); reviewer flagged it as inconsistent with the wider privacy posture. Three options on the issue.
- #3327 — metadata-tampering bypass: a PR that flips `private: true → false` reads the tampered state. Mitigations include sourcing the denylist from a protected branch or doing live visibility probes per entry.
- #3328 — bundle of P2/P3 defense-in-depth gaps: slug variants (`marcusrbrown--poly.draft.md`), subdirectory bypass, no per-GraphQL-call timeout, non-repo wiki areas (`topics/`, `entities/`, `comparisons/`), workflow step-order regression test.

The current PR ships the v1 of the gate. The deferred items are the v1.1 hardening pass.

## Verification

- `actionlint .github/workflows/merge-data.yaml` clean.
- `pnpm check-types`, `pnpm lint`, `pnpm test` — green. **620 passed + 3 todo** (+6 over baseline 614, all behavior-bearing).
- `node -e "import('./scripts/check-wiki-private-presence.ts')"` exits 0 under Node 24 strip-only.
- `node scripts/check-wiki-private-presence.ts` (no private entries on `main`) prints "no private wiki leaks detected", exits 0.
- Reviewed via persona dispatch (9 reviewers parallel, then 1 adversarial round-2 against the fixes). Round 2 found zero new issues against the dual-checkout + fail-closed implementation.
