### PR TITLE
Harden and instrument reconcile visibility-transition alerts

### DIFF
--- a/.github/workflows/reconcile-repos.yaml
+++ b/.github/workflows/reconcile-repos.yaml
@@ -64,4 +64,31 @@ jobs:
           # on the next run via the staleness gate, producing a progressive day-over-day
           # cadence instead of bursty fan-outs that exhaust upstream capacity.
           RECONCILE_MAX_DISPATCHES_PER_RUN: '12'
-        run: node scripts/reconcile-repos.ts
+        run: node scripts/reconcile-repos.ts | tee "$RUNNER_TEMP/reconcile-result.json"
+
+      - if: always()
+        name: 📋 Write step summary
+        run: |
+          # Write step summary from reconcile-repos output JSON
+          result="$RUNNER_TEMP/reconcile-result.json"
+          if [[ ! -s "$result" ]]; then
+            echo "reconcile produced no result JSON" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          {
+            echo "## Reconcile Repos Summary"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Dispatched | $(jq '.dispatches // 0' "$result") |"
+            echo "| Dispatches deferred | $(jq '.dispatchesDeferred // 0' "$result") |"
+            echo "| Dispatches failed | $(jq '.dispatchesFailed // 0' "$result") |"
+            echo "| Visibility transition issues | $(jq '.visibilityTransitionIssues // 0' "$result") |"
+            echo "| Per-repo issues | $(jq '.perRepoIssues // 0' "$result") |"
+            echo "| Rollup issues | $(jq '.rollupIssues // 0' "$result") |"
+            echo "| Issues failed | $(jq '.issuesFailed // 0' "$result") |"
+            echo "| Closed stale issues | $(jq '.closedStaleIssues // 0' "$result") |"
+            echo "| Probes failed | $(jq '.probesFailed // 0' "$result") |"
+            echo "| Committed | $(jq '.committed // false' "$result") |"
+          } >> "$GITHUB_STEP_SUMMARY"
+        shell: bash

--- a/.github/workflows/reconcile-repos.yaml
+++ b/.github/workflows/reconcile-repos.yaml
@@ -65,6 +65,7 @@ jobs:
           # cadence instead of bursty fan-outs that exhaust upstream capacity.
           RECONCILE_MAX_DISPATCHES_PER_RUN: '12'
         run: node scripts/reconcile-repos.ts | tee "$RUNNER_TEMP/reconcile-result.json"
+        shell: bash
 
       - if: always()
         name: 📋 Write step summary
@@ -84,6 +85,8 @@ jobs:
             echo "| Dispatches deferred | $(jq '.dispatchesDeferred // 0' "$result") |"
             echo "| Dispatches failed | $(jq '.dispatchesFailed // 0' "$result") |"
             echo "| Visibility transition issues | $(jq '.visibilityTransitionIssues // 0' "$result") |"
+            echo "| Visibility transitions detected | $(jq '.summary.visibilityTransitions // 0' "$result") |"
+            echo "| Visibility transition duplicates skipped | $(jq '.visibilityTransitionDuplicatesSkipped // 0' "$result") |"
             echo "| Per-repo issues | $(jq '.perRepoIssues // 0' "$result") |"
             echo "| Rollup issues | $(jq '.rollupIssues // 0' "$result") |"
             echo "| Issues failed | $(jq '.issuesFailed // 0' "$result") |"

--- a/.github/workflows/reconcile-repos.yaml
+++ b/.github/workflows/reconcile-repos.yaml
@@ -76,6 +76,8 @@ jobs:
             echo "reconcile produced no result JSON" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
