### PR TITLE
Re-verify repo visibility before external broadcast (close survey→broadcast TOCTOU)

### DIFF
--- a/.github/workflows/social-broadcast.yaml
+++ b/.github/workflows/social-broadcast.yaml
@@ -28,12 +28,21 @@ on:
         required: false
         type: boolean
         default: true
+      node_id:
+        description: Repo GraphQL node_id used to re-verify public visibility immediately before an external post, closing the recheck→broadcast TOCTOU window. Pass empty string to skip re-verification (falls back to inputs.private).
+        required: false
+        type: string
+        default: ''
     secrets:
       DISCORD_WEBHOOK_URL:
         required: false
       BLUESKY_HANDLE:
         required: false
       BLUESKY_APP_PASSWORD:
+        required: false
+      APPLICATION_ID:
+        required: false
+      APPLICATION_PRIVATE_KEY:
         required: false
 
 permissions:
@@ -51,8 +60,74 @@ jobs:
       - name: 📦 Setup
         uses: ./.github/actions/setup
 
+      # Mint a short-lived App token for the pre-post visibility re-check.
+      # Only runs when the caller opts in by passing a node_id — callers that
+      # don't pass node_id skip both this step and the verify step entirely,
+      # falling back to the existing inputs.private literal gate.
+      - name: Mint App token for visibility gate
+        id: gate-token
+        if: inputs.node_id != ''
+        # continue-on-error so a missing APPLICATION_ID secret produces outcome='failure'
+        # (not 'success') without hard-failing the job — verify then skips and Discord
+        # falls back to the inputs.private literal gate (existing caller behavior).
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      # Re-verify that the repo is still public immediately before posting to external
+      # channels. This closes the TOCTOU window between survey-repo's recheck step and
+      # the broadcast job starting (queue + runner-allocation delay). Fail mode is
+      # closed-skip: any non-confirmation (gh error, isPrivate != false, missing field,
+      # invalid node_id shape) writes public=false and exits 0 — the Discord/Bluesky
+      # steps then skip gracefully rather than hard-failing the caller's broadcast.
+      - name: 🔒 Re-verify visibility before external post
+        id: verify
+        if: steps.gate-token.outcome == 'success'
+        env:
+          NODE_ID: ${{ inputs.node_id }}
+          GH_TOKEN: ${{ steps.gate-token.outputs.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if ! printf '%s' "$NODE_ID" | grep -qE '^[A-Za-z0-9_=-]+$'; then
+            printf 'node_id shape invalid; skipping external post\n' >&2
+            echo "public=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # shellcheck disable=SC2016
+          gql_query='query($id: ID!) { node(id: $id) { ... on Repository { isPrivate } } }'
+          gh_stderr=$(mktemp)
+          trap 'rm -f "$gh_stderr"' EXIT
+          if ! response=$(gh api graphql \
+            -F id="$NODE_ID" \
+            -f query="$gql_query" \
+            2>"$gh_stderr"); then
+            printf 'GraphQL re-verify failed for node_id: %s\n' "$NODE_ID" >&2
+            printf '%s\n' '--- gh stderr ---' >&2
+            cat "$gh_stderr" >&2
+            printf '%s\n' '--- end gh stderr ---' >&2
+            printf 'repo is no longer confirmed public since recheck; skipping external post\n' >&2
+            echo "public=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! printf '%s' "$response" | jq -e '.data.node.isPrivate == false' >/dev/null; then
+            printf 'repo is no longer confirmed public since recheck; skipping external post\n' >&2
+            echo "public=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "public=true" >> "$GITHUB_OUTPUT"
+
       - name: 📣 Notify Discord
-        if: inputs.discord_message != '' && inputs.private != true
+        if: >-
+          inputs.discord_message != '' && inputs.private != true &&
+          (steps.verify.outcome == 'skipped' || steps.verify.outputs.public == 'true')
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           DISCORD_MESSAGE: ${{ inputs.discord_message }}
@@ -66,7 +141,9 @@ jobs:
       # The script (scripts/bluesky-post.ts) is intentionally retained for future
       # reactivation; only the step invocation here is gated off via `if: false`.
       - name: 🦋 Post to Bluesky
-        if: false && inputs.bluesky_text != '' && inputs.private != true
+        if: >-
+          false && inputs.bluesky_text != '' && inputs.private != true &&
+          (steps.verify.outcome == 'skipped' || steps.verify.outputs.public == 'true')
         env:
           BLUESKY_HANDLE: ${{ secrets.BLUESKY_HANDLE }}
           BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}

--- a/.github/workflows/social-broadcast.yaml
+++ b/.github/workflows/social-broadcast.yaml
@@ -124,10 +124,18 @@ jobs:
 
           echo "public=true" >> "$GITHUB_OUTPUT"
 
+      # Surface the degraded path: the caller opted in to a pre-post re-verify
+      # (passed a node_id) but the App token could not be minted, so visibility
+      # was not re-confirmed. The external post is skipped fail-closed below; this
+      # warning makes that decision visible in the run log instead of silent.
+      - name: ⚠️ Warn on unverifiable opt-in
+        if: inputs.node_id != '' && steps.gate-token.outcome != 'success'
+        run: echo "::warning::node_id supplied but visibility re-verify could not run (token mint failed); skipping external post fail-closed."
+
       - name: 📣 Notify Discord
         if: >-
           inputs.discord_message != '' && inputs.private != true &&
-          (steps.verify.outcome == 'skipped' || steps.verify.outputs.public == 'true')
+          (inputs.node_id == '' || steps.verify.outputs.public == 'true')
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           DISCORD_MESSAGE: ${{ inputs.discord_message }}
@@ -143,7 +151,7 @@ jobs:
       - name: 🦋 Post to Bluesky
         if: >-
           false && inputs.bluesky_text != '' && inputs.private != true &&
-          (steps.verify.outcome == 'skipped' || steps.verify.outputs.public == 'true')
+          (inputs.node_id == '' || steps.verify.outputs.public == 'true')
         env:
           BLUESKY_HANDLE: ${{ secrets.BLUESKY_HANDLE }}
           BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}

