### PR TITLE
feat: announce survey and invitation events to the gateway

### DIFF
--- a/.github/workflows/poll-invitations.yaml
+++ b/.github/workflows/poll-invitations.yaml
@@ -31,6 +31,27 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.FRO_BOT_POLL_PAT }}
         run: node scripts/handle-invitation.ts
 
+      # Best-effort Discord presence: announce accepted public invitations to the
+      # gateway, which posts in Fronomenal as the Fro Bot user. Only public,
+      # non-redacted repos are in the list output (handle-invitation.ts gates that).
+      # Never fails the run — gateway-announce.ts exits 0 on any error.
+      - name: 📣 Announce invitations to gateway
+        if: steps.poll.outputs.public_invitations_accepted > 0
+        env:
+          EVENT_TYPE: invitation_accepted
+          INVITATIONS_ACCEPTED: ${{ steps.poll.outputs.public_invitations_accepted }}
+          INVITATIONS_REPOS: ${{ steps.poll.outputs.public_invitations_accepted_repos }}
+          GATEWAY_PRESENCE_URL: ${{ vars.GATEWAY_PRESENCE_URL }}
+          GATEWAY_WEBHOOK_SECRET: ${{ secrets.GATEWAY_WEBHOOK_SECRET }}
+          GATEWAY_ANNOUNCE_DISABLED: ${{ vars.GATEWAY_ANNOUNCE_DISABLED }}
+        run: |
+          EVENT_CONTEXT_JSON="$(jq -nc \
+            --argjson count "$INVITATIONS_ACCEPTED" \
+            --argjson repos "$INVITATIONS_REPOS" \
+            '{count: $count, repos: $repos}')"
+          export EVENT_CONTEXT_JSON
+          node scripts/gateway-announce.ts
+
       - name: 📣 Notify Discord
         if: steps.poll.outputs.public_invitations_accepted > 0
         env:

--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -306,12 +306,14 @@ jobs:
           GATEWAY_PRESENCE_URL: ${{ vars.GATEWAY_PRESENCE_URL }}
           GATEWAY_WEBHOOK_SECRET: ${{ secrets.GATEWAY_WEBHOOK_SECRET }}
           GATEWAY_ANNOUNCE_DISABLED: ${{ vars.GATEWAY_ANNOUNCE_DISABLED }}
+          WIKI_PAGES_CHANGED: ${{ steps.wiki-commit.outputs.pages_changed || '0' }}
         run: |
           EVENT_CONTEXT_JSON="$(jq -nc \
             --arg owner "$REPO_OWNER" \
             --arg repo "$REPO_NAME" \
             --arg slug "$REPO_SLUG" \
-            '{owner: $owner, repo: $repo, slug: $slug, wiki_pages_changed: 0}')"
+            --argjson pages "${WIKI_PAGES_CHANGED:-0}" \
+            '{owner: $owner, repo: $repo, slug: $slug, wiki_pages_changed: $pages}')"
           export EVENT_CONTEXT_JSON
           node scripts/gateway-announce.ts
 

--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -288,6 +288,33 @@ jobs:
             steps.wiki-commit.conclusion == 'skipped')) && 'success' || 'failure' }}
         run: node scripts/record-survey-result.ts
 
+      # Best-effort Discord presence: announce the completed survey to the gateway,
+      # which posts in Fronomenal as the Fro Bot user. Rides behind the same recheck
+      # privacy gate as the survey itself (only public repos reach here) and fires
+      # only on a real success. Never fails the run — gateway-announce.ts exits 0 on
+      # any error and this step is excluded from the job's success aggregation.
+      - name: 📣 Announce survey to gateway
+        if: >-
+          ${{ !cancelled() && steps.recheck.conclusion == 'success' &&
+          steps.survey-agent.conclusion == 'success' &&
+          (steps.wiki-commit.conclusion == 'success' || steps.wiki-commit.conclusion == 'skipped') }}
+        env:
+          EVENT_TYPE: survey_completed
+          REPO_OWNER: ${{ steps.resolve.outputs.owner }}
+          REPO_NAME: ${{ steps.resolve.outputs.repo }}
+          REPO_SLUG: ${{ steps.ingest-prompt.outputs.target-slug }}
+          GATEWAY_PRESENCE_URL: ${{ vars.GATEWAY_PRESENCE_URL }}
+          GATEWAY_WEBHOOK_SECRET: ${{ secrets.GATEWAY_WEBHOOK_SECRET }}
+          GATEWAY_ANNOUNCE_DISABLED: ${{ vars.GATEWAY_ANNOUNCE_DISABLED }}
+        run: |
+          EVENT_CONTEXT_JSON="$(jq -nc \
+            --arg owner "$REPO_OWNER" \
+            --arg repo "$REPO_NAME" \
+            --arg slug "$REPO_SLUG" \
+            '{owner: $owner, repo: $repo, slug: $slug, wiki_pages_changed: 0}')"
+          export EVENT_CONTEXT_JSON
+          node scripts/gateway-announce.ts
+
   broadcast:
     name: Broadcast survey complete
     needs: survey-repo

--- a/docs/brainstorms/2026-05-23-discord-presence-via-control-plane-events-requirements.md
+++ b/docs/brainstorms/2026-05-23-discord-presence-via-control-plane-events-requirements.md
@@ -1,9 +1,9 @@
 # Fro Bot Discord Presence via Control-Plane Events
 
-**Date:** 2026-05-23
-**Status:** Requirements (revised after document-review)
+**Date:** 2026-05-23 (reconciled against shipped gateway 2026-06-04)
+**Status:** Requirements — gateway side SHIPPED; ready for `ce:plan`
 **Scope:** Standard
