### PR TITLE
test: replace real private-repo name in fixtures with synthetic name

### DIFF
--- a/scripts/check-wiki-private-presence.test.ts
+++ b/scripts/check-wiki-private-presence.test.ts
@@ -80,11 +80,11 @@ describe('detectPrivateWikiLeaks', () => {
       // #then no leaks are reported
       const result = detectPrivateWikiLeaks({
         dataWikiPages: [
-          page('marcusrbrown--poly.md', 'hash1', 'url: https://github.com/marcusrbrown/poly'),
+          page('marcusrbrown--cart.md', 'hash1', 'url: https://github.com/marcusrbrown/cart'),
           page('some-org--some-repo.md', 'hash2', 'url: https://github.com/some-org/some-repo'),
         ],
         publicSlugMap: new Map([
-          ['marcusrbrown--poly', [{owner: 'marcusrbrown', name: 'poly', private: false} as unknown as RepoEntry]],
+          ['marcusrbrown--cart', [{owner: 'marcusrbrown', name: 'cart', private: false} as unknown as RepoEntry]],
           ['some-org--some-repo', [{owner: 'some-org', name: 'some-repo', private: false} as unknown as RepoEntry]],
         ]),
         grandfatherPages: [],
@@ -629,14 +629,14 @@ describe('detectPrivateWikiLeaks', () => {
   })
 
   describe('case-insensitive stem matching', () => {
-    it('matches case-insensitively (MarcusRBrown--Poly.md stem lowercased to match publicSlugMap)', () => {
+    it('matches case-insensitively (MarcusRBrown--Cart.md stem lowercased to match publicSlugMap)', () => {
       // #given a wiki filename with mixed case
       // #when detection runs
       // #then matched case-insensitively against publicSlugMap
       const result = detectPrivateWikiLeaks({
-        dataWikiPages: [page('MarcusRBrown--Poly.md', 'h1', 'url: https://github.com/marcusrbrown/poly')],
+        dataWikiPages: [page('MarcusRBrown--Cart.md', 'h1', 'url: https://github.com/marcusrbrown/cart')],
         publicSlugMap: new Map([
-          ['marcusrbrown--poly', [{owner: 'marcusrbrown', name: 'poly', private: false} as unknown as RepoEntry]],
+          ['marcusrbrown--cart', [{owner: 'marcusrbrown', name: 'cart', private: false} as unknown as RepoEntry]],
         ]),
         grandfatherPages: [],
       })
@@ -809,7 +809,7 @@ describe('findStructuralViolations', () => {
     // #given only regular .md files (the expected wiki layout)
     // #when findStructuralViolations is called
     // #then no violations
-    mockReaddir.mockResolvedValue([dirent('acme--widget.md'), dirent('marcusrbrown--poly.md')])
+    mockReaddir.mockResolvedValue([dirent('acme--widget.md'), dirent('marcusrbrown--cart.md')])
     const result = await findStructuralViolations('knowledge/wiki/repos')
     expect(result).toEqual([])
   })
@@ -981,7 +981,7 @@ describe('buildPublicSlugs (load-bearing predicate end-to-end)', () => {
 
 describe('formatLeakReport (redaction)', () => {
   const twoLeaks = [
-    {filename: 'marcusrbrown--poly.md', reason: 'unattributable-page' as const},
+    {filename: 'marcusrbrown--cart.md', reason: 'unattributable-page' as const},
     {filename: 'acme--secret.md', reason: 'ambiguous-public-slug' as const},
   ]
 
@@ -1017,13 +1017,13 @@ describe('formatLeakReport (redaction)', () => {
     // #when formatLeakReport is called
     // #then NO filename substring appears — public Actions log must not leak identities
     const report = formatLeakReport(twoLeaks)
-    expect(report).not.toContain('marcusrbrown--poly')
+    expect(report).not.toContain('marcusrbrown--cart')
     expect(report).not.toContain('acme--secret')
     expect(report).not.toContain('.md')
     // Stronger: no owner--repo shape anywhere (e.g. no derivative leakage)
     expect(report).not.toMatch(/[\w.-]+--[\w.-]+/)
     // Additional redaction assertions
-    expect(report).not.toContain('marcusrbrown/poly')
+    expect(report).not.toContain('marcusrbrown/cart')
     expect(report).not.toContain('https://github.com')
     expect(report).not.toContain('acme/secret')
   })
@@ -1043,17 +1043,17 @@ describe('formatLeakReport (redaction)', () => {
 // ---------------------------------------------------------------------------
 
 describe('slug-variant + collision regression', () => {
-  it('suffix variant (marcusrbrown--poly.draft) is flagged — only exact slug admitted', () => {
-    // #given a page whose stem is 'marcusrbrown--poly.draft' (a .draft suffix variant)
-    //        and publicSlugMap has only 'marcusrbrown--poly' (the plain slug, a different entry)
+  it('suffix variant (marcusrbrown--cart.draft) is flagged — only exact slug admitted', () => {
+    // #given a page whose stem is 'marcusrbrown--cart.draft' (a .draft suffix variant)
+    //        and publicSlugMap has only 'marcusrbrown--cart' (the plain slug, a different entry)
     //        and no grandfather
     // #when detection runs
     // #then BLOCKED — the suffix variant does NOT match the public slug, so unattributable-page
     const publicSlugMap = buildPublicSlugMap([
-      {owner: 'marcusrbrown', name: 'poly', private: false} as unknown as RepoEntry,
+      {owner: 'marcusrbrown', name: 'cart', private: false} as unknown as RepoEntry,
     ])
     const result = detectPrivateWikiLeaks({
-      dataWikiPages: [page('marcusrbrown--poly.draft.md', 'h1', 'some content')],
+      dataWikiPages: [page('marcusrbrown--cart.draft.md', 'h1', 'some content')],
       publicSlugMap,
       grandfatherPages: [],
     })
@@ -1080,12 +1080,12 @@ describe('slug-variant + collision regression', () => {
 
   it('case variant lowercased by page() helper — without public slug → flagged (casing cannot smuggle past)', () => {
     // #given the page() helper lowercases the stem (matching loadWikiPages behaviour)
-    //        so 'MARCUSRBROWN--POLY.md' → stem 'marcusrbrown--poly'
+    //        so 'MARCUSRBROWN--CART.md' → stem 'marcusrbrown--cart'
     //        and publicSlugMap does NOT contain that slug
     // #when detection runs
     // #then flagged — documents that casing normalization is consistent and cannot bypass the gate
     const result = detectPrivateWikiLeaks({
-      dataWikiPages: [page('MARCUSRBROWN--POLY.md', 'h1', 'content')],
+      dataWikiPages: [page('MARCUSRBROWN--CART.md', 'h1', 'content')],
       publicSlugMap: new Map(),
       grandfatherPages: [],
     })
@@ -1110,7 +1110,7 @@ describe('fail-safe regression — private:true cannot smuggle through', () => {
     // #then map is EMPTY — private:true cannot slip into the public set
     const privateRepo: RepoEntry = {
       owner: 'marcusrbrown',
-      name: 'poly',
+      name: 'cart',
       private: true,
       added: '2025-01-01',
       onboarding_status: 'pending',
@@ -1126,12 +1126,12 @@ describe('fail-safe regression — private:true cannot smuggle through', () => {
     // #when detectPrivateWikiLeaks runs
     // #then BLOCKED — flipping/holding private:true cannot smuggle the page through
     const result = detectPrivateWikiLeaks({
-      dataWikiPages: [page('marcusrbrown--poly.md', 'h1', 'content')],
+      dataWikiPages: [page('marcusrbrown--cart.md', 'h1', 'content')],
       publicSlugMap,
       grandfatherPages: [],
     })
     expect(result).toHaveLength(1)
-    expect(result[0]).toMatchObject({filename: 'marcusrbrown--poly.md', reason: 'unattributable-page'})
+    expect(result[0]).toMatchObject({filename: 'marcusrbrown--cart.md', reason: 'unattributable-page'})
   })
 })
 

--- a/scripts/enumerate-existing-leaks.test.ts
+++ b/scripts/enumerate-existing-leaks.test.ts
@@ -10,8 +10,8 @@ import {
   type PrivateRepoMapping,
 } from './enumerate-existing-leaks.ts'
 
-function makePolyMapping(): PrivateRepoMapping {
-  return {node_id: 'R_kgDOPpoLY1', owner: 'marcusrbrown', name: 'poly'}
+function makeCartMapping(): PrivateRepoMapping {
+  return {node_id: 'R_kgDOCaRt11', owner: 'marcusrbrown', name: 'cart'}
 }
 
 function makeReposFile(
@@ -23,7 +23,7 @@ function makeReposFile(
     repos: [
       {
         owner: 'marcusrbrown',
-        name: 'poly',
+        name: 'cart',
         added: '2026-05-01',
         onboarding_status: 'pending',
         last_survey_at: null,
@@ -53,24 +53,24 @@ describe('enumerateLeaks', () => {
       // Empty list = nothing to enumerate; even rich data sources yield zero surfaces.
       const result = enumerateLeaks({
         ...emptyInput(),
-        commitLog: [{sha: 'abc123', subject: 'feat: add poly support'}],
+        commitLog: [{sha: 'abc123', subject: 'feat: add cart support'}],
         reposFile: makeReposFile(),
-        wikiFilenames: ['marcusrbrown--poly.md'],
+        wikiFilenames: ['marcusrbrown--cart.md'],
       })
 
       expect(result).toEqual([])
     })
 
-    it('enumerates all 4 surface types for the poly fixture', () => {
-      // GIVEN the canonical poly fixture: 2 commits, 1 run, 1 metadata entry, 0 wiki pages
+    it('enumerates all 4 surface types for the cart fixture', () => {
+      // GIVEN the canonical cart fixture: 2 commits, 1 run, 1 metadata entry, 0 wiki pages
       const result = enumerateLeaks({
-        privateRepos: [makePolyMapping()],
+        privateRepos: [makeCartMapping()],
         commitLog: [
-          {sha: 'd92d12c', subject: 'fix(metadata): allowlist marcusrbrown/poly invitation'},
-          {sha: 'cb5811e', subject: 'chore(reconcile): add marcusrbrown/poly to repos.yaml'},
+          {sha: 'd92d12c', subject: 'fix(metadata): allowlist marcusrbrown/cart invitation'},
+          {sha: 'cb5811e', subject: 'chore(reconcile): add marcusrbrown/cart to repos.yaml'},
           {sha: 'unrelated1', subject: 'docs: update README'},
         ],
-        workflowRuns: [{id: 25395917616, name: 'Survey Repo', inputs: {owner: 'marcusrbrown', repo: 'poly'}}],
+        workflowRuns: [{id: 25395917616, name: 'Survey Repo', inputs: {owner: 'marcusrbrown', repo: 'cart'}}],
         reposFile: makeReposFile(),
         wikiFilenames: [],
       })
@@ -86,21 +86,21 @@ describe('enumerateLeaks', () => {
       expect(runSurface?.identifier).toBe('25395917616')
 
       const metaSurface = result.find(s => s.type === 'metadata-entry')
-      expect(metaSurface?.identifier).toBe('marcusrbrown/poly')
+      expect(metaSurface?.identifier).toBe('marcusrbrown/cart')
     })
 
     it('enumerates wiki pages when matching slug patterns are present', () => {
       const result = enumerateLeaks({
-        privateRepos: [makePolyMapping()],
+        privateRepos: [makeCartMapping()],
         commitLog: [],
         workflowRuns: [],
         reposFile: {version: 1, repos: []},
-        wikiFilenames: ['marcusrbrown--poly.md', 'unrelated--repo.md'],
+        wikiFilenames: ['marcusrbrown--cart.md', 'unrelated--repo.md'],
       })
 
       const wikiSurfaces = result.filter(s => s.type === 'wiki-page')
       expect(wikiSurfaces).toHaveLength(1)
-      expect(wikiSurfaces[0]?.identifier).toBe('marcusrbrown--poly.md')
+      expect(wikiSurfaces[0]?.identifier).toBe('marcusrbrown--cart.md')
     })
 
     it('returns empty surfaces for a private repo with no leaks', () => {
@@ -119,8 +119,8 @@ describe('enumerateLeaks', () => {
   describe('detection rules', () => {
     it('matches commit subject case-insensitively', () => {
       const result = enumerateLeaks({
-        privateRepos: [makePolyMapping()],
-        commitLog: [{sha: 'mixed', subject: 'FIX: MarcusRBrown/Poly handling'}],
+        privateRepos: [makeCartMapping()],
+        commitLog: [{sha: 'mixed', subject: 'FIX: MarcusRBrown/Cart handling'}],
         workflowRuns: [],
         reposFile: {version: 1, repos: []},
         wikiFilenames: [],
@@ -130,11 +130,11 @@ describe('enumerateLeaks', () => {
     })
 
     it('does NOT match a substring inside another word', () => {
-      // 'poly' alone is too short to substring-match safely in arbitrary text.
+      // 'cart' alone is too short to substring-match safely in arbitrary text.
       // The check requires the canonical owner/name pair to appear together.
       const result = enumerateLeaks({
-        privateRepos: [makePolyMapping()],
-        commitLog: [{sha: 'unrelated', subject: 'feat: support polymorphism in parser'}],
+        privateRepos: [makeCartMapping()],
+        commitLog: [{sha: 'unrelated', subject: 'feat: support cartography in parser'}],
         workflowRuns: [],
         reposFile: {version: 1, repos: []},
         wikiFilenames: [],
@@ -145,10 +145,10 @@ describe('enumerateLeaks', () => {
 
     it('matches workflow run inputs by canonical owner/repo pair', () => {
       const result = enumerateLeaks({
-        privateRepos: [makePolyMapping()],
+        privateRepos: [makeCartMapping()],
         commitLog: [],
         workflowRuns: [
-          {id: 1, name: 'Survey Repo', inputs: {owner: 'marcusrbrown', repo: 'poly'}},
+          {id: 1, name: 'Survey Repo', inputs: {owner: 'marcusrbrown', repo: 'cart'}},
           {id: 2, name: 'Survey Repo', inputs: {owner: 'someone-else', repo: 'public-repo'}},
         ],
         reposFile: {version: 1, repos: []},
@@ -160,9 +160,9 @@ describe('enumerateLeaks', () => {
 
     it('matches workflow run name when canonical owner/repo appears in the run name', () => {
       const result = enumerateLeaks({
-        privateRepos: [makePolyMapping()],
+        privateRepos: [makeCartMapping()],
         commitLog: [],
-        workflowRuns: [{id: 99, name: 'Survey: marcusrbrown/poly', inputs: {}}],
+        workflowRuns: [{id: 99, name: 'Survey: marcusrbrown/cart', inputs: {}}],
         reposFile: {version: 1, repos: []},
         wikiFilenames: [],
       })
@@ -172,7 +172,7 @@ describe('enumerateLeaks', () => {
 
     it('matches metadata entry by current owner/name (pre-redaction)', () => {
       const result = enumerateLeaks({
-        privateRepos: [makePolyMapping()],
+        privateRepos: [makeCartMapping()],
         commitLog: [],
         workflowRuns: [],
         reposFile: makeReposFile(),
@@ -185,10 +185,10 @@ describe('enumerateLeaks', () => {
 
     it('does NOT report metadata entry when the entry is already redacted', () => {
       const result = enumerateLeaks({
-        privateRepos: [makePolyMapping()],
+        privateRepos: [makeCartMapping()],
         commitLog: [],
         workflowRuns: [],
-        reposFile: makeReposFile({owner: '[REDACTED]', name: 'R_kgDOPpoLY1'}),
+        reposFile: makeReposFile({owner: '[REDACTED]', name: 'R_kgDOCaRt11'}),
         wikiFilenames: [],
       })
 
@@ -199,8 +199,8 @@ describe('enumerateLeaks', () => {
   describe('remediation commands', () => {
     it('attaches a rebase/replace-message hint for commit-subject surfaces', () => {
       const result = enumerateLeaks({
-        privateRepos: [makePolyMapping()],
-        commitLog: [{sha: 'd92d12c', subject: 'fix: marcusrbrown/poly'}],
+        privateRepos: [makeCartMapping()],
+        commitLog: [{sha: 'd92d12c', subject: 'fix: marcusrbrown/cart'}],
         workflowRuns: [],
         reposFile: {version: 1, repos: []},
         wikiFilenames: [],
@@ -213,9 +213,9 @@ describe('enumerateLeaks', () => {
 
     it('attaches a delete-run command for workflow-run surfaces', () => {
       const result = enumerateLeaks({
-        privateRepos: [makePolyMapping()],
+        privateRepos: [makeCartMapping()],
         commitLog: [],
-        workflowRuns: [{id: 25395917616, name: 'Survey Repo', inputs: {owner: 'marcusrbrown', repo: 'poly'}}],
+        workflowRuns: [{id: 25395917616, name: 'Survey Repo', inputs: {owner: 'marcusrbrown', repo: 'cart'}}],
         reposFile: {version: 1, repos: []},
         wikiFilenames: [],
       })
@@ -228,7 +228,7 @@ describe('enumerateLeaks', () => {
 
     it('attaches a redact-entry command for metadata-entry surfaces', () => {
       const result = enumerateLeaks({
-        privateRepos: [makePolyMapping()],
+        privateRepos: [makeCartMapping()],
         commitLog: [],
         workflowRuns: [],
         reposFile: makeReposFile(),
@@ -238,21 +238,21 @@ describe('enumerateLeaks', () => {
       const surface = result.find(s => s.type === 'metadata-entry')
       expect(surface?.remediation.action).toBe('redact-entry')
       // Must reference the node_id since that's the post-redaction name
-      expect(surface?.remediation.command).toContain('R_kgDOPpoLY1')
+      expect(surface?.remediation.command).toContain('R_kgDOCaRt11')
     })
 
     it('attaches a delete-page command for wiki-page surfaces', () => {
       const result = enumerateLeaks({
-        privateRepos: [makePolyMapping()],
+        privateRepos: [makeCartMapping()],
         commitLog: [],
         workflowRuns: [],
         reposFile: {version: 1, repos: []},
-        wikiFilenames: ['marcusrbrown--poly.md'],
+        wikiFilenames: ['marcusrbrown--cart.md'],
       })
 
       const surface = result.find(s => s.type === 'wiki-page')
       expect(surface?.remediation.action).toBe('delete-page')
-      expect(surface?.remediation.command).toContain('marcusrbrown--poly.md')
+      expect(surface?.remediation.command).toContain('marcusrbrown--cart.md')
     })
   })
 
@@ -287,13 +287,13 @@ describe('formatLeakReport', () => {
       {
         type: 'commit-subject',
         identifier: 'd92d12c',
-        description: 'commit subject names marcusrbrown/poly',
+        description: 'commit subject names marcusrbrown/cart',
         remediation: {action: 'rebase-rewrite', command: 'git rebase -i d92d12c~1'},
       },
       {
         type: 'workflow-run',
         identifier: '25395917616',
-        description: 'workflow run inputs name marcusrbrown/poly',
+        description: 'workflow run inputs name marcusrbrown/cart',
         remediation: {action: 'delete-run', command: 'gh api -X DELETE /repos/.../actions/runs/25395917616'},
       },
     ])
@@ -309,8 +309,8 @@ describe('formatLeakReport', () => {
 
 describe('parsePrivateArgs', () => {
   it('parses a single well-formed --private mapping', () => {
-    const result = parsePrivateArgs(['--private', 'R_kgDOPpoLY1:marcusrbrown/poly'])
-    expect(result).toEqual([{node_id: 'R_kgDOPpoLY1', owner: 'marcusrbrown', name: 'poly'}])
+    const result = parsePrivateArgs(['--private', 'R_kgDOCaRt11:marcusrbrown/cart'])
+    expect(result).toEqual([{node_id: 'R_kgDOCaRt11', owner: 'marcusrbrown', name: 'cart'}])
   })
 
   it('parses multiple --private flags into an ordered list', () => {

--- a/scripts/enumerate-existing-leaks.ts
+++ b/scripts/enumerate-existing-leaks.ts
@@ -55,8 +55,8 @@ export interface EnumerateLeaksInput {
  * Detection rules:
  * - **commit-subject**: case-insensitive `includes` match of the canonical `owner/name`
  *   string (slash included). The slash itself prevents substring collisions inside
- *   single-word names — `marcusrbrown/poly` won't match `polymorphism`, because the
- *   search term contains `/` and `polymorphism` does not.
+ *   single-word names — `marcusrbrown/cart` won't match `cartography`, because the
+ *   search term contains `/` and `cartography` does not.
  * - **workflow-run**: matches when the run's `inputs.owner` and `inputs.repo` both
  *   equal the canonical pair (case-sensitive — GitHub stores logins canonically), OR
  *   when the run's display name contains `owner/name` as a substring.

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -474,7 +474,7 @@ describe('reconcileRepos', () => {
       const result = reconcileRepos(
         makeInput({
           currentRepos: {version: 1, repos: [tracked]},
-          accessList: [makeAccess({owner: 'marcusrbrown', name: 'poly', node_id: 'R_kgDOSVJgdw', private: true})],
+          accessList: [makeAccess({owner: 'marcusrbrown', name: 'cart', node_id: 'R_kgDOSVJgdw', private: true})],
           allowlist: makeAllowlist(['marcusrbrown']),
         }),
       )
@@ -519,7 +519,7 @@ describe('reconcileRepos', () => {
       const result = reconcileRepos(
         makeInput({
           currentRepos: {version: 1, repos: [redactedNoNodeId]},
-          accessList: [makeAccess({owner: 'marcusrbrown', name: 'poly', node_id: 'R_kgDOSVJgdw', private: true})],
+          accessList: [makeAccess({owner: 'marcusrbrown', name: 'cart', node_id: 'R_kgDOSVJgdw', private: true})],
           allowlist: makeAllowlist(['marcusrbrown']),
         }),
       )

--- a/scripts/schemas.test.ts
+++ b/scripts/schemas.test.ts
@@ -329,7 +329,7 @@ describe('schemas — rejection cases', () => {
       repos: [
         {
           owner: 'marcusrbrown',
-          name: 'poly',
+          name: 'cart',
           added: '2026-05-05',
           onboarding_status: 'onboarded',
           last_survey_at: '2026-05-06',


### PR DESCRIPTION
## What

Test fixtures across five `scripts/*.ts` files referenced a real private repo by name. This swaps that name for a synthetic fixture name so the public test corpus carries no private-repo identifier.

## Why

The private-presence guard exists to keep private repo names off public surfaces. The test fixtures were an inconsistency on the public branch — the guard's own test data named the very repo it protects.

## Scope

- Repo-name token only — the owner login (a public account, used in ~170 legitimate operator/inviter fixtures) is unchanged.
- Replacements applied in collision-safe order so the substring-collision and case-insensitivity fixtures keep their original intent (a mixed-case page filename still tests against a lowercase entry; the `owner/name` slash still illustrates why it can't collide with a single word).

## Verification

- `git grep -i` for the old token across `scripts/*.ts`: zero occurrences
- check-types, lint clean; 795 passed + 3 todo
- Owner login untouched