### PR TITLE
feat(privacy): gate data→main promotion on a private-name content scan

### DIFF
--- a/.github/workflows/merge-data.yaml
+++ b/.github/workflows/merge-data.yaml
@@ -56,14 +56,16 @@ jobs:
       # Promotion privacy gate: blocks merge if a private repo name appears in the data→main diff.
       # Design: three-dot diff (origin/main...origin/data) against private node_ids from data's
       #   repos.yaml — requires full history (fetch-depth: 0 above) and origin/data ref (fetched
-      #   below). FRO_BOT_POLL_PAT is scoped to this step only; git diff needs no token.
+      #   below). FRO_BOT_POLL_PAT is scoped to the node invocation only; git fetch needs no token.
+      # Split into two steps so FRO_BOT_POLL_PAT never enters the git subprocess environment.
+      - name: 🔒 Fetch data ref for promotion diff (no token)
+        run: git fetch --no-tags --prune origin data
+
       - name: 🔒 Block private repo names in promotion diff
         env:
           FRO_BOT_POLL_PAT: ${{ secrets.FRO_BOT_POLL_PAT }}
           PROMOTION_REPOS_YAML_PATH: data-branch-check/metadata/repos.yaml
-        run: |
-          git fetch --no-tags --prune origin data
-          node scripts/check-private-leak.ts --promotion
+        run: node scripts/check-private-leak.ts --promotion
 
       - name: 🔀 Open weekly data merge PR
         env:

--- a/.github/workflows/merge-data.yaml
+++ b/.github/workflows/merge-data.yaml
@@ -24,6 +24,8 @@ jobs:
 
       - name: ⤵ Checkout Branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0 # full history needed for three-dot diff in promotion privacy check
 
       - name: 📦 Setup
         uses: ./.github/actions/setup
@@ -50,6 +52,18 @@ jobs:
           GRANDFATHER_WIKI_REPOS_DIR: ../knowledge/wiki/repos
         working-directory: data-branch-check
         run: node ../scripts/check-wiki-private-presence.ts
+
+      # Promotion privacy gate: blocks merge if a private repo name appears in the data→main diff.
+      # Design: three-dot diff (origin/main...origin/data) against private node_ids from data's
+      #   repos.yaml — requires full history (fetch-depth: 0 above) and origin/data ref (fetched
+      #   below). FRO_BOT_POLL_PAT is scoped to this step only; git diff needs no token.
+      - name: 🔒 Block private repo names in promotion diff
+        env:
+          FRO_BOT_POLL_PAT: ${{ secrets.FRO_BOT_POLL_PAT }}
+          PROMOTION_REPOS_YAML_PATH: data-branch-check/metadata/repos.yaml
+        run: |
+          git fetch --no-tags --prune origin data
+          node scripts/check-private-leak.ts --promotion
 
       - name: 🔀 Open weekly data merge PR
         env:

--- a/.github/workflows/merge-data.yaml
+++ b/.github/workflows/merge-data.yaml
@@ -56,9 +56,11 @@ jobs:
       # Promotion privacy gate: blocks merge if a private repo name appears in the data→main diff.
       # Design: three-dot diff (origin/main...origin/data) against private node_ids from data's
       #   repos.yaml — requires full history (fetch-depth: 0 above) and origin/data ref (fetched
-      #   below). FRO_BOT_POLL_PAT is scoped to the node invocation only; git fetch needs no token.
-      # Split into two steps so FRO_BOT_POLL_PAT never enters the git subprocess environment.
-      - name: 🔒 Fetch data ref for promotion diff (no token)
+      #   below). The fetch runs under the default checkout GITHUB_TOKEN (sufficient to reach
+      #   origin/data); the broad-scope FRO_BOT_POLL_PAT is confined to the node step that resolves
+      #   private names. Splitting the steps keeps FRO_BOT_POLL_PAT out of every git subprocess —
+      #   the env-stripping in runPromotionCli enforces the same property for the diff git call.
+      - name: 🔒 Fetch data ref for promotion diff
         run: git fetch --no-tags --prune origin data
 
       - name: 🔒 Block private repo names in promotion diff

