### PR TITLE
fix: stop manual surveys from blocking promotion with orphan wiki pages

### DIFF
--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -132,7 +132,18 @@ jobs:
       # Gate: only repos already tracked in metadata/repos.yaml may have a wiki page
       # written to the data branch. A page for an un-onboarded repo would be
       # unattributable to the promotion privacy gate and would block data -> main.
-      # Overlay metadata from data (authoritative state) before checking.
+      #
+      # Metadata overlay: when the data branch exists, fetch its metadata/repos.yaml
+      # (authoritative runtime state) before running the check. If the fetch or restore
+      # fails (e.g. data branch absent, network blip), the script runs against the
+      # checked-out (main) metadata instead. The private===false predicate in
+      # publicRepoEntryExists keeps this fallback fail-safe: only entries with explicit
+      # private===false in main's promoted metadata can yield onboarded=true, so a
+      # missing data branch cannot silently admit an un-promotable repo.
+      #
+      # The node script always runs and always emits onboarded=true/false — it never
+      # hard-fails — so a git error here produces a clean onboarded=false skip rather
+      # than a red job for a legitimately un-onboarded manual dispatch.
       - name: Check repo onboarded
         id: onboarded
         env:
@@ -140,8 +151,8 @@ jobs:
           REPO_NAME: ${{ steps.resolve.outputs.repo }}
         run: |
           if git ls-remote --exit-code origin data >/dev/null 2>&1; then
-            git fetch origin data
-            git restore --source FETCH_HEAD --worktree -- metadata
+            git fetch origin data || true
+            git restore --source FETCH_HEAD --worktree -- metadata || true
           fi
           node scripts/check-repo-onboarded.ts
 

--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -129,6 +129,22 @@ jobs:
             git restore --source FETCH_HEAD --worktree -- knowledge
           fi
 
+      # Gate: only repos already tracked in metadata/repos.yaml may have a wiki page
+      # written to the data branch. A page for an un-onboarded repo would be
+      # unattributable to the promotion privacy gate and would block data -> main.
+      # Overlay metadata from data (authoritative state) before checking.
+      - name: Check repo onboarded
+        id: onboarded
+        env:
+          REPO_OWNER: ${{ steps.resolve.outputs.owner }}
+          REPO_NAME: ${{ steps.resolve.outputs.repo }}
+        run: |
+          if git ls-remote --exit-code origin data >/dev/null 2>&1; then
+            git fetch origin data
+            git restore --source FETCH_HEAD --worktree -- metadata
+          fi
+          node scripts/check-repo-onboarded.ts
+
       - name: Capture wiki baseline
         id: wiki-baseline
         run: |
@@ -240,7 +256,8 @@ jobs:
 
       - name: Commit wiki ingest to data branch
         id: wiki-commit
-        if: steps.wiki-changes.outputs.changed == 'true' && steps.recheck.conclusion == 'success'
+        if: steps.wiki-changes.outputs.changed == 'true' && steps.recheck.conclusion == 'success' &&
+          steps.onboarded.outputs.onboarded == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.FRO_BOT_PAT }}
           WIKI_OPERATION: survey
@@ -290,6 +307,7 @@ jobs:
         if: >-
           ${{ !cancelled() && steps.recheck.conclusion == 'success' &&
           steps.survey-agent.conclusion == 'success' &&
+          steps.onboarded.outputs.onboarded == 'true' &&
           (steps.wiki-commit.conclusion == 'success' || steps.wiki-commit.conclusion == 'skipped') }}
         env:
           EVENT_TYPE: survey_completed

