### PR TITLE
fix(survey-repo): use %s format for stderr markers (unblocks PR #3344 diagnostic)

### DIFF
--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -86,9 +86,11 @@ jobs:
           gh_stderr=$(mktemp)
           if ! response=$(gh api graphql -F id="$NODE_ID" -f query="$gql_query" 2>"$gh_stderr"); then
             printf 'GraphQL lookup failed for node_id: %s\n' "$NODE_ID" >&2
-            printf '--- gh stderr ---\n' >&2
+            # Use %s format so leading dashes in the marker are treated as arguments,
+            # not options (bash builtin printf otherwise rejects '---...' as an option).
+            printf '%s\n' '--- gh stderr ---' >&2
             cat "$gh_stderr" >&2
-            printf '--- end gh stderr ---\n' >&2
+            printf '%s\n' '--- end gh stderr ---' >&2
             rm -f "$gh_stderr"
             exit 1
           fi


### PR DESCRIPTION
## Why

PR #3344 added stderr capture around the GraphQL privacy gate so cross-org survey failures surface the real `gh` error. Run 26172556733 hit the same gate failure but the diagnostic output was itself broken:

```
GraphQL lookup failed for node_id: R_kgDOIKWaJA
/home/runner/work/_temp/...sh: line 13: printf: --: invalid option
printf: usage: printf [-v var] format [arguments]
##[error]Process completed with exit code 2.
```

Bash's builtin printf parses a format string beginning with `---` as an option (the `--` is its own no-op terminator on coreutils printf, but bash's builtin rejects it). The script aborted before reaching `cat "$gh_stderr"`, so the real gh CLI error never surfaced.

## What

Switch the two banner `printf` calls in the resolve step from:

```bash
printf '--- gh stderr ---\n' >&2
printf '--- end gh stderr ---\n' >&2
```

to:

```bash
printf '%s\n' '--- gh stderr ---' >&2
printf '%s\n' '--- end gh stderr ---' >&2
```

The marker text is byte-identical, so any future log-parsing tooling that anchors on those strings still works. Only the format string changes \u2014 `%s\n` accepts the marker as an argument, so the leading `---` never reaches printf's option parser.

## Verification

Locally reproduces clean:

```
$ bash -c "printf '%s\n' '--- gh stderr ---'"
--- gh stderr ---
```

actionlint clean. Diff is 4 lines + a 2-line comment explaining why the pattern matters.

## Scope

Resolve step only. The recheck step's analogous `2>/dev/null` is still deferred to follow-up #3345, intentionally bounded.

## Next

Once merged, redispatch Survey Repo for `R_kgDOIKWaJA`. The next failure should print the real gh API error between the marker lines.