### PR TITLE
docs(solutions): privacy-gate promotion-leak and structured-attribution patterns

### DIFF
--- a/docs/solutions/best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md
+++ b/docs/solutions/best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md
@@ -1,0 +1,194 @@
+---
+title: Privacy Gate Design for Data→Main Promotion Leak Prevention
+date: 2026-06-04
+category: best-practices
+module: github-workflows
+problem_type: best_practice
+component: development_workflow
+severity: high
+related_components:
+  - tooling
+  - background_job
+applies_when:
+  - promoting autonomous data-branch content into a public protected branch
+  - a private identifier can appear in a body or another entity's page, not just its own slug
+  - a resolver returns an ambiguous result that conflates "deleted" with "no access"
+  - a broad-scope credential is needed to resolve private identities
+  - a gate must decide between fail-open and fail-closed under uncertainty
+tags:
+  - privacy-gate
+  - fail-closed
+  - promotion
+  - least-privilege
+  - redaction
+  - data-branch
+  - trusted-chokepoint
+  - access-lost
+---
+
+# Privacy Gate Design for Data→Main Promotion Leak Prevention
+
+## Context
+
+This control plane promotes an autonomous agent's generated wiki and metadata from an
+unprotected `data` branch to the public `main` branch on a schedule. Private repository names
+must never reach `main`. An existing gate (`scripts/check-wiki-private-presence.ts`) already
+blocked a private repo's *own* wiki page by slug/filename — yet a private name still promoted
+cleanly to the public branch.
+
+The leak: a private repo name (`owner/name`) appeared in the **body** of a *different*,
+public repo's wiki page. The slug gate only inspects filenames and attribution, so an in-body
+mention of an unrelated private repo sailed straight through to `main`. Closing it surfaced two
+further design traps — an ambiguous-resolution fail-open hole, and a mismatched enforcement
+point — that are the real reusable lessons here.
+
+## Guidance
+
+Three rules for any gate that prevents a sensitive identifier from crossing a trust boundary.
+
+### 1. Scan content, not just identifiers
+
+A filename/slug gate answers "is this entity's own page private?" It does **not** answer "does
+any promoted content mention a private identifier?" Resolve the actual private names and scan
+the **promotion diff** (`origin/main...origin/data`) across added content lines *and* new/renamed
+file paths.
+
+Build the token set to include every form the name can take in content — not just the sanitized
+one. Here the set is canonical `owner/name`, the wiki slug `owner--slug`, **and** the raw
+`owner--name` form, so a name with underscores, dots, or uppercase is matched and redacted
+consistently (the sanitized slug alone would miss `acme/private_repo` written as
+`acme--private_repo`).
+
+### 2. Fail closed on ambiguous resolution
+
+GitHub GraphQL `node(id)` returns `null` for **both** a deleted repo and a repo the token cannot
+see — indistinguishable. If the gate *skips* that ambiguous `access-lost` result, then a
+mis-scoped or expired credential makes *every* private repo look `access-lost`, and the gate
+silently passes everything: a single credential failure disables the entire control (mass
+fail-open). Treat ambiguous resolution — and any missing/unresolvable identifier — as a **block**.
+
+Document any intentional asymmetry: a lower-trust per-PR path may legitimately skip `access-lost`,
+while the trusted promotion chokepoint blocks it. The trust context, not the result type, decides.
+
+### 3. Enforce at the trusted chokepoint, not per-PR
+
+The instinct is to gate every PR. But a per-PR gate that needs a broad credential to resolve
+private identities forces a `workflow_run` topology (to keep the credential away from PR-author
+code), which drags in a whole risk class:
+
+- **Status-check spoofing** — anyone who can push a branch with `statuses: write` can forge the
+  gate's green check.
+- **Fork-PR context derivation** — binding the run to the right PR/SHA across forks is fragile.
+- **Override-token forgery** — a PR-title or label override is attacker-controllable.
+- **Per-PR-PAT single point of failure** — the broad token's expiry blocks *every* PR.
+
+Putting the gate in the already-trusted scheduled promotion job (no PR-author code, already holds
+the broad token) **dissolves all four**. The credential expiry now blocks only the weekly
+promotion, not every PR. This pivot also shrank the build from a four-unit `workflow_run` security
+topology to a two-unit blocking-step wire-in.
+
+Pair it with least privilege: confine the broad credential to the resolution step only, and strip
+it from every other subprocess — including the `git` call that computes the diff (git reaches the
+branch with the ambient checkout token; it never needs the broad PAT). Redact output to file paths
+only, with any private token in a path replaced by `[REDACTED]`.
+
+## Why This Matters
+
+A privacy gate's failure mode must be "block promotion," never "leak." The three rules each close
+a different way the naive design leaks:
+
+- **Content scanning** catches the actual leak class (in-body mention of an unrelated private repo)
+  that a slug gate structurally cannot see.
+- **Fail-closed resolution** ensures a broken/mis-scoped credential disables *promotion*, not the
+  *gate* — the difference between a stalled pipeline (recoverable) and a silent public leak
+  (not recoverable; the public branch is the canonical record).
+- **Trusted-chokepoint enforcement** removes an entire spoofing/forgery/SPOF surface that a per-PR
+  gate would have to defend, at a fraction of the implementation cost.
+
+## When to Apply
+
+- Promoting autonomous or machine-generated content from a writable branch into a protected,
+  publicly-readable branch.
+- The sensitive identifier can appear as body text or inside another entity's page — not only as
+  its own filename.
+- The resolver has an ambiguous result that conflates "gone" with "not visible to me."
+- A broad-scope credential is required, and you want it touching the smallest possible surface.
+- You are tempted to gate per-PR — first check whether a trusted scheduled chokepoint already
+  exists downstream.
+
+## Examples
+
+### Resolution matrix: before (fail-open) vs after (fail-closed)
+
+The resolver cannot distinguish deleted from invisible:
+
+```ts
+// scripts/private-repo-resolution.ts — node() returns null for BOTH cases
+if (node === null || node === undefined) return {error: 'access-lost'}
+```
+
+Before — promotion mode skipped `access-lost`, so a mis-scoped PAT passed everything. After —
+any non-success resolution (including `access-lost`) and any missing `node_id` block:
+
+```ts
+// scripts/check-private-leak.ts — runPromotionScan
+for (const nodeId of privateNodeIds) {
+  const result = await resolver(nodeId)
+  if ('nameWithOwner' in result) {
+    resolvedNames.push(result.nameWithOwner)
+  } else {
+    // access-lost is indistinguishable from "no access" — block, never skip.
+    failedNodeIds.push(nodeId)
+  }
+}
+// A private:true entry with no usable node_id is seeded as a <missing-node-id> sentinel.
+if (failedNodeIds.length > 0) {
+  return {ok: false, resolutionFailed: true, failedNodeIds}
+}
+```
+
+### Least privilege: confine the broad credential, split the workflow
+
+```yaml
+# .github/workflows/merge-data.yaml — two steps so the PAT never enters the git subprocess
+- name: 🔒 Fetch data ref for promotion diff
+  run: git fetch --no-tags --prune origin data   # default checkout token; no broad PAT
+
+- name: 🔒 Block private repo names in promotion diff
+  env:
+    FRO_BOT_POLL_PAT: ${{ secrets.FRO_BOT_POLL_PAT }}   # broad PAT scoped to this step only
+    PROMOTION_REPOS_YAML_PATH: data-branch-check/metadata/repos.yaml
+  run: node scripts/check-private-leak.ts --promotion
+```
+
+```ts
+// scripts/check-private-leak.ts — strip the broad PAT from the git diff subprocess
+const gitEnv: NodeJS.ProcessEnv = {...process.env}
+delete gitEnv.FRO_BOT_POLL_PAT
+diff = gitDiffRunner(['diff', 'origin/main...origin/data'], gitEnv)
+```
+
+### Redaction: paths only, tokens scrubbed
+
+```ts
+// matched output never contains the resolved private name
+const redactedFiles = scanResult.matchedFiles.map(f => redactPathTokens(f, privateTokens))
+return {ok: false, matchedFiles: redactedFiles}
+// redactPathTokens replaces each token (regex-escaped, case-insensitive) with [REDACTED]
+```
+
+## Related
+
+- `docs/solutions/security-issues/private-repo-dispatch-visibility-gate-2026-05-08.md` — the
+  fail-closed-on-private/unknown predicate and opaque-identifier redaction this gate builds on.
+- `docs/solutions/security-issues/survey-workflow-side-privacy-gate-2026-05-16.md` — verify
+  privacy inside the trusted workflow before any public side effect (the per-PR-vs-chokepoint
+  framing here extends that lesson to promotion).
+- `docs/solutions/integration-issues/merge-data-pr-github-422-race-recovery-2026-05-02.md` — the
+  `data→main` promotion chokepoint this gate runs inside.
+- `docs/solutions/integration-issues/normalize-redacted-yaml-quotes-2026-05-09.md` — another
+  promotion-boundary validation lesson.
+- `docs/solutions/best-practices/autonomous-pipeline-minimum-progress-floor-2026-05-17.md` — a
+  fallback path must reuse the exact fail-closed predicates of the main gate.
+- Issues: #3407 (wire the gate), #3408 (operator-actionable blocked output), #3429 (resolver PAT
+  hygiene), #3430 (redact node_ids in failure output), #3424 (accepted commit-history exposure).