--- a/scripts/check-repo-onboarded.test.ts
+++ b/scripts/check-repo-onboarded.test.ts
@@ -1,0 +1,237 @@
+import {describe, expect, it} from 'vitest'
+import YAML from 'yaml'
+
+import {runCheck} from './check-repo-onboarded.ts'
+
+// Minimal valid repos.yaml with a single public entry
+function makeReposYaml(repos: unknown[]): string {
+  return YAML.stringify({version: 1, repos})
+}
+
+function makePublicEntry(owner: string, name: string) {
+  return {
+    owner,
+    name,
+    added: '2026-01-01',
+    onboarding_status: 'onboarded',
+    last_survey_at: null,
+    last_survey_status: null,
+    has_fro_bot_workflow: false,
+    has_renovate: false,
+    discovery_channel: 'collab',
+    next_survey_eligible_at: null,
+    private: false,
+  }
+}
+
+function makePrivateEntry(nodeId: string) {
+  return {
+    owner: '[REDACTED]',
+    name: nodeId,
+    added: '2026-01-01',
+    onboarding_status: 'onboarded',
+    last_survey_at: null,
+    last_survey_status: null,
+    has_fro_bot_workflow: false,
+    has_renovate: false,
+    discovery_channel: 'collab',
+    next_survey_eligible_at: null,
+    private: true,
+    node_id: nodeId,
+  }
+}
+
+function makeEntryNoPrivate(owner: string, name: string) {
+  return {
+    owner,
+    name,
+    added: '2026-01-01',
+    onboarding_status: 'onboarded',
+    last_survey_at: null,
+    last_survey_status: null,
+    has_fro_bot_workflow: false,
+    has_renovate: false,
+    discovery_channel: 'collab',
+    next_survey_eligible_at: null,
+    // private intentionally absent — simulates a legacy entry
+  }
+}
+
+type ReadFileImpl = typeof import('node:fs/promises').readFile
+
+function stubReadFile(content: string): ReadFileImpl {
+  return (async () => content) as unknown as ReadFileImpl
+}
+
+function stubReadFileThrow(code: string): ReadFileImpl {
+  return (async () => {
+    const err = Object.assign(new Error(`stub error: ${code}`), {code})
+    throw err
+  }) as unknown as ReadFileImpl
+}
+
+describe('runCheck', () => {
+  // Fail-closed: missing REPO_OWNER → false
+  it('returns onboarded:false when REPO_OWNER is missing', async () => {
+    const result = await runCheck({REPO_NAME: 'myrepo'})
+    expect(result.onboarded).toBe(false)
+    expect(result.reason).toBeDefined()
+  })
+
+  // Fail-closed: missing REPO_NAME → false
+  it('returns onboarded:false when REPO_NAME is missing', async () => {
+    const result = await runCheck({REPO_OWNER: 'alice'})
+    expect(result.onboarded).toBe(false)
+    expect(result.reason).toBeDefined()
+  })
+
+  // Fail-closed: empty REPO_OWNER → false
+  it('returns onboarded:false when REPO_OWNER is empty string', async () => {
+    const result = await runCheck({REPO_OWNER: '', REPO_NAME: 'myrepo'})
+    expect(result.onboarded).toBe(false)
+    expect(result.reason).toBeDefined()
+  })
+
+  // Fail-closed: empty REPO_NAME → false
+  it('returns onboarded:false when REPO_NAME is empty string', async () => {
+    const result = await runCheck({REPO_OWNER: 'alice', REPO_NAME: ''})
+    expect(result.onboarded).toBe(false)
+    expect(result.reason).toBeDefined()
+  })
+
+  // Fail-closed: ENOENT → false
+  it('returns onboarded:false when readFileImpl throws ENOENT', async () => {
+    const result = await runCheck(
+      {REPO_OWNER: 'alice', REPO_NAME: 'project'},
+      {readFileImpl: stubReadFileThrow('ENOENT')},
+    )
+    expect(result.onboarded).toBe(false)
+    expect(result.reason).toMatch(/not found/)
+  })
+
+  // Fail-closed: other read error → false
+  it('returns onboarded:false when readFileImpl throws a non-ENOENT error', async () => {
+    const result = await runCheck(
+      {REPO_OWNER: 'alice', REPO_NAME: 'project'},
+      {readFileImpl: stubReadFileThrow('EACCES')},
+    )
+    expect(result.onboarded).toBe(false)
+    expect(result.reason).toMatch(/failed to read/)
+  })
+
+  // Fail-closed: malformed YAML → false
+  it('returns onboarded:false when repos.yaml is malformed YAML', async () => {
+    const result = await runCheck(
+      {REPO_OWNER: 'alice', REPO_NAME: 'project'},
+      {readFileImpl: stubReadFile(': : invalid: yaml: [[[')},
+    )
+    expect(result.onboarded).toBe(false)
+    expect(result.reason).toMatch(/malformed YAML/)
+  })
+
+  // Fail-closed: schema-invalid repos file → false
+  it('returns onboarded:false when repos.yaml fails schema validation', async () => {
+    // version:2 is invalid per assertReposFile
+    const result = await runCheck(
+      {REPO_OWNER: 'alice', REPO_NAME: 'project'},
+      {readFileImpl: stubReadFile(YAML.stringify({version: 2, repos: []}))},
+    )
+    expect(result.onboarded).toBe(false)
+    expect(result.reason).toMatch(/schema validation/)
+  })
+
+  // Fail-closed: empty-string repos.yaml → false (YAML.parse('') is undefined → schema rejects)
+  it('returns onboarded:false when repos.yaml is an empty string', async () => {
+    const result = await runCheck({REPO_OWNER: 'alice', REPO_NAME: 'project'}, {readFileImpl: stubReadFile('')})
+    expect(result.onboarded).toBe(false)
+    expect(result.reason).toMatch(/schema validation/)
+  })
+
+  // Privacy gate: entry present with private:false → true (the ONLY path to true)
+  it('returns onboarded:true when entry exists with private:false', async () => {
+    const yaml = makeReposYaml([makePublicEntry('alice', 'project')])
+    const result = await runCheck({REPO_OWNER: 'alice', REPO_NAME: 'project'}, {readFileImpl: stubReadFile(yaml)})
+    expect(result.onboarded).toBe(true)
+    expect(result.target).toBe('alice/project')
+    expect(result.reason).toBeUndefined()
+  })
+
+  // Privacy gate: entry present but private absent → false (fail-safe default)
+  it('returns onboarded:false when entry exists but private is absent', async () => {
+    const yaml = makeReposYaml([makeEntryNoPrivate('alice', 'project')])
+    const result = await runCheck({REPO_OWNER: 'alice', REPO_NAME: 'project'}, {readFileImpl: stubReadFile(yaml)})
+    expect(result.onboarded).toBe(false)
+    expect(result.reason).toBeDefined()
+  })
+
+  // Privacy gate: entry present with private:true → false
+  it('returns onboarded:false when entry exists with private:true', async () => {
+    const yaml = makeReposYaml([makePrivateEntry('R_kgDOPRIVATE')])
+    const result = await runCheck(
+      {REPO_OWNER: '[REDACTED]', REPO_NAME: 'R_kgDOPRIVATE'},
+      {readFileImpl: stubReadFile(yaml)},
+    )
+    expect(result.onboarded).toBe(false)
+    expect(result.reason).toBeDefined()
+  })
+
+  // Fail-closed: absent entry → false
+  it('returns onboarded:false when no entry exists for the given owner/repo', async () => {
+    const yaml = makeReposYaml([makePublicEntry('alice', 'other-project')])
+    const result = await runCheck({REPO_OWNER: 'alice', REPO_NAME: 'project'}, {readFileImpl: stubReadFile(yaml)})
+    expect(result.onboarded).toBe(false)
+    expect(result.reason).toBeDefined()
+  })
+
+  // Target field: always present in result for self-debuggable logs
+  it('includes target in the result for all paths', async () => {
+    // Missing env
+    const r1 = await runCheck({})
+    expect(r1.target).toBeDefined()
+
+    // ENOENT
+    const r2 = await runCheck({REPO_OWNER: 'alice', REPO_NAME: 'project'}, {readFileImpl: stubReadFileThrow('ENOENT')})
+    expect(r2.target).toBe('alice/project')
+
+    // Success
+    const yaml = makeReposYaml([makePublicEntry('alice', 'project')])
+    const r3 = await runCheck({REPO_OWNER: 'alice', REPO_NAME: 'project'}, {readFileImpl: stubReadFile(yaml)})
+    expect(r3.target).toBe('alice/project')
+  })
+
+  // Invariant: no path other than genuine private===false match returns true
+  it('never returns onboarded:true except for a genuine private===false match', async () => {
+    const errorPaths: [string, Record<string, string | undefined>, {readFileImpl?: ReadFileImpl}?][] = [
+      ['missing env', {}],
+      ['empty owner', {REPO_OWNER: '', REPO_NAME: 'project'}],
+      ['empty repo', {REPO_OWNER: 'alice', REPO_NAME: ''}],
+      ['ENOENT', {REPO_OWNER: 'alice', REPO_NAME: 'project'}, {readFileImpl: stubReadFileThrow('ENOENT')}],
+      ['malformed yaml', {REPO_OWNER: 'alice', REPO_NAME: 'project'}, {readFileImpl: stubReadFile('!!invalid')}],
+      [
+        'schema invalid',
+        {REPO_OWNER: 'alice', REPO_NAME: 'project'},
+        {readFileImpl: stubReadFile(YAML.stringify({version: 2, repos: []}))},
+      ],
+      [
+        'private absent',
+        {REPO_OWNER: 'alice', REPO_NAME: 'project'},
+        {readFileImpl: stubReadFile(makeReposYaml([makeEntryNoPrivate('alice', 'project')]))},
+      ],
+      [
+        'private true',
+        {REPO_OWNER: '[REDACTED]', REPO_NAME: 'R_kgDOPRIVATE'},
+        {readFileImpl: stubReadFile(makeReposYaml([makePrivateEntry('R_kgDOPRIVATE')]))},
+      ],
+      [
+        'absent entry',
+        {REPO_OWNER: 'alice', REPO_NAME: 'project'},
+        {readFileImpl: stubReadFile(makeReposYaml([makePublicEntry('bob', 'other')]))},
+      ],
+    ]
+
+    for (const [label, env, deps] of errorPaths) {
+      const result = await runCheck(env, deps)
+      expect(result.onboarded, `expected onboarded:false for path: ${label}`).toBe(false)
+    }
+  })
+})

