### PR TITLE
chore(privacy): address Fro Bot NBCs on private-wiki gate

### DIFF
--- a/.github/workflows/merge-data.yaml
+++ b/.github/workflows/merge-data.yaml
@@ -28,6 +28,8 @@ jobs:
       - name: 📦 Setup
         uses: ./.github/actions/setup
 
+      # Two checkouts: scripts live on main, the wiki/metadata being promoted live on data.
+      # The privacy check below runs from the data subtree to gate the actual merge content.
       - name: ⤵ Fetch data branch for privacy check
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/scripts/check-wiki-private-presence.test.ts
+++ b/scripts/check-wiki-private-presence.test.ts
@@ -220,9 +220,68 @@ describe('resolveCanonicalSlugs', () => {
     mockExecFileSync.mockImplementation(() => {
       throw new Error('gh: HTTP 401')
     })
-    expect(() => resolveCanonicalSlugs([{node_id: 'R_kgDOABCDEF'}, {node_id: 'R_kgDOXYZ123'}])).toThrow(
-      /R_kgDOABCDEF.*R_kgDOXYZ123|R_kgDOXYZ123.*R_kgDOABCDEF/,
-    )
+    let err: unknown
+    try {
+      resolveCanonicalSlugs([{node_id: 'R_kgDOABCDEF'}, {node_id: 'R_kgDOXYZ123'}])
+    } catch (error) {
+      err = error
+    }
+    expect(err).toBeInstanceOf(Error)
+    expect((err as Error).message).toMatch(/R_kgDOABCDEF/)
+    expect((err as Error).message).toMatch(/R_kgDOXYZ123/)
+  })
+
+  it('throws with node-null mode when GraphQL returns data.node: null (Test #1)', () => {
+    // #given GraphQL returns null for the node (repo deleted or App lost access)
+    // #when resolveCanonicalSlugs is called
+    // #then it throws identifying the failure as node-null (not subprocess-threw)
+    mockExecFileSync.mockReturnValue(JSON.stringify({data: {node: null}}))
+    expect(() => resolveCanonicalSlugs([{node_id: 'R_kgDOABCDEF'}])).toThrow(/node-null/)
+  })
+
+  it('distinguishes subprocess-threw from node-null in the error message (NBC #2)', () => {
+    // #given one entry throws subprocess and another returns node: null
+    // #when resolveCanonicalSlugs is called
+    // #then the error message labels each failure with its mode
+    mockExecFileSync
+      .mockImplementationOnce(() => {
+        throw new Error('gh: HTTP 401')
+      })
+      .mockReturnValueOnce(JSON.stringify({data: {node: null}}))
+    let err: unknown
+    try {
+      resolveCanonicalSlugs([{node_id: 'R_kgDOABCDEF'}, {node_id: 'R_kgDOXYZ123'}])
+    } catch (error) {
+      err = error
+    }
+    expect(err).toBeInstanceOf(Error)
+    expect((err as Error).message).toMatch(/subprocess-threw/)
+    expect((err as Error).message).toMatch(/R_kgDOABCDEF/)
+    expect((err as Error).message).toMatch(/node-null/)
+    expect((err as Error).message).toMatch(/R_kgDOXYZ123/)
+  })
+
+  it('normalizes canonicalSlug to lowercase at storage (NBC #3)', () => {
+    // #given GitHub returns a mixed-case nameWithOwner
+    // #when resolveCanonicalSlugs is called
+    // #then the stored canonicalSlug is lowercased
+    mockExecFileSync.mockReturnValue(JSON.stringify({data: {node: {nameWithOwner: 'MarcusRBrown/Poly'}}}))
+    const result = resolveCanonicalSlugs([{node_id: 'R_kgDOABCDEF'}])
+    expect(result.resolved[0]?.canonicalSlug).toBe('marcusrbrown--poly')
+  })
+
+  it.each([
+    ['bfra-me/works', 'bfra-me--works'],
+    ['marcusrbrown/ha-config', 'marcusrbrown--ha-config'],
+    ['bfra-me/.github', 'bfra-me--.github'],
+    ['MarcusRBrown/Poly', 'marcusrbrown--poly'],
+  ])('converts nameWithOwner %s → slug %s (Test #2)', (nameWithOwner, expectedSlug) => {
+    // #given GraphQL returns a nameWithOwner with various owner/repo shapes
+    // #when resolveCanonicalSlugs is called
+    // #then the canonicalSlug is correctly lowercased and slash-replaced
+    mockExecFileSync.mockReturnValue(JSON.stringify({data: {node: {nameWithOwner}}}))
+    const result = resolveCanonicalSlugs([{node_id: 'R_kgDOABCDEF'}])
+    expect(result.resolved[0]?.canonicalSlug).toBe(expectedSlug)
   })
 })
 