--- a/docs/solutions/best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md
+++ b/docs/solutions/best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md
@@ -1,6 +1,8 @@
 ---
 title: Privacy Gate Design for Data→Main Promotion Leak Prevention
 date: 2026-06-04
+last_updated: 2026-06-04
+verified: 2026-06-04
 category: best-practices
 module: github-workflows
 problem_type: best_practice

--- a/docs/solutions/best-practices/wiki-page-structured-attribution-2026-06-04.md
+++ b/docs/solutions/best-practices/wiki-page-structured-attribution-2026-06-04.md
@@ -1,0 +1,148 @@
+---
+title: Structured-First Attribution for Public-Allowlist Privacy Gates
+date: 2026-06-04
+category: best-practices
+module: github-workflows
+problem_type: best_practice
+component: development_workflow
+severity: high
+related_components:
+  - tooling
+  - documentation
+applies_when:
+  - a gate decides whether a page is "about" an allowlisted public entity by its content
+  - page content is attacker-or-agent-influenceable and a slug can collide with a private name
+  - frontmatter carries structured provenance that is stronger than a body substring
+  - legacy pages exist without structured provenance and must not be over-blocked
+  - a frontmatter key's PRESENCE (even if malformed) should change the trust decision
+tags:
+  - privacy-gate
+  - attribution
+  - fail-closed
+  - frontmatter
+  - spoofing
+  - wiki
+  - allowlist
+  - url-matching
+---
+
+# Structured-First Attribution for Public-Allowlist Privacy Gates
+
+## Context
+
+The wiki-presence gate (`scripts/check-wiki-private-presence.ts`) blocks a `data → main`
+promotion when a wiki page's slug collides with a *private* repo's slug, unless the page can be
+**attributed** to a *public* repo of the same slug. Attribution originally asked one question:
+"does the page body contain `https://github.com/owner/name`?" That substring check is spoofable —
+a page about a private repo could embed a decoy URL for a same-slug public repo and pass — and it
+collided on prefixes (`.../repo` matched `.../repo-other`). The fix moved attribution to
+structured frontmatter `sources[].url` with an exact-segment match, while keeping a body-substring
+fallback so legacy pages without structured provenance aren't over-blocked.
+
+## Guidance
+
+### Prefer structured provenance; treat its presence as authoritative
+
+When a page carries structured provenance (frontmatter `sources`), use it as the **sole**
+authority and stop consulting the spoofable body substring. The decision hinges on a three-state
+read of the key, not a truthy check:
+
+- **key absent** → fall back to the legacy body-substring check (legacy pages pass as before)
+- **key present but malformed** (scalar, null, non-array, or array with no usable URLs) → treat as
+  **authoritative-with-no-match** → fail closed (block), do *not* rescue via body substring
+- **key present with URLs** → authoritative; attribute only if a URL exactly matches
+
+The "present-but-malformed → fail closed" branch is the subtle one: once a producer starts
+emitting structured provenance, a *broken* `sources` block must not silently downgrade to the
+weaker check, or the spoof vector reopens.
+
+### Match identifiers by exact segments, never substring
+
+Attribute by parsing the URL and comparing path **segments**, not `String.includes`. Require the
+exact host, exact owner, and exact repo — allowing only a trailing path (`/blob/...`). Substring
+matching admits a prefix collision (`owner/repo` ⊂ `owner/repo-other`) that under-blocks.
+
+### Keep the fallback for legacy data, but only when provenance is truly absent
+
+A hard cutover to structured-only would over-block every page written before the producer emitted
+`sources`. Gate the fallback strictly on *absence* of the key — present-but-empty is not absence.
+
+## Why This Matters
+
+Attribution is a trust decision over influenceable content, so every loosening is a leak vector:
+
+- **Substring attribution** lets a page assert false provenance with a decoy URL → a private page
+  masquerades as a public one (under-block, the dangerous direction for a privacy gate).
+- **Prefix-collision matching** silently attributes a page to the wrong (public) repo.
+- **Truthy instead of present/absent** reopens the spoof the moment a `sources` block is malformed.
+
+Each of these was found by review as an *under-block* hole — the gate passing something it should
+block. For a privacy gate, the only safe failure direction is over-block (flag a borderline page);
+under-block writes a private name to the public branch, which is unrecoverable.
+
+## When to Apply
+
+- A gate classifies influenceable content against an allowlist by "what is this about?"
+- A slug or identifier can collide between a sensitive and a non-sensitive entity.
+- Structured provenance exists (or can be added) that is stronger than a body mention.
+- Legacy content lacks that provenance and must keep passing without weakening new content.
+- You are comparing identifiers embedded in URLs or paths — reach for segment equality, not
+  substring.
+
+## Examples
+
+### Three-state frontmatter read (presence, not truthiness)
+
+```ts
+// scripts/check-wiki-private-presence.ts — parseFrontmatterSources
+// null → key ABSENT (legacy fallback); [] → key PRESENT but malformed (authoritative-no-match);
+// string[] → key PRESENT with usable URLs.
+if (!Object.prototype.hasOwnProperty.call(obj, 'sources')) return null
+const sources = obj.sources
+if (!Array.isArray(sources)) return []
+```
+
+### Exact-segment URL match (no prefix collision, https-only)
+
+```ts
+// sourceUrlMatchesRepo — strict host + exact owner/repo segments
+if (parsed.protocol !== 'https:') return false
+if (parsed.hostname !== 'github.com') return false
+// segments[0] === owner && segments[1] === name (trailing /blob/... allowed)
+```
+
+### Structured-first decision with legacy fallback
+
+```ts
+// detectPrivateWikiLeaks
+const structuredSources = parseFrontmatterSources(page.content)
+if (structuredSources !== null) {
+  // Structured sources present → authoritative. Body substring deliberately ignored
+  // (closes the decoy-URL spoof). Present-but-unmatched → unattributable (fail closed).
+  if (structuredSources.some(url => sourceUrlMatchesRepo(url, entry.owner, entry.name))) {
+    // attributed → passes
+  } else {
+    leaks.push({filename: page.filename, reason: 'unattributable-page'})
+  }
+} else {
+  // No parseable structured sources → legacy body-substring fallback (with migration warning).
+  if (page.content.includes(expectedUrl)) {
+    // attributed via body substring → passes, warn to add structured sources
+  } else {
+    leaks.push({filename: page.filename, reason: 'unattributable-page'})
+  }
+}
+```
+
+## Related
+
+- `docs/solutions/best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md` — the
+  companion promotion-diff gate; same fail-closed-under-uncertainty principle, different surface
+  (content scan vs slug attribution).
+- `docs/solutions/security-issues/private-repo-dispatch-visibility-gate-2026-05-08.md` — the
+  fail-closed-on-unknown predicate this attribution model extends.
+- `docs/solutions/security-issues/survey-workflow-side-privacy-gate-2026-05-16.md` — verifying
+  privacy inside the trusted workflow before a public side effect.
+- Issues: #3419 (this refresh), #3408 (operator-actionable blocked output), #3418 (self-asserted
+  provenance residual — a page lying about its own `sources` is bounded by agent identity + data
+  sole-writer, not closeable at this attribution layer).