--- a/scripts/check-repo-onboarded.ts
+++ b/scripts/check-repo-onboarded.ts
@@ -3,11 +3,14 @@ import process from 'node:process'
 
 import YAML from 'yaml'
 
-import {repoEntryExists} from './repos-metadata.ts'
+import {publicRepoEntryExists} from './repos-metadata.ts'
 
 /**
  * Gate script: reads `metadata/repos.yaml` from the current working directory and checks
- * whether the repo identified by `REPO_OWNER`/`REPO_NAME` has an entry.
+ * whether the repo identified by `REPO_OWNER`/`REPO_NAME` has an entry with
+ * `private === false` (explicit public). Aligns with the promotion privacy gate in
+ * `buildPublicSlugMap` (check-wiki-private-presence.ts), which only admits wiki pages
+ * for repos with explicit `private === false`.
  *
  * Writes `onboarded=true` or `onboarded=false` to `GITHUB_OUTPUT` (append) and to stdout
  * as a JSON line for observability. Always exits 0 — fail-closed means writing
@@ -23,63 +26,95 @@ import {repoEntryExists} from './repos-metadata.ts'
  *   - metadata/repos.yaml missing (ENOENT)
  *   - metadata/repos.yaml contains malformed YAML
  *   - parsed YAML is not a valid ReposFile (assertReposFile throws)
+ *   - entry present but private is absent or true (not explicitly public)
  */
