### PR TITLE
fix: paginate promotion-alert dedup and harden wiki-page attribution

### DIFF
--- a/scripts/check-wiki-private-presence.test.ts
+++ b/scripts/check-wiki-private-presence.test.ts
@@ -1,5 +1,6 @@
 import type {RepoEntry} from './schemas.ts'
 
+import process from 'node:process'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {
   buildPublicSlugMap,
@@ -27,8 +28,13 @@ vi.mock('node:fs/promises', () => ({
   readdir: mockReaddir,
 }))
 
+// Suppress stderr during tests to avoid polluting output with legacy-attribution warnings.
+// Individual tests that want to assert on stderr capture it explicitly.
+const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
 beforeEach(() => {
   vi.clearAllMocks()
+  stderrSpy.mockClear()
 })
 
 // ---------------------------------------------------------------------------
@@ -378,6 +384,152 @@ describe('detectPrivateWikiLeaks', () => {
       })
       expect(result).toHaveLength(1)
       expect(result[0]).toMatchObject({filename: 'R_kgDOABCDEF.md', reason: 'unattributable-page'})
+    })
+  })
+
+  describe('structured frontmatter attribution', () => {
+    it('structured pass: page with matching sources[].url in frontmatter is attributed even without body URL', () => {
+      // #given a page whose frontmatter sources list the expected public repo URL
+      //        but whose body does NOT contain the raw URL
+      // #when detection runs
+      // #then passes via structured attribution — body is irrelevant when sources are present
+      const content = [
+        '---',
+        'type: repo',
+        'sources:',
+        '  - url: https://github.com/owner/name',
+        '---',
+        'Body text with no raw URL here.',
+      ].join('\n')
+      const result = detectPrivateWikiLeaks({
+        dataWikiPages: [page('owner--name.md', 'h1', content)],
+        publicSlugMap: new Map([
+          ['owner--name', [{owner: 'owner', name: 'name', private: false} as unknown as RepoEntry]],
+        ]),
+        grandfatherPages: [],
+      })
+      expect(result).toEqual([])
+    })
+
+    it('decoy-URL spoof caught: structured sources present but non-matching, body has URL — still flagged', () => {
+      // #given a page whose frontmatter sources point to a DIFFERENT repo (non-matching)
+      //        but whose body contains the expected public URL as a decoy
+      // #when detection runs
+      // #then FLAGGED — structured sources are authoritative when present;
+      //        body substring is ignored, closing the spoof vector
+      const content = [
+        '---',
+        'type: repo',
+        'sources:',
+        '  - url: https://github.com/attacker/private-repo',
+        '---',
+        'Check out https://github.com/acme/widget for more info.',
+      ].join('\n')
+      const result = detectPrivateWikiLeaks({
+        dataWikiPages: [page('acme--widget.md', 'h1', content)],
+        publicSlugMap: new Map([
+          ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+        ]),
+        grandfatherPages: [],
+      })
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({filename: 'acme--widget.md', reason: 'unattributable-page'})
+    })
+
+    it('legacy fallback (no over-block): page with NO sources key in frontmatter — body URL passes via fallback', () => {
+      // #given a page with YAML frontmatter that has NO sources key at all
+      //        but whose body contains the expected URL
+      // #when detection runs
+      // #then passes via legacy substring fallback — no sources key means no structured authority
+      const content = [
+        '---',
+        'type: repo',
+        'title: "acme/widget"',
+        '---',
+        'See https://github.com/acme/widget for details.',
+      ].join('\n')
+      const result = detectPrivateWikiLeaks({
+        dataWikiPages: [page('acme--widget.md', 'h1', content)],
+        publicSlugMap: new Map([
+          ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+        ]),
+        grandfatherPages: [],
+      })
+      expect(result).toEqual([])
+    })
+
+    it('legacy fallback (no over-block): page with no frontmatter at all — body URL passes via fallback', () => {
+      // #given a page with no YAML frontmatter markers (legacy prose-only page)
+      //        whose body contains the expected URL
+      // #when detection runs
+      // #then passes via legacy substring fallback — exactly as the pre-existing substring check
+      const content = 'See https://github.com/acme/widget for details.'
+      const result = detectPrivateWikiLeaks({
+        dataWikiPages: [page('acme--widget.md', 'h1', content)],
+        publicSlugMap: new Map([
+          ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+        ]),
+        grandfatherPages: [],
+      })
+      expect(result).toEqual([])
+    })
+
+    it('unparseable frontmatter with body URL — falls back to substring and passes', () => {
+      // #given a page with YAML frontmatter fences but invalid YAML content
+      //        and the expected URL appears in the body
+      // #when detection runs
+      // #then falls back to legacy substring check and passes (no over-block)
+      const content = [
+        '---',
+        ': invalid: yaml: content: [[[',
+        '---',
+        'See https://github.com/acme/widget for details.',
+      ].join('\n')
+      const result = detectPrivateWikiLeaks({
+        dataWikiPages: [page('acme--widget.md', 'h1', content)],
+        publicSlugMap: new Map([
+          ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+        ]),
+        grandfatherPages: [],
+      })
+      expect(result).toEqual([])
+    })
+
+    it('negative case: no sources, no URL in body — flagged as before', () => {
+      // #given a page with no structured sources and no URL in body
+      // #when detection runs
+      // #then flagged — both structured and substring checks fail
+      const content = 'Nothing useful here.'
+      const result = detectPrivateWikiLeaks({
+        dataWikiPages: [page('acme--widget.md', 'h1', content)],
+        publicSlugMap: new Map([
+          ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+        ]),
+        grandfatherPages: [],
+      })
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({filename: 'acme--widget.md', reason: 'unattributable-page'})
+    })
+
+    it('legacy fallback emits redaction-safe stderr warning (no private owner/name)', () => {
+      // #given a page that passes via legacy substring fallback (no sources frontmatter)
+      // #when detection runs
+      // #then a warning is written to stderr referencing only the public slug (safe to log),
+      //        and never containing any private repo owner/name
+      const content = 'See https://github.com/acme/widget for details.'
+      detectPrivateWikiLeaks({
+        dataWikiPages: [page('acme--widget.md', 'h1', content)],
+        publicSlugMap: new Map([
+          ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+        ]),
+        grandfatherPages: [],
+      })
+      expect(stderrSpy).toHaveBeenCalled()
+      const written = stderrSpy.mock.calls.map(args => String(args[0])).join('')
+      // Warning must reference the safe public slug
+      expect(written).toContain('acme--widget')
+      // Warning must NOT contain any private identifier pattern (nothing beyond the public slug)
+      expect(written).not.toContain('private')
     })
   })
 