+          # Most fields read from the top level of HandleReconcileResult; the
+          # "detected" count lives under .summary.visibilityTransitions (nested).
           {
             echo "## Reconcile Repos Summary"
             echo ""

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -5585,8 +5585,11 @@ describe('reconcileRepos visibility-transition detection (Unit 9)', () => {
     expect(entry?.private).toBe(false)
   })
 
-  it('scenario 8: rapid flip within one cycle — detection uses stored state at probe time', () => {
-    // Stored: false. Probe: true. Transition fires. Next stored state becomes true.
+  it('scenario 8: queues a transition on a false→true visibility change', () => {
+    // Stored: false. Live access: true. Transition fires. Next stored state becomes true.
+    // NOTE: sequential rapid-flips (public→private→public within one cycle) are
+    // structurally identical to this single false→true case under single-probe-per-cycle
+    // semantics — separate coverage isn't needed.
     const result = reconcileRepos(
       makeInput({
         currentRepos: {version: 1, repos: [makeTransitionEntry(false)]},
@@ -5801,6 +5804,242 @@ describe('renderIssuePayload (visibility-transition rendering)', () => {
     const issue: VisibilityTransitionIssue = {kind: 'visibility-transition', node_id: TEST_NODE_ID}
     const payload: IssuePayload = renderIssuePayload(issue, 'fro-bot', '.github')
     expect(payload.labels).toEqual(['reconcile:integrity-alert', 'reconcile:visibility-transition'])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TEST FIX-1 — Same-run dedup race: two entries same node_id → one create
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('handleReconcile visibility-transition same-run dedup (FIX-1 #3332)', () => {
+  const DUPE_NODE_ID = 'R_kgDODupe3332'
+
+  it('issues.create called exactly once when two transition entries share the same node_id and listForRepo returns empty', async () => {
+    const issuesCreate = vi.fn(async () => ({data: {number: 10}}))
+    // paginate always returns empty → the listForRepo dedup won't suppress either.
+    // Only the same-run Set must suppress the second create.
+    const paginateMock = vi.fn(async () => [])
+
+    await handleReconcile(
+      baseParams({
+        appOctokit: mockOctokit({
+          paginate: paginateMock as unknown as OctokitMockOverrides['paginate'],
+          issuesCreate,
+        }),
+        readMetadata: makeReadMetadata({
+          repos: {
+            version: 1,
+            repos: [
+              // Two stored entries both pointing at the same node_id (owner/name differ
+              // only in the public vs redacted slot — unusual but possible if both an
+              // alias and the redacted form appear in the metadata state).
+              makeEntry({
+                owner: 'fro-bot',
+                name: 'repo-alpha',
+                node_id: DUPE_NODE_ID,
+                private: false,
+                onboarding_status: 'onboarded',
+              }),
+              makeEntry({
+                owner: 'fro-bot',
+                name: 'repo-beta',
+                node_id: DUPE_NODE_ID,
+                private: false,
+                onboarding_status: 'onboarded',
+              }),
+            ],
+          },
+        }),
+        userOctokit: mockOctokit({
+          listForAuthenticatedUser: async () => ({
+            data: [
+              {
+                owner: {login: 'fro-bot'},
+                name: 'repo-alpha',
+                archived: false,
+                private: true,
+                node_id: DUPE_NODE_ID,
+              },
+              {
+                owner: {login: 'fro-bot'},
+                name: 'repo-beta',
+                archived: false,
+                private: true,
+                node_id: DUPE_NODE_ID,
+              },
+            ],
+          }),
+        }),
+      }),
+    )
+
+    expect(issuesCreate).toHaveBeenCalledOnce()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TEST FIX-2 — Duplicate-skip observability: visibilityTransitionDuplicatesSkipped
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('handleReconcile visibility-transition duplicatesSkipped counter (FIX-2 #3334)', () => {
+  const SKIP_NODE_ID = 'R_kgDOSkip3334'
+  const SKIP_TITLE = `[INTEGRITY] Visibility transition for ${SKIP_NODE_ID}`
+
+  function makeSkipParams(paginateMock: OctokitMockOverrides['paginate']): HandleReconcileParams {
+    return baseParams({
+      appOctokit: mockOctokit({
+        paginate: paginateMock as unknown as OctokitMockOverrides['paginate'],
+        issuesCreate: async () => ({data: {number: 50}}),
+      }),
+      readMetadata: makeReadMetadata({
+        repos: {
+          version: 1,
+          repos: [
+            makeEntry({
+              owner: 'fro-bot',
+              name: 'skip-repo',
+              node_id: SKIP_NODE_ID,
+              private: false,
+              onboarding_status: 'onboarded',
+            }),
+          ],
+        },
+      }),
+      userOctokit: mockOctokit({
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {
+              owner: {login: 'fro-bot'},
+              name: 'skip-repo',
+              archived: false,
+              private: true,
+              node_id: SKIP_NODE_ID,
+            },
+          ],
+        }),
+      }),
+    })
+  }
+
+  it('visibilityTransitionDuplicatesSkipped is 1 when listForRepo finds existing matching title', async () => {
+    const paginateMock = vi.fn(async (_fn: unknown, opts: {labels?: string; state?: string}) => {
+      if (opts.labels === 'reconcile:visibility-transition' && opts.state === 'open') {
+        return [{number: 1, title: SKIP_TITLE, body: null, labels: [{name: 'reconcile:visibility-transition'}]}]
+      }
+      return []
+    })
+
+    const result = await handleReconcile(makeSkipParams(paginateMock as unknown as OctokitMockOverrides['paginate']))
+
+    expect(result.visibilityTransitionDuplicatesSkipped).toBe(1)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TEST FIX-3 — Hoist ensureLabelsExist: called once for N transition issues
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('handleReconcile visibility-transition label preflight hoisted (FIX-3 #3340)', () => {
+  const HOIST_NODE_ID_A = 'R_kgDOHoistA'
+  const HOIST_NODE_ID_B = 'R_kgDOHoistB'
+
+  it('getLabel called exactly twice (once per label) even when two transition issues fire', async () => {
+    const issuesCreate = vi.fn(async () => ({data: {number: 77}}))
+    const issuesGetLabel = vi.fn(async () => ({data: {name: 'label'}}))
+    const paginateMock = vi.fn(async () => [])
+
+    await handleReconcile(
+      baseParams({
+        appOctokit: mockOctokit({
+          paginate: paginateMock as unknown as OctokitMockOverrides['paginate'],
+          issuesCreate,
+          issuesGetLabel,
+        }),
+        readMetadata: makeReadMetadata({
+          repos: {
+            version: 1,
+            repos: [
+              makeEntry({
+                owner: 'fro-bot',
+                name: 'hoist-repo-a',
+                node_id: HOIST_NODE_ID_A,
+                private: false,
+                onboarding_status: 'onboarded',
+              }),
+              makeEntry({
+                owner: 'fro-bot',
+                name: 'hoist-repo-b',
+                node_id: HOIST_NODE_ID_B,
+                private: false,
+                onboarding_status: 'onboarded',
+              }),
+            ],
+          },
+        }),
+        userOctokit: mockOctokit({
+          listForAuthenticatedUser: async () => ({
+            data: [
+              {
+                owner: {login: 'fro-bot'},
+                name: 'hoist-repo-a',
+                archived: false,
+                private: true,
+                node_id: HOIST_NODE_ID_A,
+              },
+              {
+                owner: {login: 'fro-bot'},
+                name: 'hoist-repo-b',
+                archived: false,
+                private: true,
+                node_id: HOIST_NODE_ID_B,
+              },
+            ],
+          }),
+        }),
+      }),
+    )
+
+    // Two issues, two labels → getLabel called 2 times total (hoisted once), not 4 (per-issue).
+    expect(issuesGetLabel).toHaveBeenCalledTimes(2)
+    expect(issuesCreate).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TEST FIX-4 — node_id backfill from access list into stored entry
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('reconcileRepos node_id backfill (FIX-4 #3335)', () => {
+  it('backfills node_id from access list when stored entry has none', () => {
+    const ACCESS_NODE_ID = 'R_kgDOBackfill'
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {
+          version: 1,
+          repos: [
+            // Entry with no node_id — simulates the ha-config scenario
+            makeEntry({
+              owner: 'fro-bot',
+              name: 'ha-config',
+              // node_id intentionally absent
+              private: false,
+              onboarding_status: 'onboarded',
+            }),
+          ],
+        },
+        accessList: [
+          makeAccess({
+            owner: 'fro-bot',
+            name: 'ha-config',
+            node_id: ACCESS_NODE_ID,
+            private: false,
+          }),
+        ],
+      }),
+    )
+
+    const next = result.nextRepos.repos.find(r => r.name === 'ha-config')
+    expect(next?.node_id).toBe(ACCESS_NODE_ID)
   })
 })
 

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -6355,3 +6355,87 @@ describe('handleReconcile visibility-transition: transient label-check failure d
     expect(issuesGetLabel.mock.calls.length).toBeGreaterThan(2)
   })
 })
+
+describe('handleReconcile visibility-transition: partial label confirmation is not cached', () => {
+  const LABEL_NODE_ID_C = 'R_kgDOLabelC'
+  const LABEL_NODE_ID_D = 'R_kgDOLabelD'
+
+  it('second transition issue retries ensureLabelsExist when first call confirms only a subset of labels', async () => {
+    // Tracks which label names getLabel has been called for, in order
+    const getLabelCalls: string[] = []
+
+    // First label (VISIBILITY_TRANSITION_LABEL) always succeeds immediately.
+    // Second label (INTEGRITY_ALERT_LABEL) fails with a transient 500 on the first call
+    // (so ensureLabelsExist returns size=1 on issue 1 — a partial set).
+    // On the second issue's preflight, both labels should be queried again.
+    const issuesGetLabel = vi.fn(async (params: unknown) => {
+      const {name} = params as {owner: string; repo: string; name: string}
+      getLabelCalls.push(name)
+      const callIndexForThisLabel = getLabelCalls.filter(n => n === name).length
+      if (name === 'reconcile:integrity-alert' && callIndexForThisLabel === 1) {
+        // Transient failure on first attempt for the second label
+        const err = Object.assign(new Error('transient server error'), {status: 500})
+        throw err
+      }
+      return {data: {name}}
+    })
+    const issuesCreate = vi.fn(async () => ({data: {number: 99}}))
+    const paginateMock = vi.fn(async () => [])
+
+    await handleReconcile(
+      baseParams({
+        appOctokit: mockOctokit({
+          paginate: paginateMock as unknown as OctokitMockOverrides['paginate'],
+          issuesCreate,
+          issuesGetLabel,
+        }),
+        readMetadata: makeReadMetadata({
+          repos: {
+            version: 1,
+            repos: [
+              makeEntry({
+                owner: 'fro-bot',
+                name: 'partial-label-repo-c',
+                node_id: LABEL_NODE_ID_C,
+                private: false,
+                onboarding_status: 'onboarded',
+              }),
+              makeEntry({
+                owner: 'fro-bot',
+                name: 'partial-label-repo-d',
+                node_id: LABEL_NODE_ID_D,
+                private: false,
+                onboarding_status: 'onboarded',
+              }),
+            ],
+          },
+        }),
+        userOctokit: mockOctokit({
+          listForAuthenticatedUser: async () => ({
+            data: [
+              {
+                owner: {login: 'fro-bot'},
+                name: 'partial-label-repo-c',
+                archived: false,
+                private: true,
+                node_id: LABEL_NODE_ID_C,
+              },
+              {
+                owner: {login: 'fro-bot'},
+                name: 'partial-label-repo-d',
+                archived: false,
+                private: true,
+                node_id: LABEL_NODE_ID_D,
+              },
+            ],
+          }),
+        }),
+      }),
+    )
+
+    // INTEGRITY_ALERT_LABEL must be queried at least twice — once per issue's preflight —
+    // confirming the partial result from issue 1 was NOT cached and issue 2 retried.
+    const integrityLabelCallCount = getLabelCalls.filter(n => n === 'reconcile:integrity-alert').length
+    expect(integrityLabelCallCount).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -3270,7 +3270,7 @@ describe('handleReconcile (I/O shell)', () => {
     })
 
     it('regression: does not duplicate rollup when listForRepo lags behind same-run create', async () => {
-      // Reproduces the 2026-05-18 race (run 26023380395, issues #3307 + #3308):
+      // Reproduces the 2026-05-18 race where listForRepo eventual-consistency lag caused
       //
       // Setup: bfra-me grants access to 2 repos in this run (NOT pre-existing in metadata).
       // Pass 1 of reconcileRepos adds both as `pending-review` + pushes 2 rawIssues.
@@ -5808,10 +5808,10 @@ describe('renderIssuePayload (visibility-transition rendering)', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// TEST FIX-1 — Same-run dedup race: two entries same node_id → one create
+// Same-run dedup race: two entries same node_id → one create, counter incremented
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('handleReconcile visibility-transition same-run dedup (FIX-1 #3332)', () => {
+describe('handleReconcile visibility-transition same-run dedup', () => {
   const DUPE_NODE_ID = 'R_kgDODupe3332'
 
   it('issues.create called exactly once when two transition entries share the same node_id and listForRepo returns empty', async () => {
@@ -5820,7 +5820,7 @@ describe('handleReconcile visibility-transition same-run dedup (FIX-1 #3332)', (
     // Only the same-run Set must suppress the second create.
     const paginateMock = vi.fn(async () => [])
 
-    await handleReconcile(
+    const result = await handleReconcile(
       baseParams({
         appOctokit: mockOctokit({
           paginate: paginateMock as unknown as OctokitMockOverrides['paginate'],
@@ -5874,14 +5874,15 @@ describe('handleReconcile visibility-transition same-run dedup (FIX-1 #3332)', (
     )
 
     expect(issuesCreate).toHaveBeenCalledOnce()
+    expect(result.visibilityTransitionDuplicatesSkipped).toBe(1)
   })
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// TEST FIX-2 — Duplicate-skip observability: visibilityTransitionDuplicatesSkipped
+// Duplicate-skip observability: visibilityTransitionDuplicatesSkipped counter
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('handleReconcile visibility-transition duplicatesSkipped counter (FIX-2 #3334)', () => {
+describe('handleReconcile visibility-transition duplicatesSkipped counter', () => {
   const SKIP_NODE_ID = 'R_kgDOSkip3334'
   const SKIP_TITLE = `[INTEGRITY] Visibility transition for ${SKIP_NODE_ID}`
 
@@ -5936,10 +5937,10 @@ describe('handleReconcile visibility-transition duplicatesSkipped counter (FIX-2
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// TEST FIX-3 — Hoist ensureLabelsExist: called once for N transition issues
+// Label preflight hoisting: ensureLabelsExist called once for N transition issues
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('handleReconcile visibility-transition label preflight hoisted (FIX-3 #3340)', () => {
+describe('handleReconcile visibility-transition label preflight hoisted', () => {
   const HOIST_NODE_ID_A = 'R_kgDOHoistA'
   const HOIST_NODE_ID_B = 'R_kgDOHoistB'
 
@@ -6006,10 +6007,10 @@ describe('handleReconcile visibility-transition label preflight hoisted (FIX-3 #
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// TEST FIX-4 — node_id backfill from access list into stored entry
+// node_id backfill: access list populates missing node_id in stored entry
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('reconcileRepos node_id backfill (FIX-4 #3335)', () => {
+describe('reconcileRepos node_id backfill', () => {
   it('backfills node_id from access list when stored entry has none', () => {
     const ACCESS_NODE_ID = 'R_kgDOBackfill'
     const result = reconcileRepos(
@@ -6017,12 +6018,12 @@ describe('reconcileRepos node_id backfill (FIX-4 #3335)', () => {
         currentRepos: {
           version: 1,
           repos: [
-            // Entry with no node_id — simulates the ha-config scenario
+            // Entry with no node_id and no private field — simulates the ha-config legacy shape
+            // where `private` was never written (undefined, not false).
             makeEntry({
               owner: 'fro-bot',
               name: 'ha-config',
-              // node_id intentionally absent
-              private: false,
+              // node_id and private intentionally absent (legacy entry shape)
               onboarding_status: 'onboarded',
             }),
           ],
@@ -6041,10 +6042,36 @@ describe('reconcileRepos node_id backfill (FIX-4 #3335)', () => {
     const next = result.nextRepos.repos.find(r => r.name === 'ha-config')
     expect(next?.node_id).toBe(ACCESS_NODE_ID)
   })
+
+  it('backfills node_id when stored entry has undefined private (legacy entry without private field)', () => {
+    // Pins the real ha-config scenario: `private` was never written to the YAML entry,
+    // so it deserializes as undefined. node_id backfill must still work.
+    const ACCESS_NODE_ID = 'R_kgDOBackfillUndef'
+    // makeEntry without private/node_id → both fields absent (undefined), matching legacy shape
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {
+          version: 1,
+          repos: [makeEntry({owner: 'fro-bot', name: 'ha-config-legacy', onboarding_status: 'onboarded'})],
+        },
+        accessList: [
+          makeAccess({
+            owner: 'fro-bot',
+            name: 'ha-config-legacy',
+            node_id: ACCESS_NODE_ID,
+            private: false,
+          }),
+        ],
+      }),
+    )
+
+    const next = result.nextRepos.repos.find(r => r.name === 'ha-config-legacy')
+    expect(next?.node_id).toBe(ACCESS_NODE_ID)
+  })
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// TEST #13 — Dedup branch coverage (existing open issue suppresses create)
+// Dedup branch coverage: existing open issue suppresses create
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('handleReconcile visibility-transition dedup', () => {
@@ -6169,5 +6196,162 @@ describe('handleReconcile visibility-transition dedup', () => {
     // Exact-title dedup: the existing issue title does NOT match the victim's expected title,
     // so issues.create MUST be called. Old substring code would have suppressed this.
     expect(issuesCreate).toHaveBeenCalledOnce()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Same-run dedup must not suppress a retry after a failed first create
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('handleReconcile visibility-transition same-run dedup: failed first create does not suppress retry', () => {
+  const RETRY_NODE_ID = 'R_kgDORetryC'
+
+  it('second same-node entry attempts issues.create when first create rejects, and duplicatesSkipped is 0', async () => {
+    let createCallCount = 0
+    const issuesCreate = vi.fn(async () => {
+      createCallCount += 1
+      if (createCallCount === 1) {
+        const err = Object.assign(new Error('simulated API failure'), {status: 500})
+        throw err
+      }
+      return {data: {number: 99}}
+    })
+    // paginate always returns empty → listForRepo dedup won't suppress anything
+    const paginateMock = vi.fn(async () => [])
+
+    const result = await handleReconcile(
+      baseParams({
+        appOctokit: mockOctokit({
+          paginate: paginateMock as unknown as OctokitMockOverrides['paginate'],
+          issuesCreate,
+        }),
+        readMetadata: makeReadMetadata({
+          repos: {
+            version: 1,
+            repos: [
+              makeEntry({
+                owner: 'fro-bot',
+                name: 'retry-repo-a',
+                node_id: RETRY_NODE_ID,
+                private: false,
+                onboarding_status: 'onboarded',
+              }),
+              makeEntry({
+                owner: 'fro-bot',
+                name: 'retry-repo-b',
+                node_id: RETRY_NODE_ID,
+                private: false,
+                onboarding_status: 'onboarded',
+              }),
+            ],
+          },
+        }),
+        userOctokit: mockOctokit({
+          listForAuthenticatedUser: async () => ({
+            data: [
+              {
+                owner: {login: 'fro-bot'},
+                name: 'retry-repo-a',
+                archived: false,
+                private: true,
+                node_id: RETRY_NODE_ID,
+              },
+              {
+                owner: {login: 'fro-bot'},
+                name: 'retry-repo-b',
+                archived: false,
+                private: true,
+                node_id: RETRY_NODE_ID,
+              },
+            ],
+          }),
+        }),
+      }),
+    )
+
+    // Both entries must attempt issues.create because the first one failed
+    expect(issuesCreate).toHaveBeenCalledTimes(2)
+    // duplicatesSkipped must NOT be incremented for a failed-then-retry case
+    expect(result.visibilityTransitionDuplicatesSkipped).toBe(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// A transient ensureLabelsExist failure must not poison the per-run label cache
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('handleReconcile visibility-transition: transient label-check failure does not poison cache', () => {
+  const LABEL_NODE_ID_A = 'R_kgDOLabelA'
+  const LABEL_NODE_ID_B = 'R_kgDOLabelB'
+
+  it('second transition issue triggers a fresh ensureLabelsExist when first call returns empty set', async () => {
+    let getLabelCallCount = 0
+    // First call per-label returns 500 (label confirmed set will be empty); second call succeeds
+    const issuesGetLabel = vi.fn(async () => {
+      getLabelCallCount += 1
+      if (getLabelCallCount <= 2) {
+        // First two calls (for the two labels on first issue) → fail
+        const err = Object.assign(new Error('transient'), {status: 500})
+        throw err
+      }
+      return {data: {name: 'label'}}
+    })
+    const issuesCreate = vi.fn(async () => ({data: {number: 42}}))
+    const paginateMock = vi.fn(async () => [])
+
+    await handleReconcile(
+      baseParams({
+        appOctokit: mockOctokit({
+          paginate: paginateMock as unknown as OctokitMockOverrides['paginate'],
+          issuesCreate,
+          issuesGetLabel,
+        }),
+        readMetadata: makeReadMetadata({
+          repos: {
+            version: 1,
+            repos: [
+              makeEntry({
+                owner: 'fro-bot',
+                name: 'label-repo-a',
+                node_id: LABEL_NODE_ID_A,
+                private: false,
+                onboarding_status: 'onboarded',
+              }),
+              makeEntry({
+                owner: 'fro-bot',
+                name: 'label-repo-b',
+                node_id: LABEL_NODE_ID_B,
+                private: false,
+                onboarding_status: 'onboarded',
+              }),
+            ],
+          },
+        }),
+        userOctokit: mockOctokit({
+          listForAuthenticatedUser: async () => ({
+            data: [
+              {
+                owner: {login: 'fro-bot'},
+                name: 'label-repo-a',
+                archived: false,
+                private: true,
+                node_id: LABEL_NODE_ID_A,
+              },
+              {
+                owner: {login: 'fro-bot'},
+                name: 'label-repo-b',
+                archived: false,
+                private: true,
+                node_id: LABEL_NODE_ID_B,
+              },
+            ],
+          }),
+        }),
+      }),
+    )
+
+    // getLabel should be called more than 2 times — the second issue must retry label check
+    // (cache was not poisoned by the empty first result)
+    expect(issuesGetLabel.mock.calls.length).toBeGreaterThan(2)
   })
 })

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -1246,6 +1246,11 @@ export interface HandleReconcileResult {
   rollupIssues: number
   /** Count of successfully-created visibility-transition integrity-alert issues. */
   visibilityTransitionIssues: number
+  /**
+   * Count of visibility-transition creates suppressed as duplicates (listForRepo-existing-title match
+   * or same-run Set dedup). Surfaces in the JSON result so operators can observe dedup activity.
+   */
+  visibilityTransitionDuplicatesSkipped: number
   /** Count of issue-creation failures across per-repo + rollup + visibility-transition. */
   issuesFailed: number
   /** Count of stale `reconcile:pending-review` issues auto-closed this run. */
@@ -1539,6 +1544,7 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
     perRepoIssues: issueOutcome.perRepoSucceeded,
     rollupIssues: issueOutcome.rollupSucceeded + healedRollups,
     visibilityTransitionIssues: issueOutcome.visibilityTransitionSucceeded,
+    visibilityTransitionDuplicatesSkipped: issueOutcome.visibilityTransitionDuplicatesSkipped,
     issuesFailed: issueOutcome.failed,
     closedStaleIssues,
     probesFailed,
@@ -2361,15 +2367,58 @@ async function runIssueQueue(params: {
   perRepoSucceeded: number
   rollupSucceeded: number
   visibilityTransitionSucceeded: number
+  /**
+   * Count of visibility-transition creates suppressed as duplicates this run (both the
+   * listForRepo-existing-title path and the same-run Set path).
+   */
+  visibilityTransitionDuplicatesSkipped: number
   failed: number
 }> {
   let perRepoSucceeded = 0
   let rollupSucceeded = 0
   let visibilityTransitionSucceeded = 0
+  let visibilityTransitionDuplicatesSkipped = 0
   let failed = 0
+
+  // FIX-1 (#3332): same-run dedup Set. Two visibility-transition queue entries for the same
+  // node_id in one reconcile plan can both pass the listForRepo dedup check because the
+  // Issues API is eventually consistent (a just-created issue may not appear in listForRepo
+  // yet). Tracking attempted node_ids here and skipping on second occurrence prevents the
+  // duplicate regardless of API lag. Both guards (listForRepo + this Set) apply.
+  const attemptedTransitionNodeIds = new Set<string>()
+
+  // FIX-3 (#3340): hoist ensureLabelsExist before the loop. Labels don't change mid-run;
+  // calling it per-issue wastes 2 round-trips × N issues. We call it once, lazily on the
+  // first visibility-transition issue, and reuse the result for all subsequent ones.
+  // Only visibility-transition issues use these labels; per-repo and rollup go directly
+  // to callIssuesCreate without label preflight, so the hoist doesn't affect them.
+  let cachedConfirmedLabels: Set<string> | null = null
+  const TRANSITION_LABELS = [
+    {
+      name: VISIBILITY_TRANSITION_LABEL,
+      color: 'f97316',
+      description: 'Tracked repo transitioned from public to private',
+    },
+    {
+      name: INTEGRITY_ALERT_LABEL,
+      color: 'b60205',
+      description: 'Reconcile integrity alert requiring operator action',
+    },
+  ] as const
+
   for (const issue of params.issues) {
     try {
       if (issue.kind === 'visibility-transition') {
+        // FIX-1: same-run Set dedup — skip if this node_id was already attempted this run.
+        if (attemptedTransitionNodeIds.has(issue.node_id)) {
+          params.logger.info(
+            `reconcile: visibility-transition duplicate skipped (same-run set, node_id=${issue.node_id})`,
+          )
+          visibilityTransitionDuplicatesSkipped += 1 // FIX-2: increment counter
+          continue
+        }
+        attemptedTransitionNodeIds.add(issue.node_id)
+
         // Dedup: skip if an open issue with the same node_id already exists.
         // Fail-open: if paginate throws, treat as "no existing issue found" and proceed
         // to create — better to risk a duplicate than to silently drop the alert.
@@ -2392,29 +2441,27 @@ async function runIssueQueue(params: {
         // is functionally equivalent to marker extraction and cheaper (no body fetch needed).
         const expectedTitle = `[INTEGRITY] Visibility transition for ${issue.node_id}`
         const alreadyOpen = existing.some(i => i.title === expectedTitle)
-        if (alreadyOpen) continue
+        if (alreadyOpen) {
+          // FIX-2: observable duplicate-skip logging + counter.
+          params.logger.info(
+            `reconcile: visibility-transition duplicate skipped (existing open issue, node_id=${issue.node_id})`,
+          )
+          visibilityTransitionDuplicatesSkipped += 1
+          continue
+        }
 
-        // Pre-flight label creation: ensure both labels exist before calling issues.create.
-        // Defends against the Update-Repo-Settings propagation race on first run.
-        // Returns only the labels that are confirmed usable; failures exclude that label.
-        const confirmedLabels = await ensureLabelsExist(
-          params.appOctokit,
-          params.owner,
-          params.repo,
-          [
-            {
-              name: VISIBILITY_TRANSITION_LABEL,
-              color: 'f97316',
-              description: 'Tracked repo transitioned from public to private',
-            },
-            {
-              name: INTEGRITY_ALERT_LABEL,
-              color: 'b60205',
-              description: 'Reconcile integrity alert requiring operator action',
-            },
-          ],
-          params.logger,
-        )
+        // FIX-3: use cached label preflight (ensureLabelsExist called once per runIssueQueue
+        // invocation, not once per issue).
+        if (cachedConfirmedLabels === null) {
+          cachedConfirmedLabels = await ensureLabelsExist(
+            params.appOctokit,
+            params.owner,
+            params.repo,
+            TRANSITION_LABELS,
+            params.logger,
+          )
+        }
+        const confirmedLabels = cachedConfirmedLabels
         const payload = renderIssuePayload(issue, params.owner, params.repo)
         const filteredPayload: IssuePayload = {
           ...payload,
@@ -2430,6 +2477,14 @@ async function runIssueQueue(params: {
         const payload = renderIssuePayload(issue, params.owner, params.repo)
         await callIssuesCreate(params.appOctokit, payload)
       }
+      /**
+       * FIX-6 (#3337): Counter semantics — these counts reflect issues.create API
+       * acknowledgements, not confirmed-created alerts. An ambiguous 5xx (where the API
+       * processed the request but the response was lost in transit) may over-count `failed`
+       * or under-count the success counters. This is acceptable at current scale (visibility
+       * transitions are rare events); a listForRepo reconciliation pass would be needed only
+       * if these counters ever drive SLO/alerting.
+       */
       switch (issue.kind) {
         case 'per-repo': {
           perRepoSucceeded += 1
@@ -2455,7 +2510,13 @@ async function runIssueQueue(params: {
       params.logger.warn(`reconcile: issue creation failed (status=${status}); continuing.`)
     }
   }
-  return {perRepoSucceeded, rollupSucceeded, visibilityTransitionSucceeded, failed}
+  return {
+    perRepoSucceeded,
+    rollupSucceeded,
+    visibilityTransitionSucceeded,
+    visibilityTransitionDuplicatesSkipped,
+    failed,
+  }
 }
 
 /**

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -1284,7 +1284,7 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
   const maxDispatchesPerRun = params.maxDispatchesPerRun ?? loadMaxDispatchesPerRunFromEnv()
   const logger: ReconcileLogger = params.logger ?? {
     warn: message => process.stderr.write(`${message}\n`),
-    info: message => process.stdout.write(`${message}\n`),
+    info: message => process.stderr.write(`${message}\n`),
   }
   const readMetadata = params.readMetadata ?? readMetadataFromDisk
   const commitMetadataImpl = params.commitMetadata ?? defaultCommitMetadata
@@ -2380,18 +2380,16 @@ async function runIssueQueue(params: {
   let visibilityTransitionDuplicatesSkipped = 0
   let failed = 0
 
-  // FIX-1 (#3332): same-run dedup Set. Two visibility-transition queue entries for the same
+  // Same-run dedup Set. Two visibility-transition queue entries for the same
   // node_id in one reconcile plan can both pass the listForRepo dedup check because the
   // Issues API is eventually consistent (a just-created issue may not appear in listForRepo
-  // yet). Tracking attempted node_ids here and skipping on second occurrence prevents the
-  // duplicate regardless of API lag. Both guards (listForRepo + this Set) apply.
+  // yet). Tracking successfully-created node_ids here and skipping on second occurrence
+  // prevents duplicates regardless of API lag. Both guards (listForRepo + this Set) apply.
   const attemptedTransitionNodeIds = new Set<string>()
 
-  // FIX-3 (#3340): hoist ensureLabelsExist before the loop. Labels don't change mid-run;
-  // calling it per-issue wastes 2 round-trips × N issues. We call it once, lazily on the
-  // first visibility-transition issue, and reuse the result for all subsequent ones.
-  // Only visibility-transition issues use these labels; per-repo and rollup go directly
-  // to callIssuesCreate without label preflight, so the hoist doesn't affect them.
+  // Label preflight: ensureLabelsExist is hoisted out of the per-issue loop. Labels don't
+  // change mid-run; calling it per-issue wastes 2 round-trips × N issues. We call it lazily
+  // on the first visibility-transition issue and reuse when the result is confirmed (non-empty).
   let cachedConfirmedLabels: Set<string> | null = null
   const TRANSITION_LABELS = [
     {
@@ -2409,15 +2407,16 @@ async function runIssueQueue(params: {
   for (const issue of params.issues) {
     try {
       if (issue.kind === 'visibility-transition') {
-        // FIX-1: same-run Set dedup — skip if this node_id was already attempted this run.
+        // Same-run Set dedup — skip if this node_id was already successfully created this run.
+        // The set is populated AFTER a successful create, so a failed first attempt does not
+        // suppress a subsequent retry for the same node_id.
         if (attemptedTransitionNodeIds.has(issue.node_id)) {
           params.logger.info(
             `reconcile: visibility-transition duplicate skipped (same-run set, node_id=${issue.node_id})`,
           )
-          visibilityTransitionDuplicatesSkipped += 1 // FIX-2: increment counter
+          visibilityTransitionDuplicatesSkipped += 1
           continue
         }
-        attemptedTransitionNodeIds.add(issue.node_id)
 
         // Dedup: skip if an open issue with the same node_id already exists.
         // Fail-open: if paginate throws, treat as "no existing issue found" and proceed
@@ -2442,7 +2441,6 @@ async function runIssueQueue(params: {
         const expectedTitle = `[INTEGRITY] Visibility transition for ${issue.node_id}`
         const alreadyOpen = existing.some(i => i.title === expectedTitle)
         if (alreadyOpen) {
-          // FIX-2: observable duplicate-skip logging + counter.
           params.logger.info(
             `reconcile: visibility-transition duplicate skipped (existing open issue, node_id=${issue.node_id})`,
           )
@@ -2450,18 +2448,23 @@ async function runIssueQueue(params: {
           continue
         }
 
-        // FIX-3: use cached label preflight (ensureLabelsExist called once per runIssueQueue
-        // invocation, not once per issue).
-        if (cachedConfirmedLabels === null) {
-          cachedConfirmedLabels = await ensureLabelsExist(
+        // Label preflight: ensureLabelsExist is called once per runIssueQueue invocation,
+        // lazily on the first visibility-transition issue. The result is cached only when
+        // non-empty (confirmed); an empty result from a transient failure leaves the cache
+        // null so the next issue retries rather than shipping unlabeled for the rest of the run.
+        if (cachedConfirmedLabels === null || cachedConfirmedLabels.size === 0) {
+          const labels = await ensureLabelsExist(
             params.appOctokit,
             params.owner,
             params.repo,
             TRANSITION_LABELS,
             params.logger,
           )
+          if (labels.size > 0) {
+            cachedConfirmedLabels = labels
+          }
         }
-        const confirmedLabels = cachedConfirmedLabels
+        const confirmedLabels = cachedConfirmedLabels ?? new Set<string>()
         const payload = renderIssuePayload(issue, params.owner, params.repo)
         const filteredPayload: IssuePayload = {
           ...payload,
@@ -2473,17 +2476,19 @@ async function runIssueQueue(params: {
           )
         }
         await callIssuesCreate(params.appOctokit, filteredPayload)
+        // Mark as successfully created — only after the create call succeeds.
+        // This ensures a failed create does not suppress a subsequent retry for the same node_id.
+        attemptedTransitionNodeIds.add(issue.node_id)
       } else {
         const payload = renderIssuePayload(issue, params.owner, params.repo)
         await callIssuesCreate(params.appOctokit, payload)
       }
       /**
-       * FIX-6 (#3337): Counter semantics — these counts reflect issues.create API
-       * acknowledgements, not confirmed-created alerts. An ambiguous 5xx (where the API
-       * processed the request but the response was lost in transit) may over-count `failed`
-       * or under-count the success counters. This is acceptable at current scale (visibility
-       * transitions are rare events); a listForRepo reconciliation pass would be needed only
-       * if these counters ever drive SLO/alerting.
+       * Counter semantics: these counts reflect issues.create API acknowledgements, not
+       * confirmed-created alerts. An ambiguous 5xx (where the API processed the request but
+       * the response was lost in transit) may over-count `failed` or under-count the success
+       * counters. This is acceptable at current scale (visibility transitions are rare events);
+       * a listForRepo reconciliation pass would be needed only if these counters drive SLO/alerting.
        */
       switch (issue.kind) {
         case 'per-repo': {

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -2448,11 +2448,15 @@ async function runIssueQueue(params: {
           continue
         }
 
-        // Label preflight: ensureLabelsExist is called once per runIssueQueue invocation,
-        // lazily on the first visibility-transition issue. The result is cached only when
-        // non-empty (confirmed); an empty result from a transient failure leaves the cache
-        // null so the next issue retries rather than shipping unlabeled for the rest of the run.
-        if (cachedConfirmedLabels === null || cachedConfirmedLabels.size === 0) {
+        // Label preflight: ensureLabelsExist is called lazily on the first visibility-transition
+        // issue and cached for reuse. The cache is committed only when every required label is
+        // confirmed (labels.size equals TRANSITION_LABELS.length). A partial result — where a
+        // transient failure excluded one or more labels — is never cached: the cache stays null
+        // so each subsequent issue retries the full preflight until a complete set is confirmed.
+        // Regardless of whether the cache is committed, the current issue always uses the freshly
+        // computed label set from this call, not an empty fallback.
+        let confirmedLabels: Set<string>
+        if (cachedConfirmedLabels === null) {
           const labels = await ensureLabelsExist(
             params.appOctokit,
             params.owner,
@@ -2460,11 +2464,13 @@ async function runIssueQueue(params: {
             TRANSITION_LABELS,
             params.logger,
           )
-          if (labels.size > 0) {
+          if (labels.size === TRANSITION_LABELS.length) {
             cachedConfirmedLabels = labels
           }
+          confirmedLabels = labels
+        } else {
+          confirmedLabels = cachedConfirmedLabels
         }
-        const confirmedLabels = cachedConfirmedLabels ?? new Set<string>()
         const payload = renderIssuePayload(issue, params.owner, params.repo)
         const filteredPayload: IssuePayload = {
           ...payload,


### PR DESCRIPTION
Hardens and instruments the reconcile visibility-transition path — the integrity-alert machinery that fires when a tracked repo flips public→private.

## Correctness

- **Same-run dedup.** Two visibility-transition entries for the same `node_id` in one reconcile plan could both create an alert, because dedup only consulted the eventually-consistent open-issues list. A per-run set now suppresses the second create — and only after the first one actually succeeds, so a failed create still allows a genuine retry rather than being silently swallowed.
- **Label preflight.** The per-issue `getLabel`/`createLabel` round-trips are hoisted to once per run via a confirmed-label cache. The cache commits only when every required label is confirmed, so a transient partial failure can't pin later issues to an incomplete label set.

## Observability

- **Step summary.** The reconcile run now writes a markdown summary to the job's Summary tab (dispatches, transitions detected, transition issues created, duplicates skipped, failures, commit status). An operator no longer has to grep the full log to answer "did a visibility transition fire today?"
- **Duplicate-skip counter + log.** A new `visibilityTransitionDuplicatesSkipped` count in the JSON output plus an info log at the skip point — the dedup path is no longer silent.

## Reliability

- The reconcile step runs under `bash` so the `tee` that captures the result JSON can't mask a non-zero exit via pipefail.
- The result logger writes to stderr, leaving stdout as pure JSON so the captured result file stays parseable.

## Self-healing

- A legacy entry missing its `node_id` is backfilled from the live access list on the next refresh (verified against the real undefined-`private` shape and pinned by a characterization test), so the "transition can't fire without a subject" gap closes itself for any still-accessible repo.

## Tests

765 passing. New coverage: same-run dedup (incl. failed-first-create retry), the duplicates-skipped counter, label-preflight hoisting, partial-label-cache retry, and node_id backfill for the legacy shape.