-async function main(): Promise<void> {
-  const owner = process.env.REPO_OWNER
-  const repo = process.env.REPO_NAME
+
+export interface RunCheckResult {
+  onboarded: boolean
+  target: string
+  reason?: string
+}
+
+/**
+ * Parse-and-decide logic for the onboarded gate. Testable seam: does NOT call
+ * process.exit and does NOT read process.env directly.
+ *
+ * Returns fail-closed (onboarded:false) on missing env, ENOENT, malformed YAML,
+ * schema failure, or absent/non-public entry. Returns onboarded:true ONLY for a
+ * genuine private===false match.
+ */
+export async function runCheck(
+  env: Record<string, string | undefined>,
+  deps?: {readFileImpl?: typeof readFile},
+): Promise<RunCheckResult> {
+  const readFileImpl = deps?.readFileImpl ?? readFile
+  const owner = env.REPO_OWNER
+  const repo = env.REPO_NAME
 
   if (owner === undefined || owner === '' || repo === undefined || repo === '') {
-    await emitResult(false, 'REPO_OWNER and REPO_NAME must be set')
-    return
+    return {
+      onboarded: false,
+      target: `${owner ?? ''}/${repo ?? ''}`,
+      reason: 'REPO_OWNER and REPO_NAME must be set',
+    }
   }
+
+  const target = `${owner}/${repo}`
 
   let raw: string
   try {
-    raw = await readFile('metadata/repos.yaml', 'utf8')
+    raw = await readFileImpl('metadata/repos.yaml', 'utf8')
   } catch (error: unknown) {
-    const isEnoent = error instanceof Error && 'code' in error && error.code === 'ENOENT'
+    const isEnoent = error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT'
     const reason = isEnoent
       ? 'metadata/repos.yaml not found; repo is not onboarded'
       : `failed to read metadata/repos.yaml: ${error instanceof Error ? error.message : String(error)}`
-    await emitResult(false, reason)
-    return
+    return {onboarded: false, target, reason}
   }
 
   let parsed: unknown
   try {
     parsed = YAML.parse(raw)
   } catch (error: unknown) {
-    await emitResult(
-      false,
-      `metadata/repos.yaml is malformed YAML: ${error instanceof Error ? error.message : String(error)}`,
-    )
-    return
+    return {
+      onboarded: false,
+      target,
+      reason: `metadata/repos.yaml is malformed YAML: ${error instanceof Error ? error.message : String(error)}`,
+    }
   }
 
   let onboarded: boolean
   try {
-    onboarded = repoEntryExists(parsed, owner, repo)
+    onboarded = publicRepoEntryExists(parsed, owner, repo)
   } catch (error: unknown) {
-    await emitResult(
-      false,
-      `metadata/repos.yaml failed schema validation: ${error instanceof Error ? error.message : String(error)}`,
-    )
-    return
+    return {
+      onboarded: false,
+      target,
+      reason: `metadata/repos.yaml failed schema validation: ${error instanceof Error ? error.message : String(error)}`,
+    }
   }
 
-  await emitResult(onboarded, onboarded ? undefined : `${owner}/${repo} has no entry in metadata/repos.yaml`)
+  return {
+    onboarded,
+    target,
+    ...(onboarded ? {} : {reason: `${target} has no public entry in metadata/repos.yaml`}),
+  }
 }
 
-async function emitResult(onboarded: boolean, reason?: string): Promise<void> {
-  if (!onboarded && reason !== undefined) {
-    process.stderr.write(`check-repo-onboarded: ${reason}\n`)
+async function main(): Promise<void> {
+  const result = await runCheck(process.env as Record<string, string | undefined>)
+
+  if (!result.onboarded && result.reason !== undefined) {
+    process.stderr.write(`check-repo-onboarded: ${result.reason}\n`)
   }
 
-  process.stdout.write(`${JSON.stringify({onboarded, ...(reason === undefined ? {} : {reason})})}\n`)
+  process.stdout.write(
+    `${JSON.stringify({onboarded: result.onboarded, target: result.target, ...(result.reason === undefined ? {} : {reason: result.reason})})}\n`,
+  )
 
   const outputPath = process.env.GITHUB_OUTPUT
   if (outputPath !== undefined && outputPath !== '') {
-    await appendFile(outputPath, `onboarded=${String(onboarded)}\n`)
+    await appendFile(outputPath, `onboarded=${String(result.onboarded)}\n`)
   }
 }
 

--- a/scripts/check-repo-onboarded.ts
+++ b/scripts/check-repo-onboarded.ts
@@ -1,0 +1,88 @@
+import {appendFile, readFile} from 'node:fs/promises'
+import process from 'node:process'
+
+import YAML from 'yaml'
+
+import {repoEntryExists} from './repos-metadata.ts'
+
+/**
+ * Gate script: reads `metadata/repos.yaml` from the current working directory and checks
+ * whether the repo identified by `REPO_OWNER`/`REPO_NAME` has an entry.
+ *
+ * Writes `onboarded=true` or `onboarded=false` to `GITHUB_OUTPUT` (append) and to stdout
+ * as a JSON line for observability. Always exits 0 — fail-closed means writing
+ * `onboarded=false` on any error path, never `onboarded=true`.
+ *
+ * Inputs (env vars):
+ *   REPO_OWNER     — target repository owner (e.g. "fro-bot")
+ *   REPO_NAME      — target repository name (e.g. "tokentoilet")
+ *   GITHUB_OUTPUT  — path to the GitHub Actions output file (set automatically by Actions)
+ *
+ * Fail-closed paths (write onboarded=false + structured stderr, exit 0):
+ *   - REPO_OWNER or REPO_NAME unset or empty
+ *   - metadata/repos.yaml missing (ENOENT)
+ *   - metadata/repos.yaml contains malformed YAML
+ *   - parsed YAML is not a valid ReposFile (assertReposFile throws)
+ */
+async function main(): Promise<void> {
+  const owner = process.env.REPO_OWNER
+  const repo = process.env.REPO_NAME
+
+  if (owner === undefined || owner === '' || repo === undefined || repo === '') {
+    await emitResult(false, 'REPO_OWNER and REPO_NAME must be set')
+    return
+  }
+
+  let raw: string
+  try {
+    raw = await readFile('metadata/repos.yaml', 'utf8')
+  } catch (error: unknown) {
+    const isEnoent = error instanceof Error && 'code' in error && error.code === 'ENOENT'
+    const reason = isEnoent
+      ? 'metadata/repos.yaml not found; repo is not onboarded'
+      : `failed to read metadata/repos.yaml: ${error instanceof Error ? error.message : String(error)}`
+    await emitResult(false, reason)
+    return
+  }
+
+  let parsed: unknown
+  try {
+    parsed = YAML.parse(raw)
+  } catch (error: unknown) {
+    await emitResult(
+      false,
+      `metadata/repos.yaml is malformed YAML: ${error instanceof Error ? error.message : String(error)}`,
+    )
+    return
+  }
+
+  let onboarded: boolean
+  try {
+    onboarded = repoEntryExists(parsed, owner, repo)
+  } catch (error: unknown) {
+    await emitResult(
+      false,
+      `metadata/repos.yaml failed schema validation: ${error instanceof Error ? error.message : String(error)}`,
+    )
+    return
+  }
+
+  await emitResult(onboarded, onboarded ? undefined : `${owner}/${repo} has no entry in metadata/repos.yaml`)
+}
+
+async function emitResult(onboarded: boolean, reason?: string): Promise<void> {
+  if (!onboarded && reason !== undefined) {
+    process.stderr.write(`check-repo-onboarded: ${reason}\n`)
+  }
+
+  process.stdout.write(`${JSON.stringify({onboarded, ...(reason === undefined ? {} : {reason})})}\n`)
+
+  const outputPath = process.env.GITHUB_OUTPUT
+  if (outputPath !== undefined && outputPath !== '') {
+    await appendFile(outputPath, `onboarded=${String(onboarded)}\n`)
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}

--- a/scripts/repos-metadata.test.ts
+++ b/scripts/repos-metadata.test.ts
@@ -5,6 +5,7 @@ import {
   addRepoEntry,
   computeNextEligibleAt,
   recordSurveyResult,
+  repoEntryExists,
   RepoEntryNotFoundError,
   resetSurveyResult,
 } from './repos-metadata.ts'
@@ -1206,5 +1207,90 @@ describe('recordSurveyResult — next_survey_eligible_at', () => {
 
     expect(result.repos[0]?.onboarding_status).toBe('onboarded')
     expect(result.repos[0]?.next_survey_eligible_at).not.toBeNull()
+  })
+})
+
+describe('repoEntryExists', () => {
+  // Happy path: entry present for owner/repo → true
+  it('returns true when an entry exists for the given owner and repo', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [repoEntry({owner: 'alice', name: 'project'})],
+    }
+    expect(repoEntryExists(current, 'alice', 'project')).toBe(true)
+  })
+
+  // Edge: entry absent → false
+  it('returns false when no entry exists for the given owner and repo', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [repoEntry({owner: 'alice', name: 'project'})],
+    }
+    expect(repoEntryExists(current, 'bob', 'other')).toBe(false)
+  })
+
+  // Edge: empty repos list → false (no crash)
+  it('returns false without throwing when the repos list is empty', () => {
+    expect(repoEntryExists(EMPTY_REPOS, 'alice', 'project')).toBe(false)
+  })
+
+  // Edge: owner matches but name differs → false
+  it('returns false when owner matches but repo name differs', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [repoEntry({owner: 'alice', name: 'project'})],
+    }
+    expect(repoEntryExists(current, 'alice', 'other-project')).toBe(false)
+  })
+
+  // Edge: name matches but owner differs → false
+  it('returns false when repo name matches but owner differs', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [repoEntry({owner: 'alice', name: 'project'})],
+    }
+    expect(repoEntryExists(current, 'bob', 'project')).toBe(false)
+  })
+
+  // Schema validation: invalid input propagates assertReposFile throw
+  it('throws when current is not a valid ReposFile', () => {
+    expect(() => repoEntryExists(null, 'alice', 'project')).toThrow()
+    expect(() => repoEntryExists({version: 2, repos: []}, 'alice', 'project')).toThrow()
+    expect(() => repoEntryExists({repos: []}, 'alice', 'project')).toThrow()
+  })
+
+  // Case-sensitivity: exact match only
+  it('is case-sensitive — uppercase owner does not match lowercase stored entry', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [repoEntry({owner: 'alice', name: 'project'})],
+    }
+    expect(repoEntryExists(current, 'Alice', 'project')).toBe(false)
+    expect(repoEntryExists(current, 'alice', 'Project')).toBe(false)
+  })
+
+  // Multiple entries: finds the right one among many
+  it('returns true for the correct entry when multiple entries exist', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [
+        repoEntry({owner: 'alice', name: 'first'}),
+        repoEntry({owner: 'bob', name: 'second'}),
+        repoEntry({owner: 'carol', name: 'third'}),
+      ],
+    }
+    expect(repoEntryExists(current, 'bob', 'second')).toBe(true)
+    expect(repoEntryExists(current, 'alice', 'second')).toBe(false)
+  })
+
+  // Purity: does not mutate the input
+  it('does not mutate the input ReposFile', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [repoEntry({owner: 'alice', name: 'project'})],
+    }
+    const snapshot = structuredClone(current)
+    repoEntryExists(current, 'alice', 'project')
+    expect(current).toEqual(snapshot)
   })
 })

