### PR TITLE
diag(survey): surface gh api graphql stderr on privacy-gate lookup failure

### DIFF
--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -81,13 +81,18 @@ jobs:
 
           # shellcheck disable=SC2016
           gql_query='query($id: ID!) { node(id: $id) { ... on Repository { nameWithOwner isPrivate } } }'
-          response=$(gh api graphql \
-            -F id="$NODE_ID" \
-            -f query="$gql_query" \
-            2>/dev/null) || {
+          # Capture stderr to a temp file so a failure surfaces the real gh/GitHub error
+          # (auth, permission, rate limit, network) instead of a generic abort line.
+          gh_stderr=$(mktemp)
+          if ! response=$(gh api graphql -F id="$NODE_ID" -f query="$gql_query" 2>"$gh_stderr"); then
             printf 'GraphQL lookup failed for node_id: %s\n' "$NODE_ID" >&2
+            printf '--- gh stderr ---\n' >&2
+            cat "$gh_stderr" >&2
+            printf '--- end gh stderr ---\n' >&2
+            rm -f "$gh_stderr"
             exit 1
-          }
+          fi
+          rm -f "$gh_stderr"
 
           name_with_owner=$(printf '%s' "$response" | jq -er '
             .data.node


### PR DESCRIPTION
Diagnostic-only. The privacy gate's GraphQL lookup currently redirects stderr to `/dev/null` and prints a generic `GraphQL lookup failed` line. That hides the actual gh/GitHub error (auth, permission, rate limit, network), turning every failure into a guessing game.

Today's manual Reconcile Repos dispatch (#26152591177) successfully picked up the four `bfra-me` entries on `data` after PR #3342 landed (4 dispatches, was 2 yesterday). All four Survey Repo jobs failed at the gate:

| Node ID | Repo | Run |
|---|---|---|
| `R_kgDOIKWaJA` | bfra-me/ha-addon-repository | 26152631320 |
| `R_kgDOKWu8zQ` | bfra-me/renovate-action | 26152706006 |
| `MDEwOlJlcG9zaXRvcnkzMDc1NzM1OTE=` | bfra-me/works | 26152782049 |
| `R_kgDOHBEXpg` | bfra-me/.github | 26152858307 |

All four are public on github.com and resolve cleanly via `gh api graphql` from a personal token here, so the node IDs are good. What we don't know is what `FRO_BOT_PAT` is actually getting back — could be auth scope, fine-grained PAT resource restriction, rate limit, or something else. The current logging drops the answer on the floor.

## Change

Capture `gh api` stderr to a temp file. On failure, dump it into the step log between `--- gh stderr ---`/`--- end gh stderr ---` markers, then exit 1 as before. No behavior change on the success path; no production change in privacy semantics.

```bash
gh_stderr=$(mktemp)
if ! response=$(gh api graphql -F id="$NODE_ID" -f query="$gql_query" 2>"$gh_stderr"); then
  printf 'GraphQL lookup failed for node_id: %s\n' "$NODE_ID" >&2
  printf -- '--- gh stderr ---\n' >&2
  cat "$gh_stderr" >&2
  printf -- '--- end gh stderr ---\n' >&2
  rm -f "$gh_stderr"
  exit 1
fi
rm -f "$gh_stderr"
```

## Plan

1. Merge this PR.
2. Redispatch `survey-repo.yaml -f node_id=R_kgDOIKWaJA` (bfra-me/ha-addon-repository).
3. Read the surfaced stderr.
4. Open the real fix PR based on the actual error (App token swap is the leading hypothesis; if the stderr says something else, route accordingly).

## Out of scope

The recheck-visibility step (`steps.recheck`) has the same `2>/dev/null` pattern. Once the root cause is identified and fixed in the resolve step, applying the same stderr-surfacing to recheck is a follow-up. Out of this PR to keep the diagnostic surface bounded.