### PR TITLE
feat(privacy): detect public-to-private visibility transitions in reconcile

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -34,3 +34,9 @@ labels:
   - name: wiki-lint-failure
     color: '#b60205'
     description: Wiki lint execution failure
+  - name: reconcile:integrity-alert
+    color: '#e11d48'
+    description: Integrity alert requiring manual operator review
+  - name: reconcile:visibility-transition
+    color: '#f97316'
+    description: Tracked repo transitioned from public to private

--- a/scripts/check-wiki-private-presence.test.ts
+++ b/scripts/check-wiki-private-presence.test.ts
@@ -200,7 +200,7 @@ describe('resolveCanonicalSlugs', () => {
     mockExecFileSync.mockReturnValue(JSON.stringify({data: {node: {nameWithOwner: 'acme/secret'}}}))
     const result = resolveCanonicalSlugs([{node_id: 'R_kgDOABCDEF'}])
     expect(result.resolved).toEqual([{node_id: 'R_kgDOABCDEF', canonicalSlug: 'acme--secret'}])
-    expect(result.failures).toEqual([])
+    expect(Object.keys(result)).not.toContain('failures')
   })
 
   it('throws (fails closed) when GraphQL resolution fails for any entry', () => {

--- a/scripts/check-wiki-private-presence.ts
+++ b/scripts/check-wiki-private-presence.ts
@@ -81,7 +81,6 @@ export interface ResolvedEntry {
 
 export interface SlugResolutionResult {
   resolved: ResolvedEntry[]
-  failures: string[] // node_ids that failed — always empty on success; throws if non-empty
 }
 
 type FailureMode = 'subprocess-threw' | 'node-null'
@@ -111,13 +110,18 @@ export function resolveCanonicalSlugs(entries: readonly {node_id: string}[]): Sl
 
   for (const entry of entries) {
     try {
-      const stdout = execFileSync('gh', ['api', 'graphql', '-F', `nodeId=${entry.node_id}`, '-f', `query=${query}`], {
-        encoding: 'utf8',
-        stdio: ['inherit', 'pipe', 'pipe'],
-      })
+      const stdout = execFileSync(
+        'gh',
+        ['api', 'graphql', '--field', `nodeId=${entry.node_id}`, '-f', `query=${query}`],
+        {
+          encoding: 'utf8',
+          stdio: ['inherit', 'pipe', 'pipe'],
+        },
+      )
       const parsed: unknown = JSON.parse(stdout)
       if (isGraphQLRepoNameResponse(parsed)) {
         // Normalize to lowercase at storage; convert "owner/repo" → "owner--repo"
+        // GitHub's nameWithOwner is always `owner/repo` with exactly one slash — single-match replace is intentional.
         const slug = parsed.data.node.nameWithOwner.replace('/', '--').toLowerCase()
         resolved.push({node_id: entry.node_id, canonicalSlug: slug})
       } else if (isGraphQLNodeNullResponse(parsed)) {
@@ -142,7 +146,7 @@ export function resolveCanonicalSlugs(entries: readonly {node_id: string}[]): Sl
     )
   }
 
-  return {resolved, failures: []}
+  return {resolved}
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/check-wiki-private-presence.ts
+++ b/scripts/check-wiki-private-presence.ts
@@ -93,7 +93,7 @@ interface ResolutionFailure {
 /**
  * Resolve canonical slugs for all private entries via GraphQL.
  *
- * Uses parameterized `-F nodeId=` to avoid injection via crafted node_id values.
+ * Uses parameterized `--field nodeId=` to avoid injection via crafted node_id values.
  *
  * Fail-closed: if ANY entry's slug cannot be resolved, throws with each failure
  * labeled by mode so operators can act without guessing:

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -125,6 +125,7 @@ describe('reconcileRepos', () => {
         skippedPrivate: 0,
         unchanged: 0,
         flooredDispatches: 0,
+        visibilityTransitions: 0,
         // dispatched/deferred populated by the I/O shell, not the engine
         byChannel: {
           collab: {tracked: 1, dispatched: 0, deferred: 0, lostAccess: 0},
@@ -1224,6 +1225,7 @@ describe('reconcileRepos', () => {
         skippedPrivate: 0,
         unchanged: 0,
         flooredDispatches: 0,
+        visibilityTransitions: 0,
         // dispatched/deferred populated by the I/O shell, not the engine
         byChannel: {
           collab: {tracked: 3, dispatched: 0, deferred: 0, lostAccess: 1},
@@ -1266,6 +1268,7 @@ describe('reconcileRepos', () => {
         skippedPrivate: 0,
         unchanged: 1,
         flooredDispatches: 0,
+        visibilityTransitions: 0,
         byChannel: {
           collab: {tracked: 1, dispatched: 0, deferred: 0, lostAccess: 0},
           owned: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
@@ -1292,6 +1295,7 @@ describe('reconcileRepos', () => {
         skippedPrivate: 0,
         unchanged: 0,
         flooredDispatches: 0,
+        visibilityTransitions: 0,
         byChannel: emptyChannelStats(),
       })
     })
@@ -4268,6 +4272,7 @@ describe('formatCommitMessage', () => {
         skippedPrivate: 0,
         unchanged: 0,
         flooredDispatches: 0,
+        visibilityTransitions: 0,
         byChannel: emptyChannelStats(),
       }),
     ).toBe('chore(reconcile): +1 new, 0 pending-review, 0 lost-access, 2 refreshes')
@@ -4287,6 +4292,7 @@ describe('formatCommitMessage', () => {
         skippedPrivate: 0,
         unchanged: 0,
         flooredDispatches: 0,
+        visibilityTransitions: 0,
         byChannel: emptyChannelStats(),
       }),
     ).toBe('chore(reconcile): +0 new, 0 pending-review, 0 lost-access, 0 refreshes, +18 migrated')
@@ -4306,6 +4312,7 @@ describe('formatCommitMessage', () => {
         skippedPrivate: 2,
         unchanged: 0,
         flooredDispatches: 0,
+        visibilityTransitions: 0,
         byChannel: emptyChannelStats(),
       }),
     ).toBe('chore(reconcile): +0 new, 0 pending-review, 0 lost-access, 1 refreshes')
@@ -4325,6 +4332,7 @@ describe('formatCommitMessage', () => {
         skippedPrivate: 0,
         unchanged: 0,
         flooredDispatches: 0,
+        visibilityTransitions: 0,
         byChannel: emptyChannelStats(),
       }),
     ).toBe('chore(reconcile): +1 new, 0 pending-review, 0 lost-access, 1 refreshes, +18 migrated')
@@ -5450,5 +5458,152 @@ describe('handleReconcile floor integration', () => {
 
     // Both repos must appear as the first-dispatched across the 2 runs.
     expect(new Set(firstDispatched).size).toBe(2)
+  })
+})
+
+const TRANSITION_NODE_ID = 'R_kgDOTransition123'
+
+// Shared helper: build a tracked entry with a stored private flag (Unit 9 tests).
+function makeTransitionEntry(storedPrivate: boolean | undefined): RepoEntry {
+  return makeEntry({
+    owner: 'fro-bot',
+    name: 'tracked-repo',
+    node_id: TRANSITION_NODE_ID,
+    private: storedPrivate,
+    onboarding_status: 'onboarded',
+    last_survey_at: '2026-01-01',
+    last_survey_status: 'success',
+    next_survey_eligible_at: '2026-06-01', // not yet eligible — no dispatch noise
+  })
+}
+
+// Shared helper: build a perRepoStatus map for a given probe outcome (Unit 9 tests).
+function makeProbeMap(status: 'still-accessible' | 'transient' | 'deleted' | 'revoked' | 'archived' | 'malformed') {
+  return new Map([['fro-bot/tracked-repo', {status} as {status: typeof status}]])
+}
+
+describe('reconcileRepos visibility-transition detection (Unit 9)', () => {
+  const NODE_ID = TRANSITION_NODE_ID
+
+  it('scenario 1: stored false, probe returns private:true → transition issue queued', () => {
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [makeTransitionEntry(false)]},
+        accessList: [makeAccess({owner: 'fro-bot', name: 'tracked-repo', node_id: NODE_ID, private: true})],
+      }),
+    )
+    expect(result.issues).toHaveLength(1)
+    expect(result.issues[0]).toMatchObject({kind: 'visibility-transition', node_id: NODE_ID})
+    expect(result.summary.visibilityTransitions).toBe(1)
+  })
+
+  it('scenario 2: stored true, probe returns private:true → no transition (sticky)', () => {
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [makeTransitionEntry(true)]},
+        accessList: [makeAccess({owner: 'fro-bot', name: 'tracked-repo', node_id: NODE_ID, private: true})],
+      }),
+    )
+    const transitionIssues = result.issues.filter(i => i.kind === 'visibility-transition')
+    expect(transitionIssues).toHaveLength(0)
+    expect(result.summary.visibilityTransitions).toBe(0)
+  })
+
+  it('scenario 3: stored false, probe returns private:false → no transition', () => {
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [makeTransitionEntry(false)]},
+        accessList: [makeAccess({owner: 'fro-bot', name: 'tracked-repo', node_id: NODE_ID, private: false})],
+      }),
+    )
+    const transitionIssues = result.issues.filter(i => i.kind === 'visibility-transition')
+    expect(transitionIssues).toHaveLength(0)
+    expect(result.summary.visibilityTransitions).toBe(0)
+  })
+
+  it('scenario 4: stored true, probe returns private:false → no transition issue; entry recanonicalized', () => {
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [makeTransitionEntry(true)]},
+        accessList: [makeAccess({owner: 'fro-bot', name: 'tracked-repo', node_id: NODE_ID, private: false})],
+      }),
+    )
+    const transitionIssues = result.issues.filter(i => i.kind === 'visibility-transition')
+    expect(transitionIssues).toHaveLength(0)
+    expect(result.summary.visibilityTransitions).toBe(0)
+    // Entry should be updated to private:false (recanonicalized)
+    const entry = result.nextRepos.repos.find(r => r.node_id === NODE_ID)
+    expect(entry?.private).toBe(false)
+  })
+
+  it('scenario 5: stored undefined (newcomer), probe returns private:true → no transition (initial categorization)', () => {
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [makeTransitionEntry(undefined)]},
+        accessList: [makeAccess({owner: 'fro-bot', name: 'tracked-repo', node_id: NODE_ID, private: true})],
+      }),
+    )
+    const transitionIssues = result.issues.filter(i => i.kind === 'visibility-transition')
+    expect(transitionIssues).toHaveLength(0)
+    expect(result.summary.visibilityTransitions).toBe(0)
+  })
+
+  it('scenario 6: stored false, probe returns access-lost (deleted) → transition issue queued', () => {
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [makeTransitionEntry(false)]},
+        accessList: [], // not in access list
+        perRepoStatus: makeProbeMap('deleted') as Map<string, {status: string}> as never,
+      }),
+    )
+    const transitionIssues = result.issues.filter(i => i.kind === 'visibility-transition')
+    expect(transitionIssues).toHaveLength(1)
+    expect(transitionIssues[0]).toMatchObject({kind: 'visibility-transition', node_id: NODE_ID})
+    expect(result.summary.visibilityTransitions).toBe(1)
+  })
+
+  it('scenario 7: probe is transient → no transition; sticky preservation', () => {
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [makeTransitionEntry(false)]},
+        accessList: [], // not in access list
+        perRepoStatus: makeProbeMap('transient') as Map<string, {status: string}> as never,
+      }),
+    )
+    const transitionIssues = result.issues.filter(i => i.kind === 'visibility-transition')
+    expect(transitionIssues).toHaveLength(0)
+    expect(result.summary.visibilityTransitions).toBe(0)
+    // Sticky: private value preserved
+    const entry = result.nextRepos.repos.find(r => r.node_id === NODE_ID)
+    expect(entry?.private).toBe(false)
+  })
+
+  it('scenario 8: rapid flip within one cycle — detection uses stored state at probe time', () => {
+    // Stored: false. Probe: true. Transition fires. Next stored state becomes true.
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [makeTransitionEntry(false)]},
+        accessList: [makeAccess({owner: 'fro-bot', name: 'tracked-repo', node_id: NODE_ID, private: true})],
+      }),
+    )
+    expect(result.summary.visibilityTransitions).toBe(1)
+    const entry = result.nextRepos.repos.find(r => r.node_id === NODE_ID)
+    expect(entry?.private).toBe(true)
+  })
+
+  it('scenario 9: issue title contains node_id only, body uses node_id only (no owner/repo)', () => {
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [makeTransitionEntry(false)]},
+        accessList: [makeAccess({owner: 'fro-bot', name: 'tracked-repo', node_id: NODE_ID, private: true})],
+      }),
+    )
+    const issue = result.issues.find(i => i.kind === 'visibility-transition')
+    expect(issue).toBeDefined()
+    // The issue shape carries node_id; rendering is tested via renderIssuePayload indirectly.
+    // Verify the queued issue does NOT carry owner/repo fields.
+    expect(issue).not.toHaveProperty('owner')
+    expect(issue).not.toHaveProperty('repo')
+    expect((issue as {node_id: string}).node_id).toBe(NODE_ID)
   })
 })

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -5784,7 +5784,8 @@ describe('renderIssuePayload (visibility-transition rendering)', () => {
     const payload: IssuePayload = renderIssuePayload(issue, 'fro-bot', '.github')
     // The body must never contain a wiki canonical slug (owner--repo format).
     // The gh api command uses "--field" which is fine; we check for the slug pattern specifically.
-    expect(payload.body).not.toMatch(/[\w.-]+--[\w.-]+/)
+    expect(payload.body).not.toMatch(/[\w.-]+--[\w.-]+/) // canonical owner--repo slug
+    expect(payload.body).not.toMatch(/(?!owner\/repo)\b\w[\w-]*\/[\w.-]+/) // generic owner/repo slash form (excludes prose placeholder "owner/repo")
   })
 
   it('body does NOT contain a resolved owner/repo slug (no canonical identity leak)', () => {

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -19,12 +19,15 @@ import {
   migrateRepoEntry,
   ReconcileError,
   reconcileRepos,
+  renderIssuePayload,
   type AccessListEntry,
   type HandleReconcileParams,
+  type IssuePayload,
   type OctokitClient,
   type ReconcileInput,
   type ReconcileLogger,
   type RepoStatusProbe,
+  type VisibilityTransitionIssue,
 } from './reconcile-repos.ts'
 import {addRepoEntry} from './repos-metadata.ts'
 import {assertReposFile} from './schemas.ts'
@@ -2063,6 +2066,8 @@ interface OctokitMockOverrides {
   issuesCreate?: (params: unknown) => Promise<{data: {number: number}}>
   issuesUpdate?: (params: unknown) => Promise<unknown>
   issuesListForRepo?: (params: unknown) => Promise<{data: IssueListEntry[]}>
+  issuesGetLabel?: (params: unknown) => Promise<{data: {name: string}}>
+  issuesCreateLabel?: (params: unknown) => Promise<{data: {name: string}}>
 }
 
 interface AccessListApiEntry {
@@ -2198,6 +2203,8 @@ function mockOctokit(overrides: OctokitMockOverrides = {}): OctokitClient {
         create: overrides.issuesCreate ?? (async () => ({data: {number: 1}})),
         update: overrides.issuesUpdate ?? (async () => ({data: {}})),
         listForRepo: overrides.issuesListForRepo ?? (async () => ({data: [] as IssueListEntry[]})),
+        getLabel: overrides.issuesGetLabel ?? (async () => ({data: {name: 'label'}})),
+        createLabel: overrides.issuesCreateLabel ?? (async () => ({data: {name: 'label'}})),
       },
     },
   } as unknown as OctokitClient
@@ -5478,8 +5485,8 @@ function makeTransitionEntry(storedPrivate: boolean | undefined): RepoEntry {
 }
 
 // Shared helper: build a perRepoStatus map for a given probe outcome (Unit 9 tests).
-function makeProbeMap(status: 'still-accessible' | 'transient' | 'deleted' | 'revoked' | 'archived' | 'malformed') {
-  return new Map([['fro-bot/tracked-repo', {status} as {status: typeof status}]])
+function makeProbeMap(status: RepoStatusProbe['status']): Map<string, RepoStatusProbe> {
+  return new Map([['fro-bot/tracked-repo', {status} as RepoStatusProbe]])
 }
 
 describe('reconcileRepos visibility-transition detection (Unit 9)', () => {
@@ -5553,7 +5560,7 @@ describe('reconcileRepos visibility-transition detection (Unit 9)', () => {
       makeInput({
         currentRepos: {version: 1, repos: [makeTransitionEntry(false)]},
         accessList: [], // not in access list
-        perRepoStatus: makeProbeMap('deleted') as Map<string, {status: string}> as never,
+        perRepoStatus: makeProbeMap('deleted'),
       }),
     )
     const transitionIssues = result.issues.filter(i => i.kind === 'visibility-transition')
@@ -5567,7 +5574,7 @@ describe('reconcileRepos visibility-transition detection (Unit 9)', () => {
       makeInput({
         currentRepos: {version: 1, repos: [makeTransitionEntry(false)]},
         accessList: [], // not in access list
-        perRepoStatus: makeProbeMap('transient') as Map<string, {status: string}> as never,
+        perRepoStatus: makeProbeMap('transient'),
       }),
     )
     const transitionIssues = result.issues.filter(i => i.kind === 'visibility-transition')
@@ -5605,5 +5612,216 @@ describe('reconcileRepos visibility-transition detection (Unit 9)', () => {
     expect(issue).not.toHaveProperty('owner')
     expect(issue).not.toHaveProperty('repo')
     expect((issue as {node_id: string}).node_id).toBe(NODE_ID)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TEST P1-#1 + P1-#2 — Durability: fail-open dedup + label pre-flight
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('handleReconcile visibility-transition durability', () => {
+  const DUR_NODE_ID = 'R_kgDODurability1'
+
+  function makeTransitionParams(overrides: Partial<OctokitMockOverrides> = {}): HandleReconcileParams {
+    return baseParams({
+      appOctokit: mockOctokit({
+        issuesCreate: async () => ({data: {number: 99}}),
+        ...overrides,
+      }),
+      readMetadata: makeReadMetadata({
+        repos: {
+          version: 1,
+          repos: [
+            makeEntry({
+              owner: 'fro-bot',
+              name: 'dur-repo',
+              node_id: DUR_NODE_ID,
+              private: false,
+              onboarding_status: 'onboarded',
+            }),
+          ],
+        },
+      }),
+      userOctokit: mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {
+              owner: {login: 'fro-bot'},
+              name: 'dur-repo',
+              archived: false,
+              private: true,
+              node_id: DUR_NODE_ID,
+            },
+          ],
+        }),
+      }),
+    })
+  }
+
+  it('paginate throws → issues.create is still called (fail-open dedup)', async () => {
+    const issuesCreate = vi.fn(async () => ({data: {number: 99}}))
+    const paginateMock = vi.fn(async (_fn: unknown, opts: {labels?: string}) => {
+      if (opts.labels === 'reconcile:visibility-transition') {
+        throw Object.assign(new Error('network error'), {status: 503})
+      }
+      return []
+    })
+
+    await handleReconcile(
+      makeTransitionParams({
+        paginate: paginateMock as unknown as OctokitMockOverrides['paginate'],
+        issuesCreate,
+      }),
+    )
+
+    expect(issuesCreate).toHaveBeenCalledOnce()
+  })
+
+  it('label 404 → createLabel is called, then issues.create succeeds', async () => {
+    const issuesCreate = vi.fn(async () => ({data: {number: 99}}))
+    const issuesCreateLabel = vi.fn(async () => ({data: {name: 'reconcile:visibility-transition'}}))
+    const issuesGetLabel = vi.fn(async (_params: unknown) => {
+      throw Object.assign(new Error('Not Found'), {status: 404})
+    })
+
+    await handleReconcile(
+      makeTransitionParams({
+        issuesCreate,
+        issuesGetLabel,
+        issuesCreateLabel,
+      }),
+    )
+
+    expect(issuesCreateLabel).toHaveBeenCalled()
+    expect(issuesCreate).toHaveBeenCalledOnce()
+  })
+
+  it('label createLabel 422 → issues.create is still called (graceful label failure)', async () => {
+    const issuesCreate = vi.fn(async () => ({data: {number: 99}}))
+    const issuesGetLabel = vi.fn(async (_params: unknown) => {
+      throw Object.assign(new Error('Not Found'), {status: 404})
+    })
+    const issuesCreateLabel = vi.fn(async (_params: unknown) => {
+      throw Object.assign(new Error('Unprocessable Entity'), {status: 422})
+    })
+
+    await handleReconcile(
+      makeTransitionParams({
+        issuesCreate,
+        issuesGetLabel,
+        issuesCreateLabel,
+      }),
+    )
+
+    expect(issuesCreate).toHaveBeenCalledOnce()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TEST #12 — Rendering regression pin (R15 privacy guarantee)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('renderIssuePayload (visibility-transition rendering)', () => {
+  const TEST_NODE_ID = 'R_kgDOZZ_REPLACED'
+
+  it('title is exactly [INTEGRITY] Visibility transition for <node_id>', () => {
+    const issue: VisibilityTransitionIssue = {kind: 'visibility-transition', node_id: TEST_NODE_ID}
+    const payload: IssuePayload = renderIssuePayload(issue, 'fro-bot', '.github')
+    expect(payload.title).toBe(`[INTEGRITY] Visibility transition for ${TEST_NODE_ID}`)
+  })
+
+  it('body contains the node_id', () => {
+    const issue: VisibilityTransitionIssue = {kind: 'visibility-transition', node_id: TEST_NODE_ID}
+    const payload: IssuePayload = renderIssuePayload(issue, 'fro-bot', '.github')
+    expect(payload.body).toContain(TEST_NODE_ID)
+  })
+
+  it('body does NOT contain canonical-slug separator pattern "owner--repo" (R15 privacy regression pin)', () => {
+    const issue: VisibilityTransitionIssue = {kind: 'visibility-transition', node_id: TEST_NODE_ID}
+    const payload: IssuePayload = renderIssuePayload(issue, 'fro-bot', '.github')
+    // The body must never contain a wiki canonical slug (owner--repo format).
+    // The gh api command uses "--field" which is fine; we check for the slug pattern specifically.
+    expect(payload.body).not.toMatch(/\w+--\w+/)
+  })
+
+  it('body does NOT contain a resolved owner/repo slug (no canonical identity leak)', () => {
+    const issue: VisibilityTransitionIssue = {kind: 'visibility-transition', node_id: TEST_NODE_ID}
+    const payload: IssuePayload = renderIssuePayload(issue, 'fro-bot', '.github')
+    // The body must not contain a resolved owner/repo slug like "fro-bot/tracked-repo".
+    // The gh api command in the body uses "nameWithOwner" as a field name, not a value — that's fine.
+    expect(payload.body).not.toContain('fro-bot/tracked-repo')
+    expect(payload.body).not.toContain('fro-bot/.github')
+  })
+
+  it('labels are exactly [reconcile:integrity-alert, reconcile:visibility-transition]', () => {
+    const issue: VisibilityTransitionIssue = {kind: 'visibility-transition', node_id: TEST_NODE_ID}
+    const payload: IssuePayload = renderIssuePayload(issue, 'fro-bot', '.github')
+    expect(payload.labels).toEqual(['reconcile:integrity-alert', 'reconcile:visibility-transition'])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TEST #13 — Dedup branch coverage (existing open issue suppresses create)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('handleReconcile visibility-transition dedup', () => {
+  const TEST_NODE_ID = 'R_kgDODedup999'
+  const EXPECTED_TITLE = `[INTEGRITY] Visibility transition for ${TEST_NODE_ID}`
+
+  it('does NOT call issues.create when an open issue with matching title already exists', async () => {
+    const issuesCreate = vi.fn(async () => ({data: {number: 42}}))
+
+    // paginate returns one open issue whose title matches the expected dedup title
+    const paginateMock = vi.fn(async (_fn: unknown, opts: {labels?: string; state?: string}) => {
+      if (opts.labels === 'reconcile:visibility-transition' && opts.state === 'open') {
+        return [{number: 1, title: EXPECTED_TITLE, body: null, labels: [{name: 'reconcile:visibility-transition'}]}]
+      }
+      return []
+    })
+
+    await handleReconcile(
+      baseParams({
+        appOctokit: mockOctokit({
+          paginate: paginateMock as unknown as OctokitMockOverrides['paginate'],
+          issuesCreate,
+        }),
+        readMetadata: makeReadMetadata({
+          repos: {
+            version: 1,
+            repos: [
+              makeEntry({
+                owner: 'fro-bot',
+                name: 'tracked-repo',
+                node_id: TEST_NODE_ID,
+                private: false,
+                onboarding_status: 'onboarded',
+              }),
+            ],
+          },
+        }),
+        // Provide an access list entry showing the repo is now private → triggers transition
+        userOctokit: mockOctokit({
+          listForAuthenticatedUser: async () => ({
+            data: [
+              {
+                owner: {login: 'fro-bot'},
+                name: 'tracked-repo',
+                archived: false,
+                private: true,
+                node_id: TEST_NODE_ID,
+              },
+            ],
+          }),
+        }),
+      }),
+    )
+
+    // paginate was called with the visibility-transition label filter
+    expect(paginateMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({labels: 'reconcile:visibility-transition', state: 'open'}),
+    )
+    // issues.create was NOT called because the dedup found an existing open issue
+    expect(issuesCreate).not.toHaveBeenCalled()
   })
 })

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -5677,11 +5677,19 @@ describe('handleReconcile visibility-transition durability', () => {
     expect(issuesCreate).toHaveBeenCalledOnce()
   })
 
-  it('label 404 → createLabel is called, then issues.create succeeds', async () => {
-    const issuesCreate = vi.fn(async () => ({data: {number: 99}}))
-    const issuesCreateLabel = vi.fn(async () => ({data: {name: 'reconcile:visibility-transition'}}))
+  it('label 404 → createLabel is called before issues.create (call order verified)', async () => {
+    const callOrder: string[] = []
     const issuesGetLabel = vi.fn(async (_params: unknown) => {
+      callOrder.push('getLabel')
       throw Object.assign(new Error('Not Found'), {status: 404})
+    })
+    const issuesCreateLabel = vi.fn(async () => {
+      callOrder.push('createLabel')
+      return {data: {name: 'label'}}
+    })
+    const issuesCreate = vi.fn(async () => {
+      callOrder.push('create')
+      return {data: {number: 99}}
     })
 
     await handleReconcile(
@@ -5692,11 +5700,15 @@ describe('handleReconcile visibility-transition durability', () => {
       }),
     )
 
-    expect(issuesCreateLabel).toHaveBeenCalled()
+    // Both labels must be checked (and created) before the single issues.create call.
+    // Two getLabel + two createLabel (one per label) then one create.
+    expect(callOrder).toEqual(['getLabel', 'createLabel', 'getLabel', 'createLabel', 'create'])
+    expect(issuesCreateLabel).toHaveBeenCalledTimes(2)
     expect(issuesCreate).toHaveBeenCalledOnce()
   })
 
-  it('label createLabel 422 → issues.create is still called (graceful label failure)', async () => {
+  it('createLabel 422 (race) → label IS included in issues.create payload', async () => {
+    // 422 means another writer already created the label — it now exists, so include it.
     const issuesCreate = vi.fn(async () => ({data: {number: 99}}))
     const issuesGetLabel = vi.fn(async (_params: unknown) => {
       throw Object.assign(new Error('Not Found'), {status: 404})
@@ -5714,6 +5726,37 @@ describe('handleReconcile visibility-transition durability', () => {
     )
 
     expect(issuesCreate).toHaveBeenCalledOnce()
+    // Both labels should be present — 422 means the label exists (race), so it's confirmed usable.
+    const calls = issuesCreate.mock.calls as unknown as [{labels?: string[]}][]
+    expect(calls[0]?.[0]?.labels).toContain('reconcile:integrity-alert')
+    expect(calls[0]?.[0]?.labels).toContain('reconcile:visibility-transition')
+  })
+
+  it('createLabel 500 (transient) → label is EXCLUDED from issues.create payload', async () => {
+    // 500 means the label creation genuinely failed — exclude it, but still ship the issue.
+    const issuesCreate = vi.fn(async () => ({data: {number: 99}}))
+    const issuesGetLabel = vi.fn(async (_params: unknown) => {
+      throw Object.assign(new Error('Not Found'), {status: 404})
+    })
+    const issuesCreateLabel = vi.fn(async (_params: unknown) => {
+      throw Object.assign(new Error('Internal Server Error'), {status: 500})
+    })
+
+    await handleReconcile(
+      makeTransitionParams({
+        issuesCreate,
+        issuesGetLabel,
+        issuesCreateLabel,
+      }),
+    )
+
+    expect(issuesCreate).toHaveBeenCalledOnce()
+    // Both labels failed (500) — neither should be in the payload.
+    expect(issuesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        labels: [],
+      }),
+    )
   })
 })
 
@@ -5741,7 +5784,7 @@ describe('renderIssuePayload (visibility-transition rendering)', () => {
     const payload: IssuePayload = renderIssuePayload(issue, 'fro-bot', '.github')
     // The body must never contain a wiki canonical slug (owner--repo format).
     // The gh api command uses "--field" which is fine; we check for the slug pattern specifically.
-    expect(payload.body).not.toMatch(/\w+--\w+/)
+    expect(payload.body).not.toMatch(/[\w.-]+--[\w.-]+/)
   })
 
   it('body does NOT contain a resolved owner/repo slug (no canonical identity leak)', () => {
@@ -5823,5 +5866,68 @@ describe('handleReconcile visibility-transition dedup', () => {
     )
     // issues.create was NOT called because the dedup found an existing open issue
     expect(issuesCreate).not.toHaveBeenCalled()
+  })
+
+  it('issues.create IS called when existing title is a strict prefix of the new title (exact-title dedup, not substring)', async () => {
+    // RED-against-old-code proof: old substring dedup would suppress this alert because
+    // 'R_kgDOZAAAA' is a substring of 'R_kgDOZAAAAA'. New exact-title dedup must NOT suppress it.
+    const VICTIM_NODE_ID = 'R_kgDOZAAAA'
+    const LONGER_NODE_ID = `${VICTIM_NODE_ID}A` // one extra char — different repo
+    const issuesCreate = vi.fn(async () => ({data: {number: 42}}))
+
+    const paginateMock = vi.fn(async (_fn: unknown, opts: {labels?: string; state?: string}) => {
+      if (opts.labels === 'reconcile:visibility-transition' && opts.state === 'open') {
+        // Return an issue for the LONGER node_id — not the victim
+        return [
+          {
+            number: 1,
+            title: `[INTEGRITY] Visibility transition for ${LONGER_NODE_ID}`,
+            body: null,
+            labels: [{name: 'reconcile:visibility-transition'}],
+          },
+        ]
+      }
+      return []
+    })
+
+    await handleReconcile(
+      baseParams({
+        appOctokit: mockOctokit({
+          paginate: paginateMock as unknown as OctokitMockOverrides['paginate'],
+          issuesCreate,
+        }),
+        readMetadata: makeReadMetadata({
+          repos: {
+            version: 1,
+            repos: [
+              makeEntry({
+                owner: 'fro-bot',
+                name: 'victim-repo',
+                node_id: VICTIM_NODE_ID,
+                private: false,
+                onboarding_status: 'onboarded',
+              }),
+            ],
+          },
+        }),
+        userOctokit: mockOctokit({
+          listForAuthenticatedUser: async () => ({
+            data: [
+              {
+                owner: {login: 'fro-bot'},
+                name: 'victim-repo',
+                archived: false,
+                private: true,
+                node_id: VICTIM_NODE_ID,
+              },
+            ],
+          }),
+        }),
+      }),
+    )
+
+    // Exact-title dedup: the existing issue title does NOT match the victim's expected title,
+    // so issues.create MUST be called. Old substring code would have suppressed this.
+    expect(issuesCreate).toHaveBeenCalledOnce()
   })
 })

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -2396,19 +2396,40 @@ async function runIssueQueue(params: {
 
         // Pre-flight label creation: ensure both labels exist before calling issues.create.
         // Defends against the Update-Repo-Settings propagation race on first run.
-        await ensureLabelExists(params.appOctokit, params.owner, params.repo, VISIBILITY_TRANSITION_LABEL, {
-          color: 'f97316',
-          description: 'Tracked repo transitioned from public to private',
-          logger: params.logger,
-        })
-        await ensureLabelExists(params.appOctokit, params.owner, params.repo, INTEGRITY_ALERT_LABEL, {
-          color: 'b60205',
-          description: 'Reconcile integrity alert requiring operator action',
-          logger: params.logger,
-        })
+        // Returns only the labels that are confirmed usable; failures exclude that label.
+        const confirmedLabels = await ensureLabelsExist(
+          params.appOctokit,
+          params.owner,
+          params.repo,
+          [
+            {
+              name: VISIBILITY_TRANSITION_LABEL,
+              color: 'f97316',
+              description: 'Tracked repo transitioned from public to private',
+            },
+            {
+              name: INTEGRITY_ALERT_LABEL,
+              color: 'b60205',
+              description: 'Reconcile integrity alert requiring operator action',
+            },
+          ],
+          params.logger,
+        )
+        const payload = renderIssuePayload(issue, params.owner, params.repo)
+        const filteredPayload: IssuePayload = {
+          ...payload,
+          labels: payload.labels.filter(l => confirmedLabels.has(l)),
+        }
+        if (filteredPayload.labels.length === 0) {
+          params.logger.warn(
+            `reconcile: all labels unconfirmed for visibility-transition issue (node_id=${issue.node_id}); shipping unlabeled.`,
+          )
+        }
+        await callIssuesCreate(params.appOctokit, filteredPayload)
+      } else {
+        const payload = renderIssuePayload(issue, params.owner, params.repo)
+        await callIssuesCreate(params.appOctokit, payload)
       }
-      const payload = renderIssuePayload(issue, params.owner, params.repo)
-      await callIssuesCreate(params.appOctokit, payload)
       switch (issue.kind) {
         case 'per-repo': {
           perRepoSucceeded += 1
@@ -2438,39 +2459,51 @@ async function runIssueQueue(params: {
 }
 
 /**
- * Ensure a label exists in the repo. If it doesn't (404), create it. If creation 422s
- * (race with another writer), proceed silently — the label already exists. Any other
- * error is logged and swallowed so a label failure never blocks issue creation.
+ * Ensure a set of labels exist in the repo. For each label:
+ * - If it exists (getLabel succeeds): confirmed.
+ * - If 404: attempt createLabel.
+ *   - createLabel succeeds or 422 (race — already created): confirmed.
+ *   - createLabel other failure: excluded from returned set (log and continue).
+ * - getLabel non-404 failure: excluded from returned set (log and continue).
+ *
+ * Returns a Set<string> of confirmed-usable label names. The caller MUST filter
+ * the issue payload to only these labels before calling issues.create.
  */
-async function ensureLabelExists(
+async function ensureLabelsExist(
   octokit: OctokitClient,
   owner: string,
   repo: string,
-  name: string,
-  meta: {color: string; description: string; logger: ReconcileLogger},
-): Promise<void> {
-  try {
-    await octokit.rest.issues.getLabel({owner, repo, name})
-    return // label already exists
-  } catch (getError: unknown) {
-    if (!isApiStatus(getError, 404)) {
-      // Non-404 on the get — log and proceed; don't block issue creation.
-      const status = isRecord(getError) && typeof getError.status === 'number' ? getError.status : 'unknown'
-      meta.logger.warn(`reconcile: label check failed for "${name}" (status=${status}); proceeding without pre-flight.`)
-      return
+  labels: readonly {name: string; color: string; description: string}[],
+  logger: ReconcileLogger,
+): Promise<Set<string>> {
+  const confirmed = new Set<string>()
+  for (const {name, color, description} of labels) {
+    try {
+      await octokit.rest.issues.getLabel({owner, repo, name})
+      confirmed.add(name)
+      continue
+    } catch (getError: unknown) {
+      if (!isApiStatus(getError, 404)) {
+        const status = isRecord(getError) && typeof getError.status === 'number' ? getError.status : 'unknown'
+        logger.warn(`reconcile: label check failed for "${name}" (status=${status}); excluding from issue labels.`)
+        continue
+      }
+    }
+    // Label not found (404) — create it.
+    try {
+      await octokit.rest.issues.createLabel({owner, repo, name, color, description})
+      confirmed.add(name)
+    } catch (createError: unknown) {
+      if (isApiStatus(createError, 422)) {
+        // Race with another writer (e.g. Update-Repo-Settings) — label now exists; include it.
+        confirmed.add(name)
+      } else {
+        const status = isRecord(createError) && typeof createError.status === 'number' ? createError.status : 'unknown'
+        logger.warn(`reconcile: label creation failed for "${name}" (status=${status}); excluding from issue labels.`)
+      }
     }
   }
-  // Label not found — create it.
-  try {
-    await octokit.rest.issues.createLabel({owner, repo, name, color: meta.color, description: meta.description})
-  } catch (createError: unknown) {
-    if (isApiStatus(createError, 422)) {
-      // Race with another writer (e.g. Update-Repo-Settings) — label now exists; proceed.
-      return
-    }
-    const status = isRecord(createError) && typeof createError.status === 'number' ? createError.status : 'unknown'
-    meta.logger.warn(`reconcile: label creation failed for "${name}" (status=${status}); proceeding without label.`)
-  }
+  return confirmed
 }
 
 export interface IssuePayload {

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -608,9 +608,8 @@ interface ClassifyTrackedParams {
  * that is initial categorization, not a flip. Private-to-public transitions emit no alert;
  * the next mutator write recanonicalizes the entry.
  *
- * Dedup is handled at the I/O layer (`runVisibilityTransitionIssues`) — this function
- * always pushes when the flip is detected, and the async dedup step suppresses duplicates
- * before creating the GitHub issue.
+ * Dedup is handled inline in `runIssueQueue` — this function always pushes when the flip
+ * is detected, and the async dedup step suppresses duplicates before creating the GitHub issue.
  */
 function maybeQueueVisibilityTransition(params: {
   storedPrivate: boolean | undefined
@@ -1245,7 +1244,9 @@ export interface HandleReconcileResult {
   perRepoIssues: number
   /** Count of successfully-created rollup issues (from plan + self-healing). */
   rollupIssues: number
-  /** Count of issue-creation failures across per-repo + rollup. */
+  /** Count of successfully-created visibility-transition integrity-alert issues. */
+  visibilityTransitionIssues: number
+  /** Count of issue-creation failures across per-repo + rollup + visibility-transition. */
   issuesFailed: number
   /** Count of stale `reconcile:pending-review` issues auto-closed this run. */
   closedStaleIssues: number
@@ -1537,6 +1538,7 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
     dispatchesDeferred,
     perRepoIssues: issueOutcome.perRepoSucceeded,
     rollupIssues: issueOutcome.rollupSucceeded + healedRollups,
+    visibilityTransitionIssues: issueOutcome.visibilityTransitionSucceeded,
     issuesFailed: issueOutcome.failed,
     closedStaleIssues,
     probesFailed,
@@ -2346,44 +2348,132 @@ async function dispatchWithTimeout<T>(work: () => Promise<T>, timeoutMs: number)
   }
 }
 
+// Derived from Octokit's paginated list-for-repo response element type.
+type ListForRepoResponseItem = RestEndpointMethodTypes['issues']['listForRepo']['response']['data'][number]
+
 async function runIssueQueue(params: {
   appOctokit: OctokitClient
   owner: string
   repo: string
   issues: IssueQueueEntry[]
   logger: ReconcileLogger
-}): Promise<{perRepoSucceeded: number; rollupSucceeded: number; failed: number}> {
+}): Promise<{
+  perRepoSucceeded: number
+  rollupSucceeded: number
+  visibilityTransitionSucceeded: number
+  failed: number
+}> {
   let perRepoSucceeded = 0
   let rollupSucceeded = 0
+  let visibilityTransitionSucceeded = 0
   let failed = 0
   for (const issue of params.issues) {
     try {
       if (issue.kind === 'visibility-transition') {
         // Dedup: skip if an open issue with the same node_id already exists.
-        const existing = (await params.appOctokit.paginate(params.appOctokit.rest.issues.listForRepo, {
-          owner: params.owner,
-          repo: params.repo,
-          state: 'open',
-          labels: VISIBILITY_TRANSITION_LABEL,
-          per_page: 100,
-        })) as unknown as OpenIssueEntry[]
-        const alreadyOpen = existing.some(i => (i.title ?? '').includes(issue.node_id))
+        // Fail-open: if paginate throws, treat as "no existing issue found" and proceed
+        // to create — better to risk a duplicate than to silently drop the alert.
+        let existing: ListForRepoResponseItem[] = []
+        try {
+          existing = await params.appOctokit.paginate(params.appOctokit.rest.issues.listForRepo, {
+            owner: params.owner,
+            repo: params.repo,
+            state: 'open',
+            labels: VISIBILITY_TRANSITION_LABEL,
+            per_page: 100,
+          })
+        } catch (listError: unknown) {
+          const status = isRecord(listError) && typeof listError.status === 'number' ? listError.status : 'unknown'
+          params.logger.warn(
+            `reconcile: dedup list failed for visibility-transition (status=${status}); proceeding with issue creation.`,
+          )
+        }
+        // Exact-title match: the title is fully derived from node_id, so exact equality
+        // is functionally equivalent to marker extraction and cheaper (no body fetch needed).
+        const expectedTitle = `[INTEGRITY] Visibility transition for ${issue.node_id}`
+        const alreadyOpen = existing.some(i => i.title === expectedTitle)
         if (alreadyOpen) continue
+
+        // Pre-flight label creation: ensure both labels exist before calling issues.create.
+        // Defends against the Update-Repo-Settings propagation race on first run.
+        await ensureLabelExists(params.appOctokit, params.owner, params.repo, VISIBILITY_TRANSITION_LABEL, {
+          color: 'f97316',
+          description: 'Tracked repo transitioned from public to private',
+          logger: params.logger,
+        })
+        await ensureLabelExists(params.appOctokit, params.owner, params.repo, INTEGRITY_ALERT_LABEL, {
+          color: 'b60205',
+          description: 'Reconcile integrity alert requiring operator action',
+          logger: params.logger,
+        })
       }
       const payload = renderIssuePayload(issue, params.owner, params.repo)
       await callIssuesCreate(params.appOctokit, payload)
-      if (issue.kind === 'per-repo') perRepoSucceeded += 1
-      else rollupSucceeded += 1
+      switch (issue.kind) {
+        case 'per-repo': {
+          perRepoSucceeded += 1
+          break
+        }
+        case 'per-owner-rollup': {
+          rollupSucceeded += 1
+          break
+        }
+        case 'visibility-transition': {
+          visibilityTransitionSucceeded += 1
+          break
+        }
+        default: {
+          // Exhaustiveness guard: adding a new IssueQueueEntry kind must update the switch above.
+          const exhaustive: never = issue
+          throw new Error(`runIssueQueue: unhandled issue kind: ${JSON.stringify(exhaustive)}`)
+        }
+      }
     } catch (error: unknown) {
       failed += 1
       const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
       params.logger.warn(`reconcile: issue creation failed (status=${status}); continuing.`)
     }
   }
-  return {perRepoSucceeded, rollupSucceeded, failed}
+  return {perRepoSucceeded, rollupSucceeded, visibilityTransitionSucceeded, failed}
 }
 
-interface IssuePayload {
+/**
+ * Ensure a label exists in the repo. If it doesn't (404), create it. If creation 422s
+ * (race with another writer), proceed silently — the label already exists. Any other
+ * error is logged and swallowed so a label failure never blocks issue creation.
+ */
+async function ensureLabelExists(
+  octokit: OctokitClient,
+  owner: string,
+  repo: string,
+  name: string,
+  meta: {color: string; description: string; logger: ReconcileLogger},
+): Promise<void> {
+  try {
+    await octokit.rest.issues.getLabel({owner, repo, name})
+    return // label already exists
+  } catch (getError: unknown) {
+    if (!isApiStatus(getError, 404)) {
+      // Non-404 on the get — log and proceed; don't block issue creation.
+      const status = isRecord(getError) && typeof getError.status === 'number' ? getError.status : 'unknown'
+      meta.logger.warn(`reconcile: label check failed for "${name}" (status=${status}); proceeding without pre-flight.`)
+      return
+    }
+  }
+  // Label not found — create it.
+  try {
+    await octokit.rest.issues.createLabel({owner, repo, name, color: meta.color, description: meta.description})
+  } catch (createError: unknown) {
+    if (isApiStatus(createError, 422)) {
+      // Race with another writer (e.g. Update-Repo-Settings) — label now exists; proceed.
+      return
+    }
+    const status = isRecord(createError) && typeof createError.status === 'number' ? createError.status : 'unknown'
+    meta.logger.warn(`reconcile: label creation failed for "${name}" (status=${status}); proceeding without label.`)
+  }
+}
+
+export interface IssuePayload {
   owner: string
   repo: string
   title: string
@@ -2391,7 +2481,7 @@ interface IssuePayload {
   labels: string[]
 }
 
-function renderIssuePayload(issue: IssueQueueEntry, owner: string, repo: string): IssuePayload {
+export function renderIssuePayload(issue: IssueQueueEntry, owner: string, repo: string): IssuePayload {
   if (issue.kind === 'per-repo') {
     return renderPerRepoIssue(issue, owner, repo)
   }
@@ -2410,7 +2500,13 @@ function renderVisibilityTransitionIssue(issue: VisibilityTransitionIssue, owner
     '',
     `- Node ID: \`${issue.node_id}\``,
     '',
-    'The repository name is omitted because this issue stream is public. Use the operator tool (`scripts/resolve-private.ts`) to look up the canonical owner/repo by node ID and identify any wiki pages that may need manual review.',
+    'To look up the canonical owner/repo by node ID, run:',
+    '',
+    '```sh',
+    `gh api graphql --field nodeId='${issue.node_id}' -f query='query($nodeId: ID!) { node(id: $nodeId) { ... on Repository { nameWithOwner isPrivate } } }'`,
+    '```',
+    '',
+    'If the response contains `"node": null`, the canonical name is not retrievable from your token\'s scope (repo may be deleted or your token lacks access).',
     '',
     'This issue requires manual operator action. It will not be auto-closed.',
   ].join('\n')

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -2525,6 +2525,8 @@ export function renderIssuePayload(issue: IssueQueueEntry, owner: string, repo: 
 }
 
 function renderVisibilityTransitionIssue(issue: VisibilityTransitionIssue, owner: string, repo: string): IssuePayload {
+  // node_id is validated against /^[\w\-+/=]+$/ at the schema layer (scripts/schemas.ts assertRepoEntry),
+  // so this template can safely interpolate without shell-quoting.
   const title = `[INTEGRITY] Visibility transition for ${issue.node_id}`
   const body = [
     `<!-- reconcile:subject:node_id=${issue.node_id} -->`,

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -175,7 +175,19 @@ export interface PerOwnerRollupIssue {
   reason: 'unsolicited-new' | 'unsolicited-regain'
 }
 
-export type IssueQueueEntry = PerRepoIssue | PerOwnerRollupIssue
+/**
+ * Visibility-transition integrity alert. Queued when a tracked entry's stored `private`
+ * flag flips from `false` to `true` (including via `access-lost`, which fails closed as
+ * private per Unit 2 semantics). Title and body use `node_id` only — no `owner/repo` —
+ * because this issue stream is public. Operators look up the canonical name locally via
+ * the operator tool.
+ */
+export interface VisibilityTransitionIssue {
+  kind: 'visibility-transition'
+  node_id: string
+}
+
+export type IssueQueueEntry = PerRepoIssue | PerOwnerRollupIssue | VisibilityTransitionIssue
 
 /**
  * Per-channel breakdown of reconcile activity for one run. Operators read these to
@@ -252,6 +264,14 @@ export interface ReconcileSummary {
    * droughts where every tracked repo is inside {@link FLOOR_MIN_GAP_DAYS}.
    */
   flooredDispatches: number
+  /**
+   * Number of tracked entries whose stored `private` flag flipped from `false` to `true`
+   * (including via `access-lost`, which fails closed as private) this run. Each transition
+   * queues a `reconcile:visibility-transition` integrity-alert issue for manual operator
+   * review. Private-to-public transitions emit no alert; the next mutator write
+   * recanonicalizes the entry.
+   */
+  visibilityTransitions: number
   /**
    * Per-channel activity breakdown. See {@link ChannelStats} for field semantics. The
    * engine populates `tracked` and `lostAccess`; the shell populates `dispatched` and
@@ -360,6 +380,7 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
     malformed: 0,
     skippedPrivate: 0,
     flooredDispatches: 0,
+    visibilityTransitions: 0,
     byChannel: {
       collab: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
       owned: {tracked: 0, dispatched: 0, deferred: 0, lostAccess: 0},
@@ -368,6 +389,7 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
   }
   const dispatches: DispatchRequest[] = []
   const rawIssues: RawIssue[] = []
+  const transitionIssues: VisibilityTransitionIssue[] = []
 
   // Pass 1 — classify every tracked entry against the access list and probes.
   const trackedKeys = new Set<string>()
@@ -387,6 +409,7 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
       summary,
       dispatches,
       rawIssues,
+      transitionIssues,
       now,
     })
   })
@@ -543,7 +566,7 @@ export function reconcileRepos(input: ReconcileInput): ReconcileResult {
     }
   }
 
-  const issues = buildIssueQueue(rawIssues)
+  const issues: IssueQueueEntry[] = [...buildIssueQueue(rawIssues), ...transitionIssues]
 
   // Populate per-channel tracked counts after both passes complete. Counts entries
   // present on `next.repos` post-classification (excludes lost-access entries via the
@@ -575,7 +598,33 @@ interface ClassifyTrackedParams {
   summary: ReconcileSummary
   dispatches: DispatchRequest[]
   rawIssues: RawIssue[]
+  transitionIssues: VisibilityTransitionIssue[]
   now: Date
+}
+
+/**
+ * Queue a visibility-transition integrity alert when a tracked entry's stored `private`
+ * flag flips from `false` to `true`. Newcomers (no stored `private` field) are excluded —
+ * that is initial categorization, not a flip. Private-to-public transitions emit no alert;
+ * the next mutator write recanonicalizes the entry.
+ *
+ * Dedup is handled at the I/O layer (`runVisibilityTransitionIssues`) — this function
+ * always pushes when the flip is detected, and the async dedup step suppresses duplicates
+ * before creating the GitHub issue.
+ */
+function maybeQueueVisibilityTransition(params: {
+  storedPrivate: boolean | undefined
+  newPrivate: boolean
+  node_id: string | undefined
+  summary: ReconcileSummary
+  transitionIssues: VisibilityTransitionIssue[]
+}): void {
+  // Only fire on false → true. Newcomers (undefined) are excluded.
+  if (params.storedPrivate !== false) return
+  if (!params.newPrivate) return
+  if (params.node_id === undefined) return
+  params.summary.visibilityTransitions += 1
+  params.transitionIssues.push({kind: 'visibility-transition', node_id: params.node_id})
 }
 
 /**
@@ -595,6 +644,7 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
     summary,
     dispatches,
     rawIssues,
+    transitionIssues,
     now,
   } = params
 
@@ -618,6 +668,13 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
       }
       summary.lostAccess += 1
       summary.byChannel[entry.discovery_channel ?? 'collab'].lostAccess += 1
+      maybeQueueVisibilityTransition({
+        storedPrivate: entry.private,
+        newPrivate: true,
+        node_id: storedRepoNodeId(entry),
+        summary,
+        transitionIssues,
+      })
       return normalizeLostAccessEntry(entry)
     }
 
@@ -669,6 +726,13 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
         }
         summary.lostAccess += 1
         summary.byChannel[entry.discovery_channel ?? 'collab'].lostAccess += 1
+        maybeQueueVisibilityTransition({
+          storedPrivate: entry.private,
+          newPrivate: true,
+          node_id: storedRepoNodeId(entry),
+          summary,
+          transitionIssues,
+        })
         return normalizeLostAccessEntry(entry)
       }
       default: {
@@ -688,6 +752,13 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
     }
     summary.lostAccess += 1
     summary.byChannel[entry.discovery_channel ?? 'collab'].lostAccess += 1
+    maybeQueueVisibilityTransition({
+      storedPrivate: entry.private,
+      newPrivate: true,
+      node_id: access.node_id,
+      summary,
+      transitionIssues,
+    })
     return {
       ...normalizeRepoEntryForStorage(entry, {
         owner: access.owner,
@@ -756,6 +827,15 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
       (entry.last_survey_status !== 'success' || isEligibleForSurvey(entry.next_survey_eligible_at, params.now)))
 
   const accessPrivate = accessPrivateForStorage(access, accessNodePrivacy)
+
+  // Detect public-to-private visibility flip for still-accessible entries.
+  maybeQueueVisibilityTransition({
+    storedPrivate: entry.private,
+    newPrivate: accessPrivate,
+    node_id: access.node_id,
+    summary,
+    transitionIssues,
+  })
 
   if (wouldDispatchIfPublic && (entry.private !== false || accessPrivate)) {
     summary.skippedPrivate += 1
@@ -1073,6 +1153,7 @@ const DEFAULT_MAX_DISPATCHES_PER_RUN = 12
 const PENDING_REVIEW_LABEL = 'reconcile:pending-review'
 const ROLLUP_LABEL = 'reconcile:rollup-pending-review'
 const INTEGRITY_ALERT_LABEL = 'reconcile:integrity-alert'
+const VISIBILITY_TRANSITION_LABEL = 'reconcile:visibility-transition'
 // Fro Bot is one entity with two GitHub identities: the user account `fro-bot`
 // (FRO_BOT_PAT writes) and the app installation `fro-bot[bot]` (App-token writes).
 // Both have identical access to this repo and represent the same autonomous operator,
@@ -2277,6 +2358,18 @@ async function runIssueQueue(params: {
   let failed = 0
   for (const issue of params.issues) {
     try {
+      if (issue.kind === 'visibility-transition') {
+        // Dedup: skip if an open issue with the same node_id already exists.
+        const existing = (await params.appOctokit.paginate(params.appOctokit.rest.issues.listForRepo, {
+          owner: params.owner,
+          repo: params.repo,
+          state: 'open',
+          labels: VISIBILITY_TRANSITION_LABEL,
+          per_page: 100,
+        })) as unknown as OpenIssueEntry[]
+        const alreadyOpen = existing.some(i => (i.title ?? '').includes(issue.node_id))
+        if (alreadyOpen) continue
+      }
       const payload = renderIssuePayload(issue, params.owner, params.repo)
       await callIssuesCreate(params.appOctokit, payload)
       if (issue.kind === 'per-repo') perRepoSucceeded += 1
@@ -2302,7 +2395,26 @@ function renderIssuePayload(issue: IssueQueueEntry, owner: string, repo: string)
   if (issue.kind === 'per-repo') {
     return renderPerRepoIssue(issue, owner, repo)
   }
+  if (issue.kind === 'visibility-transition') {
+    return renderVisibilityTransitionIssue(issue, owner, repo)
+  }
   return renderRollupIssue(issue, owner, repo)
+}
+
+function renderVisibilityTransitionIssue(issue: VisibilityTransitionIssue, owner: string, repo: string): IssuePayload {
+  const title = `[INTEGRITY] Visibility transition for ${issue.node_id}`
+  const body = [
+    `<!-- reconcile:subject:node_id=${issue.node_id} -->`,
+    '',
+    'A tracked repository has transitioned from **public** to **private** (or access was lost, which fails closed as private).',
+    '',
+    `- Node ID: \`${issue.node_id}\``,
+    '',
+    'The repository name is omitted because this issue stream is public. Use the operator tool (`scripts/resolve-private.ts`) to look up the canonical owner/repo by node ID and identify any wiki pages that may need manual review.',
+    '',
+    'This issue requires manual operator action. It will not be auto-closed.',
+  ].join('\n')
+  return {owner, repo, title, body, labels: [INTEGRITY_ALERT_LABEL, VISIBILITY_TRANSITION_LABEL]}
 }
 
 function renderPerRepoIssue(issue: PerRepoIssue, owner: string, repo: string): IssuePayload {

--- a/scripts/schemas.test.ts
+++ b/scripts/schemas.test.ts
@@ -566,6 +566,67 @@ describe('schemas — rejection cases', () => {
     expect(error.path).toContain('node_id')
   })
 
+  it('rejects node_id containing shell metacharacters (defense-in-depth for operator copy-paste safety)', () => {
+    // node_id must match ^[A-Za-z0-9_\-+/=]+$ — shell metacharacters are rejected at parse time
+    // so they can never reach the issue body's inline gh api graphql command.
+    // Base64 chars (+, /, =) are allowed since legacy GitHub node IDs use standard base64.
+    const shellMetaIds = ["R_kgDO'injected", 'R_kgDO`cmd`', 'R_kgDO$VAR', 'R_kgDO;evil', 'R_kgDO with space']
+    for (const nodeId of shellMetaIds) {
+      const bad = {
+        version: 1,
+        repos: [
+          {
+            owner: 'fro-bot',
+            name: 'test',
+            added: '2026-04-17',
+            onboarding_status: 'pending',
+            last_survey_at: null,
+            last_survey_status: null,
+            has_fro_bot_workflow: false,
+            has_renovate: false,
+            node_id: nodeId,
+          },
+        ],
+      }
+      expect(isReposFile(bad)).toBe(false)
+      const error = catchSchemaError(() => assertReposFile(bad))
+      expect(error.path).toContain('node_id')
+    }
+  })
+
+  it('accepts node_id with valid GitHub node_id characters (alphanumeric, underscore, hyphen, and legacy base64)', () => {
+    // New-style: URL-safe base64 (A-Za-z0-9_-)
+    // Legacy-style: standard base64 (A-Za-z0-9+/=) — real entries in metadata/repos.yaml
+    const validIds = [
+      'R_kgDOSVJgdw',
+      'I_kwDOBxyz123',
+      'PR_kwDO-abc_XYZ',
+      'MDEwOlJlcG9zaXRvcnkxODY5MTU0', // legacy base64, no padding
+      'MDEwOlJlcG9zaXRvcnkzMDg1MzMxOTg=', // legacy base64, = padding
+      'MDEwOlJlcG9zaXRvcnk3Njg3NTEzMg==', // legacy base64, == padding
+    ]
+    for (const nodeId of validIds) {
+      const ok = {
+        version: 1,
+        repos: [
+          {
+            owner: 'fro-bot',
+            name: 'test',
+            added: '2026-04-17',
+            onboarding_status: 'pending',
+            last_survey_at: null,
+            last_survey_status: null,
+            has_fro_bot_workflow: false,
+            has_renovate: false,
+            node_id: nodeId,
+          },
+        ],
+      }
+      expect(isReposFile(ok)).toBe(true)
+      expect(() => assertReposFile(ok)).not.toThrow()
+    }
+  })
+
   it('rejects non-string entry in with-renovate list', () => {
     const bad = {repositories: {'with-renovate': ['valid', 42]}}
     expect(isRenovateFile(bad)).toBe(false)

--- a/scripts/schemas.ts
+++ b/scripts/schemas.ts
@@ -221,7 +221,8 @@ function isRepoEntry(value: unknown): value is RepoEntry {
       value.next_survey_eligible_at === null ||
       typeof value.next_survey_eligible_at === 'string') &&
     (value.private === undefined || typeof value.private === 'boolean') &&
-    (value.node_id === undefined || (typeof value.node_id === 'string' && value.node_id.length > 0))
+    (value.node_id === undefined ||
+      (typeof value.node_id === 'string' && value.node_id.length > 0 && /^[\w\-+/=]+$/.test(value.node_id)))
   )
 }
 
@@ -255,6 +256,8 @@ function assertRepoEntry(value: unknown, path: string): asserts value is RepoEnt
     throw new SchemaValidationError(`${path}.private`, 'expected boolean or omitted')
   if (value.node_id !== undefined && (typeof value.node_id !== 'string' || value.node_id.length === 0))
     throw new SchemaValidationError(`${path}.node_id`, 'expected non-empty string or omitted')
+  if (value.node_id !== undefined && typeof value.node_id === 'string' && !/^[\w\-+/=]+$/.test(value.node_id))
+    throw new SchemaValidationError(`${path}.node_id`, String.raw`expected safe node_id matching ^[\w\-+/=]+$`)
 }
 
 function isOnboardingStatus(value: unknown): value is OnboardingStatus {

--- a/scripts/schemas.ts
+++ b/scripts/schemas.ts
@@ -256,6 +256,8 @@ function assertRepoEntry(value: unknown, path: string): asserts value is RepoEnt
     throw new SchemaValidationError(`${path}.private`, 'expected boolean or omitted')
   if (value.node_id !== undefined && (typeof value.node_id !== 'string' || value.node_id.length === 0))
     throw new SchemaValidationError(`${path}.node_id`, 'expected non-empty string or omitted')
+  // Render sites embed node_id in shell commands (see renderVisibilityTransitionIssue in scripts/reconcile-repos.ts);
+  // keep this pattern restrictive to GitHub's base64ish node-id format.
   if (value.node_id !== undefined && typeof value.node_id === 'string' && !/^[\w\-+/=]+$/.test(value.node_id))
     throw new SchemaValidationError(`${path}.node_id`, String.raw`expected safe node_id matching ^[\w\-+/=]+$`)
 }


### PR DESCRIPTION
Reconcile now compares each tracked entry's stored `private` flag against the live probe result. A `false → true` flip (including via `access-lost`, which fails closed as private) queues a `reconcile:visibility-transition` integrity-alert issue identifying the entry by `node_id` only — title and body both omit canonical owner/repo to keep the public issue stream safe.

The body includes a copy-paste `gh api graphql` command operators can run locally to resolve the node_id to its canonical owner/repo when investigating which wiki pages need manual review.

## Durability

The privacy alert is one-shot: once metadata is committed `private: true`, the next reconcile run sees `stored.private === probe.private === true` and won't re-queue. Three failure modes that previously dropped the alert silently are now closed:

- `paginate(issues.listForRepo)` for dedup throws → fail open and create the issue anyway
- New `reconcile:visibility-transition` or `reconcile:integrity-alert` label not yet propagated to the live repo → pre-flight `getLabel`/`createLabel`; treat 422 from `createLabel` as the label-exists race
- Any label still can't be confirmed (non-404 `getLabel` or non-422 `createLabel` failure) → exclude that label from the payload; ship the issue with the surviving labels (or unlabeled with a loud warn) rather than dropping

## Privacy posture

The implementation is stricter than the plan's permissive wording: even when the probe could resolve canonical owner/repo, the issue body omits it. Operators run the inline lookup command on demand. This matches the always-redacted-everywhere posture established by the survey workflow's visibility gate.

Defense-in-depth at the schema boundary: `node_id` must now match `^[\w\-+/=]+$`, validated in both `isRepoEntry` and `assertRepoEntry`. Real base64ish GitHub IDs pass; shell metacharacters that would corrupt the operator's copy-paste are rejected at metadata-read time.

## What stays open

Private → public transitions emit no alert; the next mutator write recanonicalizes the entry. Newcomers (no stored `private` field) emit no alert either — that's an initial categorization, not a flip. `autoCloseStaleIssues` is deliberately not extended to this label; operators close transition issues manually after acting.

## Tests

649 passing + 3 todo (was 564 on main). New coverage includes:
- All 9 plan scenarios (false→true, false→false, true→true, true→false, undefined→true, false→access-lost, transient probe, rapid flip, node_id-only public surface)
- Privacy regression pin: rendered title and body never contain a canonical `owner--repo` slug (including dot-prefixed slugs like `fro-bot--.github`)
- Dedup branch coverage including a RED-against-old-substring-code regression test
- Three durability tests (paginate throws, label-404→createLabel→create, createLabel-422 vs createLabel-500 with payload inspection)
- Schema-level rejection test for `node_id` shell metacharacters

## Follow-ups (deferred)

These are tracked separately rather than expanding this PR:

- #3332 same-run dedup race (apply the PR #3321 same-run Set pattern to visibility transitions)
- #3333 surface `visibilityTransitions` counter in the reconcile Step Summary
- #3334 emit a counter/log when dedup suppresses creation
- #3335 legacy entries without `node_id` have no alertable subject when access is revoked
- #3336 rename the 'rapid flip' test to match what it actually tests
- #3337 document or tighten counter accuracy in ambiguous `issues.create` error paths