--- a/scripts/repos-metadata.test.ts
+++ b/scripts/repos-metadata.test.ts
@@ -4,8 +4,8 @@ import {describe, expect, it} from 'vitest'
 import {
   addRepoEntry,
   computeNextEligibleAt,
+  publicRepoEntryExists,
   recordSurveyResult,
-  repoEntryExists,
   RepoEntryNotFoundError,
   resetSurveyResult,
 } from './repos-metadata.ts'
@@ -1210,63 +1210,91 @@ describe('recordSurveyResult — next_survey_eligible_at', () => {
   })
 })
 
-describe('repoEntryExists', () => {
-  // Happy path: entry present for owner/repo → true
-  it('returns true when an entry exists for the given owner and repo', () => {
+describe('publicRepoEntryExists', () => {
+  // Privacy gate: entry present with private:false → true (the only path to true)
+  it('returns true when an entry exists with private:false for the given owner and repo', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [repoEntry({owner: 'alice', name: 'project', private: false})],
+    }
+    expect(publicRepoEntryExists(current, 'alice', 'project')).toBe(true)
+  })
+
+  // Privacy gate: entry present but private absent → false (fail-safe default)
+  it('returns false when an entry exists but private is absent (fail-safe default)', () => {
     const current: ReposFile = {
       version: 1,
       repos: [repoEntry({owner: 'alice', name: 'project'})],
     }
-    expect(repoEntryExists(current, 'alice', 'project')).toBe(true)
+    expect(publicRepoEntryExists(current, 'alice', 'project')).toBe(false)
+  })
+
+  // Privacy gate: entry present with private:true → false
+  it('returns false when an entry exists with private:true', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [repoEntry({owner: '[REDACTED]', name: PRIVATE_NODE_ID, private: true, node_id: PRIVATE_NODE_ID})],
+    }
+    expect(publicRepoEntryExists(current, '[REDACTED]', PRIVATE_NODE_ID)).toBe(false)
+  })
+
+  // Privacy gate: owner/name mismatch even with private:false → false
+  it('returns false when private:false but owner/name do not match', () => {
+    const current: ReposFile = {
+      version: 1,
+      repos: [repoEntry({owner: 'alice', name: 'project', private: false})],
+    }
+    expect(publicRepoEntryExists(current, 'bob', 'project')).toBe(false)
+    expect(publicRepoEntryExists(current, 'alice', 'other')).toBe(false)
   })
 
   // Edge: entry absent → false
   it('returns false when no entry exists for the given owner and repo', () => {
     const current: ReposFile = {
       version: 1,
-      repos: [repoEntry({owner: 'alice', name: 'project'})],
+      repos: [repoEntry({owner: 'alice', name: 'project', private: false})],
     }
-    expect(repoEntryExists(current, 'bob', 'other')).toBe(false)
+    expect(publicRepoEntryExists(current, 'bob', 'other')).toBe(false)
   })
 
   // Edge: empty repos list → false (no crash)
   it('returns false without throwing when the repos list is empty', () => {
-    expect(repoEntryExists(EMPTY_REPOS, 'alice', 'project')).toBe(false)
+    expect(publicRepoEntryExists(EMPTY_REPOS, 'alice', 'project')).toBe(false)
   })
 
   // Edge: owner matches but name differs → false
   it('returns false when owner matches but repo name differs', () => {
     const current: ReposFile = {
       version: 1,
-      repos: [repoEntry({owner: 'alice', name: 'project'})],
+      repos: [repoEntry({owner: 'alice', name: 'project', private: false})],
     }
-    expect(repoEntryExists(current, 'alice', 'other-project')).toBe(false)
+    expect(publicRepoEntryExists(current, 'alice', 'other-project')).toBe(false)
   })
 
   // Edge: name matches but owner differs → false
   it('returns false when repo name matches but owner differs', () => {
     const current: ReposFile = {
       version: 1,
-      repos: [repoEntry({owner: 'alice', name: 'project'})],
+      repos: [repoEntry({owner: 'alice', name: 'project', private: false})],
     }
-    expect(repoEntryExists(current, 'bob', 'project')).toBe(false)
+    expect(publicRepoEntryExists(current, 'bob', 'project')).toBe(false)
   })
 
   // Schema validation: invalid input propagates assertReposFile throw
   it('throws when current is not a valid ReposFile', () => {
-    expect(() => repoEntryExists(null, 'alice', 'project')).toThrow()
-    expect(() => repoEntryExists({version: 2, repos: []}, 'alice', 'project')).toThrow()
-    expect(() => repoEntryExists({repos: []}, 'alice', 'project')).toThrow()
+    expect(() => publicRepoEntryExists(null, 'alice', 'project')).toThrow()
+    expect(() => publicRepoEntryExists({version: 2, repos: []}, 'alice', 'project')).toThrow()
+    expect(() => publicRepoEntryExists({repos: []}, 'alice', 'project')).toThrow()
   })
 
   // Case-sensitivity: exact match only
   it('is case-sensitive — uppercase owner does not match lowercase stored entry', () => {
     const current: ReposFile = {
       version: 1,
-      repos: [repoEntry({owner: 'alice', name: 'project'})],
+      repos: [repoEntry({owner: 'alice', name: 'project', private: false})],
     }
-    expect(repoEntryExists(current, 'Alice', 'project')).toBe(false)
-    expect(repoEntryExists(current, 'alice', 'Project')).toBe(false)
+    expect(publicRepoEntryExists(current, 'Alice', 'project')).toBe(false)
+    expect(publicRepoEntryExists(current, 'alice', 'Project')).toBe(false)
   })
 
   // Multiple entries: finds the right one among many
@@ -1274,23 +1302,23 @@ describe('repoEntryExists', () => {
     const current: ReposFile = {
       version: 1,
       repos: [
-        repoEntry({owner: 'alice', name: 'first'}),
-        repoEntry({owner: 'bob', name: 'second'}),
-        repoEntry({owner: 'carol', name: 'third'}),
+        repoEntry({owner: 'alice', name: 'first', private: false}),
+        repoEntry({owner: 'bob', name: 'second', private: false}),
+        repoEntry({owner: 'carol', name: 'third', private: false}),
       ],
     }
-    expect(repoEntryExists(current, 'bob', 'second')).toBe(true)
-    expect(repoEntryExists(current, 'alice', 'second')).toBe(false)
+    expect(publicRepoEntryExists(current, 'bob', 'second')).toBe(true)
+    expect(publicRepoEntryExists(current, 'alice', 'second')).toBe(false)
   })
 
   // Purity: does not mutate the input
   it('does not mutate the input ReposFile', () => {
     const current: ReposFile = {
       version: 1,
-      repos: [repoEntry({owner: 'alice', name: 'project'})],
+      repos: [repoEntry({owner: 'alice', name: 'project', private: false})],
     }
     const snapshot = structuredClone(current)
-    repoEntryExists(current, 'alice', 'project')
+    publicRepoEntryExists(current, 'alice', 'project')
     expect(current).toEqual(snapshot)
   })
 })

