### PR TITLE
fix(survey-repo): use App token for cross-org privacy gate

### DIFF
--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -68,11 +68,24 @@ jobs:
       - name: 📦 Setup
         uses: ./.github/actions/setup
 
+      # The privacy gate's only question is "is this node a public repository?" That
+      # is a public read, but it must work for repos in any org the dispatch lands
+      # on — including orgs whose policy forbids long-lived fine-grained PATs (e.g.
+      # bfra-me requires ≤366d). An installation token minted for the calling repo's
+      # owner sidesteps PAT policy entirely while still permitting public-read GraphQL.
+      - name: Mint App token for privacy gate
+        id: gate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: 🔒 Resolve and verify
         id: resolve
         env:
           NODE_ID: ${{ inputs.node_id }}
-          GH_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+          GH_TOKEN: ${{ steps.gate-token.outputs.token }}
         run: |
           if ! printf '%s' "$NODE_ID" | grep -qE '^[A-Za-z0-9_=-]+$'; then
             printf 'Aborting: dispatch input shape invalid\n' >&2
@@ -202,7 +215,7 @@ jobs:
         if: ${{ !cancelled() && steps.survey-agent.conclusion != 'skipped' }}
         env:
           NODE_ID: ${{ inputs.node_id }}
-          GH_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+          GH_TOKEN: ${{ steps.gate-token.outputs.token }}
         run: |
           # shellcheck disable=SC2016
           gql_query='query($id: ID!) { node(id: $id) { ... on Repository { isPrivate } } }'


### PR DESCRIPTION
## Why

PR #3344's diagnostic patch finally surfaced the real error blocking bfra-me surveys:

```
gh: The 'bfra-me' organization forbids access via a fine-grained personal access tokens if the token's lifetime is greater than 366 days. Please adjust your token's lifetime at the following URL: https://github.com/settings/personal-access-tokens/11509367
```

`FRO_BOT_PAT` is a fine-grained PAT. It works fine for `fro-bot/*` and `marcusrbrown/*`, but `bfra-me` org policy forbids cross-org reads from long-lived fine-grained PATs. Every bfra-me Survey Repo dispatch fails at the privacy gate before any survey work begins.

## What

The privacy gate's only question is "is this node a public repository?" \u2014 a public read. An installation token minted for the calling repo's owner sidesteps PAT policy entirely while still permitting public-read GraphQL.

Two gate steps switch from `secrets.FRO_BOT_PAT` to a freshly-minted App installation token:

- `\ud83d\udd12 Resolve and verify` (initial node lookup)
- `\ud83d\udd12 Recheck visibility` (post-survey TOCTOU recheck)

A new step `Mint App token for privacy gate` precedes both, using the same `bcd2ba49` v3.2.0 pin and `owner: github.repository_owner` pattern as every other App-token workflow in this repo (`update-metadata.yaml`, `dispatch-renovate.yaml`, `reconcile-repos.yaml`, etc.).

## What stays on PAT

Three call sites in the workflow still use `FRO_BOT_PAT`:

- `Commit wiki ingest to data branch` \u2014 needs `fro-bot` user identity for `data` writes
- `Record survey result` \u2014 same
- `secrets.FRO_BOT_PAT` passed to `social-broadcast.yaml` \u2014 downstream identity

These are intentional and outside this fix's scope.

## Why not just shorten the PAT lifetime?

That would work today, but bfra-me's policy could tighten further and any other org with a similar policy would block us again. App tokens are the structurally correct primitive for public-read questions and they auto-rotate.

## Verification plan

1. Merge.
2. Redispatch Survey Repo for `R_kgDOIKWaJA` (bfra-me/ha-addon-repository).
3. Expected: resolve step succeeds, owner=bfra-me / repo=ha-addon-repository extracted, survey proceeds.
4. If failure: PR #3344's diagnostic patch is still in place, the new gh stderr will surface between the markers.

actionlint clean. Diff is +15/-2.