### PR TITLE
fix(reconcile): plan against authoritative metadata on data branch

### DIFF
--- a/.github/workflows/reconcile-repos.yaml
+++ b/.github/workflows/reconcile-repos.yaml
@@ -40,6 +40,18 @@ jobs:
       - name: 📦 Setup
         uses: ./.github/actions/setup
 
+      # Survey writebacks (`recordSurveyResult`) and onboarding writes land on the `data`
+      # branch, but the workflow's checkout pulls scripts from the default branch (`main`).
+      # Overlay the authoritative `metadata/` tree from `data` so reconcile plans against
+      # live state instead of whatever `main` last reflected.
+      - name: ⤵ Overlay metadata from data branch
+        env:
+          GH_TOKEN: ${{ steps.get-workflow-app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin data
+          git checkout origin/data -- metadata/
+
       - name: 🔁 Reconcile repos
         env:
           FRO_BOT_POLL_PAT: ${{ secrets.FRO_BOT_POLL_PAT }}


### PR DESCRIPTION
Reconcile reads scripts from the workflow checkout (default branch is `main`) but survey writebacks (`recordSurveyResult`) and onboarding writes land on `data`. The planner has been seeing stale metadata since survey-writeback landed.

## Observed symptoms

- The 2026-05-18, 05-19, and 05-20 reconcile crons each floor-dispatched the same two repos (`marcusrbrown/marcusrbrown` + `marcusrbrown/marcusrbrown.github.io`). Their `last_survey_at` on `main` was still `2026-04-27`, while `data` correctly recorded `2026-05-18`, `2026-05-19`, and `2026-05-20`. The planner kept reading `main` so it kept picking the same pair as oldest-first floor candidates.
- The four `bfra-me` entries from PR #3315 (`approved_contrib_repos`) were promoted to `onboarding_status: pending` on `data` via a separate flow. They never entered the dispatch pool because the planner re-read `main` (which lacks them), saw fresh collab grants, and classified them as `pendingReview` instead of dispatching the already-`pending` entries.

## Fix

A new workflow step fetches `origin/data` and overlays only the `metadata/` tree into the workflow's working directory before `node scripts/reconcile-repos.ts` runs. Scripts still come from `main`; authoritative state comes from `data`.

```yaml
- name: ⤵ Overlay metadata from data branch
  env:
    GH_TOKEN: ${{ steps.get-workflow-app-token.outputs.token }}
  run: |
    set -euo pipefail
    git fetch --no-tags origin data
    git checkout origin/data -- metadata/
```

No script changes, no new tests. The overlay was smoke-tested locally against the live repo `origin` to confirm `git fetch`/`git checkout` succeed and the resulting tree has the data-side metadata.

## Out of scope

Once this lands and the next cron exercises it, two separate follow-ups become reasonable:

1. **Channel precedence**: `collab` currently outranks `contrib` in `mergeAccessChannels`, so allowlisted-but-also-collab repos stay sticky on the longer collab cadence. A future fix can promote contrib precedence when an entry is explicitly listed in `approved_contrib_repos`.
2. **Cross-org App token scope**: if contrib probing for non-`fro-bot` orgs ever needs cross-org Octokit calls, the token may need per-owner minting. The current installation token's scope hasn't been observed as a limitation yet.