--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -301,10 +301,15 @@ jobs:
       discord_title: Repo Survey Complete
       # bluesky_text intentionally omitted — Bluesky step in social-broadcast.yaml
       # is currently gated off via `if: false`. When revived, restore copy here.
-      # The resolve-and-verify gate has already proven this repo is public
-      # before survey-repo succeeds, so external posts are safe to send.
+      # The resolve-and-verify gate has already proven this repo was public
+      # before survey-repo succeeded. private: false is the fail-safe floor;
+      # the broadcast job re-verifies visibility at post time via node_id,
+      # closing the recheck→broadcast queue window.
       private: false
+      node_id: ${{ inputs.node_id }}
     secrets:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
       BLUESKY_HANDLE: ${{ secrets.BLUESKY_HANDLE }}
       BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
+      APPLICATION_ID: ${{ secrets.APPLICATION_ID }}
+      APPLICATION_PRIVATE_KEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}


### PR DESCRIPTION
Closes a narrow but real privacy window in the survey → social-broadcast pipeline.

## The window

`survey-repo` proves a repo is public in its visibility-recheck step, then a **separate** downstream `broadcast` job posts the repo's name to an external Discord webhook. Between those two — queue delay, runner allocation — the repo can flip private, and the post still fires carrying the now-private identity. The caller passes a `private: false` literal frozen at workflow-expansion time, so the existing gate can't catch a flip that happens after recheck.

## The fix

`social-broadcast.yaml` now re-resolves the repo's visibility from its `node_id` immediately before posting, using a short-lived App token (the only credential that can read a cross-org repo's visibility). External steps post **only** when this fresh check confirms the repo is still public.

Fail-closed-skip: any non-confirmation — a GraphQL error, `isPrivate != false`, a missing field, or an invalid `node_id` shape — skips the external post and exits 0 rather than failing the caller's broadcast. A flipped repo is silently (but loggedly) not announced.

Backward compatible: callers that don't pass a `node_id` (or don't supply the App secret) fall back to the existing `inputs.private` literal gate unchanged, so the reusable-workflow contract is unbroken.

## Behavior matrix

| `node_id` | App secret | Re-verify result | External post |
| --- | --- | --- | --- |
| absent | — | skipped | existing `private` gate only (unchanged) |
| present | yes | confirmed public | posts |
| present | yes | flipped / error / missing | **skipped — window closed** |
| present | no | token mint fails (continue-on-error) | skipped → falls back to `private` gate |

## Notes

The re-verify mirrors `survey-repo`'s existing resolve/recheck pattern (same pinned App-token action, same `isPrivate` GraphQL query, same stderr-capture discipline) but changes the fail mode from hard-fail to closed-skip, since a reusable broadcast workflow shouldn't turn red because a repo it was asked to announce went private. actionlint clean; existing test suite unaffected (workflow-only change).
