### PR TITLE
docs(solutions): capture diagnostic-discipline + Issues-API race patterns

### DIFF
--- a/docs/solutions/best-practices/diagnostic-patches-observability-discipline-2026-05-20.md
+++ b/docs/solutions/best-practices/diagnostic-patches-observability-discipline-2026-05-20.md
@@ -1,0 +1,243 @@
+---
+title: Diagnostic patches must fail loudly and preserve stderr
+date: 2026-05-20
+last_updated: 2026-05-20
+verified: 2026-05-20
+category: best-practices
+module: .github/workflows/survey-repo.yaml
+problem_type: best_practice
+component: development_workflow
+severity: low
+related_components:
+  - tooling
+  - documentation
+tags:
+  - diagnostics
+  - observability
+  - bash
+  - github-actions
+  - workflow-debugging
+  - printf
+  - app-tokens
+applies_when:
+  - a workflow swallows stderr from a failing CLI call
+  - adding temporary diagnostics to expose hidden failure context
+  - marker output or logging helpers need to be shell-safe
+  - the first diagnostic patch might itself fail and obscure the original problem
+  - a public-read GraphQL call crosses an organization boundary
+---
+
+# Diagnostic patches must fail loudly and preserve stderr
+
+## Context
+
+When automation fails silently, the reflex is to throw one fix at the most obvious cause. That misses the actual problem most of the time, because the original failure mode has already proven that information is being lost. Each layer of swallowed error adds a turn to the investigation.
+
+This pattern surfaced in a real 3-step progression on `.github/workflows/survey-repo.yaml`:
+
+1. The privacy gate's `gh api graphql` call sent stderr to `/dev/null` and printed a generic "GraphQL lookup failed" line. The real `gh` error was discarded.
+2. The first diagnostic patch surfaced stderr — but used a `printf` format string starting with `---`, which Ubuntu's bash builtin `printf` rejects as an invalid option. The patch died before printing.
+3. Once the marker bug was fixed, the surfaced stderr revealed the actual cause: a cross-organization PAT lifetime policy. The real fix swapped the gate to an App installation token.
+
+Three PRs over three iterations instead of one, because each layer of swallowed error obscured the next.
+
+## Guidance
+
+### 1. Never `2>/dev/null` a workflow gate's failure-path command
+
+When `gh api`, `curl`, `jq`, or any external CLI fails inside a step that controls dispatch, operators have no visibility unless stderr is surfaced. Capture stderr to a tempfile and `cat` it on failure between stable marker lines:
+
+```bash
+gh_stderr=$(mktemp)
+if ! response=$(gh api graphql -F id="$NODE_ID" -f query="$gql_query" 2>"$gh_stderr"); then
+  printf 'GraphQL lookup failed for node_id: %s\n' "$NODE_ID" >&2
+  printf '%s\n' '--- gh stderr ---' >&2
+  cat "$gh_stderr" >&2
+  printf '%s\n' '--- end gh stderr ---' >&2
+  rm -f "$gh_stderr"
+  exit 1
+fi
+rm -f "$gh_stderr"
+```
+
+The markers do double duty: they anchor the captured stderr in the log for humans and provide a stable string for any future log-parsing tooling.
+
+### 2. Be wary of leading dashes in `printf` format strings
+
+Bash's builtin `printf` rejects format strings starting with `---` because the leading `--` parses as an invalid option. Coreutils `printf` supports `--` as an end-of-options sentinel; bash builtin does NOT. The behavior diverges on Ubuntu runners specifically, and is invisible on macOS during local testing.
+
+Use `printf '%s\n' '--- marker ---'` (marker as argument) instead of `printf '--- marker ---\n'` (marker as format string):
+
+```bash
+# Wrong — bash builtin exits with "printf: --: invalid option"
+printf '--- gh stderr ---\n' >&2
+
+# Right — bash builtin treats the marker as a %s argument
+printf '%s\n' '--- gh stderr ---' >&2
+```
+
+### 3. Cross-org public reads use App tokens, not user PATs
+
+Fine-grained PATs are subject to per-org lifetime policies. Real example from this investigation:
+
+```
+gh: The 'bfra-me' organization forbids access via a fine-grained personal access tokens
+if the token's lifetime is greater than 366 days.
+```
+
+Classic PATs avoid the lifetime policy but their renewal is your responsibility. App installation tokens auto-rotate per-run, are scoped to the installation's permissions, and answer public-read questions without policy entanglement. Mint an installation token for the calling repo's owner and consume it via `GH_TOKEN`:
+
+```yaml
+- name: Mint App token for privacy gate
+  id: gate-token
+  uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+  with:
+    app-id: ${{ secrets.APPLICATION_ID }}
+    private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+    owner: ${{ github.repository_owner }}
+
+- name: 🔒 Resolve and verify
+  env:
+    NODE_ID: ${{ inputs.node_id }}
+    GH_TOKEN: ${{ steps.gate-token.outputs.token }}
+  run: |
+    # public-read GraphQL works across orgs regardless of the calling
+    # installation's per-org permissions
+```
+
+The `owner: ${{ github.repository_owner }}` argument is load-bearing: without it, the App token defaults to the calling repo's scope and `apps.listReposAccessibleToInstallation` returns only that one repo.
+
+### 4. Keep diagnostic patches bounded
+
+A diagnostic patch should fix the immediate visibility blocker, not propagate the pattern to every symmetric call site. The first stderr-surfacing patch in this investigation touched only the `🔒 Resolve and verify` step, NOT the symmetric `🔒 Recheck visibility` step that has the same `2>/dev/null` shape. The cleanup PR for the recheck step was filed as a separate follow-up issue.
+
+Why bounded matters: every line in a diagnostic patch is a line that could itself be wrong (as the printf bug demonstrated). Smaller surface → fewer ways for the diagnostic to fail before it prints.
+
+## Why This Matters
+
+- **Three PRs instead of one.** Swallowed stderr forced the investigation to walk down the stack: surface stderr → fix the surface mechanism → fix the real error. Each layer was necessary because the previous one obscured information.
+- **Bash builtin vs coreutils `printf` is a real portability gap.** It bites on Ubuntu runners specifically, and is invisible during local macOS testing. The fix is a one-character pattern change that applies forever.
+- **Cross-org PAT policy is invisible until something fails.** App tokens are the structurally correct primitive for public-read questions — they sidestep PAT lifetime policy entirely, auto-rotate, and don't depend on a human renewing them yearly.
+
+## When to Apply
+
+This guidance applies whenever writing or reviewing a workflow that:
+
+- Calls external CLI tools (`gh`, `curl`, `jq`) in `run:` steps
+- Has a gate or conditional dispatch path that exits non-zero on failure
+- Crosses organization boundaries for reads
+- Prints diagnostic markers via `printf` with leading-dash format strings
+- Uses fine-grained PATs to call APIs in orgs other than the calling repo's owner
+
+## Examples
+
+### Swallowed stderr removed, tempfile capture added
+
+`.github/workflows/survey-repo.yaml` before (PR #3344 before):
+
+```bash
+response=$(gh api graphql \
+  -F id="$NODE_ID" \
+  -f query="$gql_query" \
+  2>/dev/null) || {
+  printf 'GraphQL lookup failed for node_id: %s\n' "$NODE_ID" >&2
+  exit 1
+}
+```
+
+After (PR #3344):
+
+```bash
+# Capture stderr to a temp file so a failure surfaces the real gh/GitHub error
+# (auth, permission, rate limit, network) instead of a generic abort line.
+gh_stderr=$(mktemp)
+if ! response=$(gh api graphql -F id="$NODE_ID" -f query="$gql_query" 2>"$gh_stderr"); then
+  printf 'GraphQL lookup failed for node_id: %s\n' "$NODE_ID" >&2
+  printf '%s\n' '--- gh stderr ---' >&2
+  cat "$gh_stderr" >&2
+  printf '%s\n' '--- end gh stderr ---' >&2
+  rm -f "$gh_stderr"
+  exit 1
+fi
+rm -f "$gh_stderr"
+```
+
+### Broken `printf` markers fixed
+
+Before (PR #3344, broken on Ubuntu):
+
+```bash
+printf '--- gh stderr ---\n' >&2
+cat "$gh_stderr" >&2
+printf '--- end gh stderr ---\n' >&2
+```
+
+After (PR #3346):
+
+```bash
+# Use %s format so leading dashes in the marker are treated as arguments,
+# not options (bash builtin printf otherwise rejects '---...' as an option).
+printf '%s\n' '--- gh stderr ---' >&2
+cat "$gh_stderr" >&2
+printf '%s\n' '--- end gh stderr ---' >&2
+```
+
+### PAT env replaced with App token
+
+Before (PR #3347 before):
+
+```yaml
+- name: 🔒 Resolve and verify
+  id: resolve
+  env:
+    NODE_ID: ${{ inputs.node_id }}
+    GH_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+  run: |
+    # ...
+
+- name: 🔒 Recheck visibility
+  id: recheck
+  env:
+    NODE_ID: ${{ inputs.node_id }}
+    GH_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+  run: |
+    # ...
+```
+
+After (PR #3347):
+
+```yaml
+- name: Mint App token for privacy gate
+  id: gate-token
+  uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+  with:
+    app-id: ${{ secrets.APPLICATION_ID }}
+    private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+    owner: ${{ github.repository_owner }}
+
+- name: 🔒 Resolve and verify
+  id: resolve
+  env:
+    NODE_ID: ${{ inputs.node_id }}
+    GH_TOKEN: ${{ steps.gate-token.outputs.token }}
+  run: |
+    # ...
+
+- name: 🔒 Recheck visibility
+  id: recheck
+  env:
+    NODE_ID: ${{ inputs.node_id }}
+    GH_TOKEN: ${{ steps.gate-token.outputs.token }}
+  run: |
+    # ...
+```
+
+## Related
+
+- [Survey Repo dispatch boundary trusted caller-provided owner/repo, leaking private identity into public Actions surface](../security-issues/survey-workflow-side-privacy-gate-2026-05-16.md) — same workflow file and same privacy gate; defense-in-depth shape rather than diagnostic discipline. Note: the code example in that doc still shows `2>/dev/null` and the leading-dash `printf` pattern; both are now updated in production but stale in the doc.
+- [The jq `//` falsy-coalesce trap in shell-driven gates](../workflow-issues/jq-falsy-coalesce-trap-in-shell-gates-2026-05-17.md) — companion "the gate can lie if the parser silently coerces" pattern in the same workflow.
+- [Autonomous-pipeline silent failures: status misclassification and additive-pipeline drift](../runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md) — same workflow-observability family; different cause shape (compound-expression status classification, not stderr blackout).
+- PR #3344 — diagnostic stderr capture
+- PR #3346 — printf marker fix
+- PR #3347 — App token for cross-org privacy gate
+- Issues #3345, #3349 — bounded follow-ups for symmetric cleanup

--- a/docs/solutions/best-practices/github-issues-api-same-run-eventual-consistency-2026-05-20.md
+++ b/docs/solutions/best-practices/github-issues-api-same-run-eventual-consistency-2026-05-20.md
@@ -1,0 +1,224 @@
+---
+title: GitHub Issues API same-run eventual consistency requires an in-memory created-ID set
+date: 2026-05-20
+last_updated: 2026-05-20
+verified: 2026-05-20
+category: best-practices
+module: scripts/reconcile-repos.ts
+problem_type: best_practice
+component: background_job
+severity: medium
+related_components:
+  - tooling
+tags:
+  - github-api
+  - issues
+  - eventual-consistency
+  - race-condition
+  - duplicate-creation
+  - reconcile
+applies_when:
+  - one process creates a GitHub issue via issues.create
+  - the same process later calls issues.listForRepo to decide whether to create
+  - dedup or self-heal logic must survive same-run API staleness
+  - stage orchestrators touch the same GitHub resource at multiple points
+---
+
+# GitHub Issues API same-run eventual consistency requires an in-memory created-ID set
+
+## Context
+
+The GitHub Issues API has an asymmetric consistency window. A `POST /repos/{owner}/{repo}/issues` call returns quickly with the created issue's number, but a subsequent `GET /repos/{owner}/{repo}/issues` call from the same process — seconds later — can return a stale list that does NOT include the freshly-created issue.
+
+Within a single workflow run, code that creates an issue and then lists issues to check for duplicates will see the OLD list and create a second duplicate. The same shape applies to PRs, labels, and comments; the Issues API is just where `fro-bot/.github` hit it first.
+
+Concrete instance: `scripts/reconcile-repos.ts` had three sequential stages:
+
+1. `runIssueQueue()` — creates `reconcile:rollup` issues for new pending-review repos.
+2. `autoCloseStaleIssues()` — closes stale rollups (orthogonal concern).
+3. `selfHealRollups()` — lists open rollup issues via `issues.listForRepo`; creates one if none exist for that owner.
+
+A rollup created in step 1 was invisible to step 3's list call. `selfHealRollups` created a duplicate. Operators saw two rollups per affected owner per run.
+
+A closely related pattern lives in [merge-data-pr-github-422-race-recovery-2026-05-02.md](../integration-issues/merge-data-pr-github-422-race-recovery-2026-05-02.md) — same eventual-consistency family on the Pulls API. There the fix is rediscovery after a transient 422; here the fix is an in-memory set carried through stages.
+
+## Guidance
+
+**Rule.** If a code path BOTH creates a GitHub issue AND later lists issues to decide on creation within the same process, carry an in-memory `Set<string>` of created identifiers through subsequent stages. For the lifetime of that run, the `Set` is the source of truth — NOT `issues.listForRepo`.
+
+The set holds whatever identifier the dedup logic keys on. For per-owner rollups, that's the owner login string. For per-PR rollups, that might be the PR node_id or label. Use the most narrow identifier that the dedup decision actually depends on.
+
+### Pattern
+
+```ts
+// 1. After the create stage emits its plan, materialize the dedup keys.
+const currentRunRollupOwners = new Set(
+  plan.issues
+    .filter(issue => issue.kind === 'per-owner-rollup')
+    .map(issue => issue.owner),
+)
+
+// 2. Pass the set through to any downstream stage that lists + creates.
+const healedRollups = await selfHealRollups({
+  appOctokit,
+  owner,
+  repo,
+  accessList,
+  allowlist,
+  logger,
+  currentRunRollupOwners,
+})
+
+// 3. Inside selfHealRollups, union the in-memory set with the API-derived set
+//    BEFORE deciding whether to create. The set is authoritative.
+const existingRollupOwners = new Set<string>(/* from issues.listForRepo */)
+for (const owner of params.currentRunRollupOwners) {
+  existingRollupOwners.add(owner)
+}
+
+if (existingRollupOwners.has(targetOwner)) {
+  // skip create — either the API already knows, or we created it ourselves this run
+  return
+}
+```
+
+### Test the race directly
+
+A regression test must reproduce the race shape: mock `issues.listForRepo` to return an empty list, pass the just-created identifier through the in-memory set, and assert that the second `issues.create` does NOT happen. Mocking the list call to return empty is the closest local approximation of GitHub's stale-read behavior.
+
+## Why This Matters
+
+- **Duplicate issues are noise that drowns signal.** Two rollups per owner per run produces alert fatigue. Operators learn to ignore them. Real problems then go unnoticed.
+- **GitHub's write→read consistency window is asymmetric and load-dependent.** Writes are reflected in the SAME call's response within ~1s, but visible to a subsequent list call only after several seconds — sometimes longer under platform load.
+- **"Just sleep a few seconds" is not a fix.** It inflates run wall-clock, is unreliable (the consistency window varies), and does not compose if stages stack.
+- **The pattern recurs across the GitHub API.** Same shape applies to PRs, labels, comments, deployments, and check runs. The dedup-via-Set pattern is the universal answer when the stages live in the same process.
+
+## When to Apply
+
+Any code path in this repo (or similar) where:
+
+- A stage orchestrator runs multiple stages within one process
+- Two or more of those stages touch the same GitHub API resource type (issues, PRs, labels, comments)
+- A later stage uses a `list*` call to decide whether to create
+- A duplicate would be operator-visible noise rather than silent
+
+Specifically in `fro-bot/.github`:
+
+- `scripts/reconcile-repos.ts` — applies, fixed in PR #3321
+- Future per-PR dedup that adds an after-create list check would apply
+- Future autoheal create-then-verify patterns would apply
+
+## Examples
+
+### Before (race window open)
+
+`selfHealRollups` only trusted the API list call. A rollup created seconds earlier in `runIssueQueue` could be invisible.
+
+```ts
+const healedRollups = await selfHealRollups({
+  appOctokit,
+  owner,
+  repo,
+  accessList,
+  allowlist,
+  logger,
+})
+```
+
+Inside `selfHealRollups`:
+
+```ts
+const { data: openRollups } = await octokit.rest.issues.listForRepo({
+  owner,
+  repo,
+  state: 'open',
+  labels: ROLLUP_LABEL,
+})
+
+const existingRollupOwners = new Set(
+  openRollups.map(issue => issue.title /* parse owner from title */),
+)
+
+for (const candidate of healableOwners) {
+  if (existingRollupOwners.has(candidate)) continue
+  await octokit.rest.issues.create({ /* duplicate created here */ })
+}
+```
+
+### After (race closed by carrying intent through stages)
+
+```ts
+const currentRunRollupOwners = new Set(
+  plan.issues
+    .filter(issue => issue.kind === 'per-owner-rollup')
+    .map(issue => issue.owner),
+)
+
+const healedRollups = await selfHealRollups({
+  appOctokit,
+  owner,
+  repo,
+  accessList,
+  allowlist,
+  logger,
+  currentRunRollupOwners,
+})
+```
+
+Inside `selfHealRollups`:
+
+```ts
+const { data: openRollups } = await octokit.rest.issues.listForRepo({
+  owner,
+  repo,
+  state: 'open',
+  labels: ROLLUP_LABEL,
+})
+
+const existingRollupOwners = new Set(
+  openRollups.map(issue => issue.title /* parse owner from title */),
+)
+
+// Union API state with in-memory created state. In-memory is authoritative
+// for anything created in this run — the API list may be lagging.
+for (const owner of params.currentRunRollupOwners) {
+  existingRollupOwners.add(owner)
+}
+
+for (const candidate of healableOwners) {
+  if (existingRollupOwners.has(candidate)) continue
+  await octokit.rest.issues.create({ /* now only fires if neither source knows */ })
+}
+```
+
+### Regression test (the shape that matters)
+
+```ts
+test('does not double-create a rollup that was just created in the same run', async () => {
+  const ownerJustCreated = 'bfra-me'
+  mockOctokit.rest.issues.listForRepo.mockResolvedValue({
+    data: [], // API list lags — empty even though we just created
+  })
+
+  await selfHealRollups({
+    appOctokit: mockOctokit,
+    owner: 'fro-bot',
+    repo: '.github',
+    accessList,
+    allowlist,
+    logger,
+    currentRunRollupOwners: new Set([ownerJustCreated]),
+  })
+
+  expect(mockOctokit.rest.issues.create).not.toHaveBeenCalled()
+})
+```
+
+## Related
+
+- [merge-data PR recovery from GitHub 422 race](../integration-issues/merge-data-pr-github-422-race-recovery-2026-05-02.md) — the closest analogue. Same GitHub eventual-consistency family, different resource (Pulls API). Fix shape differs: there the system rediscovers a PR after a transient 422 / stale `expected_head_sha`; here the system carries an in-memory created-ID set so same-run stages don't double-count or miss freshly created issues. Pair them when reasoning about same-run GitHub API consistency.
+- [Bootstrap the `data` branch before autonomous writes](../integration-issues/bootstrap-data-branch-before-autonomous-writes-2026-05-09.md) — same family of "reconcile state before acting" patterns at startup; different resource (refs vs issues).
+- PR #3321 — `fix(reconcile): suppress self-heal rollup duplicates from same-run race`
+- Issues #3307, #3308 — the duplicate rollups that prompted the investigation
+- Issue #3319 — operator-readable observability for the in-memory dedup (deferred follow-up)
+- Issue #3332 — visibility-transition same-run dedup race (same family on a different `selfHeal*` site)


### PR DESCRIPTION
Two best-practices learnings from today's session captured as durable `docs/solutions/` entries.

## diagnostic-patches-observability-discipline-2026-05-20.md

The 3-PR investigation (#3344 \u2192 #3346 \u2192 #3347) where each patch revealed the next layer of a swallowed-error problem in the Survey Repo privacy gate. Four rules with verbatim code examples:

1. Never `2>/dev/null` a workflow gate's failure-path command \u2014 capture stderr to a tempfile and `cat` it on failure between marker lines
2. Beware leading dashes in `printf` format strings \u2014 bash builtin rejects `---...` as an option, use `printf '%s\n' '--- text ---'` instead
3. Cross-org public reads use App tokens, not user PATs \u2014 fine-grained PATs hit per-org lifetime policies, App tokens auto-rotate and sidestep that class of footguns entirely
4. Keep diagnostic patches bounded \u2014 fix the immediate blocker, not every symmetric instance; that's a separate cleanup PR

Cross-links `survey-workflow-side-privacy-gate-2026-05-16.md` (companion defense-in-depth doc on the same workflow), `jq-falsy-coalesce-trap-in-shell-gates-2026-05-17.md`, `autonomous-pipeline-silent-failures-2026-04-19.md`, and the three PRs plus follow-up issues #3345/#3349.

## github-issues-api-same-run-eventual-consistency-2026-05-20.md

The in-memory created-ID `Set<string>` pattern that closes the race where `issues.listForRepo` lags behind `issues.create` within the same process (PR #3321, `scripts/reconcile-repos.ts`). The rule: any code path that BOTH creates a GitHub issue AND later lists issues to decide on creation within the same process must carry an in-memory `Set<string>` of created identifiers through subsequent stages \u2014 the `Set` is the source of truth for the lifetime of the run, NOT `issues.listForRepo`.

Cross-links `merge-data-pr-github-422-race-recovery-2026-05-02.md` as the closest analogue (same family on the Pulls API, different fix shape), `bootstrap-data-branch-before-autonomous-writes-2026-05-09.md`, PR #3321, source issues #3307/#3308, and follow-ups #3319/#3332.

## Why now

Both topics were freshly cached from today's work. Capturing them while the investigation context is hot prevents the typical degradation where compound docs land days later with vague reconstructions. Smart note #115 (which had been tracking the Issues-API race writeup since PR #3321 merged) is dismissed by this PR.