--- a/scripts/check-wiki-private-presence.test.ts
+++ b/scripts/check-wiki-private-presence.test.ts
@@ -511,12 +511,14 @@ describe('detectPrivateWikiLeaks', () => {
       expect(result[0]).toMatchObject({filename: 'acme--widget.md', reason: 'unattributable-page'})
     })
 
-    it('legacy fallback emits redaction-safe stderr warning (no private owner/name)', () => {
+    it('legacy fallback emits redaction-safe stderr warning — parsed JSON contains only slug, never sensitive names', () => {
       // #given a page that passes via legacy substring fallback (no sources frontmatter)
+      //        where 'widget-super-secret' is a sensitive private repo name that must never appear
       // #when detection runs
-      // #then a warning is written to stderr referencing only the public slug (safe to log),
-      //        and never containing any private repo owner/name
-      const content = 'See https://github.com/acme/widget for details.'
+      // #then a warning is written to stderr as parseable JSON containing ONLY the public slug,
+      //        with NO sensitive private name in the output
+      const sensitiveName = 'widget-super-secret'
+      const content = `See https://github.com/acme/widget for details. Internal name: ${sensitiveName}`
       detectPrivateWikiLeaks({
         dataWikiPages: [page('acme--widget.md', 'h1', content)],
         publicSlugMap: new Map([
@@ -526,10 +528,103 @@ describe('detectPrivateWikiLeaks', () => {
       })
       expect(stderrSpy).toHaveBeenCalled()
       const written = stderrSpy.mock.calls.map(args => String(args[0])).join('')
-      // Warning must reference the safe public slug
-      expect(written).toContain('acme--widget')
-      // Warning must NOT contain any private identifier pattern (nothing beyond the public slug)
-      expect(written).not.toContain('private')
+      // Parse the JSON to assert structure (not just substring presence)
+      const line = written.trim().split('\n')[0] ?? ''
+      const parsed = JSON.parse(line) as Record<string, unknown>
+      // Only allowed keys: level, event, message, slug
+      expect(Object.keys(parsed).sort()).toEqual(['event', 'level', 'message', 'slug'])
+      // Slug must be the safe public identifier
+      expect(parsed.slug).toBe('acme--widget')
+      // The sensitive private name must be absent from the entire stderr output
+      expect(written).not.toContain(sensitiveName)
+      // No raw filename (which would leak the owner--repo identity)
+      expect(written).not.toContain('acme--widget.md')
+    })
+  })
+
+  describe('present-but-empty sources key — authoritative fail-closed (no substring fallback)', () => {
+    it('flags: sources key present as empty array, body has decoy URL — no fallback to substring', () => {
+      // sources key IS present (empty array) → authoritative → some() is false → flagged
+      // Before fix: parseFrontmatterSources returned null → substring fallback → attributed (bug)
+      // After fix: returns [] → authoritative → flagged
+      const content = [
+        '---',
+        'type: repo',
+        'sources: []',
+        '---',
+        'See https://github.com/acme/widget for details.',
+      ].join('\n')
+      const result = detectPrivateWikiLeaks({
+        dataWikiPages: [page('acme--widget.md', 'h1', content)],
+        publicSlugMap: new Map([
+          ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+        ]),
+        grandfatherPages: [],
+      })
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({filename: 'acme--widget.md', reason: 'unattributable-page'})
+    })
+
+    it('flags: sources key present as scalar string (malformed), body has decoy URL — authoritative fail-closed', () => {
+      // sources key IS present but not an array → authoritative → return [] → flagged
+      // Before fix: !Array.isArray → return null → substring fallback → attributed (bug)
+      // After fix: present-but-non-array → return [] → flagged
+      const content = [
+        '---',
+        'type: repo',
+        'sources: "not-an-array"',
+        '---',
+        'See https://github.com/acme/widget for details.',
+      ].join('\n')
+      const result = detectPrivateWikiLeaks({
+        dataWikiPages: [page('acme--widget.md', 'h1', content)],
+        publicSlugMap: new Map([
+          ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+        ]),
+        grandfatherPages: [],
+      })
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({filename: 'acme--widget.md', reason: 'unattributable-page'})
+    })
+
+    it('flags: sources key present as null value, body has decoy URL — authoritative fail-closed', () => {
+      // sources: null → key is present, value is null → not an array → return [] → flagged
+      const content = [
+        '---',
+        'type: repo',
+        'sources: null',
+        '---',
+        'See https://github.com/acme/widget for details.',
+      ].join('\n')
+      const result = detectPrivateWikiLeaks({
+        dataWikiPages: [page('acme--widget.md', 'h1', content)],
+        publicSlugMap: new Map([
+          ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+        ]),
+        grandfatherPages: [],
+      })
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({filename: 'acme--widget.md', reason: 'unattributable-page'})
+    })
+
+    it('passes: sources key ABSENT (no sources property), body URL → legacy substring fallback (no over-block)', () => {
+      // sources key is completely absent from frontmatter → return null → substring fallback → attributed
+      // This is the pre-existing legacy case that must keep passing
+      const content = [
+        '---',
+        'type: repo',
+        'title: "acme/widget"',
+        '---',
+        'See https://github.com/acme/widget for details.',
+      ].join('\n')
+      const result = detectPrivateWikiLeaks({
+        dataWikiPages: [page('acme--widget.md', 'h1', content)],
+        publicSlugMap: new Map([
+          ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+        ]),
+        grandfatherPages: [],
+      })
+      expect(result).toEqual([])
     })
   })
 
@@ -1070,5 +1165,235 @@ describe('requireGrandfatherDir (fail-closed missing-env branch)', () => {
     // #given a clean path string
     const result = requireGrandfatherDir('/workspace/main/knowledge/wiki/repos')
     expect(result).toBe('/workspace/main/knowledge/wiki/repos')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// prefix-collision guard — sourceUrlMatchesRepo
+// ---------------------------------------------------------------------------
+
+describe('prefix-collision guard — sourceUrlMatchesRepo exact owner/repo matching', () => {
+  it('prefix-collision: source url acme/widget-private must NOT attribute page for acme/widget', () => {
+    // acme/widget-private is a prefix match for acme/widget under url.includes — must be FLAGGED
+    const content = [
+      '---',
+      'sources:',
+      '  - url: https://github.com/acme/widget-private',
+      '---',
+      'See https://github.com/acme/widget for details (decoy in body, body ignored when sources present).',
+    ].join('\n')
+    const result = detectPrivateWikiLeaks({
+      dataWikiPages: [page('acme--widget.md', 'h1', content)],
+      publicSlugMap: new Map([
+        ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+      ]),
+      grandfatherPages: [],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({filename: 'acme--widget.md', reason: 'unattributable-page'})
+  })
+
+  it('trailing path: source url with /blob/main/README.md still attributes correctly', () => {
+    // Trailing path segments beyond owner/repo are allowed — only owner and repo must match
+    const content = [
+      '---',
+      'sources:',
+      '  - url: https://github.com/acme/widget/blob/main/README.md',
+      '---',
+      'Content without extra URL.',
+    ].join('\n')
+    const result = detectPrivateWikiLeaks({
+      dataWikiPages: [page('acme--widget.md', 'h1', content)],
+      publicSlugMap: new Map([
+        ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+      ]),
+      grandfatherPages: [],
+    })
+    expect(result).toEqual([])
+  })
+
+  it('trailing slash: source url https://github.com/acme/widget/ still attributes correctly', () => {
+    const content = ['---', 'sources:', '  - url: https://github.com/acme/widget/', '---', 'Content.'].join('\n')
+    const result = detectPrivateWikiLeaks({
+      dataWikiPages: [page('acme--widget.md', 'h1', content)],
+      publicSlugMap: new Map([
+        ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+      ]),
+      grandfatherPages: [],
+    })
+    expect(result).toEqual([])
+  })
+
+  it('malformed source URL does not match (treated as no-match, not a crash)', () => {
+    const content = ['---', 'sources:', '  - url: not-a-valid-url', '---', 'Content.'].join('\n')
+    const result = detectPrivateWikiLeaks({
+      dataWikiPages: [page('acme--widget.md', 'h1', content)],
+      publicSlugMap: new Map([
+        ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+      ]),
+      grandfatherPages: [],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({filename: 'acme--widget.md', reason: 'unattributable-page'})
+  })
+
+  it('non-github host does not match (strict github.com only)', () => {
+    const content = ['---', 'sources:', '  - url: https://gitlab.com/acme/widget', '---', 'Content.'].join('\n')
+    const result = detectPrivateWikiLeaks({
+      dataWikiPages: [page('acme--widget.md', 'h1', content)],
+      publicSlugMap: new Map([
+        ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+      ]),
+      grandfatherPages: [],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({filename: 'acme--widget.md', reason: 'unattributable-page'})
+  })
+
+  it('non-https protocol (ftp) does not match — protocol restriction', () => {
+    // ftp://github.com/acme/widget should not attribute — only https: is accepted
+    const content = ['---', 'sources:', '  - url: ftp://github.com/acme/widget', '---', 'Content.'].join('\n')
+    const result = detectPrivateWikiLeaks({
+      dataWikiPages: [page('acme--widget.md', 'h1', content)],
+      publicSlugMap: new Map([
+        ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+      ]),
+      grandfatherPages: [],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({filename: 'acme--widget.md', reason: 'unattributable-page'})
+  })
+
+  it('custom port (https://github.com:444/acme/widget) does not match — port restriction', () => {
+    // Non-default port rejects the URL to close spoofing vectors
+    const content = ['---', 'sources:', '  - url: https://github.com:444/acme/widget', '---', 'Content.'].join('\n')
+    const result = detectPrivateWikiLeaks({
+      dataWikiPages: [page('acme--widget.md', 'h1', content)],
+      publicSlugMap: new Map([
+        ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+      ]),
+      grandfatherPages: [],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({filename: 'acme--widget.md', reason: 'unattributable-page'})
+  })
+
+  it('standard https://github.com/acme/widget still matches — positive regression guard', () => {
+    // Ensure protocol/port restrictions do not break the happy path
+    const content = ['---', 'sources:', '  - url: https://github.com/acme/widget', '---', 'Content.'].join('\n')
+    const result = detectPrivateWikiLeaks({
+      dataWikiPages: [page('acme--widget.md', 'h1', content)],
+      publicSlugMap: new Map([
+        ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+      ]),
+      grandfatherPages: [],
+    })
+    expect(result).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// false-frontmatter guard — anchored frontmatter regex
+// ---------------------------------------------------------------------------
+
+describe('false-frontmatter guard — body-embedded block must not be treated as authoritative', () => {
+  it('body-embedded wrong-url block does not block a page that has correct URL in plain body text', () => {
+    // Content starts with prose (no leading ---), body has an embedded --- block with wrong URL,
+    // but also has the expected URL in the leading prose.
+    // Before fix (with /m): embedded block parsed as structured sources (wrong URL) → authoritative →
+    //   body substring skipped → FLAGGED (over-block)
+    // After fix (without /m): no leading frontmatter → null → falls back to substring →
+    //   expected URL found in prose → PASSES (correct)
+    const content = [
+      'See https://github.com/acme/widget for details.',
+      '',
+      '---',
+      'sources:',
+      '  - url: https://github.com/some-other/repo',
+      '---',
+    ].join('\n')
+    const result = detectPrivateWikiLeaks({
+      dataWikiPages: [page('acme--widget.md', 'h1', content)],
+      publicSlugMap: new Map([
+        ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+      ]),
+      grandfatherPages: [],
+    })
+    expect(result).toEqual([])
+  })
+
+  it('real leading frontmatter is still parsed correctly — no regression from removing /m', () => {
+    // A page with genuine leading ---...--- frontmatter must still be attributed via structured sources
+    const content = [
+      '---',
+      'sources:',
+      '  - url: https://github.com/acme/widget',
+      '---',
+      'Content without any URL in the body.',
+    ].join('\n')
+    const result = detectPrivateWikiLeaks({
+      dataWikiPages: [page('acme--widget.md', 'h1', content)],
+      publicSlugMap: new Map([
+        ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+      ]),
+      grandfatherPages: [],
+    })
+    expect(result).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// empty-sources guard — null when no usable URLs
+// ---------------------------------------------------------------------------
+
+describe('present-sources key is authoritative regardless of content — no substring fallback', () => {
+  it('sources: [] with body URL → FLAGGED (authoritative empty array, no substring fallback)', () => {
+    // sources key IS present as empty array → authoritative → return [] → some() false → flagged
+    // Body URL is irrelevant when sources key is present
+    const content = ['---', 'sources: []', '---', 'See https://github.com/acme/widget for details.'].join('\n')
+    const result = detectPrivateWikiLeaks({
+      dataWikiPages: [page('acme--widget.md', 'h1', content)],
+      publicSlugMap: new Map([
+        ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+      ]),
+      grandfatherPages: [],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({filename: 'acme--widget.md', reason: 'unattributable-page'})
+  })
+
+  it('sources entries without url key + body URL → FLAGGED (array present → authoritative, body ignored)', () => {
+    // sources key IS present as array, entries have no url key → extracted urls = [] → return []
+    // → authoritative → body substring not checked → flagged
+    const content = [
+      '---',
+      'sources:',
+      '  - name: acme-widget',
+      '---',
+      'See https://github.com/acme/widget for details.',
+    ].join('\n')
+    const result = detectPrivateWikiLeaks({
+      dataWikiPages: [page('acme--widget.md', 'h1', content)],
+      publicSlugMap: new Map([
+        ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+      ]),
+      grandfatherPages: [],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({filename: 'acme--widget.md', reason: 'unattributable-page'})
+  })
+
+  it('sources: [] without body URL → flagged (no usable attribution)', () => {
+    // Empty sources + no body URL — cannot attribute → flagged
+    const content = ['---', 'sources: []', '---', 'No GitHub URL here.'].join('\n')
+    const result = detectPrivateWikiLeaks({
+      dataWikiPages: [page('acme--widget.md', 'h1', content)],
+      publicSlugMap: new Map([
+        ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+      ]),
+      grandfatherPages: [],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({filename: 'acme--widget.md', reason: 'unattributable-page'})
   })
 })

--- a/scripts/check-wiki-private-presence.test.ts
+++ b/scripts/check-wiki-private-presence.test.ts
@@ -1290,6 +1290,34 @@ describe('prefix-collision guard — sourceUrlMatchesRepo exact owner/repo match
     })
     expect(result).toEqual([])
   })
+
+  it('case-insensitive owner/repo: mixed-case source url Acme/Widget attributes to acme/widget entry', () => {
+    // GitHub owner/repo names are case-insensitive; a source URL with different casing for the
+    // same repo must attribute correctly rather than be over-blocked.
+    const content = ['---', 'sources:', '  - url: https://github.com/Acme/Widget', '---', 'Content.'].join('\n')
+    const result = detectPrivateWikiLeaks({
+      dataWikiPages: [page('acme--widget.md', 'h1', content)],
+      publicSlugMap: new Map([
+        ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+      ]),
+      grandfatherPages: [],
+    })
+    expect(result).toEqual([])
+  })
+
+  it('case-insensitive owner/repo: different repo name (widget-other) still does NOT match acme/widget', () => {
+    // Lowercasing both sides must not collapse different repo names — a distinct repo stays flagged.
+    const content = ['---', 'sources:', '  - url: https://github.com/acme/widget-other', '---', 'Content.'].join('\n')
+    const result = detectPrivateWikiLeaks({
+      dataWikiPages: [page('acme--widget.md', 'h1', content)],
+      publicSlugMap: new Map([
+        ['acme--widget', [{owner: 'acme', name: 'widget', private: false} as unknown as RepoEntry]],
+      ]),
+      grandfatherPages: [],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({filename: 'acme--widget.md', reason: 'unattributable-page'})
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/scripts/check-wiki-private-presence.ts
+++ b/scripts/check-wiki-private-presence.ts
@@ -99,7 +99,7 @@ function parseFrontmatterSources(content: string): string[] | null {
  * - URL host must be exactly `github.com` (strict — no www.).
  * - No explicit port (`parsed.port` must be empty string — rejects :444, etc.).
  * - URL pathname segments[0] must equal `owner` and segments[1] must equal `name`
- *   (case-sensitive; slug casing follows how RepoEntry fields are stored).
+ *   (case-insensitive; GitHub owner/repo names are case-insensitive).
  * - Trailing path segments (e.g. `/blob/main/README.md`) are allowed — only the
  *   first two segments are checked.
  * - Query string and hash are ignored (URL parsing handles this).
@@ -116,7 +116,12 @@ function sourceUrlMatchesRepo(sourceUrl: string, owner: string, name: string): b
   if (parsed.hostname !== 'github.com') return false
   if (parsed.port !== '') return false
   const segments = parsed.pathname.split('/').filter(s => s.length > 0)
-  return segments[0] === owner && segments[1] === name
+  // GitHub owner/repo names are case-insensitive: compare lowercased so a source URL like
+  // `https://github.com/Acme/Widget` correctly attributes to an entry stored as `acme/widget`.
+  // Optional chaining on segments[1] guards the `/owner`-only path (undefined?.toLowerCase()
+  // returns undefined, which !== any string, so it's a safe no-match). This can only convert
+  // an over-block into a correct attribution — it cannot match a genuinely different repo.
+  return segments[0]?.toLowerCase() === owner.toLowerCase() && segments[1]?.toLowerCase() === name.toLowerCase()
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/check-wiki-private-presence.ts
+++ b/scripts/check-wiki-private-presence.ts
@@ -28,6 +28,50 @@ export interface PrivateWikiLeak {
 }
 
 // ---------------------------------------------------------------------------
+// parseFrontmatterSources — extract structured source URLs from YAML frontmatter
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the YAML frontmatter of a wiki page and return the list of `sources[].url`
+ * strings, or `null` if frontmatter is absent, unparseable, or has no `sources` key.
+ *
+ * Return semantics:
+ * - `string[]` (may be empty)  → frontmatter parsed AND has a `sources` array (authoritative)
+ * - `null`                      → no usable structured sources; caller should fall back to substring
+ *
+ * Callers MUST NOT fall back to substring when a non-null array is returned — the
+ * presence of structured sources makes them authoritative for attribution.
+ */
+function parseFrontmatterSources(content: string): string[] | null {
+  // Match YAML frontmatter fences at the start of the file.
+  const match = /^---\r?\n([\s\S]*?)\r?\n---/m.exec(content)
+  if (!match) return null
+
+  let parsed: unknown
+  try {
+    parsed = YAML.parse(match[1] ?? '')
+  } catch {
+    return null // unparseable frontmatter → caller falls back to substring
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) return null
+
+  const sources = (parsed as Record<string, unknown>).sources
+  if (!Array.isArray(sources)) return null
+
+  // Extract url strings from each sources entry.
+  const urls: string[] = []
+  for (const src of sources) {
+    if (typeof src === 'object' && src !== null) {
+      const url = (src as Record<string, unknown>).url
+      if (typeof url === 'string') urls.push(url)
+    }
+  }
+
+  return urls
+}
+
+// ---------------------------------------------------------------------------
 // detectPrivateWikiLeaks — pure function (no I/O, no subprocess)
 // ---------------------------------------------------------------------------
 
@@ -91,8 +135,35 @@ export function detectPrivateWikiLeaks(params: {
         continue
       }
       const expectedUrl = `https://github.com/${entry.owner}/${entry.name}`
+      const structuredSources = parseFrontmatterSources(page.content)
+
+      if (structuredSources !== null) {
+        // Structured sources are present and parseable — they are authoritative.
+        // Attribution is satisfied iff at least one source URL matches the expected URL.
+        // Body substring is deliberately ignored here; structured sources close the decoy-URL spoof vector.
+        if (structuredSources.some(url => url === expectedUrl || url.includes(expectedUrl))) {
+          continue // passes: structured attribution
+        }
+        // Structured sources exist but none match — treat as unattributable.
+        // Body substring is NOT checked as a rescue when structured sources are present.
+        leaks.push({filename: page.filename, reason: 'unattributable-page'})
+        continue
+      }
+
+      // No parseable structured sources (frontmatter absent, unparseable, or no sources key).
+      // Fall back to legacy body substring check so pre-existing pages are not over-blocked.
       if (page.content.includes(expectedUrl)) {
-        continue // passes: explicitly public and attributable
+        // Emit a migration signal: this page passed via legacy substring attribution only.
+        // The public slug is safe to log; never log private repo owner/name here.
+        process.stderr.write(
+          `${JSON.stringify({
+            level: 'warn',
+            event: 'legacy-substring-attribution',
+            message: 'Page attributed via body substring; add structured frontmatter sources for stronger attribution',
+            slug: page.stem,
+          })}\n`,
+        )
+        continue // passes: legacy substring fallback
       }
 
       // Content doesn't reference the expected repo — possible slug collision.

--- a/scripts/check-wiki-private-presence.ts
+++ b/scripts/check-wiki-private-presence.ts
@@ -32,19 +32,28 @@ export interface PrivateWikiLeak {
 // ---------------------------------------------------------------------------
 
 /**
- * Parse the YAML frontmatter of a wiki page and return the list of `sources[].url`
- * strings, or `null` if frontmatter is absent, unparseable, or has no `sources` key.
+ * Parse the YAML frontmatter of a wiki page and return the `sources` attribution
+ * state with the following tri-state contract:
  *
- * Return semantics:
- * - `string[]` (may be empty)  → frontmatter parsed AND has a `sources` array (authoritative)
- * - `null`                      → no usable structured sources; caller should fall back to substring
+ * - `null`       → `sources` key is ABSENT, frontmatter is missing/unparseable, or
+ *                  the parsed value is not an object. Caller falls back to the legacy
+ *                  body-substring check (no over-block of pre-existing pages).
+ * - `[]`         → `sources` key IS PRESENT but is not an array (e.g. a scalar, null),
+ *                  OR is an array with no entries that have a `url` string.
+ *                  Key presence is authoritative — caller treats this as a failed
+ *                  attribution check (page flagged; body substring is NOT consulted).
+ * - `string[]`   → `sources` key IS PRESENT and is an array with at least one usable
+ *                  URL string. Authoritative; caller checks each URL against the repo.
  *
- * Callers MUST NOT fall back to substring when a non-null array is returned — the
- * presence of structured sources makes them authoritative for attribution.
+ * The critical distinction is key PRESENCE (`'sources' in obj`) vs absence:
+ * - Present → always return an array (possibly empty) → authoritative.
+ * - Absent  → return null → caller falls back to substring.
  */
 function parseFrontmatterSources(content: string): string[] | null {
-  // Match YAML frontmatter fences at the start of the file.
-  const match = /^---\r?\n([\s\S]*?)\r?\n---/m.exec(content)
+  // Match YAML frontmatter fences anchored to the true start of the file.
+  // The /m flag is intentionally absent so that ^ is string-start only —
+  // body-embedded ---...--- blocks must not be treated as authoritative frontmatter.
+  const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content)
   if (!match) return null
 
   let parsed: unknown
@@ -56,10 +65,17 @@ function parseFrontmatterSources(content: string): string[] | null {
 
   if (typeof parsed !== 'object' || parsed === null) return null
 
-  const sources = (parsed as Record<string, unknown>).sources
-  if (!Array.isArray(sources)) return null
+  const obj = parsed as Record<string, unknown>
 
-  // Extract url strings from each sources entry.
+  // Key ABSENT → return null so callers fall back to legacy substring.
+  if (!Object.prototype.hasOwnProperty.call(obj, 'sources')) return null
+
+  const sources = obj.sources
+
+  // Key PRESENT but not an array → authoritative empty result (fail-closed).
+  if (!Array.isArray(sources)) return []
+
+  // Key PRESENT and is an array → extract url strings (possibly returns []).
   const urls: string[] = []
   for (const src of sources) {
     if (typeof src === 'object' && src !== null) {
@@ -67,17 +83,53 @@ function parseFrontmatterSources(content: string): string[] | null {
       if (typeof url === 'string') urls.push(url)
     }
   }
-
   return urls
 }
 
 // ---------------------------------------------------------------------------
-// detectPrivateWikiLeaks — pure function (no I/O, no subprocess)
+// sourceUrlMatchesRepo — exact owner/repo URL matching without prefix collisions
 // ---------------------------------------------------------------------------
 
 /**
- * Pure function: flag data wiki pages that cannot be attributed to a known-public
+ * Return true iff `sourceUrl` refers to exactly the repo identified by `owner`
+ * and `name` on github.com.
+ *
+ * Matching rules:
+ * - Protocol must be exactly `https:` (rejects http, ftp, etc.).
+ * - URL host must be exactly `github.com` (strict — no www.).
+ * - No explicit port (`parsed.port` must be empty string — rejects :444, etc.).
+ * - URL pathname segments[0] must equal `owner` and segments[1] must equal `name`
+ *   (case-sensitive; slug casing follows how RepoEntry fields are stored).
+ * - Trailing path segments (e.g. `/blob/main/README.md`) are allowed — only the
+ *   first two segments are checked.
+ * - Query string and hash are ignored (URL parsing handles this).
+ * - Malformed URLs (parse failure) return false — never throw.
+ */
+function sourceUrlMatchesRepo(sourceUrl: string, owner: string, name: string): boolean {
+  let parsed: URL
+  try {
+    parsed = new URL(sourceUrl)
+  } catch {
+    return false
+  }
+  if (parsed.protocol !== 'https:') return false
+  if (parsed.hostname !== 'github.com') return false
+  if (parsed.port !== '') return false
+  const segments = parsed.pathname.split('/').filter(s => s.length > 0)
+  return segments[0] === owner && segments[1] === name
+}
+
+// ---------------------------------------------------------------------------
+// detectPrivateWikiLeaks — emits redaction-safe stderr warnings on substring-fallback path
+// ---------------------------------------------------------------------------
+
+/**
+ * Flag data wiki pages that cannot be attributed to a known-public
  * or unchanged-grandfathered repo.
+ *
+ * Note: this function writes redaction-safe JSON warnings to stderr when a page
+ * is attributed via the legacy body-substring fallback path. Only the public slug
+ * is emitted — no private owner/name is ever logged.
  *
  * For each data page its stem is checked in this order:
  *
@@ -141,7 +193,7 @@ export function detectPrivateWikiLeaks(params: {
         // Structured sources are present and parseable — they are authoritative.
         // Attribution is satisfied iff at least one source URL matches the expected URL.
         // Body substring is deliberately ignored here; structured sources close the decoy-URL spoof vector.
-        if (structuredSources.some(url => url === expectedUrl || url.includes(expectedUrl))) {
+        if (structuredSources.some(url => sourceUrlMatchesRepo(url, entry.owner, entry.name))) {
           continue // passes: structured attribution
         }
         // Structured sources exist but none match — treat as unattributable.

--- a/scripts/merge-data-pr.test.ts
+++ b/scripts/merge-data-pr.test.ts
@@ -47,10 +47,18 @@ interface MockOverrides {
     state: 'open' | 'closed' | 'all'
     per_page?: number
   }) => Promise<unknown>
+  paginate?: (fn: unknown, opts: unknown) => Promise<unknown[]>
 }
 
 function mockOctokit(overrides?: MockOverrides): OctokitClient {
+  const listForRepo = overrides?.listForRepo ?? (async () => ({data: []}))
+  const defaultPaginate: (fn: unknown, opts: unknown) => Promise<unknown[]> = async (fn, opts) => {
+    const call = fn as (opts: unknown) => Promise<{data: unknown[]}>
+    const response = await call(opts)
+    return response.data
+  }
   return {
+    paginate: overrides?.paginate ?? defaultPaginate,
     rest: {
       repos: {
         compareCommitsWithBasehead:
@@ -89,7 +97,7 @@ function mockOctokit(overrides?: MockOverrides): OctokitClient {
           (async () => ({
             data: {number: 99, html_url: 'https://github.com/fro-bot/.github/issues/99'},
           })),
-        listForRepo: overrides?.listForRepo ?? (async () => ({data: []})),
+        listForRepo,
       },
     },
   } as unknown as OctokitClient
@@ -1132,6 +1140,77 @@ describe('mergeDataPr', () => {
     // #then the dirty signal is preserved (exit non-zero) and the next run retries the alert
     expect(result.conflicted).toBe(true)
     expect(result.conflictAlertIssueNumber).toBeNull()
+  })
+
+  it('deduplicates conflict alert when the matching issue is beyond the first page of results', async () => {
+    const createIssue = vi.fn(async () => ({
+      data: {number: 111, html_url: 'https://github.com/fro-bot/.github/issues/111'},
+    }))
+    // paginate returns a large list; the matching alert appears beyond what a single per_page:30 call would return
+    const manyOpenIssues = Array.from({length: 35}, (_, i) => ({
+      number: i + 1,
+      title: `Unrelated open issue ${i + 1}`,
+      state: 'open' as const,
+    }))
+    const alertOnPage2 = {
+      number: 36,
+      title: 'Conflicted data promotion PR: data -> main (PR #42)',
+      state: 'open' as const,
+    }
+    const paginate = vi.fn(async () => [...manyOpenIssues, alertOnPage2])
+    const octokit = mockOctokit({
+      getPullRequest: async () => ({data: {mergeable_state: 'dirty', head: {sha: 'data-commit-sha'}}}),
+      createIssue,
+      paginate: paginate as MockOverrides['paginate'],
+    })
+
+    // #given an existing conflict alert is open on a page that a per_page:30 call would miss
+    // #when the merge PR script runs
+    const result = await mergeDataPr({octokit, now: new Date('2026-04-16T00:00:00.000Z')})
+
+    // #then the exhaustive paginated scan finds the alert and does NOT create a duplicate
+    expect(result.conflicted).toBe(true)
+    expect(result.conflictAlertIssueNumber).toBeNull()
+    expect(createIssue).not.toHaveBeenCalled()
+  })
+
+  it('deduplicates stale-divergence alert when the matching issue is beyond the first page of results', async () => {
+    const createIssue = vi.fn(async () => ({
+      data: {number: 77, html_url: 'https://github.com/fro-bot/.github/issues/77'},
+    }))
+    const manyOpenIssues = Array.from({length: 35}, (_, i) => ({
+      number: i + 1,
+      title: `Unrelated open issue ${i + 1}`,
+      state: 'open' as const,
+    }))
+    const alertOnPage2 = {
+      number: 36,
+      title: 'Stale data branch divergence: data is older than 14 days',
+      state: 'open' as const,
+    }
+    const paginate = vi.fn(async () => [...manyOpenIssues, alertOnPage2])
+    const octokit = mockOctokit({
+      compareCommitsWithBasehead: async () => ({
+        data: {
+          files: [{filename: 'metadata/repos.yaml'}],
+          merge_base_commit: {sha: 'merge-base-sha', commit: {committer: {date: isoDaysAgo(20)}}},
+          commits: [{sha: 'stale-data-commit-sha', commit: {committer: {date: isoDaysAgo(20)}}}],
+          ahead_by: 3,
+          behind_by: 0,
+          total_commits: 3,
+        },
+      }),
+      createIssue,
+      paginate: paginate as MockOverrides['paginate'],
+    })
+
+    // #given an existing stale-divergence alert is open on a page that a per_page:30 call would miss
+    // #when the merge PR script runs
+    const result = await mergeDataPr({octokit, now: new Date('2026-04-16T00:00:00.000Z')})
+
+    // #then the exhaustive paginated scan finds the alert and does NOT create a duplicate
+    expect(result.staleAlertIssueNumber).toBeNull()
+    expect(createIssue).not.toHaveBeenCalled()
   })
 
   it('rethrows when conflict-alert creation fails with a non-retryable error', async () => {

--- a/scripts/merge-data-pr.ts
+++ b/scripts/merge-data-pr.ts
@@ -381,14 +381,14 @@ async function maybeCreateConflictAlert(params: {
   headBranch: string
   baseBranch: string
 }): Promise<number | null> {
-  const existingIssues = await params.octokit.rest.issues.listForRepo({
+  const existingIssues = await params.octokit.paginate(params.octokit.rest.issues.listForRepo, {
     owner: params.owner,
     repo: params.repo,
     state: 'open',
-    per_page: 30,
+    per_page: 100,
   })
 
-  const existingAlert = existingIssues.data.find(issue => issue.title.startsWith(CONFLICT_ALERT_TITLE_PREFIX))
+  const existingAlert = existingIssues.find(issue => issue.title.startsWith(CONFLICT_ALERT_TITLE_PREFIX))
 
   if (existingAlert !== undefined) {
     return null
@@ -486,14 +486,14 @@ async function maybeCreateStaleDivergenceAlert(params: {
 
   const alertTitle = `Stale data branch divergence: ${params.headBranch} is older than 14 days`
 
-  const existingIssues = await params.octokit.rest.issues.listForRepo({
+  const existingIssues = await params.octokit.paginate(params.octokit.rest.issues.listForRepo, {
     owner: params.owner,
     repo: params.repo,
     state: 'open',
-    per_page: 30,
+    per_page: 100,
   })
 
-  const existingAlert = existingIssues.data.find(issue => issue.title.startsWith('Stale data branch divergence:'))
+  const existingAlert = existingIssues.find(issue => issue.title.startsWith('Stale data branch divergence:'))
 
   if (existingAlert !== undefined) {
     return null

--- a/scripts/merge-data-pr.ts
+++ b/scripts/merge-data-pr.ts
@@ -381,6 +381,8 @@ async function maybeCreateConflictAlert(params: {
   headBranch: string
   baseBranch: string
 }): Promise<number | null> {
+  // Paginate exhaustively over every open issue so dedup holds regardless of how many
+  // are open; a single page could miss an existing alert and file a duplicate each run.
   const existingIssues = await params.octokit.paginate(params.octokit.rest.issues.listForRepo, {
     owner: params.owner,
     repo: params.repo,
@@ -486,6 +488,8 @@ async function maybeCreateStaleDivergenceAlert(params: {
 
   const alertTitle = `Stale data branch divergence: ${params.headBranch} is older than 14 days`
 
+  // Paginate exhaustively over every open issue so dedup holds regardless of how many
+  // are open; a single page could miss an existing alert and file a duplicate each run.
   const existingIssues = await params.octokit.paginate(params.octokit.rest.issues.listForRepo, {
     owner: params.owner,
     repo: params.repo,


### PR DESCRIPTION
## What this fixes

Two hardening fixes to the autonomous control plane, both surfaced while clearing follow-up work on the data-promotion and privacy paths.

### Conflict-alert dedup now scans every open issue

The merge-data promotion creates a conflict alert (and a stale-divergence alert) when it can't cleanly promote `data` to `main`. Both dedup checks listed only the **first 30 open issues** before deciding whether an alert already existed — so once the repo carried more than 30 open issues, an existing alert on a later page was missed and a duplicate got filed on every run. Both queries now paginate exhaustively, so dedup holds no matter how many issues are open.

### Wiki-page attribution is no longer spoofable by a decoy URL

The wiki-presence privacy gate decides whether a page that matches a public repo's slug is legitimately **about** that public repo, or is a private repo's page wearing a colliding name. It used to confirm this with a raw substring search for the public repo's URL anywhere in the page body — which a page could satisfy with a decoy URL while actually concerning a different repo.

Attribution now prefers the page's **structured frontmatter `sources[].url`**:

- A page that declares `sources` must have one matching its public repo by **exact owner/repo** (https + `github.com` + default port; trailing paths like `/blob/...` allowed) — a sibling name like `owner/repo-other` no longer matches, and a decoy URL in the body is ignored when structured sources are present.
- A page with **no `sources` key at all** (legacy/prose-only) falls back to the original body check, so existing pages keep passing unchanged.
- The frontmatter parse is anchored to the true start of the file, so a fence block embedded in the body can't masquerade as authoritative sources.

A page that passes only via the legacy body fallback emits a redaction-safe migration warning (slug only, never a private name).

## Known limitation

This gate trusts a page's **own** declared `sources`. It stops a colliding page from being mis-attributed by a stray URL, but it does not — and cannot at this layer — prove that a page's body content genuinely concerns the repo its frontmatter claims. That provenance boundary is enforced upstream by the Fro Bot agent identity, the `data`-branch sole-writer model, and the authority guard; this check is one defense-in-depth layer, not the whole trust story. Tracked as a follow-up.

## Verification

- 793 tests pass (3 todo); types, lint, and strip-only script load all clean.
- Real wiki pages confirmed to self-reference their own repo in `sources[].url`, so the stricter structured match flags zero existing pages.