-**This document:** control-plane side only. The gateway-side feature is tracked in [fro-bot/agent#671](https://github.com/fro-bot/agent/issues/671).
+**This document:** control-plane side only. The gateway-side feature shipped in [fro-bot/agent#671](https://github.com/fro-bot/agent/issues/671) via agent PR #697 (2026-05-30) and is deployed to Fronomenal through `marcusrbrown/infra`. The contract below has been reconciled against the shipped implementation (`packages/gateway/src/http/{announce-schema,announce-handler,hmac}.ts`); see the **Shipped-Gateway Reconciliation** section.
 
 ## Feature
 
@@ -88,8 +88,8 @@ fro-bot/.github (control plane)            fro-bot/agent (gateway)
 1. **`scripts/gateway-announce.ts`** — new TypeScript module, runs under Node 24 native TS. Responsibilities:
    - Read event type, structured context, and timestamp from env vars passed by the calling workflow step
    - Read `GATEWAY_WEBHOOK_SECRET` and `GATEWAY_PRESENCE_URL` from env
-   - Build canonical JSON payload (field ordering deterministic; see Payload Contract below)
-   - Compute HMAC-SHA256 over the canonicalized payload bytes
+   - Build the JSON payload (serialized once via `JSON.stringify`; field ordering is irrelevant since the gateway signs raw bytes, not canonical JSON — see Shipped-Gateway Reconciliation)
+   - Compute HMAC-SHA256 over `timestamp + "." + body` using the exact serialized body bytes
    - Honor kill-switch env var (when set, log and exit 0 without POSTing)
    - POST with single retry on transient failure (network error or HTTP 5xx); on final failure, log structured stderr warning and exit 0 (do not fail the workflow)
 2. **Composer step in event-firing workflows** — added to:
@@ -110,20 +110,24 @@ The control plane sends this exact shape to `POST /v1/announce`:
   "context": {                                     // event-specific structured data; see Event Types below
     // event-specific keys
   },
-  "rendered_text": null                            // v1: always null. v2 forward: pre-composed in-character message text. Gateway falls back to its templates when null.
+  "rendered_text": null                            // REQUIRED field, type `string | null`. v1 always sends null but the key MUST be present (gateway schema rejects omission). v2 forward: pre-composed text; gateway templates when null.
 }
 ```
 
-**Canonicalization for signing**:
-- Encode as JSON with **lexicographically sorted keys at every level**, no whitespace
-- UTF-8 byte encoding
-- HMAC-SHA256 over the canonical bytes, hex-encoded (lowercase)
-- Signature transmitted in `X-Gateway-Signature` header (HMAC hex)
-- Timestamp transmitted in `X-Gateway-Timestamp` header AND in the body's `fired_at` field; gateway MUST verify they match
+**Signing — reconciled against shipped gateway (`hmac.ts`, agent PR #697)**:
 
-**Replay window**: the gateway should reject requests where `|now - fired_at| > 5 minutes`. Strictly informational here; implementation is gateway-side.
+The shipped gateway signs over the **exact raw request body bytes it receives** — there is NO JSON canonicalization. The control plane therefore signs the precise bytes it sends ("sign what you send"): serialize the payload once, sign those bytes, send those bytes. No key sorting, no re-serialization.
 
-**Constant-time comparison**: HMAC verification on the gateway side MUST use constant-time comparison. Stated as a requirement on the gateway issue; not enforceable from the POST side.
+- **Signed message** = `<X-Gateway-Timestamp value>` + `"."` + `<raw JSON body bytes>` — a literal `.` delimiter between the timestamp string and the body bytes. (Shipped: `createHmac('sha256', secret).update(timestampHeader).update('.').update(rawBody)`.)
+- **Algorithm**: HMAC-SHA256 with `GATEWAY_WEBHOOK_SECRET`.
+- **Encoding**: lowercase hex, exactly 64 chars. No `v1=` prefix, no base64.
+- **Signature header**: `X-Gateway-Signature`. **Timestamp header**: `X-Gateway-Timestamp`.
+- **`fired_at` ↔ header**: the body's `fired_at` MUST be **byte-identical** to the `X-Gateway-Timestamp` header value — the gateway rejects with **400** on mismatch via raw string equality. The control plane sets both from the same ISO-8601 string in a single step.
+- **Body size**: gateway caps the body at **8 KiB** (`ANNOUNCE_MAX_BODY_BYTES`); v1 payloads are well under this.
+
+**Replay window**: gateway rejects when the timestamp is outside a **5-minute** window (shipped `REPLAY_WINDOW_MS = 5 * 60 * 1000`), and rejects a re-used signature (replay cache). Both return **401** (generic body — no oracle distinguishing bad-sig / stale / replay).
+
+**Constant-time comparison**: verified on the gateway side (shipped); not enforceable from the POST side.
 
 ### v1 Event Types
 
@@ -143,7 +147,8 @@ These ship after v1 proves out the contract. Listed here so the gateway issue ca
 
 ### Outage Policy
 
-- Single retry on transient failure (network error, HTTP 5xx) with 5-second backoff
+- Single retry on transient failure (**network error or HTTP 5xx**, which includes the gateway's **503** drain/shutdown response) with 5-second backoff
+- **Do NOT retry 4xx**: `400`/`401` indicate a signing, timestamp-mismatch, or schema bug that a retry cannot fix; `429` (rate-limited) won't clear within a single 5-second backoff and v1 volume is low. Treat all 4xx as terminal — log and exit 0.
 - On final failure: structured stderr log line carrying event type and HTTP status (no canonical identifiers in the failure message — repos in the context field stay in the body, which isn't logged on failure), then exit 0
 - Lost events are acceptable in v1; the control plane has its own audit trail (data-branch commits, metadata files, GitHub Actions run logs)
 - No buffer, no queue, no replay
@@ -162,12 +167,29 @@ Only `invitation_accepted` and `survey_completed` events ship in v1. Both carry 
 - `invitation_accepted` only includes public invitations (already gated in `scripts/handle-invitation.ts`)
 - The fast-follower `reconcile_notable` will need an additional privacy review before shipping — the `byChannel` rollup could carry channel-classification telemetry that's meaningful only for public-discovery surfaces; that boundary is the fast-follower's problem to resolve
 
+## Shipped-Gateway Reconciliation
+
+The gateway side shipped in agent PR #697 (2026-05-30). This section pins the control-plane build to the gateway's actual implementation. Where the original brainstorm and the shipped code disagreed, **the shipped code wins** and the contract above has been updated to match.
+
+| Aspect | Original brainstorm assumption | Shipped gateway reality | Control-plane action |
+|---|---|---|---|
+| Signing input | Canonical JSON (lexicographically sorted keys, re-serialized) | Raw request body bytes, no canonicalization | **Sign the exact bytes sent.** Serialize once, sign those bytes, send those bytes. Drop all key-sorting logic. |
+| Signed message | HMAC over canonical body only | `HMAC(secret, timestamp + "." + rawBody)` — timestamp string + literal `.` + body bytes | Build the signed message as `timestamp + "." + body` with the exact body bytes. |
+| `fired_at` vs header | "gateway MUST verify they match" (advisory) | Hard **400** on raw-string mismatch | Set `fired_at` and `X-Gateway-Timestamp` from one identical ISO-8601 string. |
+| `rendered_text` | Optional, send `null` | Schema-**required** field, type `string \| null` | Always include the key with value `null` in v1. |
+| Endpoint availability | Assumed always-on | Opt-in: live only when gateway has BOTH `GATEWAY_WEBHOOK_SECRET` and `GATEWAY_PRESENCE_CHANNEL_ID` | No control-plane code impact, but pre-flight: confirm the deployed gateway has both set (it is, per `marcusrbrown/infra`). Until then, the kill switch / black-hole tolerance (SC5) covers a not-listening endpoint. |
+| Rejection statuses | 4xx vs 5xx unspecified | 413/429/400/401 (4xx terminal); 503 on drain (retryable) | Retry only network-error/5xx (incl. 503); treat 4xx as terminal. |
+| Body size | unspecified | 8 KiB cap | v1 payloads are tiny; no action. |
+| Replay/rate-limit | gateway-side | 5-min window, 60 req/min, dedup on signature | No control-plane action; informs SC3 expectations. |
+
+**Net effect on the control-plane build:** *simpler* than the brainstorm — the canonicalization module (sort keys, stable re-serialize) is **deleted from scope**. The signer becomes: `const body = JSON.stringify(payload); const sig = hmacSha256Hex(secret, ` + "`${timestamp}.${body}`" + `)`. The one new sharp edge is that `payload.fired_at` must be set from the same `timestamp` variable used for the header, before `JSON.stringify`, so the signed body and the header agree.
+
 ## Functional Requirements
 
-- **R1**: `scripts/gateway-announce.ts` accepts event type, structured context, and timestamp from env vars and produces a canonicalized JSON payload matching the contract above
+- **R1**: `scripts/gateway-announce.ts` accepts event type, structured context, and timestamp from env vars and produces a JSON payload matching the contract above, serialized once so the signed bytes equal the sent bytes (no canonicalization — the gateway signs raw body bytes)
 - **R2**: HMAC-SHA256 signature uses the `GATEWAY_WEBHOOK_SECRET` env var; signature is hex-encoded and transmitted in the `X-Gateway-Signature` header
 - **R3**: The script POSTs to the URL in `GATEWAY_PRESENCE_URL` env var with `Content-Type: application/json`, `X-Gateway-Signature`, and `X-Gateway-Timestamp` headers
-- **R4**: On HTTP 5xx or network error, the script retries exactly once after a 5-second backoff; on second failure, logs a structured stderr line and exits 0
+- **R4**: On HTTP 5xx (including 503) or network error, the script retries exactly once after a 5-second backoff; on second failure, logs a structured stderr line and exits 0. 4xx responses (400/401/429) are terminal — no retry (a signing/schema bug or rate-limit won't clear on retry)
 - **R5**: When the repo variable `GATEWAY_ANNOUNCE_DISABLED` is truthy, the script logs `gateway-announce: kill switch active; skipping POST` to stderr and exits 0 before any network call or HMAC computation
 - **R6**: `survey-repo.yaml` invokes `gateway-announce.ts` in a new step after the `Record survey result` step, only when the recheck succeeded (same gate as the existing `Record survey result` step). Event type: `survey_completed`. Context: `{owner, repo, slug, wiki_pages_changed}`
 - **R7**: `poll-invitations.yaml` invokes `gateway-announce.ts` when `steps.poll.outputs.public_invitations_accepted > 0`. Event type: `invitation_accepted`. Context: `{count, repos: [...]}` — repos populated from invitation handler output (will require a small change to `scripts/handle-invitation.ts` to emit the list)
@@ -199,9 +221,11 @@ The legacy `discord-notify.ts` webhook posting (still present, no callers as of 
 - **Q1**: Output of `scripts/handle-invitation.ts` currently exposes only the count of accepted public invitations via step output. To populate `context.repos`, the script needs to also expose the list of repo identifiers (owner/name pairs) — either as a stringified JSON step output or via a small artifact file. Planning resolves the exact mechanism.
 - **Q2**: The `Record survey result` step computes `SURVEY_STATUS` from a multi-step truth table. The gateway-announce step needs the same success gate; planning decides whether to reuse the same env-var pattern or extract a shared step output.
 - **Q3**: `GATEWAY_PRESENCE_URL` — repo variable or repo secret? URLs aren't secret in the security sense, but the gateway endpoint URL is rarely-rotated and not useful to attackers without the HMAC secret. Probably variable; planning confirms.
-- **Q4**: Test strategy for `scripts/gateway-announce.ts` — unit-test the canonicalization, HMAC, retry, and kill-switch logic with mocked fetch. No live integration test in CI (gateway is production).
-- **Q5**: Should `gateway-announce.ts` use Node's built-in `crypto` for HMAC and built-in `fetch` for the POST, or pull in a dep? Lean toward built-in (matches repo's zero-dep ethos for control-plane scripts).
-- **Q6**: Versioning policy on the contract — `v: 1` in the payload is the simple knob. When v2 ships the composer, it bumps to `v: 2` and gateway supports both during transition? Or does v2 stay `v: 1` since `rendered_text` was always in the contract? Planning decides.
+- **Q4**: Test strategy for `scripts/gateway-announce.ts` — unit-test the signed-message construction (`timestamp + "." + body`, byte-exact), HMAC hex output against a known vector matching the gateway's `hmac.test.ts`, `fired_at`↔header equality, retry (5xx/503 only, 4xx terminal), and kill-switch logic with mocked fetch. No live integration test in CI (gateway is production).
+- **Q5**: Should `gateway-announce.ts` use Node's built-in `crypto` for HMAC and built-in `fetch` for the POST, or pull in a dep? Lean toward built-in (matches repo's zero-dep ethos for control-plane scripts). **Reinforced by shipped reality**: the gateway uses Node `createHmac('sha256', ...)` with hex digest — `crypto.createHmac` on the control-plane side produces a byte-identical signature with no dep.
+- **Q6**: Versioning policy on the contract — `v: 1` in the payload is the knob. **Resolved by shipped reality**: the gateway schema fixes `v` to literal `1` and `rendered_text` is already in the v1 schema, so v2's composer stays `v: 1` and simply populates `rendered_text` (no version bump, no dual-support transition needed). Confirm in planning.
+- **Q7 (new, from reconciliation)**: The signer must set `fired_at` and the `X-Gateway-Timestamp` header from the **same** timestamp string, captured once before serialization, or the gateway 400s on mismatch. Planning pins this as an explicit single-source-of-timestamp requirement in `gateway-announce.ts`.
+- **Q8 (new, from reconciliation)**: Pre-flight — confirm the deployed Fronomenal gateway has both `GATEWAY_WEBHOOK_SECRET` and `GATEWAY_PRESENCE_CHANNEL_ID` set (endpoint is opt-in). SC5 (black-hole tolerance) means a not-yet-configured endpoint won't break workflows, but SC1/SC2 (real posts land) can't pass until both are set on the `marcusrbrown/infra` deployment and the matching `GATEWAY_WEBHOOK_SECRET` is mirrored into this repo's secrets.
 
 ## Out-of-Scope but Worth Flagging
 
@@ -212,7 +236,7 @@ The legacy `discord-notify.ts` webhook posting (still present, no callers as of 
 
 - **Sunset PR #3368** — removed the journal-entry pipeline. Did not replace the channel; v1 here is the replacement
 - **Explorer research (2026-05-23)** — capability matrix on `fro-bot/agent` gateway + `marcusrbrown/infra` deployment (informs the gateway issue contents)
-- **`fro-bot/agent#671`** — gateway-side build (filed 2026-05-23)
+- **`fro-bot/agent#671`** — gateway-side build; **SHIPPED 2026-05-30 via agent PR #697** ("signed announce webhook"). Endpoint live (`POST /v1/announce`), opt-in (active only when the gateway has both `GATEWAY_WEBHOOK_SECRET` and `GATEWAY_PRESENCE_CHANNEL_ID` set), deployed to Fronomenal via `marcusrbrown/infra`. Gateway internals: `packages/gateway/src/http/{announce-schema,announce-handler,hmac,replay-cache,rate-limit}.ts`
 - **`marcusrbrown/infra`** — will need a deploy secret rollout (`GATEWAY_WEBHOOK_SECRET`) and possibly env var (`GATEWAY_PRESENCE_CHANNEL_ID`) once the gateway side lands
 - **PR #3293 / `docs/solutions/security-issues/survey-workflow-side-privacy-gate-2026-05-16.md`** — the privacy gate on `survey-repo.yaml` is what makes `survey_completed` safe to broadcast
 - **`scripts/handle-invitation.ts`** — needs a small change to expose the list of accepted repos (Q1 above)

--- a/docs/plans/2026-06-04-001-feat-gateway-announce-presence-plan.md
+++ b/docs/plans/2026-06-04-001-feat-gateway-announce-presence-plan.md
@@ -1,0 +1,417 @@
+---
+title: 'feat: Control-plane gateway-announce for Fro Bot Discord presence'
+type: feat
+status: active
+date: 2026-06-04
+origin: docs/brainstorms/2026-05-23-discord-presence-via-control-plane-events-requirements.md
+deepened: 2026-06-04
+---
+
+# feat: Control-plane gateway-announce for Fro Bot Discord presence
+
+## Overview
+
+Add a control-plane signer, `scripts/gateway-announce.ts`, that POSTs HMAC-signed event payloads to
+the Fro Bot gateway's `POST /v1/announce` endpoint, and wire it into two event-firing workflows so
+Fro Bot posts in-character messages in Fronomenal **as the Fro Bot Discord user** when it completes
+a survey or accepts repository invitations. The gateway side already shipped (agent PR #697,
+2026-05-30) and is deployed via `marcusrbrown/infra`; this plan builds only the POST side against
+that shipped contract.
+
+The signing model is the load-bearing detail: the gateway verifies
+`HMAC-SHA256(secret, "<timestamp>.<rawBody>")` over the **exact request body bytes** — no JSON
+canonicalization. The control plane therefore signs the precise bytes it sends, and the body's
+`fired_at` must be byte-identical to the `X-Gateway-Timestamp` header (the gateway 400s on
+mismatch).
+
+## Problem Frame
+
+The Fro Bot character has presence in Fronomenal Discord but no way to talk about what it does. The
+control plane fires notable events daily (surveys complete, invitations accepted) but they stay
+invisible since the operational-log sunset (PR #3368). This plan gives the character things to say,
+posted from its own Discord identity via the gateway — not from an opaque webhook bot. See origin:
+`docs/brainstorms/2026-05-23-discord-presence-via-control-plane-events-requirements.md`.
+
+## Requirements Trace
+
+- R1. `scripts/gateway-announce.ts` reads event type, structured context, and timestamp from env and
+  produces a JSON payload matching the shipped contract (`v:1`, `event_type`, `fired_at`, `context`,
+  `rendered_text:null`), serialized once so signed bytes equal sent bytes.
+- R2. HMAC-SHA256 over `"<timestamp>.<body>"` using `GATEWAY_WEBHOOK_SECRET`; lowercase hex (64
+  chars); sent in `X-Gateway-Signature`.
+- R3. POST to `GATEWAY_PRESENCE_URL` with `Content-Type: application/json`, `X-Gateway-Signature`,
+  `X-Gateway-Timestamp`; `fired_at` byte-identical to the timestamp header.
+- R4. Retry exactly once (5s backoff) on network error or HTTP 5xx (incl. 503); 4xx (400/401/429) is
+  terminal. On final failure, log structured stderr and exit 0 (never fail the workflow).
+- R5. Kill switch: when `GATEWAY_ANNOUNCE_DISABLED` is truthy, log and exit 0 before any HMAC
+  computation or network call.
+- R6. `survey-repo.yaml` invokes the signer after `Record survey result`, gated on the same success
+  condition; event `survey_completed`, context `{owner, repo, slug, wiki_pages_changed}`.
+- R7. `poll-invitations.yaml` invokes the signer when `public_invitations_accepted > 0`; event
+  `invitation_accepted`, context `{count, repos:[{owner,name}]}` — requires `handle-invitation.ts`
+  to emit the accepted-public-repos list.
+- R8. `metadata/README.md` documents `GATEWAY_WEBHOOK_SECRET`, `GATEWAY_PRESENCE_URL`,
+  `GATEWAY_ANNOUNCE_DISABLED`.
+- R9. Payload carries `rendered_text:null` (schema-required key) — forward-compatible with the v2
+  composer.
+
+## Scope Boundaries
+
+- No LLM message composition (v2; gateway templates render v1).
+- No `reconcile_notable` / `wiki_lint_findings` events (fast-followers, post-v1).
+- No high-risk privacy events (visibility transitions, integrity alerts) — stay on GitHub surfaces.
+- No durable queue / outage buffering — best-effort, single-retry.
+- No gateway-side work (shipped; this is POST-side only).
+- No multi-channel routing — single Fronomenal channel (gateway config).
+
+### Deferred to Separate Tasks
+
+- Retiring `scripts/discord-notify.ts`: separate PR once v1 proves stable (origin "What This Replaces").
+- Rollout in `marcusrbrown/infra` — setting `GATEWAY_WEBHOOK_SECRET` + `GATEWAY_PRESENCE_CHANNEL_ID`
+  on the deployed gateway and mirroring `GATEWAY_WEBHOOK_SECRET`/`GATEWAY_PRESENCE_URL` into this
+  repo's secrets/vars: operator task, prerequisite for SC1/SC2 (see Q8).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/discord-notify.ts` — the closest sibling: exported pure `postDiscordEmbed(params)` with
+  injectable `webhookUrl`, built-in `fetch` (line ~77), `import.meta.url` entrypoint guard (~128),
+  429-retry loop, structured stderr, JSON to stdout. Mirror its shape (minus the webhook framing).
+- `scripts/bluesky-post.ts` — injectable-seam + env-override pattern, entrypoint guard (~93).
+- `.github/workflows/survey-repo.yaml` — `Record survey result` step gate:
+  `if: ${{ !cancelled() && steps.survey-agent.conclusion != 'skipped' && steps.recheck.conclusion == 'success' }}`;
+  env exposes `steps.resolve.outputs.{owner,repo}`, `inputs.node_id`, `steps.recheck.outputs.private`,
+  and computes `SURVEY_STATUS`. `wiki-commit` step has `id: wiki-commit` but emits no page count.
+- `.github/workflows/poll-invitations.yaml` — `id: poll` runs `handle-invitation.ts` with
+  `GITHUB_TOKEN: ${{ secrets.FRO_BOT_POLL_PAT }}`; `Notify Discord` gated on
+  `steps.poll.outputs.public_invitations_accepted > 0`.
+- `scripts/handle-invitation.ts` — `formatInvitationGithubOutput` emits only
+  `public_invitations_accepted=<n>`; `countPublicAcceptedInvitations` counts accepted non-redacted
+  entries. Needs a second output for the repos list.
+- `metadata/README.md` — "Workflow secret mapping" table; `vars.X` vs `secrets.X` convention
+  (`vars.FRO_BOT_MODEL`, `secrets.FRO_BOT_PAT`).
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/diagnostic-patches-observability-discipline-2026-05-20.md` — never
+  `2>/dev/null` a gate; structured stderr; `printf '%s\n' '--- marker ---'` (leading `---` trap).
+- `docs/solutions/runtime-errors/node-strip-only-typescript-2026-04-18.md` — strip-only-safe syntax;
+  the `Test Scripts Load` CI job must cover the new entrypoint.
+- `docs/solutions/workflow-issues/github-actions-step-output-interpolation-2026-04-21.md` — pass
+  `${{ steps.*.outputs.* }}` through `env:`, reference `${VAR}` in shell; never inline into `run:`.
+- `docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md` — a best-effort
+  announce step must NOT be folded into `SURVEY_STATUS`; its failure stays non-fatal and out of the
+  required-step status aggregation.
+- `docs/solutions/security-issues/survey-workflow-side-privacy-gate-2026-05-16.md` — only emit after
+  the verified privacy gate; `survey_completed` rides behind the existing `recheck` gate.
+
+### External References
+
+- Shipped gateway contract (agent PR #697): `packages/gateway/src/http/{announce-schema,announce-handler,hmac}.ts`.
+  Signed message `createHmac('sha256', secret).update(timestamp).update('.').update(rawBody).digest('hex')`;
+  5-min replay window; 8 KiB body cap; 60 req/min; rejection codes 413/429/400/401/503.
+- Node built-in `crypto.createHmac('sha256', ...)` produces a byte-identical signature — zero-dep.
+
+## Key Technical Decisions
+
+- **Sign exact bytes, no canonicalization.** `const body = JSON.stringify(payload)` once; sign
+  `` `${timestamp}.${body}` ``; POST `body`. Matches the gateway's raw-body verification.
+- **Single source of timestamp.** Capture one ISO-8601 string; set both `payload.fired_at` and the
+  `X-Gateway-Timestamp` header from it before serializing. Prevents the gateway's 400-on-mismatch.
+- **Built-in `crypto` + `fetch`, zero dep.** Consistent with `discord-notify.ts` and the repo's
+  zero-dep control-plane ethos.
+- **Fail-soft, best-effort.** Announce never fails a workflow (exit 0 on any final failure) and is
+  excluded from `SURVEY_STATUS` aggregation — it is telemetry, not a required step.
+- **Retry only 5xx/503/network.** 4xx is a signing/schema/rate-limit condition a 5s retry can't fix.
+- **`GATEWAY_PRESENCE_URL` is a repo variable; `GATEWAY_WEBHOOK_SECRET` is a secret.** The URL isn't
+  useful without the HMAC secret; matches the `vars`-for-config / `secrets`-for-credentials split.
+- **Kill switch short-circuits first** — before HMAC or network, so it's a true mute.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Q1 (repos list for `context.repos`): add a `public_invitations_accepted_repos=<json>` step output
+  to `handle-invitation.ts` alongside the existing count; derive from accepted non-redacted results.
+- Q2 (survey success gate): reuse the `Record survey result` `if:` gate; do not extract a shared
+  output.
+- Q3 (`GATEWAY_PRESENCE_URL` var vs secret): repo **variable** (`vars.GATEWAY_PRESENCE_URL`).
+- Q4 (test strategy): unit-test signed-message construction (byte-exact), HMAC hex against a known
+  vector matching the gateway's `hmac.test.ts`, `fired_at`↔header equality, retry classification,
+  kill switch — all with mocked `fetch`. No live CI integration test.
+- Q5 (crypto/fetch dep): Node built-ins, no dep.
+- Q6 (versioning): `v` stays literal `1`; v2 populates `rendered_text` without a version bump
+  (shipped schema already carries the key).
+- Q7 (single-timestamp requirement): explicit in Unit 1 — one timestamp string drives body + header.
+
+### Deferred to Implementation
+
+- Q8 (rollout pre-flight): confirming the deployed gateway has `GATEWAY_WEBHOOK_SECRET` +
+  `GATEWAY_PRESENCE_CHANNEL_ID` and mirroring the secret/var into this repo is an operator task in
+  `marcusrbrown/infra`. SC5 (black-hole tolerance) means the workflows ship safely before this; SC1/SC2
+  can only be verified after. Not a code dependency.
+- `wiki_pages_changed` exact source: the `wiki-commit` step emits no count today. Implementation
+  decides whether to add a `pages_changed` output to that step or derive it from the porcelain the
+  commit step already computes (favor a small step output; fall back to `0` if unavailable, since the
+  field is descriptive, not gating).
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation
+> specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+workflow step (survey-repo / poll-invitations)
+  └─ env: EVENT_TYPE, EVENT_CONTEXT_JSON, GATEWAY_PRESENCE_URL (var),
+          GATEWAY_WEBHOOK_SECRET (secret), GATEWAY_ANNOUNCE_DISABLED (var)
+      └─ node scripts/gateway-announce.ts
+            1. kill switch? → log + exit 0
+            2. ts = new Date().toISOString()
+            3. payload = {v:1, event_type, fired_at: ts, context, rendered_text:null}
+            4. body = JSON.stringify(payload)              # serialize ONCE
+            5. sig  = hmacSha256Hex(secret, `${ts}.${body}`)
+            6. POST url, body, headers{X-Gateway-Signature:sig, X-Gateway-Timestamp:ts}
+                 ├─ 2xx → log ok, exit 0
+                 ├─ 5xx/503/network → retry once (5s) → fail → log stderr, exit 0
+                 └─ 4xx → terminal → log stderr, exit 0
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: `scripts/gateway-announce.ts` signer + CLI**
+
+**Goal:** A strip-only-safe, zero-dep module that builds the payload, signs the exact bytes, POSTs
+with the retry/kill-switch policy, and never fails the workflow.
+
+**Requirements:** R1, R2, R3, R4, R5, R9
+
+**Dependencies:** None
+
+**Files:**
+- Create: `scripts/gateway-announce.ts`
+- Test: `scripts/gateway-announce.test.ts`
+
+**Approach:**
+- Export a pure `announce(params)` with injectable seams: `fetch` (default `globalThis.fetch`),
+  `secret`/`url`/`killSwitch` (default from env), `now` (default `() => new Date().toISOString()`),
+  and a `sleep` injectable so the retry-backoff test doesn't wait 5s.
+- Build `payload` with `rendered_text: null` always present; `fired_at` = the single `now()` string.
+- `JSON.stringify(payload)` once; compute `crypto.createHmac('sha256', secret).update(ts).update('.').update(body).digest('hex')`.
+- POST with `X-Gateway-Signature`/`X-Gateway-Timestamp` (= same `ts`) + `Content-Type: application/json`.
+- Retry classification: network throw or `res.status >= 500` → one retry after `sleep(5000)`; `4xx`
+  → terminal. Any final non-2xx/throw → structured stderr (event type + coarse status/error class
+  ONLY) + return a result the CLI maps to exit 0.
+- **Auth-material redaction (hard rule):** no stderr line, stdout JSON result, or thrown error may
+  contain `GATEWAY_WEBHOOK_SECRET`, the derived `X-Gateway-Signature`, the `X-Gateway-Timestamp`, or
+  the full request body/headers. Log only event type + coarse status/error class. (`context.repos`
+  also stays out of failure logs per the privacy boundary.)
+- Kill switch checked before steps 2-6.
+- CLI wrapper under the `import.meta.url === \`file://${process.argv[1]}\`` guard: read
+  `EVENT_TYPE`, `EVENT_CONTEXT_JSON` (parse), call `announce`, print JSON result to stdout, exit 0.
+
+**Execution note:** Test-first. Write the signed-message + HMAC-vector test before the signer so the
+byte-exact `"<ts>.<body>"` formula is locked against the gateway's `hmac.test.ts`.
+
+**Patterns to follow:** `scripts/discord-notify.ts` (fetch + retry + entrypoint guard + stderr/stdout
+split); `scripts/bluesky-post.ts` (env-override seams).
+
+**Test scenarios:**
+- Happy path: valid env → POST issued with correct URL, headers, and body; result indicates posted;
+  exit 0.
+- HMAC vector: given a fixed secret, timestamp, and body, the hex signature equals the value the
+  gateway's formula produces (`createHmac('sha256',secret).update(ts).update('.').update(body).digest('hex')`).
+- `fired_at`↔header: the POSTed body's `fired_at` byte-equals the `X-Gateway-Timestamp` header.
+- Payload shape: `v===1`, `rendered_text` key present and `null`, `context` passed through verbatim.
+- Edge case: `EVENT_CONTEXT_JSON` malformed → structured stderr, exit 0 (no POST).
+- Error path: first attempt 503 → one retry after `sleep` → second 200 → posted (assert exactly one
+  retry, sleep called once).
+- Error path: two consecutive 5xx → structured stderr (status, no repo names), exit 0.
+- Error path: network throw then throw → retried once, then stderr + exit 0.
+- Error path: 400/401/429 → NO retry, structured stderr, exit 0.
+- Kill switch: `GATEWAY_ANNOUNCE_DISABLED=true` → logs kill-switch line, no HMAC, no fetch, exit 0.
+- Missing `GATEWAY_PRESENCE_URL` or `GATEWAY_WEBHOOK_SECRET` → skipped result + stderr, exit 0 (don't
+  throw; mirror discord-notify's missing-config tolerance).
+- Redaction: a failing POST's stderr/result contains the event type + coarse status but NOT any
+  `context.repos` owner/name, the secret, the signature, the timestamp, or the request body.
+- Redaction (success path): the stdout JSON result does not echo the secret or signature.
+
+**Verification:** All scenarios pass with mocked `fetch`/`sleep`; `node -e "import('./scripts/gateway-announce.ts')"`
+loads under strip-only; types + lint clean.
+
+- [ ] **Unit 2: `handle-invitation.ts` emits accepted-public-repos list**
+
+**Goal:** Expose the list of accepted public repos so `poll-invitations.yaml` can build
+`context.repos` for the announce.
+
+**Requirements:** R7
+
+**Dependencies:** None (parallel with Unit 1)
+
+**Files:**
+- Modify: `scripts/handle-invitation.ts`
+- Modify: `scripts/handle-invitation.test.ts`
+
+**Approach:**
+- In `formatInvitationGithubOutput`, add a second line
+  `public_invitations_accepted_repos=<json>` where the JSON is an array of `{owner, name}` from
+  accepted non-redacted (public) results — reuse the exact predicate that
+  `countPublicAcceptedInvitations` uses so count and list never disagree.
+- Keep the existing `public_invitations_accepted=<n>` line unchanged (backward compatible).
+- JSON must be single-line (GITHUB_OUTPUT is line-based); private/redacted entries excluded.
+
+**Execution note:** Test-first — add the list-output assertion before the formatter change.
+
+**Patterns to follow:** the existing `formatInvitationGithubOutput` / `countPublicAcceptedInvitations`
+pair in `scripts/handle-invitation.ts`.
+
+**Test scenarios:**
+- Happy path: 2 accepted public + 1 accepted private → list output has exactly the 2 public
+  `{owner,name}`; count output is `2`; list and count agree.
+- Edge case: 0 accepted → count `0`, list output `[]`.
+- Edge case: only private/redacted accepted → count `0`, list `[]` (no redacted names emitted).
+- Integration: the emitted line is valid single-line JSON parseable by `JSON.parse`.
+
+**Verification:** existing handle-invitation tests stay green; new list-output tests pass; no redacted
+identifier appears in the list.
+
+- [ ] **Unit 3: Wire `survey_completed` into `survey-repo.yaml`**
+
+**Goal:** Fire a `survey_completed` announce after a successful survey, best-effort, behind the
+existing privacy/success gate.
+
+**Requirements:** R6
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `.github/workflows/survey-repo.yaml`
+
+**Approach:**
+- Add a step after `Record survey result`, gated on the same condition AND `SURVEY_STATUS == 'success'`
+  (announce only when the survey actually landed). It rides behind the existing `recheck` privacy gate,
+  so only public repos reach it.
+- Pass values via `env:` (not inline into `run:`): `EVENT_TYPE: survey_completed`,
+  `EVENT_CONTEXT_JSON` built from `steps.resolve.outputs.{owner,repo}`, the slug, and a
+  `wiki_pages_changed` count; `GATEWAY_PRESENCE_URL: ${{ vars.GATEWAY_PRESENCE_URL }}`,
+  `GATEWAY_WEBHOOK_SECRET: ${{ secrets.GATEWAY_WEBHOOK_SECRET }}`,
+  `GATEWAY_ANNOUNCE_DISABLED: ${{ vars.GATEWAY_ANNOUNCE_DISABLED }}`.
+- Source `wiki_pages_changed`: add a small `pages_changed` output to the `wiki-commit` step if cheap
+  (count of changed `knowledge/wiki` paths it already stages); otherwise default `0` in the context
+  builder (descriptive field, non-gating).
+- Build `EVENT_CONTEXT_JSON` in a tiny shell step using env-passed values + `jq -nc` (or a heredoc),
+  never raw `${{ }}` interpolation in the body string.
+- Do NOT fold this step into `SURVEY_STATUS`; it is best-effort telemetry.
+- Declare `GATEWAY_WEBHOOK_SECRET` in the workflow's secret usage; keep least-privilege permissions.
+
+**Patterns to follow:** the `Record survey result` env-passing block; `Notify Discord` gating style.
+
+**Test scenarios:** Test expectation: none — workflow YAML, no executable unit surface. Validation is
+`actionlint` + a live `workflow_dispatch` (see Verification).
+
+**Verification:** `actionlint` clean; the new step's `if:` matches the success+recheck gate; the
+payload context is built from verified outputs only; secret appears only in this step's env. Live
+proof deferred to rollout (SC1).
+
+- [ ] **Unit 4: Wire `invitation_accepted` into `poll-invitations.yaml`**
+
+**Goal:** Fire a single aggregated `invitation_accepted` announce when ≥1 public invitation was
+accepted.
+
+**Requirements:** R7
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Modify: `.github/workflows/poll-invitations.yaml`
+
+**Approach:**
+- Add a step after `Poll invitations`, gated on `steps.poll.outputs.public_invitations_accepted > 0`.
+- Build `EVENT_CONTEXT_JSON` = `{count, repos}` from `steps.poll.outputs.public_invitations_accepted`
+  and `steps.poll.outputs.public_invitations_accepted_repos` (the Unit 2 JSON list), passed via `env:`.
+- Same gateway env trio as Unit 3 (`vars.GATEWAY_PRESENCE_URL`, `secrets.GATEWAY_WEBHOOK_SECRET`,
+  `vars.GATEWAY_ANNOUNCE_DISABLED`).
+- Single POST aggregating the cycle (not per-repo).
+- Declare `GATEWAY_WEBHOOK_SECRET` in the workflow's secret usage.
+
+**Patterns to follow:** the existing `Notify Discord` step gating in `poll-invitations.yaml`.
+
+**Test scenarios:** Test expectation: none — workflow YAML. Validation is `actionlint` + live dispatch
+(SC2).
+
+**Verification:** `actionlint` clean; step fires only when count > 0; `context.repos` comes from the
+Unit 2 list output (public only); secret scoped to the step.
+
+- [ ] **Unit 5: Document secrets/vars in `metadata/README.md`**
+
+**Goal:** Document the three new config values and which workflows consume them.
+
+**Requirements:** R8
+
+**Dependencies:** Units 3, 4 (names/usage finalized)
+
+**Files:**
+- Modify: `metadata/README.md`
+
+**Approach:**
+- Add `GATEWAY_WEBHOOK_SECRET` (secret), `GATEWAY_PRESENCE_URL` (variable), `GATEWAY_ANNOUNCE_DISABLED`
+  (variable, kill switch) to the secrets/vars documentation, noting `survey-repo.yaml` and
+  `poll-invitations.yaml` as consumers and the gateway-opt-in prerequisite (both gateway-side values
+  must be set for the endpoint to be live).
+- Keep first-person/operator tone; no plan/unit/session taxonomy in the doc.
+
+**Patterns to follow:** the existing "Workflow secret mapping" table format.
+
+**Test scenarios:** Test expectation: none — documentation.
+
+**Verification:** markdownlint clean; table format matches existing rows; no taxonomy leakage.
+
+## System-Wide Impact
+
+- **Interaction graph:** Two workflows gain a best-effort trailing step; `handle-invitation.ts` gains
+  one additive step output. No change to survey/invitation control flow or `SURVEY_STATUS`.
+- **Error propagation:** Announce failures are swallowed (exit 0) by design — they never propagate to
+  workflow status. This is intentional and called out so a future editor doesn't "fix" it into a
+  failure.
+- **State lifecycle risks:** None — no persistence, no `data` branch writes, no metadata mutation.
+- **API surface parity:** The signed-bytes formula must stay byte-identical to the gateway's
+  `hmac.ts`; any future gateway contract change (version bump, header rename) requires a matching
+  control-plane change. Memory ID 4450 pins the current contract.
+- **Integration coverage:** Unit tests prove the signer; the HMAC-vector test is the cross-system
+  contract check. End-to-end (real Discord post) is verified live at rollout, not in CI.
+- **Unchanged invariants:** `discord-notify.ts` stays (retired in a later PR); Bluesky stays gated
+  off; the survey/invitation privacy gates are unchanged and remain the only thing that lets
+  `survey_completed`/`invitation_accepted` carry public identifiers.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Signed bytes drift from gateway verification (canonicalization mistake) | Sign the exact `JSON.stringify` output; HMAC-vector test matches the gateway's `hmac.ts` formula |
+| `fired_at` ≠ header → gateway 400 | Single timestamp string drives both; explicit test |
+| Announce failure breaks a survey/invitation run | Fail-soft exit 0; excluded from `SURVEY_STATUS`; retry only 5xx/503 |
+| Private identifier leaks into Discord | Rides behind existing recheck/public gates; only public events ship; stderr redaction on failure |
+| Endpoint not yet configured on the gateway | SC5 black-hole tolerance — workflows ship safely; SC1/SC2 verified post-rollout (Q8) |
+| Strip-only syntax regression | strip-only-safe code + `Test Scripts Load` CI covers the new entrypoint |
+| Auth material (secret/signature) leaked into CI logs | Hard redaction rule in Unit 1: logs carry event type + coarse status only; explicit redaction tests for secret/signature/body |
+| Runner clock skew > 5 min → gateway 401 (replay window) | `fired_at` uses runner wall clock; GitHub runners are NTP-synced so skew is sub-second in practice. Failure is a benign fail-soft 401 (no post), not a leak; noted for operators |
+| Fail-soft hides repeated announce failures from workflow status | Accepted for telemetry; operator signal is the absence of expected Discord posts. A future health-check is out of v1 scope |
+
+## Documentation / Operational Notes
+
+- Rollout (operator, `marcusrbrown/infra`): set `GATEWAY_WEBHOOK_SECRET` + `GATEWAY_PRESENCE_CHANNEL_ID`
+  on the deployed gateway; mirror `GATEWAY_WEBHOOK_SECRET` (secret) and `GATEWAY_PRESENCE_URL`
+  (variable) into this repo. Until then the pipeline is silent-safe.
+- Post-v1: assess template quality in Fronomenal; if weak, the v2 composer (`rendered_text`) rises in
+  priority. Capture the signer pattern in `docs/solutions/` after live verification.
+
+## Sources & References
+
+- **Origin document:** docs/brainstorms/2026-05-23-discord-presence-via-control-plane-events-requirements.md
+- Shipped gateway: `fro-bot/agent` PR #697 (#671), `packages/gateway/src/http/{announce-schema,announce-handler,hmac}.ts`
+- Related code: `scripts/discord-notify.ts`, `scripts/bluesky-post.ts`, `scripts/handle-invitation.ts`,
+  `.github/workflows/survey-repo.yaml`, `.github/workflows/poll-invitations.yaml`, `metadata/README.md`
+- Related learnings: diagnostic-observability-discipline-2026-05-20, node-strip-only-typescript-2026-04-18,
+  github-actions-step-output-interpolation-2026-04-21, autonomous-pipeline-silent-failures-2026-04-19,
+  survey-workflow-side-privacy-gate-2026-05-16
+- Contract memory: ID 4450

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -139,15 +139,28 @@ PAT split summary:
 
 ### Workflow secret mapping
 
-| Workflow                | Secrets passed (explicit, not inherited)                                |
-| ----------------------- | ----------------------------------------------------------------------- |
-| `fro-bot.yaml`          | `FRO_BOT_PAT`, `OPENCODE_AUTH_JSON`, `OMO_PROVIDERS`, `OPENCODE_CONFIG` |
-| `fro-bot-autoheal.yaml` | Same 4 (via reusable call to `fro-bot.yaml`)                            |
-| `apply-branding.yaml`   | Same 4 (via reusable call to `fro-bot.yaml`)                            |
-| `poll-invitations.yaml` | `FRO_BOT_POLL_PAT` only                                                 |
-| `merge-data.yaml`       | `GITHUB_TOKEN` (auto-provisioned, job-scoped permissions)               |
-| `reconcile-repos.yaml`  | `FRO_BOT_POLL_PAT` + `APPLICATION_ID` + `APPLICATION_PRIVATE_KEY`       |
-| `update-metadata.yaml`  | `APPLICATION_ID` + `APPLICATION_PRIVATE_KEY`                            |
+| Workflow                | Secrets passed (explicit, not inherited)                                                |
+| ----------------------- | --------------------------------------------------------------------------------------- |
+| `fro-bot.yaml`          | `FRO_BOT_PAT`, `OPENCODE_AUTH_JSON`, `OMO_PROVIDERS`, `OPENCODE_CONFIG`                 |
+| `fro-bot-autoheal.yaml` | Same 4 (via reusable call to `fro-bot.yaml`)                                            |
+| `apply-branding.yaml`   | Same 4 (via reusable call to `fro-bot.yaml`)                                            |
+| `poll-invitations.yaml` | `FRO_BOT_POLL_PAT`, `GATEWAY_WEBHOOK_SECRET` (presence)                                 |
+| `survey-repo.yaml`      | `FRO_BOT_PAT`, `FRO_BOT_POLL_PAT`, `APPLICATION_*`, `GATEWAY_WEBHOOK_SECRET` (presence) |
+| `merge-data.yaml`       | `GITHUB_TOKEN` (auto-provisioned, job-scoped permissions)                               |
+| `reconcile-repos.yaml`  | `FRO_BOT_POLL_PAT` + `APPLICATION_ID` + `APPLICATION_PRIVATE_KEY`                       |
+| `update-metadata.yaml`  | `APPLICATION_ID` + `APPLICATION_PRIVATE_KEY`                                            |
+
+### Gateway presence (Discord)
+
+`survey-repo.yaml` and `poll-invitations.yaml` post in-character event announcements to the Fro Bot gateway, which relays them into Fronomenal Discord as the Fro Bot user. These steps are best-effort: they never fail the workflow, and they stay silent unless the gateway is configured.
+
+| Name                        | Type     | Purpose                                                 |
+| --------------------------- | -------- | ------------------------------------------------------- |
+| `GATEWAY_WEBHOOK_SECRET`    | secret   | HMAC-SHA256 signing key for the announce payload        |
+| `GATEWAY_PRESENCE_URL`      | variable | Gateway `POST /v1/announce` endpoint URL                |
+| `GATEWAY_ANNOUNCE_DISABLED` | variable | Kill switch — any truthy value mutes all announce POSTs |
+
+The gateway endpoint is opt-in: it accepts announcements only when the gateway deployment itself has both its webhook secret and presence channel configured. Until `GATEWAY_PRESENCE_URL` and `GATEWAY_WEBHOOK_SECRET` are set here, the announce steps log a skip and exit cleanly.
 
 ## Editing metadata files
 

--- a/scripts/gateway-announce.test.ts
+++ b/scripts/gateway-announce.test.ts
@@ -3,11 +3,7 @@ import {createHmac} from 'node:crypto'
 import process from 'node:process'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-const modulePromise: Promise<{
-  announce: typeof import('./gateway-announce.js').announce
-}> = import(`./gateway-announce${'.js'}`)
-const {announce} = await modulePromise
+import {announce, isEventType} from './gateway-announce.ts'
 
 // Helpers
 const TEST_URL = 'https://gateway.example.com/v1/announce'
@@ -190,7 +186,7 @@ describe('announce', () => {
 
   // ─── Two consecutive 5xx ──────────────────────────────────────────────────
 
-  it('two consecutive 5xx: returns posted:false, no secret or sig in stderr', async () => {
+  it('two consecutive 5xx: returns posted:false with failure:http, no secret or sig in stderr', async () => {
     const fetchImpl = makeStatusFetch(503, 503)
     const sleepSpy = vi.fn(noSleep)
 
@@ -207,6 +203,8 @@ describe('announce', () => {
     )
 
     expect((result as {posted: boolean}).posted).toBe(false)
+    expect((result as {posted: boolean; failure?: string}).failure).toBe('http')
+    expect((result as {posted: boolean; status?: number}).status).toBe(503)
     expect(fetchImpl).toHaveBeenCalledTimes(2)
     expect(sleepSpy).toHaveBeenCalledOnce()
 
@@ -219,7 +217,7 @@ describe('announce', () => {
 
   // ─── Network throw twice ──────────────────────────────────────────────────
 
-  it('network throw twice: retried once, returns posted:false with error=network-error', async () => {
+  it('network throw twice: retried once, returns posted:false with failure:network', async () => {
     const netErr = new Error('ECONNREFUSED')
     const fetchImpl = vi.fn().mockRejectedValue(netErr) as unknown as typeof globalThis.fetch
     const sleepSpy = vi.fn(noSleep)
@@ -234,15 +232,15 @@ describe('announce', () => {
       sleep: sleepSpy,
     })
 
-    expect((result as {posted: boolean; error?: string}).posted).toBe(false)
-    expect((result as {posted: boolean; error?: string}).error).toBe('network-error')
+    expect((result as {posted: boolean}).posted).toBe(false)
+    expect((result as {posted: boolean; failure?: string}).failure).toBe('network')
     expect(fetchImpl).toHaveBeenCalledTimes(2)
     expect(sleepSpy).toHaveBeenCalledOnce()
   })
 
   // ─── 4xx → no retry ───────────────────────────────────────────────────────
 
-  it.each([400, 401, 429])('status %i: no retry, returns posted:false', async status => {
+  it.each([400, 401, 429])('status %i: no retry, returns posted:false with failure:http', async status => {
     const fetchImpl = makeStatusFetch(status)
 
     const result = await announce({
@@ -255,7 +253,8 @@ describe('announce', () => {
       sleep: noSleep,
     })
 
-    expect((result as {posted: boolean; status?: number}).posted).toBe(false)
+    expect((result as {posted: boolean}).posted).toBe(false)
+    expect((result as {posted: boolean; failure?: string}).failure).toBe('http')
     expect((result as {posted: boolean; status?: number}).status).toBe(status)
     expect(fetchImpl).toHaveBeenCalledOnce()
   })
@@ -299,6 +298,42 @@ describe('announce', () => {
     expect(result).toEqual({posted: false, skipped: 'kill-switch'})
     expect(fetchImpl).not.toHaveBeenCalled()
     delete process.env.GATEWAY_ANNOUNCE_DISABLED
+  })
+
+  it('kill switch whitespace: "  false  " is NOT active (whitespace-trimmed)', async () => {
+    const fetchImpl = makeOkFetch(200)
+
+    const result = await announce({
+      eventType: TEST_EVENT_TYPE,
+      context: TEST_CONTEXT,
+      now: () => TEST_TS,
+      secret: TEST_SECRET,
+      url: TEST_URL,
+      killSwitch: '  false  ',
+      fetchImpl,
+      sleep: noSleep,
+    })
+
+    expect(result).toEqual({posted: true, status: 200})
+    expect(fetchImpl).toHaveBeenCalledOnce()
+  })
+
+  it('kill switch whitespace: "  true  " IS active (whitespace-trimmed)', async () => {
+    const fetchImpl = vi.fn() as unknown as typeof globalThis.fetch
+
+    const result = await announce({
+      eventType: TEST_EVENT_TYPE,
+      context: TEST_CONTEXT,
+      now: () => TEST_TS,
+      secret: TEST_SECRET,
+      url: TEST_URL,
+      killSwitch: '  true  ',
+      fetchImpl,
+      sleep: noSleep,
+    })
+
+    expect(result).toEqual({posted: false, skipped: 'kill-switch'})
+    expect(fetchImpl).not.toHaveBeenCalled()
   })
 
   // ─── Missing config ───────────────────────────────────────────────────────
@@ -451,5 +486,80 @@ describe('announce', () => {
     expect(result).toEqual({posted: true, status: 200})
     expect(fetchImpl).toHaveBeenCalledTimes(2)
     expect(sleepSpy).toHaveBeenCalledOnce()
+  })
+
+  // ─── isEventType guard ────────────────────────────────────────────────────
+
+  it('isEventType: accepts valid event types', () => {
+    expect(isEventType('survey_completed')).toBe(true)
+    expect(isEventType('invitation_accepted')).toBe(true)
+  })
+
+  it('isEventType: rejects invalid event types', () => {
+    expect(isEventType('')).toBe(false)
+    expect(isEventType('unknown_event')).toBe(false)
+    expect(isEventType('SURVEY_COMPLETED')).toBe(false)
+  })
+
+  // ─── FIX 9: 5xx-then-throw retry test ────────────────────────────────────
+
+  it('503 then network throw: fetch called twice, sleep once, returns failure:network, no secret/sig/body/ts in stderr', async () => {
+    const netErr = new Error('ECONNRESET')
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', {status: 503}))
+      .mockRejectedValueOnce(netErr) as unknown as typeof globalThis.fetch
+    const sleepSpy = vi.fn(noSleep)
+
+    const {result, stderr} = await captureStderr(async () =>
+      announce({
+        eventType: TEST_EVENT_TYPE,
+        context: TEST_CONTEXT,
+        now: () => TEST_TS,
+        secret: TEST_SECRET,
+        url: TEST_URL,
+        fetchImpl,
+        sleep: sleepSpy,
+      }),
+    )
+
+    expect((result as {posted: boolean}).posted).toBe(false)
+    expect((result as {posted: boolean; failure?: string}).failure).toBe('network')
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(sleepSpy).toHaveBeenCalledOnce()
+
+    // Redaction: none of the sensitive material must appear in stderr.
+    const [, init] = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit]
+    const sentBody = init.body as string
+    const actualSig = createHmac('sha256', TEST_SECRET).update(TEST_TS).update('.').update(sentBody).digest('hex')
+
+    expect(stderr).not.toContain(TEST_SECRET)
+    expect(stderr).not.toContain(actualSig)
+    expect(stderr).not.toContain(sentBody)
+    expect(stderr).not.toContain(TEST_TS)
+  })
+
+  it('AbortSignal timeout on both attempts: retried once, returns failure:network, exit-0 path', async () => {
+    // Simulate AbortError (what AbortSignal.timeout fires) on every call.
+    const abortErr = new DOMException('The operation was aborted.', 'AbortError')
+    const fetchImpl = vi.fn().mockRejectedValue(abortErr) as unknown as typeof globalThis.fetch
+    const sleepSpy = vi.fn(noSleep)
+
+    const result = await announce({
+      eventType: TEST_EVENT_TYPE,
+      context: TEST_CONTEXT,
+      now: () => TEST_TS,
+      secret: TEST_SECRET,
+      url: TEST_URL,
+      fetchImpl,
+      sleep: sleepSpy,
+      timeoutMs: 1, // tiny timeout for test
+    })
+
+    expect((result as {posted: boolean}).posted).toBe(false)
+    expect((result as {posted: boolean; failure?: string}).failure).toBe('network')
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(sleepSpy).toHaveBeenCalledOnce()
+    // announce never throws — the caller (CLI) always gets a result and exits 0.
   })
 })

--- a/scripts/gateway-announce.test.ts
+++ b/scripts/gateway-announce.test.ts
@@ -3,7 +3,7 @@ import {createHmac} from 'node:crypto'
 import process from 'node:process'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {announce, isEventType} from './gateway-announce.ts'
+import {announce, isEventType, runCli, type AnnounceResult} from './gateway-announce.ts'
 
 // Helpers
 const TEST_URL = 'https://gateway.example.com/v1/announce'
@@ -561,5 +561,185 @@ describe('announce', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2)
     expect(sleepSpy).toHaveBeenCalledOnce()
     // announce never throws — the caller (CLI) always gets a result and exits 0.
+  })
+})
+
+describe('runCli', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // ─── Kill switch short-circuits everything ────────────────────────────────
+
+  it('kill switch active: returns skipped:kill-switch, announceImpl not called, short-circuits even without EVENT_TYPE/EVENT_CONTEXT_JSON', async () => {
+    const spy = vi.fn()
+    const {result, stderr} = await captureStderr(async () =>
+      runCli({GATEWAY_ANNOUNCE_DISABLED: 'true'}, {announceImpl: spy as unknown as typeof announce}),
+    )
+
+    expect(result).toEqual({posted: false, skipped: 'kill-switch'})
+    expect(spy).not.toHaveBeenCalled()
+    expect(stderr).toContain('kill switch active')
+  })
+
+  // ─── EVENT_TYPE validation ────────────────────────────────────────────────
+
+  it('missing EVENT_TYPE: returns missing-event-type, announceImpl not called', async () => {
+    const spy = vi.fn()
+
+    const result = await runCli(
+      {EVENT_CONTEXT_JSON: '{"owner":"fro-bot"}'},
+      {announceImpl: spy as unknown as typeof announce},
+    )
+
+    expect(result).toEqual({posted: false, failure: 'missing-event-type'})
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('empty EVENT_TYPE: returns missing-event-type, announceImpl not called', async () => {
+    const spy = vi.fn()
+
+    const result = await runCli(
+      {EVENT_TYPE: '', EVENT_CONTEXT_JSON: '{"owner":"fro-bot"}'},
+      {announceImpl: spy as unknown as typeof announce},
+    )
+
+    expect(result).toEqual({posted: false, failure: 'missing-event-type'})
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('invalid EVENT_TYPE ("bogus"): returns invalid-event-type, announceImpl not called', async () => {
+    const spy = vi.fn()
+
+    const result = await runCli(
+      {EVENT_TYPE: 'bogus', EVENT_CONTEXT_JSON: '{"owner":"fro-bot"}'},
+      {announceImpl: spy as unknown as typeof announce},
+    )
+
+    expect(result).toEqual({posted: false, failure: 'invalid-event-type'})
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  // ─── EVENT_CONTEXT_JSON validation ───────────────────────────────────────
+
+  it('missing EVENT_CONTEXT_JSON: returns missing-context, announceImpl not called', async () => {
+    const spy = vi.fn()
+
+    const result = await runCli({EVENT_TYPE: 'survey_completed'}, {announceImpl: spy as unknown as typeof announce})
+
+    expect(result).toEqual({posted: false, failure: 'missing-context'})
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('empty EVENT_CONTEXT_JSON: returns missing-context, announceImpl not called', async () => {
+    const spy = vi.fn()
+
+    const result = await runCli(
+      {EVENT_TYPE: 'survey_completed', EVENT_CONTEXT_JSON: ''},
+      {announceImpl: spy as unknown as typeof announce},
+    )
+
+    expect(result).toEqual({posted: false, failure: 'missing-context'})
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('malformed EVENT_CONTEXT_JSON ("{not json"): returns malformed-context', async () => {
+    const spy = vi.fn()
+
+    const result = await runCli(
+      {EVENT_TYPE: 'survey_completed', EVENT_CONTEXT_JSON: '{not json'},
+      {announceImpl: spy as unknown as typeof announce},
+    )
+
+    expect(result).toEqual({posted: false, failure: 'malformed-context'})
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('non-object EVENT_CONTEXT_JSON ("[]"): returns malformed-context', async () => {
+    const spy = vi.fn()
+
+    const result = await runCli(
+      {EVENT_TYPE: 'survey_completed', EVENT_CONTEXT_JSON: '[]'},
+      {announceImpl: spy as unknown as typeof announce},
+    )
+
+    expect(result).toEqual({posted: false, failure: 'malformed-context'})
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('non-object EVENT_CONTEXT_JSON ("null"): returns malformed-context', async () => {
+    const spy = vi.fn()
+
+    const result = await runCli(
+      {EVENT_TYPE: 'survey_completed', EVENT_CONTEXT_JSON: 'null'},
+      {announceImpl: spy as unknown as typeof announce},
+    )
+
+    expect(result).toEqual({posted: false, failure: 'malformed-context'})
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('non-object EVENT_CONTEXT_JSON ("42"): returns malformed-context', async () => {
+    const spy = vi.fn()
+
+    const result = await runCli(
+      {EVENT_TYPE: 'survey_completed', EVENT_CONTEXT_JSON: '42'},
+      {announceImpl: spy as unknown as typeof announce},
+    )
+
+    expect(result).toEqual({posted: false, failure: 'malformed-context'})
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  // ─── Happy path: delegates to announceImpl ────────────────────────────────
+
+  it('valid env: announceImpl called once with parsed eventType + context, returns its result', async () => {
+    const expectedResult: AnnounceResult = {posted: true, status: 200}
+    const spy = vi.fn().mockResolvedValue(expectedResult)
+    const ctx = {owner: 'fro-bot', repo: 'test-repo', slug: 'test-slug', wiki_pages_changed: 3}
+
+    const result = await runCli(
+      {EVENT_TYPE: 'survey_completed', EVENT_CONTEXT_JSON: JSON.stringify(ctx)},
+      {announceImpl: spy as unknown as typeof announce},
+    )
+
+    expect(result).toEqual(expectedResult)
+    expect(spy).toHaveBeenCalledOnce()
+    expect(spy).toHaveBeenCalledWith({eventType: 'survey_completed', context: ctx})
+  })
+
+  it('valid env with invitation_accepted: announceImpl called with correct eventType', async () => {
+    const expectedResult: AnnounceResult = {posted: true, status: 201}
+    const spy = vi.fn().mockResolvedValue(expectedResult)
+    const ctx = {owner: 'acme', repo: 'widget', slug: 'acme-widget', wiki_pages_changed: 1}
+
+    const result = await runCli(
+      {EVENT_TYPE: 'invitation_accepted', EVENT_CONTEXT_JSON: JSON.stringify(ctx)},
+      {announceImpl: spy as unknown as typeof announce},
+    )
+
+    expect(result).toEqual(expectedResult)
+    expect(spy).toHaveBeenCalledWith({eventType: 'invitation_accepted', context: ctx})
+  })
+
+  // ─── Redaction: secret-shaped env values never leak to stderr ────────────
+
+  it('redaction: secret-shaped env value does not appear in stderr on any failure path', async () => {
+    const secretShapedValue = 'ghp_supersecrettoken1234567890abcdef'
+    const spy = vi.fn()
+
+    const {stderr} = await captureStderr(async () =>
+      runCli(
+        {
+          GATEWAY_WEBHOOK_SECRET: secretShapedValue,
+          EVENT_TYPE: 'bogus',
+          EVENT_CONTEXT_JSON: '{"owner":"fro-bot"}',
+        },
+        {announceImpl: spy as unknown as typeof announce},
+      ),
+    )
+
+    expect(stderr).not.toContain(secretShapedValue)
+    expect(spy).not.toHaveBeenCalled()
   })
 })

--- a/scripts/gateway-announce.test.ts
+++ b/scripts/gateway-announce.test.ts
@@ -1,0 +1,455 @@
+import {Buffer} from 'node:buffer'
+import {createHmac} from 'node:crypto'
+import process from 'node:process'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const modulePromise: Promise<{
+  announce: typeof import('./gateway-announce.js').announce
+}> = import(`./gateway-announce${'.js'}`)
+const {announce} = await modulePromise
+
+// Helpers
+const TEST_URL = 'https://gateway.example.com/v1/announce'
+const TEST_SECRET = 'test-secret-value'
+const TEST_TS = '2026-06-04T12:00:00.000Z'
+const TEST_EVENT_TYPE = 'survey_completed' as const
+const TEST_CONTEXT = {owner: 'fro-bot', repo: 'test-repo', slug: 'test-slug', wiki_pages_changed: 3}
+
+async function noSleep(_ms: number): Promise<void> {
+  return Promise.resolve()
+}
+
+function makeOkFetch(status = 200): typeof globalThis.fetch {
+  return vi.fn().mockResolvedValue(new Response('ok', {status})) as unknown as typeof globalThis.fetch
+}
+
+function makeStatusFetch(...statuses: number[]): typeof globalThis.fetch {
+  const mock = vi.fn()
+  for (const s of statuses) {
+    mock.mockResolvedValueOnce(new Response('', {status: s}))
+  }
+  return mock as unknown as typeof globalThis.fetch
+}
+
+// Capture stderr output during a test
+async function captureStderr(fn: () => Promise<unknown>): Promise<{result: unknown; stderr: string}> {
+  const chunks: string[] = []
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+    chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString())
+    return true
+  })
+  return fn()
+    .then(result => {
+      stderrSpy.mockRestore()
+      return {result, stderr: chunks.join('')}
+    })
+    .catch(error => {
+      stderrSpy.mockRestore()
+      throw error
+    })
+}
+
+describe('announce', () => {
+  beforeEach(() => {
+    // Ensure env vars are not set by default
+    delete process.env.GATEWAY_WEBHOOK_SECRET
+    delete process.env.GATEWAY_PRESENCE_URL
+    delete process.env.GATEWAY_ANNOUNCE_DISABLED
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // ─── Happy path ───────────────────────────────────────────────────────────
+
+  it('happy path: POSTs to correct URL with all 3 required headers and returns posted:true', async () => {
+    const fetchImpl = makeOkFetch(200)
+
+    const result = await announce({
+      eventType: TEST_EVENT_TYPE,
+      context: TEST_CONTEXT,
+      now: () => TEST_TS,
+      secret: TEST_SECRET,
+      url: TEST_URL,
+      fetchImpl,
+      sleep: noSleep,
+    })
+
+    expect(result).toEqual({posted: true, status: 200})
+    expect(fetchImpl).toHaveBeenCalledOnce()
+
+    const [calledUrl, init] = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit]
+    expect(calledUrl).toBe(TEST_URL)
+    expect(init.method).toBe('POST')
+
+    const reqHeaders = init.headers as Record<string, string>
+    expect(reqHeaders['Content-Type']).toBe('application/json')
+    expect(reqHeaders['X-Gateway-Timestamp']).toBe(TEST_TS)
+    expect(typeof reqHeaders['X-Gateway-Signature']).toBe('string')
+    expect(reqHeaders['X-Gateway-Signature']).toHaveLength(64)
+    expect(/^[0-9a-f]{64}$/.test(reqHeaders['X-Gateway-Signature'] ?? '')).toBe(true)
+  })
+
+  // ─── HMAC vector ─────────────────────────────────────────────────────────
+
+  it('HMAC vector: signature equals createHmac(sha256,secret).update(ts).update(".").update(body).digest(hex)', async () => {
+    const fetchImpl = makeOkFetch(200)
+
+    await announce({
+      eventType: TEST_EVENT_TYPE,
+      context: TEST_CONTEXT,
+      now: () => TEST_TS,
+      secret: TEST_SECRET,
+      url: TEST_URL,
+      fetchImpl,
+      sleep: noSleep,
+    })
+
+    const [, init] = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit]
+    const sentBody = init.body as string
+    const sentSig = (init.headers as Record<string, string>)['X-Gateway-Signature']
+
+    // Compute expected signature independently — matches gateway hmac.ts formula exactly.
+    const expectedSig = createHmac('sha256', TEST_SECRET).update(TEST_TS).update('.').update(sentBody).digest('hex')
+
+    expect(sentSig).toBe(expectedSig)
+  })
+
+  // ─── fired_at ↔ header byte-equality ─────────────────────────────────────
+
+  it('fired_at in posted body byte-equals the X-Gateway-Timestamp header', async () => {
+    const fetchImpl = makeOkFetch(200)
+
+    await announce({
+      eventType: TEST_EVENT_TYPE,
+      context: TEST_CONTEXT,
+      now: () => TEST_TS,
+      secret: TEST_SECRET,
+      url: TEST_URL,
+      fetchImpl,
+      sleep: noSleep,
+    })
+
+    const [, init] = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit]
+    const sentBody = JSON.parse(init.body as string) as Record<string, unknown>
+    const tsHeader = (init.headers as Record<string, string>)['X-Gateway-Timestamp']
+
+    expect(sentBody.fired_at).toBe(tsHeader)
+    expect(sentBody.fired_at).toBe(TEST_TS)
+  })
+
+  // ─── Payload shape ────────────────────────────────────────────────────────
+
+  it('payload shape: v===1, rendered_text key present and null, context passed verbatim', async () => {
+    const fetchImpl = makeOkFetch(200)
+    const ctx = {owner: 'acme', repo: 'widget', slug: 'acme-widget', wiki_pages_changed: 7}
+
+    await announce({
+      eventType: 'invitation_accepted',
+      context: ctx,
+      now: () => TEST_TS,
+      secret: TEST_SECRET,
+      url: TEST_URL,
+      fetchImpl,
+      sleep: noSleep,
+    })
+
+    const [, init] = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string) as Record<string, unknown>
+
+    expect(body.v).toBe(1)
+    expect(body.event_type).toBe('invitation_accepted')
+    expect(Object.prototype.hasOwnProperty.call(body, 'rendered_text')).toBe(true)
+    expect(body.rendered_text).toBeNull()
+    expect(body.context).toEqual(ctx)
+  })
+
+  // ─── 503 then 200 → one retry ─────────────────────────────────────────────
+
+  it('503 then 200: retries once, sleep called exactly once, returns posted:true', async () => {
+    const fetchImpl = makeStatusFetch(503, 200)
+    const sleepSpy = vi.fn(noSleep)
+
+    const result = await announce({
+      eventType: TEST_EVENT_TYPE,
+      context: TEST_CONTEXT,
+      now: () => TEST_TS,
+      secret: TEST_SECRET,
+      url: TEST_URL,
+      fetchImpl,
+      sleep: sleepSpy,
+    })
+
+    expect(result).toEqual({posted: true, status: 200})
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(sleepSpy).toHaveBeenCalledOnce()
+    expect(sleepSpy).toHaveBeenCalledWith(5000)
+  })
+
+  // ─── Two consecutive 5xx ──────────────────────────────────────────────────
+
+  it('two consecutive 5xx: returns posted:false, no secret or sig in stderr', async () => {
+    const fetchImpl = makeStatusFetch(503, 503)
+    const sleepSpy = vi.fn(noSleep)
+
+    const {result, stderr} = await captureStderr(async () =>
+      announce({
+        eventType: TEST_EVENT_TYPE,
+        context: TEST_CONTEXT,
+        now: () => TEST_TS,
+        secret: TEST_SECRET,
+        url: TEST_URL,
+        fetchImpl,
+        sleep: sleepSpy,
+      }),
+    )
+
+    expect((result as {posted: boolean}).posted).toBe(false)
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(sleepSpy).toHaveBeenCalledOnce()
+
+    // Redaction: secret and signature must not appear in stderr.
+    expect(stderr).not.toContain(TEST_SECRET)
+    // Signature is not known here, but we can verify the secret isn't echoed.
+    expect(stderr).toContain('survey_completed')
+    expect(stderr).toContain('503')
+  })
+
+  // ─── Network throw twice ──────────────────────────────────────────────────
+
+  it('network throw twice: retried once, returns posted:false with error=network-error', async () => {
+    const netErr = new Error('ECONNREFUSED')
+    const fetchImpl = vi.fn().mockRejectedValue(netErr) as unknown as typeof globalThis.fetch
+    const sleepSpy = vi.fn(noSleep)
+
+    const result = await announce({
+      eventType: TEST_EVENT_TYPE,
+      context: TEST_CONTEXT,
+      now: () => TEST_TS,
+      secret: TEST_SECRET,
+      url: TEST_URL,
+      fetchImpl,
+      sleep: sleepSpy,
+    })
+
+    expect((result as {posted: boolean; error?: string}).posted).toBe(false)
+    expect((result as {posted: boolean; error?: string}).error).toBe('network-error')
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(sleepSpy).toHaveBeenCalledOnce()
+  })
+
+  // ─── 4xx → no retry ───────────────────────────────────────────────────────
+
+  it.each([400, 401, 429])('status %i: no retry, returns posted:false', async status => {
+    const fetchImpl = makeStatusFetch(status)
+
+    const result = await announce({
+      eventType: TEST_EVENT_TYPE,
+      context: TEST_CONTEXT,
+      now: () => TEST_TS,
+      secret: TEST_SECRET,
+      url: TEST_URL,
+      fetchImpl,
+      sleep: noSleep,
+    })
+
+    expect((result as {posted: boolean; status?: number}).posted).toBe(false)
+    expect((result as {posted: boolean; status?: number}).status).toBe(status)
+    expect(fetchImpl).toHaveBeenCalledOnce()
+  })
+
+  // ─── Kill switch ──────────────────────────────────────────────────────────
+
+  it('kill switch: no fetch, no HMAC, returns skipped:kill-switch, stderr line present', async () => {
+    const fetchImpl = vi.fn() as unknown as typeof globalThis.fetch
+
+    const {result, stderr} = await captureStderr(async () =>
+      announce({
+        eventType: TEST_EVENT_TYPE,
+        context: TEST_CONTEXT,
+        now: () => TEST_TS,
+        secret: TEST_SECRET,
+        url: TEST_URL,
+        killSwitch: 'true',
+        fetchImpl,
+        sleep: noSleep,
+      }),
+    )
+
+    expect(result).toEqual({posted: false, skipped: 'kill-switch'})
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(stderr).toContain('kill switch active')
+  })
+
+  it('kill switch via env: GATEWAY_ANNOUNCE_DISABLED=1 skips', async () => {
+    process.env.GATEWAY_ANNOUNCE_DISABLED = '1'
+    const fetchImpl = vi.fn() as unknown as typeof globalThis.fetch
+
+    const result = await announce({
+      eventType: TEST_EVENT_TYPE,
+      context: TEST_CONTEXT,
+      secret: TEST_SECRET,
+      url: TEST_URL,
+      fetchImpl,
+      sleep: noSleep,
+    })
+
+    expect(result).toEqual({posted: false, skipped: 'kill-switch'})
+    expect(fetchImpl).not.toHaveBeenCalled()
+    delete process.env.GATEWAY_ANNOUNCE_DISABLED
+  })
+
+  // ─── Missing config ───────────────────────────────────────────────────────
+
+  it('missing secret: returns skipped:missing-config, no fetch', async () => {
+    const fetchImpl = vi.fn() as unknown as typeof globalThis.fetch
+
+    const result = await announce({
+      eventType: TEST_EVENT_TYPE,
+      context: TEST_CONTEXT,
+      url: TEST_URL,
+      fetchImpl,
+      sleep: noSleep,
+    })
+
+    expect(result).toEqual({posted: false, skipped: 'missing-config'})
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('missing url: returns skipped:missing-config, no fetch', async () => {
+    const fetchImpl = vi.fn() as unknown as typeof globalThis.fetch
+
+    const result = await announce({
+      eventType: TEST_EVENT_TYPE,
+      context: TEST_CONTEXT,
+      secret: TEST_SECRET,
+      fetchImpl,
+      sleep: noSleep,
+    })
+
+    expect(result).toEqual({posted: false, skipped: 'missing-config'})
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  // ─── Redaction ────────────────────────────────────────────────────────────
+
+  it('redaction: failing POST stderr/result contains event type + status but NOT secret, sig, body, or context.repos values', async () => {
+    const sensitiveContext = {
+      repos: [{owner: 'secret-owner', name: 'secret-repo'}],
+      count: 1,
+    }
+    const fetchImpl = makeStatusFetch(503, 503)
+    const sleepSpy = vi.fn(noSleep)
+
+    const {result, stderr} = await captureStderr(async () =>
+      announce({
+        eventType: 'invitation_accepted',
+        context: sensitiveContext,
+        now: () => TEST_TS,
+        secret: TEST_SECRET,
+        url: TEST_URL,
+        fetchImpl,
+        sleep: sleepSpy,
+      }),
+    )
+
+    // Compute what the signature would have been to verify it's not in stderr.
+    const [, init] = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit]
+    const sentBody = init.body as string
+    const actualSig = createHmac('sha256', TEST_SECRET).update(TEST_TS).update('.').update(sentBody).digest('hex')
+
+    // Must contain event type and coarse status.
+    expect(stderr).toContain('invitation_accepted')
+    expect(stderr).toContain('503')
+
+    // Must NOT contain auth material or sensitive context.
+    expect(stderr).not.toContain(TEST_SECRET)
+    expect(stderr).not.toContain(actualSig)
+    expect(stderr).not.toContain(TEST_TS)
+    expect(stderr).not.toContain('secret-owner')
+    expect(stderr).not.toContain('secret-repo')
+    expect(stderr).not.toContain(sentBody)
+
+    // Result must not echo secret or signature.
+    const resultStr = JSON.stringify(result)
+    expect(resultStr).not.toContain(TEST_SECRET)
+    expect(resultStr).not.toContain(actualSig)
+    expect(resultStr).not.toContain('secret-owner')
+    expect(resultStr).not.toContain('secret-repo')
+  })
+
+  it('redaction (success path): stdout result does not echo secret or signature', async () => {
+    const fetchImpl = makeOkFetch(200)
+
+    const result = await announce({
+      eventType: TEST_EVENT_TYPE,
+      context: TEST_CONTEXT,
+      now: () => TEST_TS,
+      secret: TEST_SECRET,
+      url: TEST_URL,
+      fetchImpl,
+      sleep: noSleep,
+    })
+
+    const [, init] = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit]
+    const sentBody = init.body as string
+    const actualSig = createHmac('sha256', TEST_SECRET).update(TEST_TS).update('.').update(sentBody).digest('hex')
+
+    const resultStr = JSON.stringify(result)
+    expect(resultStr).not.toContain(TEST_SECRET)
+    expect(resultStr).not.toContain(actualSig)
+  })
+
+  // ─── Signed bytes are the exact bytes sent ────────────────────────────────
+
+  it('signed bytes are the exact bytes sent: body used for signing equals body in request', async () => {
+    const fetchImpl = makeOkFetch(200)
+
+    await announce({
+      eventType: TEST_EVENT_TYPE,
+      context: TEST_CONTEXT,
+      now: () => TEST_TS,
+      secret: TEST_SECRET,
+      url: TEST_URL,
+      fetchImpl,
+      sleep: noSleep,
+    })
+
+    const [, init] = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit]
+    const sentBody = init.body as string
+    const sentSig = (init.headers as Record<string, string>)['X-Gateway-Signature']
+    const sentTs = (init.headers as Record<string, string>)['X-Gateway-Timestamp'] ?? ''
+
+    // Verify the signature against the EXACT bytes sent.
+    const recomputedSig = createHmac('sha256', TEST_SECRET).update(sentTs).update('.').update(sentBody).digest('hex')
+
+    expect(sentSig).toBe(recomputedSig)
+  })
+
+  // ─── Network throw on first, 200 on retry ─────────────────────────────────
+
+  it('network throw on first attempt then 200 on retry: returns posted:true', async () => {
+    const netErr = new Error('ETIMEDOUT')
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValueOnce(netErr)
+      .mockResolvedValueOnce(new Response('ok', {status: 200})) as unknown as typeof globalThis.fetch
+    const sleepSpy = vi.fn(noSleep)
+
+    const result = await announce({
+      eventType: TEST_EVENT_TYPE,
+      context: TEST_CONTEXT,
+      now: () => TEST_TS,
+      secret: TEST_SECRET,
+      url: TEST_URL,
+      fetchImpl,
+      sleep: sleepSpy,
+    })
+
+    expect(result).toEqual({posted: true, status: 200})
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(sleepSpy).toHaveBeenCalledOnce()
+  })
+})

--- a/scripts/gateway-announce.ts
+++ b/scripts/gateway-announce.ts
@@ -33,6 +33,10 @@ export type AnnounceResult =
   | {posted: false; skipped: 'kill-switch' | 'missing-config'}
   | {posted: false; failure: 'http'; status: number}
   | {posted: false; failure: 'network'}
+  | {posted: false; failure: 'missing-event-type'}
+  | {posted: false; failure: 'invalid-event-type'}
+  | {posted: false; failure: 'missing-context'}
+  | {posted: false; failure: 'malformed-context'}
 
 async function defaultSleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
@@ -156,34 +160,43 @@ export async function announce(params: AnnounceParams): Promise<AnnounceResult> 
   return {posted: false, failure: 'http', status: res.status}
 }
 
-async function main(): Promise<void> {
+/**
+ * Parse-and-dispatch logic for the CLI entrypoint. Reads from the provided env
+ * map; does NOT call process.exit or read process.env directly.
+ *
+ * Kill-switch is checked first — short-circuits even when EVENT_TYPE /
+ * EVENT_CONTEXT_JSON are absent. Writes structured diagnostics to stderr
+ * (redaction unchanged: event type class + coarse status only).
+ */
+export async function runCli(
+  env: Record<string, string | undefined>,
+  deps?: {announceImpl?: typeof announce},
+): Promise<AnnounceResult> {
+  const announceImpl = deps?.announceImpl ?? announce
+
   // Kill-switch check before any parsing — mutes cleanly even if env vars are missing.
-  const killSwitchRaw = process.env.GATEWAY_ANNOUNCE_DISABLED
-  if (isKillSwitchActive(killSwitchRaw)) {
+  if (isKillSwitchActive(env.GATEWAY_ANNOUNCE_DISABLED)) {
     process.stderr.write('gateway-announce: kill switch active; skipping POST\n')
-    process.stdout.write(`${JSON.stringify({posted: false, skipped: 'kill-switch'})}\n`)
-    process.exit(0)
+    return {posted: false, skipped: 'kill-switch'}
   }
 
-  const eventType = process.env.EVENT_TYPE
-  const contextJson = process.env.EVENT_CONTEXT_JSON
+  const eventType = env.EVENT_TYPE
 
   if (eventType === undefined || eventType === '') {
     process.stderr.write('gateway-announce: EVENT_TYPE not set\n')
-    process.stdout.write(`${JSON.stringify({posted: false, failure: 'missing-event-type'})}\n`)
-    process.exit(0)
+    return {posted: false, failure: 'missing-event-type'}
   }
 
   if (!isEventType(eventType)) {
     process.stderr.write(`gateway-announce: EVENT_TYPE is not a valid event type class\n`)
-    process.stdout.write(`${JSON.stringify({posted: false, failure: 'invalid-event-type'})}\n`)
-    process.exit(0)
+    return {posted: false, failure: 'invalid-event-type'}
   }
+
+  const contextJson = env.EVENT_CONTEXT_JSON
 
   if (contextJson === undefined || contextJson === '') {
     process.stderr.write('gateway-announce: EVENT_CONTEXT_JSON not set\n')
-    process.stdout.write(`${JSON.stringify({posted: false, failure: 'missing-context'})}\n`)
-    process.exit(0)
+    return {posted: false, failure: 'missing-context'}
   }
 
   let context: Record<string, unknown>
@@ -196,15 +209,17 @@ async function main(): Promise<void> {
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error)
     process.stderr.write(`gateway-announce: malformed EVENT_CONTEXT_JSON: ${detail}\n`)
-    process.stdout.write(`${JSON.stringify({posted: false, failure: 'malformed-context'})}\n`)
-    process.exit(0)
+    return {posted: false, failure: 'malformed-context'}
   }
 
-  const result = await announce({
+  return announceImpl({
     eventType,
     context,
   })
+}
 
+async function main(): Promise<void> {
+  const result = await runCli(process.env)
   process.stdout.write(`${JSON.stringify(result)}\n`)
   process.exit(0)
 }

--- a/scripts/gateway-announce.ts
+++ b/scripts/gateway-announce.ts
@@ -1,0 +1,184 @@
+import {createHmac} from 'node:crypto'
+import process from 'node:process'
+
+export type EventType = 'survey_completed' | 'invitation_accepted'
+
+export interface AnnounceParams {
+  eventType: EventType
+  context: Record<string, unknown>
+  /** Override the current timestamp. Defaults to `() => new Date().toISOString()`. */
+  now?: () => string
+  /** Override the HMAC secret. Defaults to `process.env.GATEWAY_WEBHOOK_SECRET`. */
+  secret?: string
+  /** Override the gateway URL. Defaults to `process.env.GATEWAY_PRESENCE_URL`. */
+  url?: string
+  /** Override the kill-switch value. Defaults to `process.env.GATEWAY_ANNOUNCE_DISABLED`. */
+  killSwitch?: string
+  /** Override the fetch implementation. Defaults to `globalThis.fetch`. */
+  fetchImpl?: typeof globalThis.fetch
+  /** Override the sleep implementation. Defaults to a real 5s sleep. */
+  sleep?: (ms: number) => Promise<void>
+}
+
+export type AnnounceResult =
+  | {posted: true; status: number}
+  | {posted: false; skipped: 'kill-switch' | 'missing-config'}
+  | {posted: false; status?: number; error?: string}
+
+async function defaultSleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function hmacSha256Hex(secret: string, message: string): string {
+  return createHmac('sha256', secret).update(message).digest('hex')
+}
+
+/**
+ * POST an HMAC-signed event payload to the gateway presence endpoint.
+ *
+ * Signs the exact bytes sent (no canonicalization). The `fired_at` field in
+ * the body is byte-identical to the `X-Gateway-Timestamp` header — both are
+ * driven from a single timestamp string captured before serialization.
+ *
+ * Returns a discriminated result; never throws. The CLI maps any result to
+ * exit 0 so announce failures never fail a workflow.
+ */
+export async function announce(params: AnnounceParams): Promise<AnnounceResult> {
+  const killSwitch = params.killSwitch ?? process.env.GATEWAY_ANNOUNCE_DISABLED
+  if (killSwitch !== undefined && killSwitch !== '' && killSwitch !== 'false' && killSwitch !== '0') {
+    process.stderr.write('gateway-announce: kill switch active; skipping POST\n')
+    return {posted: false, skipped: 'kill-switch'}
+  }
+
+  const secret = params.secret ?? process.env.GATEWAY_WEBHOOK_SECRET
+  const url = params.url ?? process.env.GATEWAY_PRESENCE_URL
+
+  if (secret === undefined || secret === '' || url === undefined || url === '') {
+    process.stderr.write(
+      `gateway-announce: missing config (${secret === undefined || secret === '' ? 'GATEWAY_WEBHOOK_SECRET' : 'GATEWAY_PRESENCE_URL'} not set); skipping POST\n`,
+    )
+    return {posted: false, skipped: 'missing-config'}
+  }
+
+  const getNow = params.now ?? (() => new Date().toISOString())
+  const fetchImpl = params.fetchImpl ?? globalThis.fetch
+  const sleep = params.sleep ?? defaultSleep
+
+  // Capture timestamp ONCE — drives both fired_at and X-Gateway-Timestamp header.
+  const ts = getNow()
+
+  const payload = {
+    v: 1,
+    event_type: params.eventType,
+    fired_at: ts,
+    context: params.context,
+    rendered_text: null,
+  }
+
+  // Serialize ONCE — sign these exact bytes, send these exact bytes.
+  const body = JSON.stringify(payload)
+
+  // HMAC-SHA256(secret, "<timestamp>.<body>") — matches gateway hmac.ts formula.
+  const sig = hmacSha256Hex(secret, `${ts}.${body}`)
+
+  const headers = {
+    'Content-Type': 'application/json',
+    'X-Gateway-Signature': sig,
+    'X-Gateway-Timestamp': ts,
+  }
+
+  const doPost = async (): Promise<Response> => fetchImpl(url, {method: 'POST', headers, body})
+
+  let res: Response
+  try {
+    res = await doPost()
+  } catch {
+    // Network error on first attempt — retry once.
+    await sleep(5000)
+    try {
+      res = await doPost()
+    } catch (error) {
+      const errMsg = error instanceof Error ? error.message : String(error)
+      // Redact: log only event type + error class, never secret/sig/body/context.repos.
+      process.stderr.write(
+        `gateway-announce: event_type=${params.eventType} error=network-error detail=${errMsg.slice(0, 80)}\n`,
+      )
+      return {posted: false, error: 'network-error'}
+    }
+  }
+
+  if (res.status >= 200 && res.status < 300) {
+    return {posted: true, status: res.status}
+  }
+
+  // 5xx (including 503) — retry once.
+  if (res.status >= 500) {
+    const firstStatus = res.status
+    await sleep(5000)
+    let retryRes: Response
+    try {
+      retryRes = await doPost()
+    } catch (error) {
+      const errMsg = error instanceof Error ? error.message : String(error)
+      process.stderr.write(
+        `gateway-announce: event_type=${params.eventType} status=${firstStatus} retry=network-error detail=${errMsg.slice(0, 80)}\n`,
+      )
+      return {posted: false, status: firstStatus, error: 'network-error'}
+    }
+
+    if (retryRes.status >= 200 && retryRes.status < 300) {
+      return {posted: true, status: retryRes.status}
+    }
+
+    // Redact: log only event type + coarse status, never secret/sig/body/context.repos.
+    process.stderr.write(`gateway-announce: event_type=${params.eventType} status=${retryRes.status} posted=false\n`)
+    return {posted: false, status: retryRes.status}
+  }
+
+  // 4xx — terminal, no retry.
+  process.stderr.write(`gateway-announce: event_type=${params.eventType} status=${res.status} posted=false\n`)
+  return {posted: false, status: res.status}
+}
+
+async function main(): Promise<void> {
+  const eventType = process.env.EVENT_TYPE
+  const contextJson = process.env.EVENT_CONTEXT_JSON
+
+  if (eventType === undefined || eventType === '') {
+    process.stderr.write('gateway-announce: EVENT_TYPE not set\n')
+    process.stdout.write(`${JSON.stringify({posted: false, error: 'missing-event-type'})}\n`)
+    process.exit(0)
+  }
+
+  if (contextJson === undefined || contextJson === '') {
+    process.stderr.write('gateway-announce: EVENT_CONTEXT_JSON not set\n')
+    process.stdout.write(`${JSON.stringify({posted: false, error: 'missing-context'})}\n`)
+    process.exit(0)
+  }
+
+  let context: Record<string, unknown>
+  try {
+    const parsed: unknown = JSON.parse(contextJson)
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new TypeError('context must be a JSON object')
+    }
+    context = parsed as Record<string, unknown>
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    process.stderr.write(`gateway-announce: malformed EVENT_CONTEXT_JSON: ${detail}\n`)
+    process.stdout.write(`${JSON.stringify({posted: false, error: 'malformed-context'})}\n`)
+    process.exit(0)
+  }
+
+  const result = await announce({
+    eventType: eventType as EventType,
+    context,
+  })
+
+  process.stdout.write(`${JSON.stringify(result)}\n`)
+  process.exit(0)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}

--- a/scripts/gateway-announce.ts
+++ b/scripts/gateway-announce.ts
@@ -3,6 +3,12 @@ import process from 'node:process'
 
 export type EventType = 'survey_completed' | 'invitation_accepted'
 
+const VALID_EVENT_TYPES = new Set<string>(['survey_completed', 'invitation_accepted'])
+
+export function isEventType(value: string): value is EventType {
+  return VALID_EVENT_TYPES.has(value)
+}
+
 export interface AnnounceParams {
   eventType: EventType
   context: Record<string, unknown>
@@ -18,12 +24,15 @@ export interface AnnounceParams {
   fetchImpl?: typeof globalThis.fetch
   /** Override the sleep implementation. Defaults to a real 5s sleep. */
   sleep?: (ms: number) => Promise<void>
+  /** Per-attempt fetch timeout in ms. Defaults to 10000. */
+  timeoutMs?: number
 }
 
 export type AnnounceResult =
   | {posted: true; status: number}
   | {posted: false; skipped: 'kill-switch' | 'missing-config'}
-  | {posted: false; status?: number; error?: string}
+  | {posted: false; failure: 'http'; status: number}
+  | {posted: false; failure: 'network'}
 
 async function defaultSleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
@@ -31,6 +40,11 @@ async function defaultSleep(ms: number): Promise<void> {
 
 function hmacSha256Hex(secret: string, message: string): string {
   return createHmac('sha256', secret).update(message).digest('hex')
+}
+
+function isKillSwitchActive(raw: string | undefined): boolean {
+  const ks = (raw ?? '').trim().toLowerCase()
+  return ks !== '' && ks !== 'false' && ks !== '0'
 }
 
 /**
@@ -44,8 +58,8 @@ function hmacSha256Hex(secret: string, message: string): string {
  * exit 0 so announce failures never fail a workflow.
  */
 export async function announce(params: AnnounceParams): Promise<AnnounceResult> {
-  const killSwitch = params.killSwitch ?? process.env.GATEWAY_ANNOUNCE_DISABLED
-  if (killSwitch !== undefined && killSwitch !== '' && killSwitch !== 'false' && killSwitch !== '0') {
+  const killSwitchRaw = params.killSwitch ?? process.env.GATEWAY_ANNOUNCE_DISABLED
+  if (isKillSwitchActive(killSwitchRaw)) {
     process.stderr.write('gateway-announce: kill switch active; skipping POST\n')
     return {posted: false, skipped: 'kill-switch'}
   }
@@ -63,6 +77,7 @@ export async function announce(params: AnnounceParams): Promise<AnnounceResult> 
   const getNow = params.now ?? (() => new Date().toISOString())
   const fetchImpl = params.fetchImpl ?? globalThis.fetch
   const sleep = params.sleep ?? defaultSleep
+  const timeoutMs = params.timeoutMs ?? 10_000
 
   // Capture timestamp ONCE — drives both fired_at and X-Gateway-Timestamp header.
   const ts = getNow()
@@ -87,13 +102,14 @@ export async function announce(params: AnnounceParams): Promise<AnnounceResult> 
     'X-Gateway-Timestamp': ts,
   }
 
-  const doPost = async (): Promise<Response> => fetchImpl(url, {method: 'POST', headers, body})
+  const doPost = async (): Promise<Response> =>
+    fetchImpl(url, {method: 'POST', headers, body, signal: AbortSignal.timeout(timeoutMs)})
 
   let res: Response
   try {
     res = await doPost()
   } catch {
-    // Network error on first attempt — retry once.
+    // Network error or timeout on first attempt — retry once.
     await sleep(5000)
     try {
       res = await doPost()
@@ -103,7 +119,7 @@ export async function announce(params: AnnounceParams): Promise<AnnounceResult> 
       process.stderr.write(
         `gateway-announce: event_type=${params.eventType} error=network-error detail=${errMsg.slice(0, 80)}\n`,
       )
-      return {posted: false, error: 'network-error'}
+      return {posted: false, failure: 'network'}
     }
   }
 
@@ -123,7 +139,7 @@ export async function announce(params: AnnounceParams): Promise<AnnounceResult> 
       process.stderr.write(
         `gateway-announce: event_type=${params.eventType} status=${firstStatus} retry=network-error detail=${errMsg.slice(0, 80)}\n`,
       )
-      return {posted: false, status: firstStatus, error: 'network-error'}
+      return {posted: false, failure: 'network'}
     }
 
     if (retryRes.status >= 200 && retryRes.status < 300) {
@@ -132,27 +148,41 @@ export async function announce(params: AnnounceParams): Promise<AnnounceResult> 
 
     // Redact: log only event type + coarse status, never secret/sig/body/context.repos.
     process.stderr.write(`gateway-announce: event_type=${params.eventType} status=${retryRes.status} posted=false\n`)
-    return {posted: false, status: retryRes.status}
+    return {posted: false, failure: 'http', status: retryRes.status}
   }
 
   // 4xx — terminal, no retry.
   process.stderr.write(`gateway-announce: event_type=${params.eventType} status=${res.status} posted=false\n`)
-  return {posted: false, status: res.status}
+  return {posted: false, failure: 'http', status: res.status}
 }
 
 async function main(): Promise<void> {
+  // Kill-switch check before any parsing — mutes cleanly even if env vars are missing.
+  const killSwitchRaw = process.env.GATEWAY_ANNOUNCE_DISABLED
+  if (isKillSwitchActive(killSwitchRaw)) {
+    process.stderr.write('gateway-announce: kill switch active; skipping POST\n')
+    process.stdout.write(`${JSON.stringify({posted: false, skipped: 'kill-switch'})}\n`)
+    process.exit(0)
+  }
+
   const eventType = process.env.EVENT_TYPE
   const contextJson = process.env.EVENT_CONTEXT_JSON
 
   if (eventType === undefined || eventType === '') {
     process.stderr.write('gateway-announce: EVENT_TYPE not set\n')
-    process.stdout.write(`${JSON.stringify({posted: false, error: 'missing-event-type'})}\n`)
+    process.stdout.write(`${JSON.stringify({posted: false, failure: 'missing-event-type'})}\n`)
+    process.exit(0)
+  }
+
+  if (!isEventType(eventType)) {
+    process.stderr.write(`gateway-announce: EVENT_TYPE is not a valid event type class\n`)
+    process.stdout.write(`${JSON.stringify({posted: false, failure: 'invalid-event-type'})}\n`)
     process.exit(0)
   }
 
   if (contextJson === undefined || contextJson === '') {
     process.stderr.write('gateway-announce: EVENT_CONTEXT_JSON not set\n')
-    process.stdout.write(`${JSON.stringify({posted: false, error: 'missing-context'})}\n`)
+    process.stdout.write(`${JSON.stringify({posted: false, failure: 'missing-context'})}\n`)
     process.exit(0)
   }
 
@@ -166,12 +196,12 @@ async function main(): Promise<void> {
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error)
     process.stderr.write(`gateway-announce: malformed EVENT_CONTEXT_JSON: ${detail}\n`)
-    process.stdout.write(`${JSON.stringify({posted: false, error: 'malformed-context'})}\n`)
+    process.stdout.write(`${JSON.stringify({posted: false, failure: 'malformed-context'})}\n`)
     process.exit(0)
   }
 
   const result = await announce({
-    eventType: eventType as EventType,
+    eventType,
     context,
   })
 

--- a/scripts/handle-invitation.test.ts
+++ b/scripts/handle-invitation.test.ts
@@ -1097,6 +1097,86 @@ describe('formatInvitationGithubOutput', () => {
         {invitationId: 1, inviter: 'marcusrbrown', owner: 'fro-bot', repo: 'public-repo', status: 'accepted'},
         {invitationId: 2, inviter: 'marcusrbrown', owner: '[REDACTED]', repo: 'R_kgDOPRIVATE', status: 'accepted'},
       ]),
-    ).toBe('public_invitations_accepted=1\n')
+    ).toBe(
+      'public_invitations_accepted=1\npublic_invitations_accepted_repos=[{"owner":"fro-bot","name":"public-repo"}]\n',
+    )
+  })
+
+  it('emits both count and repos list for 2 public + 1 private accepted', () => {
+    const output = formatInvitationGithubOutput([
+      {invitationId: 1, inviter: 'marcusrbrown', owner: 'fro-bot', repo: 'alpha', status: 'accepted'},
+      {invitationId: 2, inviter: 'marcusrbrown', owner: 'fro-bot', repo: 'beta', status: 'accepted'},
+      {invitationId: 3, inviter: 'marcusrbrown', owner: '[REDACTED]', repo: 'R_kgDOPRIVATE', status: 'accepted'},
+    ])
+    const lines = output.split('\n').filter(l => l.length > 0)
+    const countLine = lines.find(l => l.startsWith('public_invitations_accepted='))
+    const reposLine = lines.find(l => l.startsWith('public_invitations_accepted_repos='))
+
+    // count line is unchanged and correct
+    expect(countLine).toBe('public_invitations_accepted=2')
+
+    // repos line contains exactly the 2 public entries
+    const reposJson = reposLine?.slice('public_invitations_accepted_repos='.length) ?? ''
+    const repos = JSON.parse(reposJson) as unknown[]
+    expect(repos).toHaveLength(2)
+    expect(repos).toContainEqual({owner: 'fro-bot', name: 'alpha'})
+    expect(repos).toContainEqual({owner: 'fro-bot', name: 'beta'})
+
+    // count and list agree
+    expect(repos).toHaveLength(2)
+  })
+
+  it('emits count=0 and repos=[] when there are no accepted invitations', () => {
+    const output = formatInvitationGithubOutput([
+      {
+        invitationId: 1,
+        inviter: 'marcusrbrown',
+        owner: 'fro-bot',
+        repo: 'skipped-repo',
+        status: 'skipped',
+        reason: 'inviter-not-allowlisted',
+      },
+    ])
+    const lines = output.split('\n').filter(l => l.length > 0)
+    const countLine = lines.find(l => l.startsWith('public_invitations_accepted='))
+    const reposLine = lines.find(l => l.startsWith('public_invitations_accepted_repos='))
+
+    expect(countLine).toBe('public_invitations_accepted=0')
+    const reposJson = reposLine?.slice('public_invitations_accepted_repos='.length) ?? ''
+    expect(JSON.parse(reposJson)).toEqual([])
+  })
+
+  it('emits count=0 and repos=[] when only private/redacted invitations were accepted', () => {
+    const output = formatInvitationGithubOutput([
+      {invitationId: 1, inviter: 'marcusrbrown', owner: '[REDACTED]', repo: 'R_kgDOPRIVATE1', status: 'accepted'},
+      {invitationId: 2, inviter: 'marcusrbrown', owner: '[REDACTED]', repo: 'R_kgDOPRIVATE2', status: 'accepted'},
+    ])
+    const lines = output.split('\n').filter(l => l.length > 0)
+    const countLine = lines.find(l => l.startsWith('public_invitations_accepted='))
+    const reposLine = lines.find(l => l.startsWith('public_invitations_accepted_repos='))
+
+    expect(countLine).toBe('public_invitations_accepted=0')
+    const reposJson = reposLine?.slice('public_invitations_accepted_repos='.length) ?? ''
+    expect(JSON.parse(reposJson)).toEqual([])
+
+    // no redacted owner or node_id leaks into the output
+    expect(output).not.toContain('[REDACTED]')
+    expect(output).not.toContain('R_kgDOPRIVATE1')
+    expect(output).not.toContain('R_kgDOPRIVATE2')
+  })
+
+  it('emits a single-line JSON value that round-trips through JSON.parse', () => {
+    const output = formatInvitationGithubOutput([
+      {invitationId: 1, inviter: 'marcusrbrown', owner: 'fro-bot', repo: 'my-repo', status: 'accepted'},
+    ])
+    const reposLine = output.split('\n').find(l => l.startsWith('public_invitations_accepted_repos=')) ?? ''
+    const reposJson = reposLine.slice('public_invitations_accepted_repos='.length)
+
+    // must be single-line (no embedded newlines)
+    expect(reposJson).not.toContain('\n')
+
+    // must round-trip
+    const parsed = JSON.parse(reposJson) as unknown[]
+    expect(parsed).toEqual([{owner: 'fro-bot', name: 'my-repo'}])
   })
 })

--- a/scripts/handle-invitation.ts
+++ b/scripts/handle-invitation.ts
@@ -404,12 +404,23 @@ function invitationCommitMessage(target: {owner: string; repo: string}): string 
   return `chore(metadata): add ${target.owner}/${target.repo} from invitation polling`
 }
 
+function filterPublicAcceptedInvitations(processed: readonly InvitationProcessResult[]): AcceptedInvitationResult[] {
+  return processed.filter(
+    (result): result is AcceptedInvitationResult => result.status === 'accepted' && result.owner !== REDACTED_OWNER,
+  )
+}
+
 export function countPublicAcceptedInvitations(processed: readonly InvitationProcessResult[]): number {
-  return processed.filter(result => result.status === 'accepted' && result.owner !== REDACTED_OWNER).length
+  return filterPublicAcceptedInvitations(processed).length
 }
 
 export function formatInvitationGithubOutput(processed: readonly InvitationProcessResult[]): string {
-  return `public_invitations_accepted=${countPublicAcceptedInvitations(processed)}\n`
+  const publicAccepted = filterPublicAcceptedInvitations(processed)
+  const repos = publicAccepted.map(result => ({owner: result.owner, name: result.repo}))
+  return (
+    `public_invitations_accepted=${publicAccepted.length}\n` +
+    `public_invitations_accepted_repos=${JSON.stringify(repos)}\n`
+  )
 }
 
 function sanitizePrivateInvitationError(message: string, nodeIdOrRedacted: string): string {

--- a/scripts/wiki-ingest.test.ts
+++ b/scripts/wiki-ingest.test.ts
@@ -7,10 +7,12 @@ import {describe, expect, it, vi} from 'vitest'
 const wikiIngestModulePromise: Promise<{
   buildWikiIngestChanges: typeof import('./wiki-ingest.js').buildWikiIngestChanges
   commitWikiChanges: typeof import('./wiki-ingest.js').commitWikiChanges
+  countWikiPages: typeof import('./wiki-ingest.js').countWikiPages
   parsePorcelainPaths: typeof import('./wiki-ingest.js').parsePorcelainPaths
   WikiIngestError: typeof import('./wiki-ingest.js').WikiIngestError
 }> = import(`./wiki-ingest${'.js'}`)
-const {buildWikiIngestChanges, commitWikiChanges, parsePorcelainPaths, WikiIngestError} = await wikiIngestModulePromise
+const {buildWikiIngestChanges, commitWikiChanges, countWikiPages, parsePorcelainPaths, WikiIngestError} =
+  await wikiIngestModulePromise
 
 interface MockOverrides {
   getBranch?: (params: {owner: string; repo: string; branch: string}) => Promise<unknown>
@@ -899,5 +901,55 @@ describe('commitWikiChanges (422 surfacing)', () => {
     // #then the original error bubbles without retries
     await expect(action).rejects.toMatchObject({status: 422})
     expect(updateRef).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('countWikiPages', () => {
+  it('counts pages in all four category directories', () => {
+    // #given paths covering all four wiki entry categories
+    const paths = [
+      'knowledge/wiki/repos/fro-bot--agent.md',
+      'knowledge/wiki/topics/vitest.md',
+      'knowledge/wiki/entities/mise.md',
+      'knowledge/wiki/comparisons/vitest-vs-jest.md',
+    ]
+
+    // #when the paths are counted
+    // #then all four are included
+    expect(countWikiPages(paths)).toBe(4)
+  })
+
+  it('excludes knowledge/index.md and knowledge/log.md', () => {
+    // #given the catalog/log machinery files alongside a real entry
+    const paths = ['knowledge/index.md', 'knowledge/log.md', 'knowledge/wiki/repos/fro-bot--agent.md']
+
+    // #when the paths are counted
+    // #then only the entry page is counted
+    expect(countWikiPages(paths)).toBe(1)
+  })
+
+  it('excludes paths outside the four category directories', () => {
+    // #given paths that live outside the four canonical category dirs
+    const paths = ['knowledge/wiki/README.md', 'knowledge/schema.md', 'knowledge/wiki/repos/fro-bot--agent.md']
+
+    // #when the paths are counted
+    // #then only the entry under repos/ is counted
+    expect(countWikiPages(paths)).toBe(1)
+  })
+
+  it('excludes nested paths and non-.md files', () => {
+    // #given a nested path and a non-markdown file that should not count
+    const paths = ['knowledge/wiki/repos/sub/x.md', 'knowledge/wiki/repos/x.txt', 'knowledge/wiki/topics/vitest.md']
+
+    // #when the paths are counted
+    // #then only the flat .md entry is counted
+    expect(countWikiPages(paths)).toBe(1)
+  })
+
+  it('returns 0 for an empty input', () => {
+    // #given no paths at all
+    // #when the paths are counted
+    // #then the result is zero
+    expect(countWikiPages([])).toBe(0)
   })
 })

--- a/scripts/wiki-ingest.ts
+++ b/scripts/wiki-ingest.ts
@@ -1,7 +1,7 @@
 import type {Dirent} from 'node:fs'
 import type {Octokit} from '@octokit/rest'
 import {execFile} from 'node:child_process'
-import {readdir, readFile} from 'node:fs/promises'
+import {appendFile, readdir, readFile} from 'node:fs/promises'
 import {basename} from 'node:path'
 import process from 'node:process'
 import {promisify} from 'node:util'
@@ -862,6 +862,25 @@ function defaultCommitMessage(payload: WikiIngestPayload): string {
   return `feat(knowledge): ${payload.operation} ${payload.target}`
 }
 
+const WIKI_PAGE_PATTERN = /^knowledge\/wiki\/(?:repos|topics|entities|comparisons)\/[^/]+\.md$/
+
+/**
+ * Count the number of wiki entry pages in a list of paths.
+ * Only paths matching `knowledge/wiki/(repos|topics|entities|comparisons)/<filename>.md`
+ * are counted. Excludes knowledge/index.md, knowledge/log.md, and any paths outside
+ * the four category directories.
+ */
+export function countWikiPages(paths: string[]): number {
+  return paths.filter(p => WIKI_PAGE_PATTERN.test(p)).length
+}
+
+async function emitPagesChanged(n: number): Promise<void> {
+  const outputPath = process.env.GITHUB_OUTPUT
+  if (outputPath !== undefined && outputPath !== '') {
+    await appendFile(outputPath, `pages_changed=${n}\n`)
+  }
+}
+
 async function main(): Promise<void> {
   const payloadPath = process.argv[2] ?? process.env.WIKI_INGEST_INPUT
   const existingFiles = await loadExistingWikiFiles()
@@ -871,6 +890,8 @@ async function main(): Promise<void> {
   let repo: string | undefined
   let branch: string | undefined
   let message: string
+
+  let committedPagePaths: string[]
 
   if (payloadPath !== undefined && payloadPath !== '') {
     const payload = parsePayload(await readFile(payloadPath, 'utf8'))
@@ -887,10 +908,12 @@ async function main(): Promise<void> {
     repo = payload.repo
     branch = payload.branch
     message = payload.message ?? defaultCommitMessage(payload)
+    committedPagePaths = payload.pages.map(p => p.path)
   } else {
     const changedPaths = await getChangedWikiPaths()
     if (changedPaths.length === 0) {
-      process.stdout.write(`${JSON.stringify({committed: false, attempts: 1})}\n`)
+      await emitPagesChanged(0)
+      process.stdout.write(`${JSON.stringify({committed: false, attempts: 1, pagesChanged: 0})}\n`)
       return
     }
 
@@ -910,6 +933,7 @@ async function main(): Promise<void> {
     message =
       process.env.WIKI_COMMIT_MESSAGE ??
       `feat(knowledge): ${process.env.WIKI_OPERATION ?? 'event'} ${process.env.WIKI_TARGET ?? 'wiki update'}`
+    committedPagePaths = changedPaths
   }
 
   const result = await commitWikiChanges({
@@ -920,7 +944,9 @@ async function main(): Promise<void> {
     files: built.files,
   })
 
-  process.stdout.write(`${JSON.stringify(result)}\n`)
+  const pagesChanged = countWikiPages(committedPagePaths)
+  await emitPagesChanged(pagesChanged)
+  process.stdout.write(`${JSON.stringify({...result, pagesChanged})}\n`)
 }
 
 function parseSources(raw: string | undefined): WikiSource[] {


### PR DESCRIPTION
Fro Bot now speaks up in Fronomenal when something worth sharing happens. The control plane detects events and sends a signed payload to the gateway, which renders and posts as the Fro Bot user.

## What this adds

- A signer (`scripts/gateway-announce.ts`) that builds an event payload, signs it with HMAC-SHA256 over `timestamp + "." + body`, and POSTs it to the gateway's announce endpoint. The signature covers the exact bytes sent — no canonicalization — so it matches the gateway's verification byte-for-byte.
- Two wired events: `survey_completed` (after a survey lands, behind the existing public-visibility recheck) and `invitation_accepted` (when public invitations are accepted).
- An accepted-public-repos list output on the invitation handler, so the invitation event can name what was joined — public entries only.

## Safety and privacy

- Best-effort by design: every failure path exits cleanly and is excluded from survey/poll status. A quiet or unreachable gateway never breaks a survey or an invitation run.
- The survey announce only fires after the visibility recheck confirms the repo is public; the invitation list excludes anything redacted or private.
- The webhook secret is scoped to the announce step alone and never appears in logs, output, or errors — only the event type and a coarse status are logged.
- A per-request timeout keeps a hung gateway from stalling the workflow; a repository variable (`GATEWAY_ANNOUNCE_DISABLED`) mutes announcements without a code change.

## Rollout

The steps stay dormant until `GATEWAY_WEBHOOK_SECRET` and `GATEWAY_PRESENCE_URL` are set here and the gateway has a channel configured. Until then they log a skip and exit. Secrets and variables are documented in `metadata/README.md`.