--- a/docs/plans/2026-06-03-001-feat-wire-private-leak-guard-plan.md
+++ b/docs/plans/2026-06-03-001-feat-wire-private-leak-guard-plan.md
@@ -1,0 +1,302 @@
+---
+title: 'feat: Gate the data→main promotion with the private-leak scan'
+type: feat
+status: complete
+date: 2026-06-03
+origin: 'GitHub issue #3407'
+deepened: 2026-06-03
+---
+
+# feat: Gate the data→main promotion with the private-leak scan
+
+## Overview
+
+`scripts/check-private-leak.ts` carries a tested pure core — `checkPrivateLeak(privateNames, diff, override)`
+(33 tests) — that scans a unified diff for case-insensitive matches of private-repo tokens (`owner/name`
+canonical + `owner--slug` wiki form) across added lines, new-file paths, and rename/copy destinations,
+returning matched FILE paths only (never the name). The names are resolved from `data`'s redacted
+`node_id` entries via a broad-scope classic PAT (`FRO_BOT_POLL_PAT`) — the only credential that can read
+cross-account private repos.
+
+This plan wires that scan into the **`data→main` promotion gate** in `.github/workflows/merge-data.yaml`,
+as a blocking step beside the existing `check-wiki-private-presence` gate. It scans the promotion delta
+(`main...data`) for private repo names before the promotion PR is opened, and blocks promotion on
+detection.
+
+**This is the correct enforcement point.** The leak chased on 2026-06-03 (a private `owner/name` in a wiki
+page *body*) entered via the autonomous agent writing to `data`, then surfaced toward `main` through the
+weekly promotion — not via a human PR. The slug-based `check-wiki-private-presence` gate misses in-body
+mentions; `check-private-leak` resolves the actual names and scans the promotion content, catching exactly
+that class. The promotion job is already a trusted, scheduled context with no PR-author code, so the broad
+PAT runs safely there — eliminating the `workflow_run` topology, status-spoofing surface, fork-PR
+derivation, and per-PR PAT fragility that a PR-time gate would require.
+
+## Problem Frame
+
+A private repo name can reach `main` in any promoted file — wiki body text, metadata, docs. The existing
+promotion gate (`check-wiki-private-presence`) is slug/attribution-based: it blocks a private *page*
+(filename) and checks public-repo attribution, but does not scan page *bodies* for arbitrary private-name
+mentions. The 2026-06-03 incident proved the gap: `marcusrbrown/poly` sat in `renovate-config.md`'s body
+and promoted cleanly. `check-private-leak` closes that gap by resolving the private names and scanning the
+promotion delta. It exists and is tested; it needs a trusted execution context and a blocking wire-in (see
+origin: issue #3407).
+
+## Requirements Trace
+
+- R1. The private-leak scan runs in `merge-data.yaml` and blocks the `data→main` promotion when a private
+  repo name appears in the promotion delta.
+- R2. The broad-scope `FRO_BOT_POLL_PAT` runs only in this trusted, no-PR-author-code job, scoped to the
+  resolution step.
+- R3. The gate is fail-closed: if private names cannot be fully resolved (transient/auth/rate-limit), the
+  promotion is blocked, not allowed through.
+- R4. Failure output names only file paths, never the resolved private name (already true in the script;
+  must remain true through logs and step summaries).
+- R5. The scan covers in-body mentions (the class the slug-based gate misses), reusing the existing pure
+  `checkPrivateLeak` core unchanged.
+
+## Scope Boundaries
+
+- The pure `checkPrivateLeak` scanning core and `scripts/resolve-private.ts` are shipped — not redesigned.
+- The slug-based `check-wiki-private-presence` gate stays; this scan is additive, not a replacement.
+- Pre-existing leaks already on both `data` and `main` (e.g. the accepted commit-history exposure, #3424)
+  are out of scope — the gate scans the promotion *delta*, consistent with that acceptance.
+
+### Deferred to Separate Tasks
+
+- **Per-PR-to-`main` defense-in-depth gate** (the original `workflow_run` design): a secondary layer that
+  would catch a private name added by a *direct human PR* to `main` (e.g. fixtures/docs, the #3406 class).
+  Deferred because (a) `check-wiki-authority` already blocks non-Fro-Bot edits to `knowledge/`+`metadata/`,
+  (b) it requires the full `workflow_run` topology (status-spoofing surface, fork derivation, per-PR PAT
+  SPOF) that the promotion gate avoids, and (c) the promotion gate already covers the motivating class.
+  If built later, it must use an App-pinned check (not a `github.token` status) to avoid the spoofing
+  surface, derive PR context from `GET /commits/{sha}/pulls` with an exact identity chain, and keep the
+  PAT off PR-author code.
+- **Agent-write-path invariant** (upstream): the ultimate source is the agent writing the name to `data`
+  (publicly readable before promotion). A machine-checkable invariant emitted at agent-write time —
+  tracked in `fro-bot/agent`, not here.
+- `#3408` (agent-actionable BLOCKED output / operator-report mode).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `.github/workflows/merge-data.yaml` — the promotion job. Already: checks out `data` into
+  `data-branch-check`, runs `check-wiki-private-presence.ts` as a blocking step (`working-directory:
+  data-branch-check`), then `merge-data-pr.ts` opens the PR. Mints an App token; `permissions: contents:
+  read`. The new scan slots in beside the wiki gate, before `merge-data-pr.ts`.
+- `scripts/check-private-leak.ts` — pure `checkPrivateLeak(privateNames, diff, override)` (unchanged).
+  `main()` currently derives a *PR* context (event payload, `gh pr diff`); this plan adds a **promotion
+  mode** that instead resolves names from `data`'s `repos.yaml` and scans the `main...data` git diff.
+- `scripts/private-repo-resolution.ts` — `makeGhNodeIdResolver(token)` is the seam for passing the PAT to
+  only the resolution step.
+- `scripts/check-wiki-private-presence.ts` — the sibling gate; mirror its blocking-step shape and redacted
+  output. Note it is slug/attribution-based (the gap this scan fills).
+
+### Institutional Learnings
+
+- `docs/solutions/security-issues/survey-workflow-side-privacy-gate-2026-05-16.md` — verify privacy inside
+  the trusted workflow before any public side effect.
+- `docs/solutions/security-issues/private-repo-dispatch-visibility-gate-2026-05-08.md` — keep canonical
+  `owner/repo` opaque; fail-closed with opaque IDs.
+- `docs/solutions/best-practices/diagnostic-patches-observability-discipline-2026-05-20.md` — never
+  `2>/dev/null` a gate's stderr; PAT policy failures hide until runtime.
+- `docs/solutions/best-practices/autonomous-pipeline-minimum-progress-floor-2026-05-17.md` — a fallback
+  path must reuse the exact fail-closed predicates of the main gate.
+
+### External References
+
+- The promotion gate needs no `workflow_run`/status/branch-protection mechanics — it is a blocking job
+  step, identical in shape to the existing `check-wiki-private-presence` gate. (The `workflow_run` research
+  from the prior plan revision applies only to the deferred per-PR layer.)
+
+## Key Technical Decisions
+
+- **Enforce at the `data→main` promotion, not per-PR.** This is the trusted chokepoint where private names
+  reach the canonical public branch, it matches the motivating leak's actual path (agent→`data`→promotion),
+  and it runs the broad PAT safely (no PR-author code). It dissolves the status-spoofing, fork-derivation,
+  override-forgery, and per-PR-PAT-SPOF findings the per-PR design carried.
+- **Scan the promotion delta (`main...data`).** Newly-promoted content is what this gate is responsible
+  for; pre-existing both-branch content is out of scope (consistent with the #3424 history acceptance).
+  Use a three-dot diff (`git diff origin/main...origin/data`) so the scan reflects what promotion adds to
+  `main`.
+- **Reuse the pure core; add a promotion entry path.** Feed `checkPrivateLeak` the git diff + the resolved
+  names. The PR-context derivation (`readPullRequestContext`, `gh pr diff`) is not used in this path.
+- **PAT scoped to the resolver step.** Pass `FRO_BOT_POLL_PAT` only to `makeGhNodeIdResolver(token)`; the
+  diff is local git, no token needed for it.
+- **Exhaustive resolution matrix (fail-closed).** Define the outcome for every resolution result:
+  `access-lost` (deleted/no-access) → skip that node_id (no current content to leak); any other failure
+  (transient/auth/rate-limit/unknown) → **block promotion** (cannot guarantee a complete scan); all
+  resolved + no diff match → allow.
+- **Block exactly like the wiki gate.** On detection or unresolved-failure, the step exits non-zero before
+  `merge-data-pr.ts` runs, so no promotion PR is opened. Redacted output (file paths only) to stderr +
+  step summary.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Enforcement point → **`data→main` promotion gate** (document-review convergent finding; per-PR deferred
+  to defense-in-depth).
+- Scan target → **`main...data` three-dot diff** (the promotion delta).
+- Override mechanism → **none needed** — the promotion job is operator-supervised (scheduled/dispatch); an
+  operator who must promote a flagged-but-acceptable state edits `data` or re-runs after redaction.
+- Status posting / required-check registration → **not applicable** — blocking step, not a posted status.
+
+### Deferred to Implementation
+
+- Whether promotion mode is a flag/subcommand of `check-private-leak.ts` or a thin sibling entrypoint that
+  imports `checkPrivateLeak` — decide when writing Unit 1 (favor the smallest change that keeps the PR
+  path intact and untested-by-this-plan).
+- Exact git plumbing for the delta in CI (the job has both `main` checkout and the `data-branch-check`
+  subtree; whether to `git fetch origin main data` and diff refs, or diff the two working trees) — settle
+  against the live checkout layout.
+- Whether to also emit a GitHub step-summary table of matched files (paths only) for operator visibility.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation
+> specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+merge-data.yaml (schedule / workflow_dispatch — trusted, no PR-author code)
+  ├─ mint App token
+  ├─ checkout main (scripts)  +  checkout data → data-branch-check
+  ├─ step: check-wiki-private-presence.ts        (existing slug/attribution gate — blocks)
+  ├─ step: check-private-leak.ts  [promotion mode]   ← NEW blocking gate
+  │     1. resolve private node_ids → names      (FRO_BOT_POLL_PAT, this step only)
+  │          └─ any non-access-lost failure → exit 1 (block, fail-closed)
+  │     2. diff = git diff origin/main...origin/data
+  │     3. checkPrivateLeak(names, diff) → ok | matchedFiles
+  │          └─ matchedFiles → exit 1 (block), redacted report (paths only)
+  └─ step: merge-data-pr.ts                       (only runs if both gates pass)
+```
+
+## Implementation Units
+
+- [x] **Unit 1: Add a promotion-scan path to `check-private-leak.ts`**
+
+**Goal:** Resolve private names from `data`'s `repos.yaml` and scan the `main...data` diff using the
+existing pure core, with an exhaustive fail-closed resolution matrix — without disturbing the existing
+PR-path code.
+
+**Requirements:** R2, R3, R4, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `scripts/check-private-leak.ts`
+- Modify: `scripts/check-private-leak.test.ts`
+- Reference (no change): `scripts/private-repo-resolution.ts`, `scripts/check-private-leak.ts`'s pure
+  `checkPrivateLeak`
+
+**Approach:**
+- Add a promotion entry path (flag/subcommand or sibling entrypoint — decided in implementation) that:
+  reads private node_ids from `data`'s `repos.yaml` (the job already has the `data` subtree), resolves each
+  via `makeGhNodeIdResolver(FRO_BOT_POLL_PAT)`, builds the `owner/name` + `owner--slug` token set, obtains
+  the `main...data` diff, runs `checkPrivateLeak(tokens, diff)`, and exits non-zero with a redacted report
+  on match.
+- Implement the exhaustive resolution matrix: `access-lost` → skip; any other failure → exit non-zero
+  (block); success → include token. Keep all redaction guarantees (paths only; no resolved name in any
+  output).
+- Leave the existing PR-context path (`readPullRequestContext`, `fetchPrDiff`, override comment) intact and
+  unused by this path, so the shipped PR-path tests stay green.
+
+**Execution note:** Test-first. Add failing tests for the resolution matrix and the diff-scan promotion
+path before adding the entry code.
+
+**Patterns to follow:**
+- `makeGhNodeIdResolver(token)` token-injection seam.
+- The existing redacted-output + fail-closed-on-unresolved logic already in `check-private-leak.ts`.
+- `check-wiki-private-presence.ts` reads `data`'s `repos.yaml` from the subtree — mirror that input source.
+
+**Test scenarios:**
+- Happy path: all private node_ids resolve; `main...data` diff has no private token → exit 0 (allow).
+- Happy path: diff added line contains a private `owner/name` (in-body mention) → exit non-zero,
+  `matchedFiles` lists the file, output contains no resolved name.
+- Edge case: a private token appears as a new wiki page path (`owner--slug.md`) → detected via the new-path
+  surface.
+- Error path: a node_id returns a non-`access-lost` failure (transient/auth) → exit non-zero (block), no
+  name leaked.
+- Edge case: an `access-lost` node_id is skipped (not fatal); scan proceeds on the rest.
+- Edge case: no private entries in `data`'s `repos.yaml` → exit 0 (nothing to scan).
+- Integration: the broad PAT is passed only to the resolver; the diff is obtained from local git with no
+  token (assert via injected client/spy).
+
+**Verification:** New promotion-path tests cover the full resolution matrix and diff/new-path detection;
+the pure `checkPrivateLeak` tests and the existing PR-path tests remain green; no resolved name appears in
+any asserted output.
+
+- [x] **Unit 2: Wire the promotion scan into `merge-data.yaml` as a blocking gate**
+
+**Goal:** Run the promotion scan in the trusted promotion job, with `FRO_BOT_POLL_PAT` scoped to that step,
+blocking the promotion before `merge-data-pr.ts` on detection or unresolved failure.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `.github/workflows/merge-data.yaml`
+
+**Approach:**
+- Add a step after `🔒 Block private wiki pages` and before `🔀 Open weekly data merge PR` that runs the
+  promotion scan. Provide `FRO_BOT_POLL_PAT` in that step's `env` only (not job-level); keep the diff
+  computed from local git refs (`git fetch origin main data` as needed, three-dot diff).
+- Because the step exits non-zero on detection/unresolved-failure, `merge-data-pr.ts` does not run and no
+  promotion PR is opened — identical blocking semantics to the existing wiki gate.
+- Add `FRO_BOT_POLL_PAT` to the workflow's secret usage. Keep `permissions: contents: read`.
+
+**Execution note:** YAML-only; validate with `actionlint`. Confirm the secret is declared where the
+workflow contract requires it.
+
+**Patterns to follow:**
+- The existing `🔒 Block private wiki pages` step (blocking gate shape, `data-branch-check` subtree).
+- Per-step secret scoping used across the App-token workflows (secret in step `env`, never job-level).
+
+**Test scenarios:** Test expectation: none — workflow YAML with no executable unit surface. Validation is
+`actionlint` + a live `workflow_dispatch` of `Merge Data Branch` confirming a seeded private-name in the
+`data` delta blocks promotion and a clean delta promotes.
+
+**Verification:** `actionlint` clean; a `workflow_dispatch` run with a private name present in the `data`
+delta exits at the new gate and opens no PR; a clean run proceeds to `merge-data-pr.ts`; the PAT appears
+only in the new step's environment.
+
+## System-Wide Impact
+
+- **Interaction graph:** Adds one blocking step to `merge-data.yaml`; no change to `check-wiki-private-presence`,
+  `merge-data-pr.ts`, or the PR-path of `check-private-leak.ts`.
+- **Error propagation:** Detection or unresolved-resolution → non-zero exit → promotion PR not opened
+  (fail-closed). No new status or branch-protection surface.
+- **State lifecycle risks:** None of the SHA-race / fork-derivation / status-staleness risks of the per-PR
+  design apply — there is no PR context and no posted status here.
+- **API surface parity:** None — internal gate.
+- **Integration coverage:** A live `workflow_dispatch` must confirm the blocking behavior end-to-end
+  (resolution + diff + block) before relying on the gate; unit tests cover the script, not the wiring.
+- **Unchanged invariants:** The pure `checkPrivateLeak`, `resolve-private.ts`, the existing PR-path,
+  `check-wiki-private-presence`, and `merge-data-pr.ts` are all unchanged.
+
+## Risks & Dependencies
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| PAT rotation/expiry/rate-limit blocks the weekly promotion (fail-closed) | Med | Med | Scope shrunk from "every PR" to "weekly promotion" (operator-supervised); resolution failure is observable in the run; operator re-runs after token fix |
+| Pre-existing both-branch leak not caught (delta-only scan) | Low | Low | Intentional — pre-existing/historical exposure is accepted (#3424); the agent-write-path invariant (upstream) is the ultimate source control |
+| Data branch publicly readable before promotion — gate is downstream of the true source | Med | Med | Accepted: promotion gate is the best trusted chokepoint in this repo before the canonical `main` record; agent-write-path hardening tracked upstream in `fro-bot/agent` |
+| Resolved private name leaks via step output/log | Low | High | Reuse the script's redaction (paths only); assert no name in output; never `2>/dev/null` the step |
+
+## Documentation / Operational Notes
+
+- Note the new promotion gate in `metadata/README.md` (promotion section) once Unit 2 lands.
+- After the live `workflow_dispatch` exercise, capture the promotion-gate pattern in a
+  `docs/solutions/security-issues/` learning (the in-body scan closes the gap the slug gate left).
+
+## Sources & References
+
+- **Origin document:** GitHub issue #3407 (Wire Check Private Leak in a trusted topology)
+- Related code: `scripts/check-private-leak.ts`, `scripts/private-repo-resolution.ts`,
+  `.github/workflows/merge-data.yaml`, `scripts/check-wiki-private-presence.ts`
+- Related issues: #3408 (operator-report mode), #3424 (history-exposure acceptance), #3327 (defense-in-depth
+  parent, closed)
+- Decision context: document-review on 2026-06-03 (adversarial 0.96 + product-lens 0.94 convergent finding)
+  pivoted enforcement from per-PR to the promotion gate, dissolving the status-spoofing, fork-derivation,
+  override-forgery, and per-PR-PAT-SPOF risks of the prior revision.

--- a/scripts/check-private-leak.test.ts
+++ b/scripts/check-private-leak.test.ts
@@ -1,8 +1,9 @@
+import type {GitDiffRunner, ReposYamlReader, ResolverFactory} from './check-private-leak.ts'
 import type {NodeIdResolver} from './private-repo-resolution.ts'
 import {Buffer} from 'node:buffer'
 import process from 'node:process'
 import {describe, expect, it, vi} from 'vitest'
-import {checkPrivateLeak, main, runPromotionScan} from './check-private-leak.ts'
+import {checkPrivateLeak, main, runPromotionCli, runPromotionScan} from './check-private-leak.ts'
 
 // ---------------------------------------------------------------------------
 // Module-level hoisted mocks — shared across all describe blocks.
@@ -363,7 +364,7 @@ describe('checkPrivateLeak — rename/copy path detection (Round-3 FIX #1)', () 
 })
 
 // ---------------------------------------------------------------------------
-// Round-3 FIX #2 — access-lost should SKIP, not fail-closed
+// Round-3 FIX #2 — access-lost and error fail-closed
 // Round-3 FIX #3 — stderr sanitization
 // Round-3 FIX #4 — no bare-name false positives (pure function)
 // ---------------------------------------------------------------------------
@@ -501,7 +502,7 @@ describe('main() — fail-closed and no-name-leak (FIX #1, FIX #4)', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Round-3 FIX #2 — access-lost should SKIP, not fail-closed (CLI-level)
+// Round-3 FIX #2 — access-lost skip vs error fail-closed (CLI-level, PR path)
 // ---------------------------------------------------------------------------
 
 describe('main() — access-lost skip vs error fail-closed (Round-3 FIX #2)', () => {
@@ -714,7 +715,7 @@ describe('checkPrivateLeak — no bare-name false positives (Round-3 FIX #4)', (
 })
 
 // ---------------------------------------------------------------------------
-// runPromotionScan — promotion-mode entry path (Unit 1)
+// runPromotionScan — promotion-mode entry path
 // ---------------------------------------------------------------------------
 
 /**
@@ -731,6 +732,53 @@ function makeReposYaml(nodeIds: string[]): string {
     )
     .join('\n')
   return `version: 1\nrepos:\n${entries}\n`
+}
+
+/**
+ * Build a minimal repos.yaml with a private entry that has no node_id field.
+ */
+function makeReposYamlMissingNodeId(): string {
+  return `version: 1
+repos:
+  - owner: "[REDACTED]"
+    name: repo-no-id
+    private: true
+    added: "2024-01-01"
+    onboarding_status: onboarded
+    last_survey_at: null
+    last_survey_status: null
+    has_fro_bot_workflow: false
+    has_renovate: false
+`
+}
+
+/**
+ * Build a minimal repos.yaml with two private entries: one with a node_id, one without.
+ * Used to test that a missing node_id blocks even when other entries are valid.
+ */
+function makeReposYamlOneMissingOnePresent(): string {
+  return `version: 1
+repos:
+  - owner: "[REDACTED]"
+    name: repo-no-id
+    private: true
+    added: "2024-01-01"
+    onboarding_status: onboarded
+    last_survey_at: null
+    last_survey_status: null
+    has_fro_bot_workflow: false
+    has_renovate: false
+  - owner: "[REDACTED]"
+    name: repo-with-id
+    private: true
+    node_id: R_valid
+    added: "2024-01-01"
+    onboarding_status: onboarded
+    last_survey_at: null
+    last_survey_status: null
+    has_fro_bot_workflow: false
+    has_renovate: false
+`
 }
 
 /**
@@ -786,8 +834,8 @@ describe('runPromotionScan — happy path: diff contains private owner/name → 
   })
 })
 
-describe('runPromotionScan — edge: private token as new wiki page path → detected', () => {
-  it('returns ok:false when a new wiki page path contains the owner--slug form', async () => {
+describe('runPromotionScan — edge: private token as new wiki page path → detected and redacted', () => {
+  it('returns ok:false when a new wiki page path contains the owner--slug form; path is redacted', async () => {
     // #given: private repo resolves; diff adds a new file whose path is the slug form
     const reposYaml = makeReposYaml(['R_promo_3'])
     const resolver: NodeIdResolver = async nodeId => {
@@ -806,7 +854,70 @@ describe('runPromotionScan — edge: private token as new wiki page path → det
 
     const result = await runPromotionScan({reposYaml, resolver, diff})
 
-    expect(result).toEqual({ok: false, matchedFiles: ['knowledge/wiki/repos/acme--private-repo.md']})
+    // #then: blocked; the matched file path has the private token redacted
+    expect(result.ok).toBe(false)
+    if (!result.ok && 'matchedFiles' in result) {
+      // The path must NOT contain the literal private token
+      for (const file of result.matchedFiles) {
+        expect(file).not.toContain('acme--private-repo')
+        expect(file).not.toContain('acme/private-repo')
+        // The redaction marker must be present
+        expect(file).toContain('[REDACTED]')
+      }
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fix D — redaction: matched path containing a private token is redacted
+// ---------------------------------------------------------------------------
+
+describe('runPromotionScan — Fix D: matched path redaction', () => {
+  it('redacts the private token from a matched file path in the returned result', async () => {
+    // #given: private repo resolves; diff adds content to a file whose path contains the slug
+    const reposYaml = makeReposYaml(['R_redact'])
+    const resolver: NodeIdResolver = async nodeId => {
+      if (nodeId === 'R_redact') return {nameWithOwner: 'secretowner/secret-repo'}
+      return {error: 'error'}
+    }
+    // The matched file path contains the slug form of the private repo
+    const diff = makePromoDiff('knowledge/wiki/repos/secretowner--secret-repo.md', [
+      'See secretowner/secret-repo for details.',
+    ])
+
+    const result = await runPromotionScan({reposYaml, resolver, diff})
+
+    // #then: blocked
+    expect(result.ok).toBe(false)
+    if (!result.ok && 'matchedFiles' in result) {
+      const serialized = JSON.stringify(result)
+      // The literal private tokens must NOT appear in the result
+      expect(serialized).not.toContain('secretowner/secret-repo')
+      expect(serialized).not.toContain('secretowner--secret-repo')
+      expect(serialized).not.toContain('secretowner')
+      // The redaction marker must be present
+      expect(serialized).toContain('[REDACTED]')
+    }
+  })
+
+  it('does not redact paths that do not contain a private token', async () => {
+    // #given: private repo resolves; diff adds content to a public-named file
+    const reposYaml = makeReposYaml(['R_no_redact'])
+    const resolver: NodeIdResolver = async nodeId => {
+      if (nodeId === 'R_no_redact') return {nameWithOwner: 'secretowner/secret-repo'}
+      return {error: 'error'}
+    }
+    // The matched file path does NOT contain the private token
+    const diff = makePromoDiff('docs/public-doc.md', ['See secretowner/secret-repo for details.'])
+
+    const result = await runPromotionScan({reposYaml, resolver, diff})
+
+    // #then: blocked; path is preserved (no token in path)
+    expect(result.ok).toBe(false)
+    if (!result.ok && 'matchedFiles' in result) {
+      // The path itself is public — it should be preserved as-is
+      expect(result.matchedFiles).toContain('docs/public-doc.md')
+    }
   })
 })
 
@@ -842,9 +953,27 @@ describe('runPromotionScan — error: non-access-lost failure → BLOCK (fail-cl
   })
 })
 
-describe('runPromotionScan — edge: access-lost node_id is skipped, scan proceeds', () => {
-  it('skips access-lost node_ids and scans with remaining resolved names', async () => {
-    // #given: one access-lost, one resolves; diff has no private name → ok
+// ---------------------------------------------------------------------------
+// Fix A — access-lost must BLOCK in promotion mode (not skip)
+// ---------------------------------------------------------------------------
+
+describe('runPromotionScan — Fix A: access-lost BLOCKS (fail-closed)', () => {
+  it('BLOCKS when a node_id returns access-lost — includes it in failedNodeIds', async () => {
+    // #given: one node_id returns access-lost
+    // access-lost is indistinguishable between "deleted" and "no-access/mis-scoped-token".
+    // A mis-scoped PAT makes every private repo look access-lost → must block, not skip.
+    const reposYaml = makeReposYaml(['R_access_lost'])
+    const resolver: NodeIdResolver = async () => ({error: 'access-lost'})
+    const diff = makePromoDiff('docs/foo.md', ['some content'])
+
+    const result = await runPromotionScan({reposYaml, resolver, diff})
+
+    // #then: fail-closed — access-lost blocks promotion
+    expect(result).toEqual({ok: false, resolutionFailed: true, failedNodeIds: ['R_access_lost']})
+  })
+
+  it('BLOCKS when one node_id is access-lost and one resolves successfully', async () => {
+    // #given: one access-lost, one resolves; diff has no private name
     const reposYaml = makeReposYaml(['R_gone', 'R_present'])
     const resolver: NodeIdResolver = async nodeId => {
       if (nodeId === 'R_gone') return {error: 'access-lost'}
@@ -855,23 +984,81 @@ describe('runPromotionScan — edge: access-lost node_id is skipped, scan procee
 
     const result = await runPromotionScan({reposYaml, resolver, diff})
 
-    // access-lost is skipped; scan proceeds with the resolved name; no match → ok
-    expect(result).toEqual({ok: true})
+    // #then: access-lost blocks — R_gone is in failedNodeIds
+    expect(result).toEqual({ok: false, resolutionFailed: true, failedNodeIds: ['R_gone']})
   })
 
-  it('skips access-lost and still blocks when the remaining resolved name appears in diff', async () => {
-    // #given: one access-lost, one resolves; diff DOES contain the resolved name
-    const reposYaml = makeReposYaml(['R_gone', 'R_present'])
-    const resolver: NodeIdResolver = async nodeId => {
-      if (nodeId === 'R_gone') return {error: 'access-lost'}
-      if (nodeId === 'R_present') return {nameWithOwner: 'acme/private-repo'}
-      return {error: 'error'}
-    }
-    const diff = makePromoDiff('docs/foo.md', ['See acme/private-repo for details.'])
+  it('BLOCKS when ALL node_ids are access-lost', async () => {
+    // #given: all private repos are access-lost
+    const reposYaml = makeReposYaml(['R_gone1', 'R_gone2'])
+    const resolver: NodeIdResolver = async () => ({error: 'access-lost'})
+    const diff = makePromoDiff('docs/foo.md', ['some content'])
 
     const result = await runPromotionScan({reposYaml, resolver, diff})
 
-    expect(result).toEqual({ok: false, matchedFiles: ['docs/foo.md']})
+    // #then: all access-lost → all in failedNodeIds
+    expect(result).toEqual({ok: false, resolutionFailed: true, failedNodeIds: ['R_gone1', 'R_gone2']})
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fix B — missing/empty node_id on a private entry must BLOCK
+// ---------------------------------------------------------------------------
+
+describe('runPromotionScan — Fix B: missing/empty node_id BLOCKS', () => {
+  it('BLOCKS when a private entry has no node_id field', async () => {
+    // #given: repos.yaml with a private entry that has no node_id
+    const reposYaml = makeReposYamlMissingNodeId()
+    const resolver: NodeIdResolver = vi.fn()
+    const diff = makePromoDiff('docs/foo.md', ['some content'])
+
+    const result = await runPromotionScan({reposYaml, resolver, diff})
+
+    // #then: fail-closed — missing node_id blocks promotion
+    expect(result.ok).toBe(false)
+    if (!result.ok && 'resolutionFailed' in result) {
+      expect(result.resolutionFailed).toBe(true)
+      // The sentinel placeholder must appear (never any owner/name)
+      expect(result.failedNodeIds).toContain('<missing-node-id>')
+      // The resolver must NOT have been called (no node_id to resolve)
+      expect(resolver).not.toHaveBeenCalled()
+    }
+  })
+
+  it('BLOCKS when mix of missing node_id and valid node_id — missing entry blocks regardless', async () => {
+    // #given: one entry with missing node_id, one with a valid node_id that resolves
+    // The schema allows node_id to be omitted (undefined) but not empty string.
+    const reposYaml = makeReposYamlOneMissingOnePresent()
+    const resolver: NodeIdResolver = async nodeId => {
+      if (nodeId === 'R_valid') return {nameWithOwner: 'acme/private-repo'}
+      return {error: 'error'}
+    }
+    const diff = makePromoDiff('docs/foo.md', ['some content'])
+
+    const result = await runPromotionScan({reposYaml, resolver, diff})
+
+    // #then: blocked because of the missing node_id entry
+    expect(result.ok).toBe(false)
+    if (!result.ok && 'resolutionFailed' in result) {
+      expect(result.resolutionFailed).toBe(true)
+      expect(result.failedNodeIds).toContain('<missing-node-id>')
+    }
+  })
+
+  it('the sentinel placeholder never contains owner or name', async () => {
+    // #given: private entry with no node_id
+    const reposYaml = makeReposYamlMissingNodeId()
+    const resolver: NodeIdResolver = vi.fn()
+    const diff = makePromoDiff('docs/foo.md', ['some content'])
+
+    const result = await runPromotionScan({reposYaml, resolver, diff})
+
+    const serialized = JSON.stringify(result)
+    // The sentinel must not contain any owner/name information
+    expect(serialized).not.toContain('repo-no-id')
+    expect(serialized).not.toContain('REDACTED"') // the owner field value
+    // But the sentinel placeholder itself is present
+    expect(serialized).toContain('<missing-node-id>')
   })
 })
 
@@ -944,5 +1131,466 @@ describe('runPromotionScan — integration: PAT passed only to resolver, diff ne
     await runPromotionScan({reposYaml, resolver, diff})
 
     expect(calls).toEqual(['R_a', 'R_b'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fix E — runPromotionCli: CLI-level tests via injectable seams
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal repos.yaml string for CLI tests.
+ */
+function makeCliReposYaml(nodeIds: string[]): string {
+  return makeReposYaml(nodeIds)
+}
+
+interface SeamOpts {
+  nodeIds?: string[]
+  resolverResult?: NodeIdResolver
+  diffOutput?: string
+  reposYamlContent?: string
+  gitThrows?: Error
+  reposYamlThrows?: Error
+}
+
+interface SeamResult {
+  gitDiffRunner: GitDiffRunner
+  reposYamlReader: ReposYamlReader
+  resolverFactory: ResolverFactory
+  capturedGitEnvs: NodeJS.ProcessEnv[]
+}
+
+/**
+ * Build standard seam fakes for runPromotionCli tests.
+ * Moved to outer scope to satisfy unicorn/consistent-function-scoping.
+ */
+function makeSeams(opts: SeamOpts = {}): SeamResult {
+  const capturedGitEnvs: NodeJS.ProcessEnv[] = []
+
+  const gitDiffRunner: GitDiffRunner = (_args, env) => {
+    capturedGitEnvs.push({...env})
+    if (opts.gitThrows !== undefined) throw opts.gitThrows
+    return opts.diffOutput ?? ''
+  }
+
+  const reposYamlReader: ReposYamlReader = async () => {
+    if (opts.reposYamlThrows !== undefined) throw opts.reposYamlThrows
+    return opts.reposYamlContent ?? makeCliReposYaml(opts.nodeIds ?? [])
+  }
+
+  const resolverFactory: ResolverFactory = (_pat: string): NodeIdResolver =>
+    opts.resolverResult ?? (async () => ({nameWithOwner: 'acme/private-repo'}))
+
+  return {gitDiffRunner, reposYamlReader, resolverFactory, capturedGitEnvs}
+}
+
+describe('runPromotionCli — Fix E: CLI-level tests via injectable seams', () => {
+  it('returns 1 when FRO_BOT_POLL_PAT is not set', async () => {
+    const stderrOutput: string[] = []
+    vi.spyOn(process.stderr, 'write').mockImplementation((msg: unknown) => {
+      stderrOutput.push(String(msg))
+      return true
+    })
+
+    const savedPat = process.env.FRO_BOT_POLL_PAT
+    delete process.env.FRO_BOT_POLL_PAT
+
+    try {
+      const {gitDiffRunner, reposYamlReader, resolverFactory} = makeSeams()
+      const exitCode = await runPromotionCli(gitDiffRunner, reposYamlReader, resolverFactory)
+
+      expect(exitCode).toBe(1)
+      expect(stderrOutput.join('')).toContain('FRO_BOT_POLL_PAT not set')
+    } finally {
+      if (savedPat !== undefined) process.env.FRO_BOT_POLL_PAT = savedPat
+      vi.restoreAllMocks()
+    }
+  })
+
+  it('returns 1 when repos.yaml cannot be read', async () => {
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      const {gitDiffRunner, reposYamlReader, resolverFactory} = makeSeams({
+        reposYamlThrows: new Error('ENOENT: no such file'),
+      })
+      const exitCode = await runPromotionCli(gitDiffRunner, reposYamlReader, resolverFactory)
+
+      expect(exitCode).toBe(1)
+    } finally {
+      delete process.env.FRO_BOT_POLL_PAT
+      vi.restoreAllMocks()
+    }
+  })
+
+  it('returns 1 when git diff fails', async () => {
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      const {gitDiffRunner, reposYamlReader, resolverFactory} = makeSeams({
+        nodeIds: [],
+        gitThrows: new Error('git: not a git repository'),
+      })
+      const exitCode = await runPromotionCli(gitDiffRunner, reposYamlReader, resolverFactory)
+
+      expect(exitCode).toBe(1)
+    } finally {
+      delete process.env.FRO_BOT_POLL_PAT
+      vi.restoreAllMocks()
+    }
+  })
+
+  it('returns 0 when all node_ids resolve and diff is clean', async () => {
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      const {gitDiffRunner, reposYamlReader, resolverFactory} = makeSeams({
+        nodeIds: ['R_clean'],
+        resolverResult: async () => ({nameWithOwner: 'acme/private-repo'}),
+        diffOutput: makePromoDiff('docs/public.md', ['some public content']),
+      })
+      const exitCode = await runPromotionCli(gitDiffRunner, reposYamlReader, resolverFactory)
+
+      expect(exitCode).toBe(0)
+    } finally {
+      delete process.env.FRO_BOT_POLL_PAT
+      vi.restoreAllMocks()
+    }
+  })
+
+  it('returns 1 when resolution fails (access-lost) — blocks promotion', async () => {
+    const stderrOutput: string[] = []
+    vi.spyOn(process.stderr, 'write').mockImplementation((msg: unknown) => {
+      stderrOutput.push(String(msg))
+      return true
+    })
+
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      const {gitDiffRunner, reposYamlReader, resolverFactory} = makeSeams({
+        nodeIds: ['R_access_lost_cli'],
+        resolverResult: async () => ({error: 'access-lost'}),
+        diffOutput: '',
+      })
+      const exitCode = await runPromotionCli(gitDiffRunner, reposYamlReader, resolverFactory)
+
+      expect(exitCode).toBe(1)
+      const stderrText = stderrOutput.join('')
+      // access-lost is now a blocking condition
+      expect(stderrText).toContain('BLOCKING')
+      expect(stderrText).toContain('R_access_lost_cli')
+    } finally {
+      delete process.env.FRO_BOT_POLL_PAT
+      vi.restoreAllMocks()
+    }
+  })
+
+  it('returns 1 when diff contains a matched private file', async () => {
+    const stderrOutput: string[] = []
+    vi.spyOn(process.stderr, 'write').mockImplementation((msg: unknown) => {
+      stderrOutput.push(String(msg))
+      return true
+    })
+
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      const {gitDiffRunner, reposYamlReader, resolverFactory} = makeSeams({
+        nodeIds: ['R_match'],
+        resolverResult: async () => ({nameWithOwner: 'acme/private-repo'}),
+        diffOutput: makePromoDiff('docs/foo.md', ['See acme/private-repo for details.']),
+      })
+      const exitCode = await runPromotionCli(gitDiffRunner, reposYamlReader, resolverFactory)
+
+      expect(exitCode).toBe(1)
+      const stderrText = stderrOutput.join('')
+      // The private name must NOT appear in stderr (redacted)
+      expect(stderrText).not.toContain('acme/private-repo')
+      expect(stderrText).not.toContain('acme--private-repo')
+    } finally {
+      delete process.env.FRO_BOT_POLL_PAT
+      vi.restoreAllMocks()
+    }
+  })
+
+  it('Fix C: git runner env does NOT contain FRO_BOT_POLL_PAT', async () => {
+    // #given: FRO_BOT_POLL_PAT is set in process.env
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    process.env.FRO_BOT_POLL_PAT = 'super-secret-pat'
+    try {
+      const {gitDiffRunner, reposYamlReader, resolverFactory, capturedGitEnvs} = makeSeams({
+        nodeIds: ['R_env_test'],
+        resolverResult: async () => ({nameWithOwner: 'acme/private-repo'}),
+        diffOutput: '',
+      })
+      await runPromotionCli(gitDiffRunner, reposYamlReader, resolverFactory)
+
+      // #then: the git runner was called at least once
+      expect(capturedGitEnvs.length).toBeGreaterThan(0)
+      // #then: FRO_BOT_POLL_PAT must NOT be in the env passed to git
+      for (const env of capturedGitEnvs) {
+        expect(env).not.toHaveProperty('FRO_BOT_POLL_PAT')
+        expect(Object.values(env)).not.toContain('super-secret-pat')
+      }
+    } finally {
+      delete process.env.FRO_BOT_POLL_PAT
+      vi.restoreAllMocks()
+    }
+  })
+
+  it('Fix C: PAT reaches the resolver factory but not the git runner', async () => {
+    // #given: FRO_BOT_POLL_PAT is set
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    process.env.FRO_BOT_POLL_PAT = 'resolver-only-pat'
+    const capturedPats: string[] = []
+
+    try {
+      const {gitDiffRunner, reposYamlReader, capturedGitEnvs} = makeSeams({
+        nodeIds: ['R_pat_routing'],
+        diffOutput: '',
+      })
+
+      // Custom resolver factory that captures the PAT
+      const resolverFactory: ResolverFactory = (pat: string): NodeIdResolver => {
+        capturedPats.push(pat)
+        return async () => ({nameWithOwner: 'acme/private-repo'})
+      }
+
+      await runPromotionCli(gitDiffRunner, reposYamlReader, resolverFactory)
+
+      // #then: PAT reached the resolver factory
+      expect(capturedPats).toContain('resolver-only-pat')
+      // #then: PAT did NOT reach the git runner
+      for (const env of capturedGitEnvs) {
+        expect(env).not.toHaveProperty('FRO_BOT_POLL_PAT')
+      }
+    } finally {
+      delete process.env.FRO_BOT_POLL_PAT
+      vi.restoreAllMocks()
+    }
+  })
+
+  it('no resolved private name appears in captured stdout+stderr', async () => {
+    // #given: a private repo resolves; diff matches it
+    const stdoutOutput: string[] = []
+    const stderrOutput: string[] = []
+    vi.spyOn(process.stdout, 'write').mockImplementation((msg: unknown) => {
+      stdoutOutput.push(String(msg))
+      return true
+    })
+    vi.spyOn(process.stderr, 'write').mockImplementation((msg: unknown) => {
+      stderrOutput.push(String(msg))
+      return true
+    })
+
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      const {gitDiffRunner, reposYamlReader, resolverFactory} = makeSeams({
+        nodeIds: ['R_no_leak'],
+        resolverResult: async () => ({nameWithOwner: 'secretowner/secret-repo'}),
+        diffOutput: makePromoDiff('docs/foo.md', ['See secretowner/secret-repo for details.']),
+      })
+      await runPromotionCli(gitDiffRunner, reposYamlReader, resolverFactory)
+
+      const allOutput = [...stdoutOutput, ...stderrOutput].join('')
+      // The private name must NEVER appear in any output
+      expect(allOutput).not.toContain('secretowner/secret-repo')
+      expect(allOutput).not.toContain('secretowner--secret-repo')
+      expect(allOutput).not.toContain('secretowner')
+    } finally {
+      delete process.env.FRO_BOT_POLL_PAT
+      vi.restoreAllMocks()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// FIX 1 (token coverage) — buildTokensForName raw double-dash form
+// ---------------------------------------------------------------------------
+
+describe('buildTokensForName — raw double-dash form (FIX 1)', () => {
+  // buildTokensForName is not exported; exercise it via runPromotionScan which
+  // calls it internally and uses the returned tokens for both matching and redaction.
+
+  it('includes the raw double-dash form for a name with underscore (acme/private_repo)', async () => {
+    // #given: a private repo whose name contains an underscore.
+    // The slug sanitizes underscore → hyphen (acme--private-repo), but the raw form preserves it
+    // (acme--private_repo). Without the raw form in the token set, a diff containing
+    // "acme--private_repo" would not be detected.
+    const reposYaml = makeReposYaml(['R_underscore'])
+    const resolver: NodeIdResolver = async nodeId => {
+      if (nodeId === 'R_underscore') return {nameWithOwner: 'acme/private_repo'}
+      return {error: 'error'}
+    }
+    // Diff adds a content line containing the raw double-dash form (underscore preserved).
+    // The slug form (acme--private-repo) would NOT match this line — only the raw form does.
+    const diff = makePromoDiff('docs/some-doc.md', ['See acme--private_repo for details.'])
+
+    const result = await runPromotionScan({reposYaml, resolver, diff})
+
+    // #then: the raw double-dash form is in the token set → detected as a leak
+    expect(result.ok).toBe(false)
+  })
+
+  it('redacts the raw double-dash form (acme--private_repo) in the matched path output', async () => {
+    // #given: same scenario — raw double-dash form in a new file path
+    const reposYaml = makeReposYaml(['R_underscore_redact'])
+    const resolver: NodeIdResolver = async nodeId => {
+      if (nodeId === 'R_underscore_redact') return {nameWithOwner: 'acme/private_repo'}
+      return {error: 'error'}
+    }
+    const diff = [
+      'diff --git a/knowledge/wiki/repos/acme--private_repo.md b/knowledge/wiki/repos/acme--private_repo.md',
+      'new file mode 100644',
+      '--- /dev/null',
+      '+++ b/knowledge/wiki/repos/acme--private_repo.md',
+      '@@ -0,0 +1 @@',
+      '+Some unrelated content',
+    ].join('\n')
+
+    const result = await runPromotionScan({reposYaml, resolver, diff})
+
+    // #then: blocked; the matched path must NOT contain the literal private_repo token
+    expect(result.ok).toBe(false)
+    if (!result.ok && 'matchedFiles' in result) {
+      for (const file of result.matchedFiles) {
+        expect(file).not.toContain('private_repo')
+        expect(file).not.toContain('acme--private_repo')
+        expect(file).toContain('[REDACTED]')
+      }
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// FIX 2 (PR-path redaction parity) — matched files redacted in main() stderr
+// ---------------------------------------------------------------------------
+
+describe('main() — PR-path matched file redaction (FIX 2)', () => {
+  it('redacts the private token from matched file paths printed to stderr on failure', async () => {
+    // #given: a private repo resolves; diff adds a new file whose path contains the slug
+    mockReadFile.mockResolvedValue(makeEvent())
+    mockExecFileSync.mockReset()
+    mockExecFileSync
+      .mockReturnValueOnce(makeYamlBase64(['R_pr_redact'])) // fetchPrivateNodeIds
+      .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'synth-owner/synth_private'}}})) // resolver → resolves
+      // fetchPrDiff: diff adds a new file whose path contains the slug form
+      .mockReturnValueOnce(
+        [
+          'diff --git a/knowledge/wiki/repos/synth-owner--synth_private.md b/knowledge/wiki/repos/synth-owner--synth_private.md',
+          'new file mode 100644',
+          '--- /dev/null',
+          '+++ b/knowledge/wiki/repos/synth-owner--synth_private.md',
+          '@@ -0,0 +1 @@',
+          '+Some content',
+        ].join('\n'),
+      )
+
+    const stderrOutput: string[] = []
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((msg: unknown) => {
+      stderrOutput.push(String(msg))
+      return true
+    })
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    try {
+      await expect(main()).rejects.toThrow('process.exit called')
+
+      const stderrText = stderrOutput.join('')
+
+      // #then: the "Matched files:" header is present
+      expect(stderrText).toContain('Matched files:')
+
+      // #then: the private token does NOT appear literally in stderr
+      expect(stderrText).not.toContain('synth_private')
+      expect(stderrText).not.toContain('synth-owner--synth_private')
+      expect(stderrText).not.toContain('synth-owner/synth_private')
+
+      // #then: the redaction marker IS present (path was redacted, not dropped)
+      expect(stderrText).toContain('[REDACTED]')
+    } finally {
+      stderrSpy.mockRestore()
+      exitSpy.mockRestore()
+      delete process.env.GITHUB_EVENT_PATH
+      mockExecFileSync.mockReset()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// FIX 3 (correctness) — regex-metachar token redacted literally, not as pattern
+// ---------------------------------------------------------------------------
+
+describe('redactPathTokens — regex-metachar token (FIX 3)', () => {
+  // redactPathTokens is not exported; exercise via runPromotionScan which calls it
+  // on matched file paths before returning them.
+
+  it('redacts a token containing regex metacharacters literally without throwing', async () => {
+    // #given: a synthetic owner/name that produces regex metacharacters in the slug.
+    // "a.c/d+e" → raw double-dash form "a.c--d+e" contains '.' and '+' which are regex metacharacters.
+    // The redaction must treat them as literals, not regex operators.
+    const reposYaml = makeReposYaml(['R_metachar'])
+    const resolver: NodeIdResolver = async nodeId => {
+      if (nodeId === 'R_metachar') return {nameWithOwner: 'a.c/d+e'}
+      return {error: 'error'}
+    }
+    // Diff adds a new file whose path contains the raw double-dash form of the token.
+    // If '.' or '+' were interpreted as regex metacharacters, the match/redaction would be wrong.
+    const diff = [
+      'diff --git a/knowledge/wiki/repos/a.c--d+e.md b/knowledge/wiki/repos/a.c--d+e.md',
+      'new file mode 100644',
+      '--- /dev/null',
+      '+++ b/knowledge/wiki/repos/a.c--d+e.md',
+      '@@ -0,0 +1 @@',
+      '+Some content',
+    ].join('\n')
+
+    // #when: runPromotionScan is called — must not throw a regex error
+    let result: Awaited<ReturnType<typeof runPromotionScan>>
+    expect(() => {
+      result = undefined as unknown as typeof result
+    }).not.toThrow()
+
+    result = await runPromotionScan({reposYaml, resolver, diff})
+
+    // #then: the literal path is detected (not a regex false-negative)
+    expect(result.ok).toBe(false)
+
+    if (!result.ok && 'matchedFiles' in result) {
+      for (const file of result.matchedFiles) {
+        // The literal token must be redacted, not left as-is or partially matched
+        expect(file).not.toContain('a.c--d+e')
+        expect(file).toContain('[REDACTED]')
+      }
+    }
+  })
+
+  it('does not match unrelated paths when token contains regex metacharacters', async () => {
+    // #given: token "a.c/d+e" — the '.' would match any char and '+' is a quantifier if unescaped.
+    // A path like "axc--dde.md" should NOT be matched (only the literal "a.c--d+e" should match).
+    const reposYaml = makeReposYaml(['R_metachar_no_false_pos'])
+    const resolver: NodeIdResolver = async nodeId => {
+      if (nodeId === 'R_metachar_no_false_pos') return {nameWithOwner: 'a.c/d+e'}
+      return {error: 'error'}
+    }
+    // Diff adds a file whose path would match if '.' and '+' were regex metacharacters,
+    // but should NOT match because the literal token is different.
+    const diff = makePromoDiff('knowledge/wiki/repos/axc--dde.md', ['Some content'])
+
+    const result = await runPromotionScan({reposYaml, resolver, diff})
+
+    // #then: no match — the path does not contain the literal token
+    expect(result.ok).toBe(true)
   })
 })

--- a/scripts/check-private-leak.test.ts
+++ b/scripts/check-private-leak.test.ts
@@ -1,9 +1,8 @@
+import type {NodeIdResolver} from './private-repo-resolution.ts'
 import {Buffer} from 'node:buffer'
 import process from 'node:process'
-
 import {describe, expect, it, vi} from 'vitest'
-
-import {checkPrivateLeak, main} from './check-private-leak.ts'
+import {checkPrivateLeak, main, runPromotionScan} from './check-private-leak.ts'
 
 // ---------------------------------------------------------------------------
 // Module-level hoisted mocks — shared across all describe blocks.
@@ -711,5 +710,239 @@ describe('checkPrivateLeak — no bare-name false positives (Round-3 FIX #4)', (
     ].join('\n')
     const result = checkPrivateLeak(['acme/go', 'acme--go'], diff, override)
     expect(result).toEqual({ok: false, matchedFiles: ['docs/tech.md']})
+  })
+})
+
+// ---------------------------------------------------------------------------
+// runPromotionScan — promotion-mode entry path (Unit 1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal repos.yaml YAML string with the given private node_ids.
+ */
+function makeReposYaml(nodeIds: string[]): string {
+  if (nodeIds.length === 0) {
+    return 'version: 1\nrepos: []\n'
+  }
+  const entries = nodeIds
+    .map(
+      (id, i) =>
+        `  - owner: "[REDACTED]"\n    name: repo-${i}\n    private: true\n    node_id: ${id}\n    added: "2024-01-01"\n    onboarding_status: onboarded\n    last_survey_at: null\n    last_survey_status: null\n    has_fro_bot_workflow: false\n    has_renovate: false`,
+    )
+    .join('\n')
+  return `version: 1\nrepos:\n${entries}\n`
+}
+
+/**
+ * Build a minimal unified diff with added lines for promotion-scan tests.
+ */
+function makePromoDiff(filePath: string, additions: string[]): string {
+  const lines = [
+    `diff --git a/${filePath} b/${filePath}`,
+    `--- a/${filePath}`,
+    `+++ b/${filePath}`,
+    '@@ -1,0 +1 @@',
+    ...additions.map(l => `+${l}`),
+  ]
+  return lines.join('\n')
+}
+
+describe('runPromotionScan — happy path: all resolve, no match → exit 0', () => {
+  it('returns ok:true when all node_ids resolve and diff has no private token', async () => {
+    // #given: one private node_id resolves; diff has no private name
+    const reposYaml = makeReposYaml(['R_promo_1'])
+    const resolver: NodeIdResolver = async nodeId => {
+      if (nodeId === 'R_promo_1') return {nameWithOwner: 'acme/private-repo'}
+      return {error: 'error'}
+    }
+    const diff = makePromoDiff('knowledge/wiki/topics/rust.md', ['Some content about Rust.'])
+
+    const result = await runPromotionScan({reposYaml, resolver, diff})
+
+    expect(result).toEqual({ok: true})
+  })
+})
+
+describe('runPromotionScan — happy path: diff contains private owner/name → block', () => {
+  it('returns ok:false with matchedFiles when diff added line contains the private name', async () => {
+    // #given: one private node_id resolves to acme/private-repo; diff adds that name in body
+    const reposYaml = makeReposYaml(['R_promo_2'])
+    const resolver: NodeIdResolver = async nodeId => {
+      if (nodeId === 'R_promo_2') return {nameWithOwner: 'acme/private-repo'}
+      return {error: 'error'}
+    }
+    const diff = makePromoDiff('knowledge/wiki/topics/rust.md', ['See acme/private-repo for details.'])
+
+    const result = await runPromotionScan({reposYaml, resolver, diff})
+
+    // #then: blocked, file listed, no resolved name in matchedFiles (paths only)
+    expect(result).toEqual({ok: false, matchedFiles: ['knowledge/wiki/topics/rust.md']})
+    // Verify the result does NOT contain the resolved name itself (only file paths)
+    if (!result.ok && 'matchedFiles' in result) {
+      for (const file of result.matchedFiles) {
+        expect(file).not.toContain('acme/private-repo')
+      }
+    }
+  })
+})
+
+describe('runPromotionScan — edge: private token as new wiki page path → detected', () => {
+  it('returns ok:false when a new wiki page path contains the owner--slug form', async () => {
+    // #given: private repo resolves; diff adds a new file whose path is the slug form
+    const reposYaml = makeReposYaml(['R_promo_3'])
+    const resolver: NodeIdResolver = async nodeId => {
+      if (nodeId === 'R_promo_3') return {nameWithOwner: 'acme/private-repo'}
+      return {error: 'error'}
+    }
+    // New file added with slug path — the path itself is the leak surface
+    const diff = [
+      'diff --git a/knowledge/wiki/repos/acme--private-repo.md b/knowledge/wiki/repos/acme--private-repo.md',
+      'new file mode 100644',
+      '--- /dev/null',
+      '+++ b/knowledge/wiki/repos/acme--private-repo.md',
+      '@@ -0,0 +1 @@',
+      '+Some unrelated content',
+    ].join('\n')
+
+    const result = await runPromotionScan({reposYaml, resolver, diff})
+
+    expect(result).toEqual({ok: false, matchedFiles: ['knowledge/wiki/repos/acme--private-repo.md']})
+  })
+})
+
+describe('runPromotionScan — error: non-access-lost failure → BLOCK (fail-closed)', () => {
+  it('returns a resolution-failure result when a node_id returns a transient/auth error', async () => {
+    // #given: one node_id fails with a non-access-lost error (transient/auth)
+    const reposYaml = makeReposYaml(['R_promo_fail'])
+    const resolver: NodeIdResolver = async () => ({error: 'error'})
+    const diff = makePromoDiff('knowledge/wiki/topics/rust.md', ['Some content.'])
+
+    const result = await runPromotionScan({reposYaml, resolver, diff})
+
+    // #then: fail-closed — resolution failure blocks promotion
+    expect(result).toEqual({ok: false, resolutionFailed: true, failedNodeIds: ['R_promo_fail']})
+  })
+
+  it('does not leak the resolved name in the failure result', async () => {
+    // #given: one resolves, one fails — the resolved name must not appear in the result
+    const reposYaml = makeReposYaml(['R_ok', 'R_fail'])
+    const resolver: NodeIdResolver = async nodeId => {
+      if (nodeId === 'R_ok') return {nameWithOwner: 'acme/private-repo'}
+      return {error: 'error'}
+    }
+    const diff = makePromoDiff('docs/foo.md', ['some content'])
+
+    const result = await runPromotionScan({reposYaml, resolver, diff})
+
+    expect(result).toEqual({ok: false, resolutionFailed: true, failedNodeIds: ['R_fail']})
+    // The resolved name must not appear anywhere in the result object
+    const serialized = JSON.stringify(result)
+    expect(serialized).not.toContain('acme/private-repo')
+    expect(serialized).not.toContain('acme')
+  })
+})
+
+describe('runPromotionScan — edge: access-lost node_id is skipped, scan proceeds', () => {
+  it('skips access-lost node_ids and scans with remaining resolved names', async () => {
+    // #given: one access-lost, one resolves; diff has no private name → ok
+    const reposYaml = makeReposYaml(['R_gone', 'R_present'])
+    const resolver: NodeIdResolver = async nodeId => {
+      if (nodeId === 'R_gone') return {error: 'access-lost'}
+      if (nodeId === 'R_present') return {nameWithOwner: 'acme/private-repo'}
+      return {error: 'error'}
+    }
+    const diff = makePromoDiff('docs/foo.md', ['some content'])
+
+    const result = await runPromotionScan({reposYaml, resolver, diff})
+
+    // access-lost is skipped; scan proceeds with the resolved name; no match → ok
+    expect(result).toEqual({ok: true})
+  })
+
+  it('skips access-lost and still blocks when the remaining resolved name appears in diff', async () => {
+    // #given: one access-lost, one resolves; diff DOES contain the resolved name
+    const reposYaml = makeReposYaml(['R_gone', 'R_present'])
+    const resolver: NodeIdResolver = async nodeId => {
+      if (nodeId === 'R_gone') return {error: 'access-lost'}
+      if (nodeId === 'R_present') return {nameWithOwner: 'acme/private-repo'}
+      return {error: 'error'}
+    }
+    const diff = makePromoDiff('docs/foo.md', ['See acme/private-repo for details.'])
+
+    const result = await runPromotionScan({reposYaml, resolver, diff})
+
+    expect(result).toEqual({ok: false, matchedFiles: ['docs/foo.md']})
+  })
+})
+
+describe('runPromotionScan — edge: zero private entries → exit 0 (nothing to scan)', () => {
+  it('returns ok:true immediately when repos.yaml has no private entries', async () => {
+    // #given: repos.yaml with only public entries (no private: true)
+    const reposYaml = `version: 1
+repos:
+  - owner: "publicowner"
+    name: "public-repo"
+    private: false
+    added: "2024-01-01"
+    onboarding_status: onboarded
+    last_survey_at: null
+    last_survey_status: null
+    has_fro_bot_workflow: false
+    has_renovate: false
+`
+    const resolverSpy = vi.fn<NodeIdResolver>()
+    const diff = makePromoDiff('docs/foo.md', ['some content'])
+
+    const result = await runPromotionScan({reposYaml, resolver: resolverSpy, diff})
+
+    // #then: ok immediately, resolver never called
+    expect(result).toEqual({ok: true})
+    expect(resolverSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns ok:true when repos.yaml has an empty repos array', async () => {
+    const reposYaml = 'version: 1\nrepos: []\n'
+    const resolverSpy = vi.fn<NodeIdResolver>()
+    const diff = makePromoDiff('docs/foo.md', ['some content'])
+
+    const result = await runPromotionScan({reposYaml, resolver: resolverSpy, diff})
+
+    expect(result).toEqual({ok: true})
+    expect(resolverSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('runPromotionScan — integration: PAT passed only to resolver, diff needs no token', () => {
+  it('passes the resolver as an injectable dependency (token wiring is caller responsibility)', async () => {
+    // #given: a resolver spy that captures what it was called with
+    const reposYaml = makeReposYaml(['R_token_test'])
+    const capturedNodeIds: string[] = []
+    const resolver: NodeIdResolver = async nodeId => {
+      capturedNodeIds.push(nodeId)
+      return {nameWithOwner: 'acme/private-repo'}
+    }
+    const diff = makePromoDiff('docs/foo.md', ['some content'])
+
+    await runPromotionScan({reposYaml, resolver, diff})
+
+    // #then: resolver was called with the node_id from repos.yaml
+    expect(capturedNodeIds).toEqual(['R_token_test'])
+    // The diff is passed directly — no token involved in obtaining it (caller's responsibility)
+    // This test verifies the seam: resolver is injectable, diff is injectable, no ambient token
+  })
+
+  it('the resolver receives each private node_id exactly once', async () => {
+    // #given: two private node_ids
+    const reposYaml = makeReposYaml(['R_a', 'R_b'])
+    const calls: string[] = []
+    const resolver: NodeIdResolver = async nodeId => {
+      calls.push(nodeId)
+      return {nameWithOwner: `acme/repo-${nodeId}`}
+    }
+    const diff = makePromoDiff('docs/foo.md', ['some content'])
+
+    await runPromotionScan({reposYaml, resolver, diff})
+
+    expect(calls).toEqual(['R_a', 'R_b'])
   })
 })

--- a/scripts/check-private-leak.ts
+++ b/scripts/check-private-leak.ts
@@ -1,8 +1,8 @@
+import type {NodeIdResolver} from './private-repo-resolution.ts'
 import {Buffer} from 'node:buffer'
 import {execFileSync} from 'node:child_process'
 import {readFile} from 'node:fs/promises'
 import process from 'node:process'
-
 import {parse as parseYaml} from 'yaml'
 import {isRecord, makeGhNodeIdResolver} from './private-repo-resolution.ts'
 import {assertReposFile} from './schemas.ts'
@@ -13,6 +13,28 @@ import {computeRepoSlug} from './wiki-slug.ts'
 // ---------------------------------------------------------------------------
 
 export type GuardResult = {readonly ok: true} | {readonly ok: false; readonly matchedFiles: readonly string[]}
+
+/**
+ * Result of a promotion scan.
+ *
+ * - `{ok: true}` — scan passed (no private tokens found in diff).
+ * - `{ok: false, matchedFiles}` — private token found; matchedFiles lists affected file paths only.
+ * - `{ok: false, resolutionFailed: true, failedNodeIds}` — one or more node_ids could not be
+ *   resolved (non-access-lost failure); promotion is blocked fail-closed.
+ */
+export type PromotionScanResult =
+  | {readonly ok: true}
+  | {readonly ok: false; readonly matchedFiles: readonly string[]}
+  | {readonly ok: false; readonly resolutionFailed: true; readonly failedNodeIds: readonly string[]}
+
+export interface PromotionScanInputs {
+  /** Raw YAML text of data branch's metadata/repos.yaml */
+  readonly reposYaml: string
+  /** Injectable resolver — caller wires FRO_BOT_POLL_PAT into makeGhNodeIdResolver(token) */
+  readonly resolver: NodeIdResolver
+  /** Unified diff text (main...data three-dot diff) */
+  readonly diff: string
+}
 
 export interface OverrideOptions {
   readonly titlePrefixed: boolean
@@ -217,6 +239,196 @@ function postOverrideComment(prNumber: number, author: string): void {
 }
 
 // ---------------------------------------------------------------------------
+// Promotion scan — pure testable core
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the private token set from a resolved nameWithOwner string.
+ * Returns [canonical, slug] — both carry the owner prefix for specificity.
+ * Bare name is intentionally excluded (false-positive risk on short names).
+ */
+function buildTokensForName(nameWithOwner: string): string[] {
+  const slashIndex = nameWithOwner.indexOf('/')
+  if (slashIndex < 1) return []
+  const owner = nameWithOwner.slice(0, slashIndex)
+  const name = nameWithOwner.slice(slashIndex + 1)
+  if (owner === '' || name === '') return []
+  const tokens: string[] = [nameWithOwner]
+  try {
+    tokens.push(computeRepoSlug(owner, name))
+  } catch {
+    // computeRepoSlug throws on empty segments — skip slug form
+  }
+  return tokens
+}
+
+/**
+ * Promotion-mode scan: pure, injectable, testable.
+ *
+ * Resolves private node_ids from repos.yaml content, builds the token set, and
+ * runs `checkPrivateLeak` against the provided diff. The resolver and diff are
+ * both injectable so tests can exercise the full matrix without shelling out.
+ *
+ * Resolution matrix (exhaustive, fail-closed):
+ * - `access-lost` → SKIP (repo deleted/no-access; no current content to leak)
+ * - any other failure (transient/auth/rate-limit/unknown) → BLOCK: returns
+ *   `{ok:false, resolutionFailed:true, failedNodeIds}` — never silently passes
+ * - success → include `owner/name` + `owner--slug` in the token set
+ *
+ * Zero private entries → `{ok:true}` immediately (nothing to scan).
+ *
+ * Redaction guarantee: no resolved private name appears in any returned value.
+ * The caller (CLI shell) is responsible for redacted stderr output.
+ */
+export async function runPromotionScan(inputs: PromotionScanInputs): Promise<PromotionScanResult> {
+  const {reposYaml, resolver, diff} = inputs
+
+  // Parse repos.yaml and extract private node_ids.
+  const parsed: unknown = parseYaml(reposYaml)
+  assertReposFile(parsed)
+  const privateNodeIds = parsed.repos
+    .filter(r => r.private === true && typeof r.node_id === 'string' && r.node_id.length > 0)
+    .map(r => r.node_id as string)
+
+  // Zero private entries → nothing to scan.
+  if (privateNodeIds.length === 0) {
+    return {ok: true}
+  }
+
+  // Resolve each node_id — exhaustive matrix.
+  const resolvedNames: string[] = []
+  const failedNodeIds: string[] = []
+
+  for (const nodeId of privateNodeIds) {
+    const result = await resolver(nodeId)
+    if ('nameWithOwner' in result) {
+      resolvedNames.push(result.nameWithOwner)
+    } else if (result.error === 'access-lost') {
+      // access-lost: repo gone, no current content to leak — skip safely.
+      // (Caller logs this with the node_id; we don't log here to keep this pure.)
+    } else {
+      // Non-access-lost failure: transient/auth/rate-limit/unknown — fail closed.
+      // Cannot guarantee a complete scan; block promotion.
+      failedNodeIds.push(nodeId)
+    }
+  }
+
+  // Any non-access-lost failure → block (fail-closed).
+  if (failedNodeIds.length > 0) {
+    return {ok: false, resolutionFailed: true, failedNodeIds}
+  }
+
+  // Build token set from resolved names.
+  const privateTokens: string[] = []
+  for (const nameWithOwner of resolvedNames) {
+    privateTokens.push(...buildTokensForName(nameWithOwner))
+  }
+
+  // Run the pure scan. No override in promotion mode (operator-supervised scheduled job).
+  const scanResult = checkPrivateLeak(privateTokens, diff, {titlePrefixed: false, isOperator: false})
+  return scanResult
+}
+
+/**
+ * CLI shell for promotion mode: wires env (FRO_BOT_POLL_PAT), reads repos.yaml
+ * from the data subtree, runs git diff, maps result to exit code.
+ *
+ * Accepts the repos.yaml path via PROMOTION_REPOS_YAML_PATH env (injectable for
+ * testing; defaults to 'metadata/repos.yaml' relative to CWD which is the
+ * data-branch-check subtree in CI).
+ */
+async function runPromotionCli(): Promise<void> {
+  const pat = process.env.FRO_BOT_POLL_PAT
+  if (pat === undefined || pat === '') {
+    process.stderr.write(
+      'check-private-leak: FRO_BOT_POLL_PAT not set. This is required for promotion mode to resolve private repo names.\n',
+    )
+    process.exit(1)
+  }
+
+  // Read repos.yaml from the data subtree (CWD = data-branch-check in CI).
+  const reposYamlPath = process.env.PROMOTION_REPOS_YAML_PATH ?? 'metadata/repos.yaml'
+  let reposYaml: string
+  try {
+    reposYaml = await readFile(reposYamlPath, 'utf8')
+  } catch (error) {
+    process.stderr.write(
+      `check-private-leak: could not read repos.yaml at ${reposYamlPath}: ${error instanceof Error ? error.message : String(error)}\n`,
+    )
+    process.exit(1)
+  }
+
+  // Obtain the main...data diff via local git — no token needed.
+  let diff: string
+  try {
+    diff = execFileSync('git', ['diff', 'origin/main...origin/data'], {encoding: 'utf8'})
+  } catch (error) {
+    process.stderr.write(
+      `check-private-leak: could not obtain main...data diff: ${error instanceof Error ? error.message : String(error)}\n`,
+    )
+    process.exit(1)
+  }
+
+  // Wire FRO_BOT_POLL_PAT ONLY to the resolver — not to the diff or any other call.
+  const resolver = makeGhNodeIdResolver(pat)
+
+  // Parse repos.yaml to log access-lost node_ids (the pure function doesn't log).
+  const parsedForLog: unknown = parseYaml(reposYaml)
+  assertReposFile(parsedForLog)
+  const privateNodeIds = parsedForLog.repos
+    .filter(r => r.private === true && typeof r.node_id === 'string' && r.node_id.length > 0)
+    .map(r => r.node_id as string)
+
+  // Wrap resolver to emit redacted stderr for access-lost and error cases.
+  const loggingResolver = async (nodeId: string) => {
+    const result = await resolver(nodeId)
+    if ('nameWithOwner' in result) {
+      // Success — no logging (name is private; never log it)
+    } else if (result.error === 'access-lost') {
+      process.stderr.write(
+        `check-private-leak [promotion]: node_id=${nodeId} access-lost (deleted/no-access), skipping\n`,
+      )
+    } else {
+      process.stderr.write(`check-private-leak [promotion]: could not resolve node_id=${nodeId} (error)\n`)
+    }
+    return result
+  }
+
+  const result = await runPromotionScan({reposYaml, resolver: loggingResolver, diff})
+
+  if (result.ok) {
+    process.stdout.write(`check-private-leak [promotion]: ok (scanned ${privateNodeIds.length} private node_id(s))\n`)
+    return
+  }
+
+  if ('resolutionFailed' in result && result.resolutionFailed) {
+    // Fail-closed: resolution failure blocks promotion.
+    process.stderr.write(
+      `check-private-leak [promotion]: FAILED — could not resolve private node_id(s): ${result.failedNodeIds.join(', ')}\n`,
+    )
+    process.stderr.write('check-private-leak [promotion]: cannot guarantee a complete scan — blocking promotion\n')
+    process.exit(1)
+  }
+
+  // Diff match: print file paths only, never the matched name.
+  process.stderr.write(
+    'check-private-leak [promotion]: FAILED — private repository name(s) detected in promotion diff\n',
+  )
+  process.stderr.write('\nMatched files:\n')
+  if ('matchedFiles' in result) {
+    for (const file of result.matchedFiles) {
+      process.stderr.write(`  - ${file}\n`)
+    }
+  }
+  process.stderr.write(
+    '\nTo look up the private repository locally, run: GH_TOKEN=<operator-PAT> node scripts/resolve-private.ts metadata/repos.yaml\n',
+  )
+  process.stderr.write('  (This prints a node_id → owner/name table for all private entries.)\n')
+  process.stderr.write('To resolve: redact the private name from the data branch and re-run the promotion.\n')
+  process.exit(1)
+}
+
+// ---------------------------------------------------------------------------
 // CLI entrypoint
 // ---------------------------------------------------------------------------
 
@@ -343,5 +555,9 @@ export async function main(): Promise<void> {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  await main()
+  if (process.argv.includes('--promotion')) {
+    await runPromotionCli()
+  } else {
+    await main()
+  }
 }

--- a/scripts/check-private-leak.ts
+++ b/scripts/check-private-leak.ts
@@ -88,6 +88,12 @@ const OPERATOR_LOGIN = 'marcusrbrown'
  *    extended headers, and via `diff --git a/X b/Y` when X ≠ Y (rename without content change).
  * 3. **Added content lines** — `+` lines (excluding `+++` headers).
  *
+ * Scope invariant: the *path* of a MODIFIED file (not new/renamed) is not itself a scanned
+ * surface — such a file is caught only if a private token also appears in one of its added `+`
+ * lines. This is correct by construction for `main...data` promotions (wiki pages arrive as
+ * additions; pre-existing paths are grandfathered by the slug gate), but a future caller scanning
+ * a different diff shape must not assume modified-file paths are covered.
+ *
  * Returns which FILES contained a match, never which token matched.
  * Override: if `override.titlePrefixed && override.isOperator` → bypass and return `{ok:true}`.
  */

--- a/scripts/check-private-leak.ts
+++ b/scripts/check-private-leak.ts
@@ -18,9 +18,10 @@ export type GuardResult = {readonly ok: true} | {readonly ok: false; readonly ma
  * Result of a promotion scan.
  *
  * - `{ok: true}` — scan passed (no private tokens found in diff).
- * - `{ok: false, matchedFiles}` — private token found; matchedFiles lists affected file paths only.
+ * - `{ok: false, matchedFiles}` — private token found; matchedFiles lists affected file paths only
+ *   (any path segment containing a private token is redacted to `[REDACTED]`).
  * - `{ok: false, resolutionFailed: true, failedNodeIds}` — one or more node_ids could not be
- *   resolved (non-access-lost failure); promotion is blocked fail-closed.
+ *   resolved (including access-lost); promotion is blocked fail-closed.
  */
 export type PromotionScanResult =
   | {readonly ok: true}
@@ -40,6 +41,27 @@ export interface OverrideOptions {
   readonly titlePrefixed: boolean
   readonly isOperator: boolean
 }
+
+// ---------------------------------------------------------------------------
+// Seam types for CLI testability (Fix E)
+// ---------------------------------------------------------------------------
+
+/**
+ * Injectable git-diff runner. Receives an explicit env so FRO_BOT_POLL_PAT
+ * never reaches the git subprocess (Fix C). Defaults to the real execFileSync.
+ */
+export type GitDiffRunner = (args: string[], env: NodeJS.ProcessEnv) => string
+
+/**
+ * Injectable repos.yaml reader. Defaults to fs.readFile.
+ */
+export type ReposYamlReader = (path: string) => Promise<string>
+
+/**
+ * Injectable resolver factory. Receives the PAT and returns a NodeIdResolver.
+ * Defaults to makeGhNodeIdResolver.
+ */
+export type ResolverFactory = (pat: string) => NodeIdResolver
 
 // ---------------------------------------------------------------------------
 // Operator override
@@ -244,8 +266,12 @@ function postOverrideComment(prNumber: number, author: string): void {
 
 /**
  * Build the private token set from a resolved nameWithOwner string.
- * Returns [canonical, slug] — both carry the owner prefix for specificity.
+ * Returns [canonical, raw-double-dash, slug] — all carry the owner prefix for specificity.
+ * The raw double-dash form (`owner--name`) is added before the slug so it is always present
+ * even if computeRepoSlug throws. For simple names the raw form equals the slug; for names
+ * with underscores, dots, or uppercase it differs and closes a scan+redaction gap.
  * Bare name is intentionally excluded (false-positive risk on short names).
+ * Duplicate forms are collapsed via a Set round-trip.
  */
 function buildTokensForName(nameWithOwner: string): string[] {
   const slashIndex = nameWithOwner.indexOf('/')
@@ -253,13 +279,35 @@ function buildTokensForName(nameWithOwner: string): string[] {
   const owner = nameWithOwner.slice(0, slashIndex)
   const name = nameWithOwner.slice(slashIndex + 1)
   if (owner === '' || name === '') return []
-  const tokens: string[] = [nameWithOwner]
+  // Raw double-dash form — original chars, no sanitization. Always added first.
+  const rawDoubleDash = `${owner}--${name}`
+  const tokens: string[] = [nameWithOwner, rawDoubleDash]
   try {
     tokens.push(computeRepoSlug(owner, name))
   } catch {
     // computeRepoSlug throws on empty segments — skip slug form
   }
-  return tokens
+  // Dedup: identical forms (e.g. simple names where raw == slug) don't double up.
+  return [...new Set(tokens)]
+}
+
+/**
+ * Redact any occurrence of a known private token within a file path string.
+ *
+ * Approach: replace each private token (case-insensitive) found in the path with
+ * `[REDACTED]`. This keeps the path structure operator-actionable (directory depth,
+ * extension, surrounding segments are preserved) while never printing the literal
+ * private name. Operators can run `node scripts/resolve-private.ts metadata/repos.yaml`
+ * to map node_ids back to owner/name.
+ */
+function redactPathTokens(filePath: string, privateTokens: readonly string[]): string {
+  let result = filePath
+  for (const token of privateTokens) {
+    // Case-insensitive replacement of the token anywhere in the path.
+    const escaped = token.replaceAll(/[$()*+.?[\\\]^{|}]/g, String.raw`\$&`)
+    result = result.replaceAll(new RegExp(escaped, 'gi'), '[REDACTED]')
+  }
+  return result
 }
 
 /**
@@ -270,50 +318,68 @@ function buildTokensForName(nameWithOwner: string): string[] {
  * both injectable so tests can exercise the full matrix without shelling out.
  *
  * Resolution matrix (exhaustive, fail-closed):
- * - `access-lost` → SKIP (repo deleted/no-access; no current content to leak)
- * - any other failure (transient/auth/rate-limit/unknown) → BLOCK: returns
- *   `{ok:false, resolutionFailed:true, failedNodeIds}` — never silently passes
+ * - `access-lost` → BLOCK: returns `{ok:false, resolutionFailed:true, failedNodeIds}`.
+ *   Rationale: GitHub GraphQL `node()` returns null for BOTH a deleted repo AND a repo
+ *   the token cannot see. A mis-scoped/expired PAT makes every private repo look
+ *   access-lost → treating it as "skip" would make the gate pass everything (mass
+ *   fail-open). The cost — a genuinely-deleted repo's stale node_id blocks promotion
+ *   until an operator removes it from data's repos.yaml — is the correct tradeoff for
+ *   a privacy gate. Operators can verify and clean up stale entries manually.
+ * - any other failure (transient/auth/rate-limit/unknown) → BLOCK: same result.
+ *   Cannot guarantee a complete scan; block promotion.
+ * - `private:true` entry with missing/empty node_id → BLOCK: included as the sentinel
+ *   string `"<missing-node-id>"` in failedNodeIds (never any owner/name).
  * - success → include `owner/name` + `owner--slug` in the token set
  *
  * Zero private entries → `{ok:true}` immediately (nothing to scan).
  *
  * Redaction guarantee: no resolved private name appears in any returned value.
+ * Matched file paths have private tokens replaced with `[REDACTED]`.
  * The caller (CLI shell) is responsible for redacted stderr output.
  */
 export async function runPromotionScan(inputs: PromotionScanInputs): Promise<PromotionScanResult> {
   const {reposYaml, resolver, diff} = inputs
 
-  // Parse repos.yaml and extract private node_ids.
+  // Parse repos.yaml and extract private entries.
   const parsed: unknown = parseYaml(reposYaml)
   assertReposFile(parsed)
-  const privateNodeIds = parsed.repos
-    .filter(r => r.private === true && typeof r.node_id === 'string' && r.node_id.length > 0)
-    .map(r => r.node_id as string)
+  const privateEntries = parsed.repos.filter(r => r.private === true)
 
   // Zero private entries → nothing to scan.
-  if (privateNodeIds.length === 0) {
+  if (privateEntries.length === 0) {
     return {ok: true}
   }
+
+  // Fix B: any private entry with missing/empty node_id is a blocking condition.
+  // We cannot scan what we cannot identify — fail closed.
+  const missingNodeIdCount = privateEntries.filter(r => typeof r.node_id !== 'string' || r.node_id.length === 0).length
+
+  const privateNodeIds = privateEntries
+    .filter(r => typeof r.node_id === 'string' && r.node_id.length > 0)
+    .map(r => r.node_id as string)
 
   // Resolve each node_id — exhaustive matrix.
   const resolvedNames: string[] = []
   const failedNodeIds: string[] = []
 
+  // Seed with missing-node-id sentinels (Fix B).
+  for (let i = 0; i < missingNodeIdCount; i++) {
+    failedNodeIds.push('<missing-node-id>')
+  }
+
   for (const nodeId of privateNodeIds) {
     const result = await resolver(nodeId)
     if ('nameWithOwner' in result) {
       resolvedNames.push(result.nameWithOwner)
-    } else if (result.error === 'access-lost') {
-      // access-lost: repo gone, no current content to leak — skip safely.
-      // (Caller logs this with the node_id; we don't log here to keep this pure.)
     } else {
-      // Non-access-lost failure: transient/auth/rate-limit/unknown — fail closed.
-      // Cannot guarantee a complete scan; block promotion.
+      // Fix A: access-lost → BLOCK (same as any other failure).
+      // access-lost is indistinguishable between "deleted" and "no-access/mis-scoped-token".
+      // Treating it as skip would make a mis-scoped PAT silently pass everything.
       failedNodeIds.push(nodeId)
     }
   }
 
-  // Any non-access-lost failure → block (fail-closed).
+  // Any failure (access-lost, transient, auth, missing node_id) → block (fail-closed).
   if (failedNodeIds.length > 0) {
     return {ok: false, resolutionFailed: true, failedNodeIds}
   }
@@ -326,8 +392,35 @@ export async function runPromotionScan(inputs: PromotionScanInputs): Promise<Pro
 
   // Run the pure scan. No override in promotion mode (operator-supervised scheduled job).
   const scanResult = checkPrivateLeak(privateTokens, diff, {titlePrefixed: false, isOperator: false})
+
+  // Fix D: redact private tokens from matched file paths before returning.
+  if (!scanResult.ok && 'matchedFiles' in scanResult) {
+    const redactedFiles = scanResult.matchedFiles.map(f => redactPathTokens(f, privateTokens))
+    return {ok: false, matchedFiles: redactedFiles}
+  }
+
   return scanResult
 }
+
+// ---------------------------------------------------------------------------
+// Default seam implementations for runPromotionCli
+// ---------------------------------------------------------------------------
+
+/**
+ * Default git-diff runner: strips FRO_BOT_POLL_PAT from the subprocess env
+ * so the PAT never reaches git (Fix C). The env argument is the already-sanitized
+ * env built by the caller.
+ */
+const defaultGitDiffRunner: GitDiffRunner = (args: string[], env: NodeJS.ProcessEnv): string =>
+  execFileSync('git', args, {encoding: 'utf8', env})
+
+const defaultReposYamlReader: ReposYamlReader = async (path: string): Promise<string> => readFile(path, 'utf8')
+
+const defaultResolverFactory: ResolverFactory = (pat: string): NodeIdResolver => makeGhNodeIdResolver(pat)
+
+// ---------------------------------------------------------------------------
+// Promotion CLI shell — injectable seams for testability (Fix E)
+// ---------------------------------------------------------------------------
 
 /**
  * CLI shell for promotion mode: wires env (FRO_BOT_POLL_PAT), reads repos.yaml
@@ -336,57 +429,85 @@ export async function runPromotionScan(inputs: PromotionScanInputs): Promise<Pro
  * Accepts the repos.yaml path via PROMOTION_REPOS_YAML_PATH env (injectable for
  * testing; defaults to 'metadata/repos.yaml' relative to CWD which is the
  * data-branch-check subtree in CI).
+ *
+ * Injectable seams (all default to real implementations):
+ * - `gitDiffRunner`: receives args + a PAT-stripped env; never sees FRO_BOT_POLL_PAT
+ * - `reposYamlReader`: reads the repos.yaml file
+ * - `resolverFactory`: builds the NodeIdResolver from the PAT
+ *
+ * Returns an exit code (0 = pass, 1 = block/error) instead of calling process.exit
+ * directly, so tests can assert without killing the test process. The entrypoint
+ * wrapper maps the return value to process.exit.
  */
-async function runPromotionCli(): Promise<void> {
+export async function runPromotionCli(
+  gitDiffRunner: GitDiffRunner = defaultGitDiffRunner,
+  reposYamlReader: ReposYamlReader = defaultReposYamlReader,
+  resolverFactory: ResolverFactory = defaultResolverFactory,
+): Promise<number> {
   const pat = process.env.FRO_BOT_POLL_PAT
   if (pat === undefined || pat === '') {
     process.stderr.write(
       'check-private-leak: FRO_BOT_POLL_PAT not set. This is required for promotion mode to resolve private repo names.\n',
     )
-    process.exit(1)
+    return 1
   }
 
   // Read repos.yaml from the data subtree (CWD = data-branch-check in CI).
   const reposYamlPath = process.env.PROMOTION_REPOS_YAML_PATH ?? 'metadata/repos.yaml'
   let reposYaml: string
   try {
-    reposYaml = await readFile(reposYamlPath, 'utf8')
+    reposYaml = await reposYamlReader(reposYamlPath)
   } catch (error) {
     process.stderr.write(
       `check-private-leak: could not read repos.yaml at ${reposYamlPath}: ${error instanceof Error ? error.message : String(error)}\n`,
     )
-    process.exit(1)
+    return 1
   }
+
+  // Fix C: build a sanitized env that excludes FRO_BOT_POLL_PAT before passing to git.
+  // The PAT must reach ONLY makeGhNodeIdResolver — never the git subprocess.
+  const gitEnv: NodeJS.ProcessEnv = {...process.env}
+  delete gitEnv.FRO_BOT_POLL_PAT
 
   // Obtain the main...data diff via local git — no token needed.
   let diff: string
   try {
-    diff = execFileSync('git', ['diff', 'origin/main...origin/data'], {encoding: 'utf8'})
+    diff = gitDiffRunner(['diff', 'origin/main...origin/data'], gitEnv)
   } catch (error) {
     process.stderr.write(
       `check-private-leak: could not obtain main...data diff: ${error instanceof Error ? error.message : String(error)}\n`,
     )
-    process.exit(1)
+    return 1
   }
 
   // Wire FRO_BOT_POLL_PAT ONLY to the resolver — not to the diff or any other call.
-  const resolver = makeGhNodeIdResolver(pat)
+  const resolver = resolverFactory(pat)
 
-  // Parse repos.yaml to log access-lost node_ids (the pure function doesn't log).
+  // Parse repos.yaml to log access-lost and missing-node-id cases (the pure function doesn't log).
   const parsedForLog: unknown = parseYaml(reposYaml)
   assertReposFile(parsedForLog)
-  const privateNodeIds = parsedForLog.repos
-    .filter(r => r.private === true && typeof r.node_id === 'string' && r.node_id.length > 0)
+  const allPrivateEntries = parsedForLog.repos.filter(r => r.private === true)
+  const privateNodeIds = allPrivateEntries
+    .filter(r => typeof r.node_id === 'string' && r.node_id.length > 0)
     .map(r => r.node_id as string)
 
+  // Log missing node_id entries (Fix B — these will block in runPromotionScan).
+  const missingCount = allPrivateEntries.length - privateNodeIds.length
+  if (missingCount > 0) {
+    process.stderr.write(
+      `check-private-leak [promotion]: ${missingCount} private entry/entries have no node_id — will block\n`,
+    )
+  }
+
   // Wrap resolver to emit redacted stderr for access-lost and error cases.
-  const loggingResolver = async (nodeId: string) => {
+  // Fix A: access-lost now BLOCKS — log it as a blocking condition, not a skip.
+  const loggingResolver: NodeIdResolver = async (nodeId: string) => {
     const result = await resolver(nodeId)
     if ('nameWithOwner' in result) {
       // Success — no logging (name is private; never log it)
     } else if (result.error === 'access-lost') {
       process.stderr.write(
-        `check-private-leak [promotion]: node_id=${nodeId} access-lost (deleted/no-access), skipping\n`,
+        `check-private-leak [promotion]: node_id=${nodeId} access-lost (deleted or token cannot see it) — BLOCKING\n`,
       )
     } else {
       process.stderr.write(`check-private-leak [promotion]: could not resolve node_id=${nodeId} (error)\n`)
@@ -398,23 +519,24 @@ async function runPromotionCli(): Promise<void> {
 
   if (result.ok) {
     process.stdout.write(`check-private-leak [promotion]: ok (scanned ${privateNodeIds.length} private node_id(s))\n`)
-    return
+    return 0
   }
 
   if ('resolutionFailed' in result && result.resolutionFailed) {
-    // Fail-closed: resolution failure blocks promotion.
+    // Fail-closed: resolution failure (including access-lost) blocks promotion.
     process.stderr.write(
       `check-private-leak [promotion]: FAILED — could not resolve private node_id(s): ${result.failedNodeIds.join(', ')}\n`,
     )
     process.stderr.write('check-private-leak [promotion]: cannot guarantee a complete scan — blocking promotion\n')
-    process.exit(1)
+    return 1
   }
 
-  // Diff match: print file paths only, never the matched name.
+  // Diff match: print redacted file paths only, never the matched name.
+  // Fix D: paths are already redacted by runPromotionScan before being returned here.
   process.stderr.write(
     'check-private-leak [promotion]: FAILED — private repository name(s) detected in promotion diff\n',
   )
-  process.stderr.write('\nMatched files:\n')
+  process.stderr.write('\nMatched files (private tokens redacted):\n')
   if ('matchedFiles' in result) {
     for (const file of result.matchedFiles) {
       process.stderr.write(`  - ${file}\n`)
@@ -425,7 +547,7 @@ async function runPromotionCli(): Promise<void> {
   )
   process.stderr.write('  (This prints a node_id → owner/name table for all private entries.)\n')
   process.stderr.write('To resolve: redact the private name from the data branch and re-run the promotion.\n')
-  process.exit(1)
+  return 1
 }
 
 // ---------------------------------------------------------------------------
@@ -499,25 +621,10 @@ export async function main(): Promise<void> {
   }
 
   // Build the full set of tokens to scan for.
-  // For each resolved nameWithOwner (owner/name), include:
-  //   - canonical form:  owner/name
-  //   - wiki slug form:  owner--slug  (e.g. computeRepoSlug('org', 'repo') → 'org--repo')
-  // Bare name (without owner) is intentionally excluded: short names like 'go', 'api', 'web'
-  // substring-match unrelated content and cause false-positive blocks on clean PRs.
-  // Both tokens above carry the owner prefix, so they remain specific.
+  // P3: use buildTokensForName to share token semantics with the promotion path.
   const privateTokens: string[] = []
   for (const nameWithOwner of resolvedNames) {
-    const slashIndex = nameWithOwner.indexOf('/')
-    if (slashIndex < 1) continue
-    const owner = nameWithOwner.slice(0, slashIndex)
-    const name = nameWithOwner.slice(slashIndex + 1)
-    if (owner === '' || name === '') continue
-    privateTokens.push(nameWithOwner) // canonical: owner/name
-    try {
-      privateTokens.push(computeRepoSlug(owner, name)) // wiki slug: owner--slug
-    } catch {
-      // computeRepoSlug throws on empty segments — skip slug form if it can't be computed
-    }
+    privateTokens.push(...buildTokensForName(nameWithOwner))
   }
 
   // Fetch diff and evaluate.
@@ -540,10 +647,11 @@ export async function main(): Promise<void> {
   }
 
   // Failure: print file paths only, never the matched name.
+  // Redact any private token from the matched file paths before printing (parity with promotion path).
   process.stderr.write('check-private-leak: FAILED — private repository name(s) detected in PR diff\n')
   process.stderr.write('\nMatched files:\n')
   for (const file of result.matchedFiles) {
-    process.stderr.write(`  - ${file}\n`)
+    process.stderr.write(`  - ${redactPathTokens(file, privateTokens)}\n`)
   }
   // FIX #5: corrected remediation command (resolve-private takes a file path, not a node_id).
   process.stderr.write(
@@ -556,7 +664,8 @@ export async function main(): Promise<void> {
 
 if (import.meta.url === `file://${process.argv[1]}`) {
   if (process.argv.includes('--promotion')) {
-    await runPromotionCli()
+    const exitCode = await runPromotionCli()
+    process.exit(exitCode)
   } else {
     await main()
   }


### PR DESCRIPTION
Gates the weekly `data → main` promotion on a content scan for private repository names, closing the leak class where a private `owner/name` mentioned in a wiki page **body** (not just a page filename) promotes cleanly to the public `main` branch.

## Why

The slug-based `check-wiki-private-presence` gate blocks private *pages* by filename and checks public-repo attribution, but it does not scan page *bodies* for arbitrary private-name mentions. A private name recently reached `main` exactly this way — sitting in another repo's wiki page body — and promoted without tripping any gate.

`check-private-leak.ts` already has a tested pure core that resolves private names from `data`'s redacted `node_id` entries and scans a diff for them. This wires that scan into the promotion job as a blocking step beside the existing wiki gate.

## What

- **New promotion-mode scan** in `check-private-leak.ts`: resolves private node_ids from `data`'s `repos.yaml`, builds the token set (`owner/name` + `owner--slug` + raw `owner--name`), scans the `main...data` promotion delta, and blocks on any match — reusing the existing pure scanning core unchanged.
- **Blocking gate** in `merge-data.yaml`: runs after the wiki-presence gate and before the promotion PR is opened. On detection or any unresolved-name failure, the promotion PR is never created.
- **Enforced at the promotion chokepoint**, not per-PR: the trusted scheduled job has no PR-author code, so the broad-scope token runs safely there — no `workflow_run` topology, status surface, or per-PR token dependency.

## Safety properties

- **Fail-closed resolution.** If a private name can't be fully resolved — including the ambiguous "node returns null" case (deleted *or* token-can't-see) — the promotion is blocked, not allowed through. A mis-scoped or expired token can no longer silently pass every private repo.
- **Missing identifiers block.** A `private: true` entry without a usable `node_id` blocks rather than being skipped.
- **Least privilege.** The broad token reaches only the name-resolution step; the git diff runs with the token stripped from its environment, and the workflow fetch step carries no token at all.
- **Redacted output.** Failure output names only file paths, with any private token in a path replaced by `[REDACTED]` — in both the promotion and PR scan paths.

## Verification

- check-types, lint, **826 tests (+3 todo)**, actionlint, and the strip-only script-load check all pass.
- The workflow wiring is validated by actionlint; its end-to-end behavior will be confirmed with a manual `Merge Data Branch` run (a seeded private name in the `data` delta must block; a clean delta must promote).

Closes #3407.