--- a/scripts/repos-metadata.ts
+++ b/scripts/repos-metadata.ts
@@ -408,8 +408,16 @@ export function resetSurveyResult(current: unknown, input: ResetSurveyResultInpu
 /**
  * Pure predicate: returns true iff `metadata/repos.yaml` has an entry whose
  * `owner` and `name` exactly match the given `owner` and `repo` strings
- * (case-sensitive, matching how entries are stored and how `recordSurveyResult`
- * locates them).
+ * AND whose `private` field is explicitly `false`.
+ *
+ * This intentionally requires `private === false` (strict equality). An entry
+ * with `private` absent or `private: true` does NOT match — mirroring the
+ * promotion privacy gate in `buildPublicSlugMap` (check-wiki-private-presence.ts),
+ * which only admits wiki pages for repos with explicit `private === false`.
+ * Absent/undefined `private` is treated as private (fail-safe default).
+ *
+ * Does NOT use node_id or redacted-entry matching — this predicate is for the
+ * public-promotable presence check only, not for locating entries by identity key.
  *
  * Does NOT throw on a missing entry — that is the whole point of a boolean
  * predicate. If `current` is not a valid repos file, `assertReposFile` throws
@@ -417,9 +425,9 @@ export function resetSurveyResult(current: unknown, input: ResetSurveyResultInpu
  *
  * Pure: no I/O, no mutation of `current`.
  */
-export function repoEntryExists(current: unknown, owner: string, repo: string): boolean {
+export function publicRepoEntryExists(current: unknown, owner: string, repo: string): boolean {
   assertReposFile(current, 'repos')
-  return current.repos.some(entry => entry.owner === owner && entry.name === repo)
+  return current.repos.some(entry => entry.owner === owner && entry.name === repo && entry.private === false)
 }
 
 export class RepoEntryNotFoundError extends Error {

--- a/scripts/repos-metadata.ts
+++ b/scripts/repos-metadata.ts
@@ -405,6 +405,23 @@ export function resetSurveyResult(current: unknown, input: ResetSurveyResultInpu
   }
 }
 
+/**
+ * Pure predicate: returns true iff `metadata/repos.yaml` has an entry whose
+ * `owner` and `name` exactly match the given `owner` and `repo` strings
+ * (case-sensitive, matching how entries are stored and how `recordSurveyResult`
+ * locates them).
+ *
+ * Does NOT throw on a missing entry — that is the whole point of a boolean
+ * predicate. If `current` is not a valid repos file, `assertReposFile` throws
+ * and the caller decides how to handle it (fail-closed).
+ *
+ * Pure: no I/O, no mutation of `current`.
+ */
+export function repoEntryExists(current: unknown, owner: string, repo: string): boolean {
+  assertReposFile(current, 'repos')
+  return current.repos.some(entry => entry.owner === owner && entry.name === repo)
+}
+
 export class RepoEntryNotFoundError extends Error {
   readonly code = 'REPO_ENTRY_NOT_FOUND'
   // Explicit field declarations + assignment in the constructor body, not parameter properties.


### PR DESCRIPTION
A manually dispatched survey of a repository that isn't tracked in metadata/repos.yaml would write a wiki page to the data branch anyway. That page is unattributable to any public repo, so the promotion privacy gate fail-closes and blocks every data → main merge until the page is removed by hand (issue #3440).

This closes the gap at the source: a survey now writes its wiki page (and announces) only when the resolved repo has an explicit public entry in metadata/repos.yaml.

## What changed

- A `publicRepoEntryExists` predicate that requires an entry with explicit `private: false` — the same condition the promotion privacy gate uses to admit a page. The two now agree exactly, so a survey can never write a page the promotion gate would later reject.
- A fail-closed `check-repo-onboarded` step in the survey workflow: it reads the authoritative metadata from the data branch, and skips the wiki commit and the announcement when the repo isn't a tracked public repo. Every error path (missing inputs, absent or malformed metadata) treats the repo as not onboarded.
- The survey run stays green when it skips — an un-onboarded manual dispatch is a clean no-op, not a failure.

Reconcile-driven surveys are unaffected: they add the repos.yaml entry before dispatching, so the entry is always present by survey time.

## Notes

- The one orphan page that triggered #3440 was already removed from the data branch; the promotion gate passes again. This prevents recurrence.
- Closes #3440.