--- a/docs/solutions/best-practices/wiki-page-structured-attribution-2026-06-04.md
+++ b/docs/solutions/best-practices/wiki-page-structured-attribution-2026-06-04.md
@@ -1,6 +1,8 @@
 ---
 title: Structured-First Attribution for Public-Allowlist Privacy Gates
 date: 2026-06-04
+last_updated: 2026-06-04
+verified: 2026-06-04
 category: best-practices
 module: github-workflows
 problem_type: best_practice


### PR DESCRIPTION
Captures two reusable privacy-gate patterns from the recent promotion-gate work as `docs/solutions/` learnings.

## Docs added

- **`best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md`** — the data→main promotion content gate: scan content (not just slugs/filenames) for private names in the promotion diff, fail closed on ambiguous credential resolution (a `node()→null` that can't distinguish "deleted" from "no access"), and enforce at the trusted scheduled chokepoint rather than per-PR (which dissolves the status-spoofing, fork-derivation, and broad-token single-point-of-failure surface a per-PR gate would carry). Includes the least-privilege credential scoping and output redaction.

- **`best-practices/wiki-page-structured-attribution-2026-06-04.md`** — the wiki-presence gate's attribution model: structured frontmatter `sources[].url` as the authoritative signal (read by key *presence*, not truthiness), exact path-segment URL matching to avoid prefix collisions, and a body-substring fallback retained only for legacy pages without structured provenance. Documents why each looser variant was an under-block (leak-direction) hole.

Both quote the shipped, reviewed code and cross-link the related security-issues learnings.

Closes #3419.