--- a/scripts/check-wiki-private-presence.ts
+++ b/scripts/check-wiki-private-presence.ts
@@ -49,7 +49,7 @@ export function detectPrivateWikiLeaks(params: {
 }
 
 // ---------------------------------------------------------------------------
-// Type guard for GraphQL response (P2 #6 — no unsafe casts at JSON boundary)
+// Type guards for GraphQL response (no unsafe casts at JSON boundary)
 // ---------------------------------------------------------------------------
 
 function isGraphQLRepoNameResponse(value: unknown): value is {data: {node: {nameWithOwner: string}}} {
@@ -62,8 +62,16 @@ function isGraphQLRepoNameResponse(value: unknown): value is {data: {node: {name
   return typeof node.nameWithOwner === 'string' && node.nameWithOwner.length > 0
 }
 
+function isGraphQLNodeNullResponse(value: unknown): value is {data: {node: null}} {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as Record<string, unknown>
+  if (typeof v.data !== 'object' || v.data === null) return false
+  const data = v.data as Record<string, unknown>
+  return data.node === null
+}
+
 // ---------------------------------------------------------------------------
-// resolveCanonicalSlugs — exported for testing; fail-closed (P1 #2)
+// resolveCanonicalSlugs — exported for testing; fail-closed
 // ---------------------------------------------------------------------------
 
 export interface ResolvedEntry {
@@ -76,46 +84,65 @@ export interface SlugResolutionResult {
   failures: string[] // node_ids that failed — always empty on success; throws if non-empty
 }
 
+type FailureMode = 'subprocess-threw' | 'node-null'
+
+interface ResolutionFailure {
+  node_id: string
+  mode: FailureMode
+}
+
 /**
  * Resolve canonical slugs for all private entries via GraphQL.
  *
- * Fail-closed: if ANY entry's slug cannot be resolved (API error, lost access,
- * deleted repo), throws with the list of failing node_ids. The caller must not
- * proceed — a canonical leak could slip through undetected.
+ * Uses parameterized `-F nodeId=` to avoid injection via crafted node_id values.
+ *
+ * Fail-closed: if ANY entry's slug cannot be resolved, throws with each failure
+ * labeled by mode so operators can act without guessing:
+ *   [subprocess-threw] — network/rate-limit/auth issue
+ *   [node-null]        — repo deleted or App lost access
  *
  * Captures all subprocess output; never echoes to stdout/stderr.
  */
 export function resolveCanonicalSlugs(entries: readonly {node_id: string}[]): SlugResolutionResult {
   const resolved: ResolvedEntry[] = []
-  const failures: string[] = []
+  const failures: ResolutionFailure[] = []
+
+  const query = 'query($nodeId: ID!) { node(id: $nodeId) { ... on Repository { nameWithOwner } } }'
 
   for (const entry of entries) {
     try {
-      const stdout = execFileSync(
-        'gh',
-        ['api', 'graphql', '-f', `query={ node(id: "${entry.node_id}") { ... on Repository { nameWithOwner } } }`],
-        {encoding: 'utf8', stdio: ['inherit', 'pipe', 'pipe']},
-      )
+      const stdout = execFileSync('gh', ['api', 'graphql', '-F', `nodeId=${entry.node_id}`, '-f', `query=${query}`], {
+        encoding: 'utf8',
+        stdio: ['inherit', 'pipe', 'pipe'],
+      })
       const parsed: unknown = JSON.parse(stdout)
       if (isGraphQLRepoNameResponse(parsed)) {
-        // Convert "owner/repo" → "owner--repo" (wiki slug convention)
-        resolved.push({node_id: entry.node_id, canonicalSlug: parsed.data.node.nameWithOwner.replace('/', '--')})
+        // Normalize to lowercase at storage; convert "owner/repo" → "owner--repo"
+        const slug = parsed.data.node.nameWithOwner.replace('/', '--').toLowerCase()
+        resolved.push({node_id: entry.node_id, canonicalSlug: slug})
+      } else if (isGraphQLNodeNullResponse(parsed)) {
+        failures.push({node_id: entry.node_id, mode: 'node-null'})
       } else {
-        // Unexpected response shape — treat as failure
-        failures.push(entry.node_id)
+        // Unexpected response shape — treat as subprocess-level failure
+        failures.push({node_id: entry.node_id, mode: 'subprocess-threw'})
       }
     } catch {
-      failures.push(entry.node_id)
+      failures.push({node_id: entry.node_id, mode: 'subprocess-threw'})
     }
   }
 
   if (failures.length > 0) {
+    const lines = failures.map(f => {
+      const hint =
+        f.mode === 'node-null' ? 'investigate repo lifecycle/App access' : 'investigate network/rate-limit/auth'
+      return `  [${f.mode}] ${f.node_id} (${hint})`
+    })
     throw new Error(
-      `check-wiki-private-presence: cannot verify private wiki presence — ${failures.length} private ${failures.length === 1 ? 'entry' : 'entries'} failed slug resolution: ${failures.join(', ')}. Investigate token scope / repo access before re-running.`,
+      `check-wiki-private-presence: cannot verify private wiki presence (${failures.length} ${failures.length === 1 ? 'entry' : 'entries'} unresolved):\n${lines.join('\n')}`,
     )
   }
 
-  return {resolved, failures}
+  return {resolved, failures: []}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses the four non-blocking concerns and two missing-test items Fro Bot raised on PR #3329 (private-wiki gate v1).

## What changed

### `scripts/check-wiki-private-presence.ts`

**Parameterize the GraphQL call.** `node_id` is no longer interpolated into the query string. The call now uses `gh api graphql -F nodeId=<value> -f query='query($nodeId: ID!) { node(id: $nodeId) { ... } }'`. A crafted `node_id` with `"` or `)` previously produced malformed GraphQL → API reject → script failed closed; the injection surface is gone entirely, and error messages are clearer too. Same pattern `survey-repo.yaml` already uses.

**Distinguish failure modes.** `resolveCanonicalSlugs` internally tracks each unresolved entry as `subprocess-threw` (network/rate-limit/auth) or `node-null` (deleted repo, revoked App access). The thrown error labels each entry with its mode and a targeted remediation hint:

```
check-wiki-private-presence: cannot verify private wiki presence (2 entries unresolved):
  [subprocess-threw] R_kgDOABCDEF (investigate network/rate-limit/auth)
  [node-null] R_kgDOXYZ123 (investigate repo lifecycle/App access)
```

Operators can act per-entry without grep-and-guess.

**Normalize canonical slug at storage.** `resolveCanonicalSlugs` now applies `.toLowerCase()` before storing the resolved slug. GitHub preserves `nameWithOwner` case (so `bfra-me/Works` could come back capitalized); the comparison already used `.toLowerCase()` on both sides, but storage wasn't normalized. Defensive cleanup — if the comparison ever changes, the storage shape stays correct.

### `.github/workflows/merge-data.yaml`

Added a two-line comment above the second checkout explaining the dual-checkout rationale: scripts live on `main`, the wiki/metadata being promoted live on `data`. Future maintainers no longer have to reverse-engineer the layout.

### `scripts/check-wiki-private-presence.test.ts`

Two missing tests called out in the review:

- **`node: null` GraphQL response throws.** Locks in the contract that a `null` node is treated as a failure (mode `node-null`), not a silent skip.
- **`nameWithOwner` → `owner--repo` slug conversion edge cases.** `it.each` covering hyphen-in-owner (`bfra-me/works`), hyphen-in-repo (`marcusrbrown/ha-config`), dot-in-repo (`bfra-me/.github`), and uppercase normalization (`MarcusRBrown/Poly` → `marcusrbrown--poly`). Catches a future "improvement" to the replacement that breaks one of the live conventions.

Plus a small NBC #2 distinction test that proves a mixed subprocess-threw + node-null failure set produces both mode labels in the error.

## Verification

- `pnpm check-types`, `pnpm lint`, `pnpm test` — green. **627 passed + 3 todo** (+7 over PR #3329's 620, all behavior-bearing).
- `actionlint .github/workflows/merge-data.yaml` clean.
- `node -e "import('./scripts/check-wiki-private-presence.ts')"` exits 0 under Node 24 strip-only.
- `node scripts/check-wiki-private-presence.ts` against current `main` (no private entries) prints "no private wiki leaks detected", exits 0.

## Deferred (still tracked)

The three larger design follow-ups from #3329's review remain open:

- #3326 — stderr output re-leaks canonical filenames (design decision: redact / privileged-log / accept)
- #3327 — metadata-tampering bypass (mitigation choice: trusted denylist source / live visibility probe / sticky-private record). The parameterized GraphQL call in this PR removes the injection surface that worsened the bypass, but the bypass itself is unchanged.
- #3328 — defense-in-depth gaps (slug variants, subdirectory bypass, per-call timeout, non-repo wiki areas)

The single Fro Bot review item NOT addressed here is missing test #3 (comment near `.replace(/\.md$/i, '')` documenting the strict stem extraction) — that fits naturally with the #3328 work since both touch slug-variant handling.

Refs PR #3329.
