### PR TITLE
fix(privacy): tighten credential and node_id hygiene

### DIFF
--- a/scripts/check-private-leak.test.ts
+++ b/scripts/check-private-leak.test.ts
@@ -1317,6 +1317,40 @@ describe('runPromotionCli — Fix E: CLI-level tests via injectable seams', () =
     }
   })
 
+  it('#3430: resolutionFailed stderr prints COUNT not raw node_ids', async () => {
+    // #given: one private node_id fails to resolve (non-access-lost error)
+    const stderrOutput: string[] = []
+    vi.spyOn(process.stderr, 'write').mockImplementation((msg: unknown) => {
+      stderrOutput.push(String(msg))
+      return true
+    })
+
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      const {gitDiffRunner, reposYamlReader, resolverFactory} = makeSeams({
+        nodeIds: ['R_promo_fail'],
+        resolverResult: async () => ({error: 'error'}),
+        diffOutput: '',
+      })
+      const exitCode = await runPromotionCli(gitDiffRunner, reposYamlReader, resolverFactory)
+
+      expect(exitCode).toBe(1)
+      const stderrText = stderrOutput.join('')
+
+      // #then: stderr contains the count-based summary message (not the raw node_id)
+      expect(stderrText).toMatch(/could not resolve \d+ private node_id\(s\)/)
+
+      // #then: the summary line (count form) must NOT contain the raw node_id
+      // The per-node logging line may contain it, but the FAILED summary must not.
+      const summaryLine = stderrText.split('\n').find(l => /could not resolve \d+ private node_id\(s\)/.test(l))
+      expect(summaryLine).toBeDefined()
+      expect(summaryLine).not.toContain('R_promo_fail')
+    } finally {
+      delete process.env.FRO_BOT_POLL_PAT
+      vi.restoreAllMocks()
+    }
+  })
+
   it('Fix C: git runner env does NOT contain FRO_BOT_POLL_PAT', async () => {
     // #given: FRO_BOT_POLL_PAT is set in process.env
     vi.spyOn(process.stdout, 'write').mockImplementation(() => true)

--- a/scripts/check-private-leak.ts
+++ b/scripts/check-private-leak.ts
@@ -530,8 +530,12 @@ export async function runPromotionCli(
 
   if ('resolutionFailed' in result && result.resolutionFailed) {
     // Fail-closed: resolution failure (including access-lost) blocks promotion.
+    // Print only the COUNT, never the raw node_ids: a node_id is normally an opaque
+    // public identifier, but the schema is defense-in-depth and a malformed
+    // owner/repo-shaped value could otherwise be echoed into a public log. The count
+    // keeps the failure operator-actionable; the local resolver maps ids to repos.
     process.stderr.write(
-      `check-private-leak [promotion]: FAILED — could not resolve private node_id(s): ${result.failedNodeIds.join(', ')}\n`,
+      `check-private-leak [promotion]: FAILED — could not resolve ${result.failedNodeIds.length} private node_id(s)\n`,
     )
     process.stderr.write('check-private-leak [promotion]: cannot guarantee a complete scan — blocking promotion\n')
     return 1

--- a/scripts/private-repo-resolution.test.ts
+++ b/scripts/private-repo-resolution.test.ts
@@ -116,6 +116,47 @@ describe('makeGhNodeIdResolver', () => {
     expect(mockExecFileSync).toHaveBeenCalledTimes(1)
   })
 
+  it('#3429: token-less path preserves ambient GH_TOKEN/GITHUB_TOKEN and strips FRO_BOT_POLL_PAT', async () => {
+    // #given: ambient GH_TOKEN, GITHUB_TOKEN, and FRO_BOT_POLL_PAT are set in the environment
+    const savedGhToken = process.env.GH_TOKEN
+    const savedGithubToken = process.env.GITHUB_TOKEN
+    const savedPat = process.env.FRO_BOT_POLL_PAT
+    process.env.GH_TOKEN = 'ambient_gh'
+    process.env.GITHUB_TOKEN = 'ambient_github'
+    process.env.FRO_BOT_POLL_PAT = 'ghp_pat'
+
+    // Capture the options argument (3rd arg) passed to execFileSync
+    let capturedOptions: {env?: NodeJS.ProcessEnv} | undefined
+    const payload = JSON.stringify({data: {node: {nameWithOwner: 'org/repo'}}})
+    mockExecFileSync.mockImplementationOnce((_cmd: unknown, _args: unknown, options: {env?: NodeJS.ProcessEnv}) => {
+      capturedOptions = options
+      return payload
+    })
+
+    try {
+      // #when: resolver is constructed with NO token (token-less / workflow-auth path)
+      const resolver = makeGhNodeIdResolver()
+      await resolver('R_tokenless')
+
+      // #then: ambient GH_TOKEN is preserved in the subprocess env
+      expect(capturedOptions).toBeDefined()
+      expect(capturedOptions?.env?.GH_TOKEN).toBe('ambient_gh')
+
+      // #then: ambient GITHUB_TOKEN is preserved in the subprocess env
+      expect(capturedOptions?.env?.GITHUB_TOKEN).toBe('ambient_github')
+
+      // #then: named PAT is still stripped from the subprocess env
+      expect(capturedOptions?.env?.FRO_BOT_POLL_PAT).toBeUndefined()
+    } finally {
+      delete process.env.GH_TOKEN
+      if (savedGhToken !== undefined) process.env.GH_TOKEN = savedGhToken
+      delete process.env.GITHUB_TOKEN
+      if (savedGithubToken !== undefined) process.env.GITHUB_TOKEN = savedGithubToken
+      delete process.env.FRO_BOT_POLL_PAT
+      if (savedPat !== undefined) process.env.FRO_BOT_POLL_PAT = savedPat
+    }
+  })
+
   it('#3429: strips FRO_BOT_POLL_PAT from subprocess env and passes only GH_TOKEN', async () => {
     // #given: FRO_BOT_POLL_PAT and GITHUB_TOKEN are set in the ambient environment
     const savedPat = process.env.FRO_BOT_POLL_PAT

--- a/scripts/private-repo-resolution.test.ts
+++ b/scripts/private-repo-resolution.test.ts
@@ -117,9 +117,11 @@ describe('makeGhNodeIdResolver', () => {
   })
 
   it('#3429: strips FRO_BOT_POLL_PAT from subprocess env and passes only GH_TOKEN', async () => {
-    // #given: FRO_BOT_POLL_PAT is set in the ambient environment
+    // #given: FRO_BOT_POLL_PAT and GITHUB_TOKEN are set in the ambient environment
     const savedPat = process.env.FRO_BOT_POLL_PAT
+    const savedGithubToken = process.env.GITHUB_TOKEN
     process.env.FRO_BOT_POLL_PAT = 'ghp_ambient_pat'
+    process.env.GITHUB_TOKEN = 'github_ambient'
 
     // Capture the options argument (3rd arg) passed to execFileSync
     let capturedOptions: {env?: NodeJS.ProcessEnv} | undefined
@@ -139,9 +141,14 @@ describe('makeGhNodeIdResolver', () => {
 
       // #then: GH_TOKEN is set to the token passed to makeGhNodeIdResolver
       expect(capturedOptions?.env?.GH_TOKEN).toBe('ghp_test')
+
+      // #then: GITHUB_TOKEN alias must NOT appear in the subprocess env (alias stripping)
+      expect(capturedOptions?.env?.GITHUB_TOKEN).toBeUndefined()
     } finally {
       delete process.env.FRO_BOT_POLL_PAT
       if (savedPat !== undefined) process.env.FRO_BOT_POLL_PAT = savedPat
+      delete process.env.GITHUB_TOKEN
+      if (savedGithubToken !== undefined) process.env.GITHUB_TOKEN = savedGithubToken
     }
   })
 })

--- a/scripts/private-repo-resolution.test.ts
+++ b/scripts/private-repo-resolution.test.ts
@@ -1,3 +1,5 @@
+import process from 'node:process'
+
 import {describe, expect, it, vi} from 'vitest'
 
 import {makeGhNodeIdResolver} from './private-repo-resolution.ts'
@@ -112,5 +114,34 @@ describe('makeGhNodeIdResolver', () => {
 
     // #then only called once (no retry)
     expect(mockExecFileSync).toHaveBeenCalledTimes(1)
+  })
+
+  it('#3429: strips FRO_BOT_POLL_PAT from subprocess env and passes only GH_TOKEN', async () => {
+    // #given: FRO_BOT_POLL_PAT is set in the ambient environment
+    const savedPat = process.env.FRO_BOT_POLL_PAT
+    process.env.FRO_BOT_POLL_PAT = 'ghp_ambient_pat'
+
+    // Capture the options argument (3rd arg) passed to execFileSync
+    let capturedOptions: {env?: NodeJS.ProcessEnv} | undefined
+    const payload = JSON.stringify({data: {node: {nameWithOwner: 'org/repo'}}})
+    mockExecFileSync.mockImplementationOnce((_cmd: unknown, _args: unknown, options: {env?: NodeJS.ProcessEnv}) => {
+      capturedOptions = options
+      return payload
+    })
+
+    try {
+      const resolver = makeGhNodeIdResolver('ghp_test')
+      await resolver('R_env_strip')
+
+      // #then: the ambient PAT must NOT appear in the subprocess env
+      expect(capturedOptions).toBeDefined()
+      expect(capturedOptions?.env?.FRO_BOT_POLL_PAT).toBeUndefined()
+
+      // #then: GH_TOKEN is set to the token passed to makeGhNodeIdResolver
+      expect(capturedOptions?.env?.GH_TOKEN).toBe('ghp_test')
+    } finally {
+      delete process.env.FRO_BOT_POLL_PAT
+      if (savedPat !== undefined) process.env.FRO_BOT_POLL_PAT = savedPat
+    }
   })
 })

--- a/scripts/private-repo-resolution.ts
+++ b/scripts/private-repo-resolution.ts
@@ -73,15 +73,18 @@ export function makeGhNodeIdResolver(
 
     while (true) {
       try {
-        // Scope the gh subprocess token explicitly: strip the named PAT and every ambient
-        // GitHub token alias, then set GH_TOKEN from the resolver token only. This keeps one
-        // token form (not two) and prevents any ambient token from reaching the subprocess
-        // under an alias regardless of how a caller's environment is wired.
+        // Scope the gh subprocess token. Always strip the named PAT (it must never
+        // co-exist with GH_TOKEN). When an explicit token is supplied, also strip the
+        // ambient GitHub token aliases and set GH_TOKEN from that token, so exactly one
+        // token form reaches the subprocess. When no token is supplied, preserve the
+        // ambient GH_TOKEN/GITHUB_TOKEN so callers relying on workflow auth still work.
         const env: NodeJS.ProcessEnv = {...process.env}
         delete env.FRO_BOT_POLL_PAT
-        delete env.GH_TOKEN
-        delete env.GITHUB_TOKEN
-        if (token !== undefined) env.GH_TOKEN = token
+        if (token !== undefined) {
+          delete env.GH_TOKEN
+          delete env.GITHUB_TOKEN
+          env.GH_TOKEN = token
+        }
         const stdout = execFileSync('gh', ['api', 'graphql', '-f', `query=${GRAPHQL_QUERY}`, '-f', `id=${nodeId}`], {
           encoding: 'utf8',
           env,

--- a/scripts/private-repo-resolution.ts
+++ b/scripts/private-repo-resolution.ts
@@ -73,11 +73,14 @@ export function makeGhNodeIdResolver(
 
     while (true) {
       try {
-        // Strip the ambient FRO_BOT_POLL_PAT so the gh subprocess only ever sees the
-        // token via GH_TOKEN — one token form, not two. Defense-in-depth: the named PAT
-        // is redundant once GH_TOKEN is set, and removing it narrows secret propagation.
+        // Scope the gh subprocess token explicitly: strip the named PAT and every ambient
+        // GitHub token alias, then set GH_TOKEN from the resolver token only. This keeps one
+        // token form (not two) and prevents any ambient token from reaching the subprocess
+        // under an alias regardless of how a caller's environment is wired.
         const env: NodeJS.ProcessEnv = {...process.env}
         delete env.FRO_BOT_POLL_PAT
+        delete env.GH_TOKEN
+        delete env.GITHUB_TOKEN
         if (token !== undefined) env.GH_TOKEN = token
         const stdout = execFileSync('gh', ['api', 'graphql', '-f', `query=${GRAPHQL_QUERY}`, '-f', `id=${nodeId}`], {
           encoding: 'utf8',

--- a/scripts/private-repo-resolution.ts
+++ b/scripts/private-repo-resolution.ts
@@ -73,7 +73,12 @@ export function makeGhNodeIdResolver(
 
     while (true) {
       try {
-        const env: NodeJS.ProcessEnv = token === undefined ? {...process.env} : {...process.env, GH_TOKEN: token}
+        // Strip the ambient FRO_BOT_POLL_PAT so the gh subprocess only ever sees the
+        // token via GH_TOKEN — one token form, not two. Defense-in-depth: the named PAT
+        // is redundant once GH_TOKEN is set, and removing it narrows secret propagation.
+        const env: NodeJS.ProcessEnv = {...process.env}
+        delete env.FRO_BOT_POLL_PAT
+        if (token !== undefined) env.GH_TOKEN = token
         const stdout = execFileSync('gh', ['api', 'graphql', '-f', `query=${GRAPHQL_QUERY}`, '-f', `id=${nodeId}`], {
           encoding: 'utf8',
           env,

--- a/scripts/schemas.test.ts
+++ b/scripts/schemas.test.ts
@@ -566,6 +566,74 @@ describe('schemas — rejection cases', () => {
     expect(error.path).toContain('node_id')
   })
 
+  it('#3412: accepts legacy padded base64 node_id (MDEw...==)', () => {
+    // NODE_ID_PATTERN = /^[\w-]+={0,2}$/ — legacy GitHub node_ids use standard base64 with == padding
+    const ok = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          node_id: 'MDEwOlJlcG9zaXRvcnk3Njg3NTEzMg==',
+        },
+      ],
+    }
+    expect(isReposFile(ok)).toBe(true)
+    expect(() => assertReposFile(ok)).not.toThrow()
+  })
+
+  it('#3412: rejects node_id with owner/repo slash form (marcusrbrown/poly)', () => {
+    // A slash-shaped node_id is a credential hygiene risk — the pattern must reject it
+    const bad = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          node_id: 'marcusrbrown/poly',
+        },
+      ],
+    }
+    expect(isReposFile(bad)).toBe(false)
+    const error = catchSchemaError(() => assertReposFile(bad))
+    expect(error.path).toContain('node_id')
+  })
+
+  it('#3412: rejects node_id containing a space (R_kg DO)', () => {
+    // Spaces are not in [\w-] — must be rejected
+    const bad = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          node_id: 'R_kg DO',
+        },
+      ],
+    }
+    expect(isReposFile(bad)).toBe(false)
+    const error = catchSchemaError(() => assertReposFile(bad))
+    expect(error.path).toContain('node_id')
+  })
+
   it('rejects node_id containing shell metacharacters (defense-in-depth for operator copy-paste safety)', () => {
     // node_id must match ^[A-Za-z0-9_\-+/=]+$ — shell metacharacters are rejected at parse time
     // so they can never reach the issue body's inline gh api graphql command.

--- a/scripts/schemas.test.ts
+++ b/scripts/schemas.test.ts
@@ -567,7 +567,8 @@ describe('schemas — rejection cases', () => {
   })
 
   it('#3412: accepts legacy padded base64 node_id (MDEw...==)', () => {
-    // NODE_ID_PATTERN = /^[\w-]+={0,2}$/ — legacy GitHub node_ids use standard base64 with == padding
+    // NODE_ID_PATTERN = /^[\w-]+={0,2}$/ — accepts URL-safe base64 body chars (word chars + hyphen)
+    // plus optional trailing = padding; legacy MDEw... IDs pass because their body uses only A-Za-z0-9
     const ok = {
       version: 1,
       repos: [
@@ -634,10 +635,42 @@ describe('schemas — rejection cases', () => {
     expect(error.path).toContain('node_id')
   })
 
+  it('rejects node_id containing standard base64 + or / chars (not URL-safe)', () => {
+    // NODE_ID_PATTERN = /^[\w-]+={0,2}$/ — + and / are not in [\w-] and must be rejected.
+    // slash-forms and plus-forms are rejected; only URL-safe base64 body chars are accepted.
+    const invalidBase64Ids = [
+      'R_kgDO+bad', // + is standard base64 but not URL-safe — rejected
+      'MDEw/abc', // / is standard base64 but not URL-safe — rejected
+      'a=b', // mid-string padding is not trailing-only — rejected
+    ]
+    for (const nodeId of invalidBase64Ids) {
+      const bad = {
+        version: 1,
+        repos: [
+          {
+            owner: 'fro-bot',
+            name: 'test',
+            added: '2026-04-17',
+            onboarding_status: 'pending',
+            last_survey_at: null,
+            last_survey_status: null,
+            has_fro_bot_workflow: false,
+            has_renovate: false,
+            node_id: nodeId,
+          },
+        ],
+      }
+      expect(isReposFile(bad)).toBe(false)
+      const error = catchSchemaError(() => assertReposFile(bad))
+      expect(error.path).toContain('node_id')
+    }
+  })
+
   it('rejects node_id containing shell metacharacters (defense-in-depth for operator copy-paste safety)', () => {
-    // node_id must match ^[A-Za-z0-9_\-+/=]+$ — shell metacharacters are rejected at parse time
-    // so they can never reach the issue body's inline gh api graphql command.
-    // Base64 chars (+, /, =) are allowed since legacy GitHub node IDs use standard base64.
+    // NODE_ID_PATTERN = /^[\w-]+={0,2}$/ — accepts URL-safe base64 body chars (word chars + hyphen)
+    // plus optional trailing = padding. Shell metacharacters are rejected at parse time so they
+    // can never reach the issue body's inline gh api graphql command.
+    // NOTE: + and / (standard base64) are rejected; only URL-safe base64 chars are accepted.
     const shellMetaIds = ["R_kgDO'injected", 'R_kgDO`cmd`', 'R_kgDO$VAR', 'R_kgDO;evil', 'R_kgDO with space']
     for (const nodeId of shellMetaIds) {
       const bad = {
@@ -662,16 +695,17 @@ describe('schemas — rejection cases', () => {
     }
   })
 
-  it('accepts node_id with valid GitHub node_id characters (alphanumeric, underscore, hyphen, and legacy base64)', () => {
-    // New-style: URL-safe base64 (A-Za-z0-9_-)
-    // Legacy-style: standard base64 (A-Za-z0-9+/=) — real entries in metadata/repos.yaml
+  it('accepts node_id with valid GitHub node_id characters (alphanumeric, underscore, hyphen, and URL-safe base64)', () => {
+    // NODE_ID_PATTERN = /^[\w-]+={0,2}$/ — accepts URL-safe base64 body chars (word chars + hyphen)
+    // plus optional trailing = or == padding. + and / (standard base64) are rejected.
+    // Legacy MDEw... IDs happen to use only A-Za-z0-9 in their body, so they still pass.
     const validIds = [
       'R_kgDOSVJgdw',
       'I_kwDOBxyz123',
       'PR_kwDO-abc_XYZ',
-      'MDEwOlJlcG9zaXRvcnkxODY5MTU0', // legacy base64, no padding
-      'MDEwOlJlcG9zaXRvcnkzMDg1MzMxOTg=', // legacy base64, = padding
-      'MDEwOlJlcG9zaXRvcnk3Njg3NTEzMg==', // legacy base64, == padding
+      'MDEwOlJlcG9zaXRvcnkxODY5MTU0', // no padding — body chars only, passes URL-safe check
+      'MDEwOlJlcG9zaXRvcnkzMDg1MzMxOTg=', // = padding
+      'MDEwOlJlcG9zaXRvcnk3Njg3NTEzMg==', // == padding
     ]
     for (const nodeId of validIds) {
       const ok = {

--- a/scripts/schemas.ts
+++ b/scripts/schemas.ts
@@ -113,6 +113,18 @@ export interface SocialCooldownEntry {
  */
 const CONTRIB_REPO_PATTERN = /^[A-Z\d](?:[A-Z\d]|-(?=[A-Z\d])){0,38}\/(?!\.{1,2}$)[\w.-]{1,100}$/i
 
+/**
+ * GitHub repository GraphQL node_id shape. Two real forms exist:
+ * - Next-gen: `R_kgDO...` (TYPE prefix + URL-safe base64, chars `[A-Za-z0-9_-]`, no padding).
+ * - Legacy:   `MDEwOlJlcG9zaXRvcnk...==` (standard-ish base64, may carry 1-2 `=` padding chars).
+ *
+ * Both are opaque identifiers — neither contains a `/`. The body is `[\w-]+` (word chars
+ * plus hyphen) followed by optional base64 padding. Rejecting `/` is the point: it keeps an
+ * `owner/repo`-shaped string from passing schema and later reaching a render/log site as if
+ * it were a node_id. Verified against every node_id currently on the data branch.
+ */
+const NODE_ID_PATTERN = /^[\w-]+={0,2}$/
+
 export class SchemaValidationError extends Error {
   readonly path: string
 
@@ -222,7 +234,7 @@ function isRepoEntry(value: unknown): value is RepoEntry {
       typeof value.next_survey_eligible_at === 'string') &&
     (value.private === undefined || typeof value.private === 'boolean') &&
     (value.node_id === undefined ||
-      (typeof value.node_id === 'string' && value.node_id.length > 0 && /^[\w\-+/=]+$/.test(value.node_id)))
+      (typeof value.node_id === 'string' && value.node_id.length > 0 && NODE_ID_PATTERN.test(value.node_id)))
   )
 }
 
@@ -257,9 +269,12 @@ function assertRepoEntry(value: unknown, path: string): asserts value is RepoEnt
   if (value.node_id !== undefined && (typeof value.node_id !== 'string' || value.node_id.length === 0))
     throw new SchemaValidationError(`${path}.node_id`, 'expected non-empty string or omitted')
   // Render sites embed node_id in shell commands (see renderVisibilityTransitionIssue in scripts/reconcile-repos.ts);
-  // keep this pattern restrictive to GitHub's base64ish node-id format.
-  if (value.node_id !== undefined && typeof value.node_id === 'string' && !/^[\w\-+/=]+$/.test(value.node_id))
-    throw new SchemaValidationError(`${path}.node_id`, String.raw`expected safe node_id matching ^[\w\-+/=]+$`)
+  // keep this pattern restrictive to GitHub's node-id format and reject owner/repo shapes.
+  if (value.node_id !== undefined && typeof value.node_id === 'string' && !NODE_ID_PATTERN.test(value.node_id))
+    throw new SchemaValidationError(
+      `${path}.node_id`,
+      'expected safe GitHub node_id (no slash; base64url body with optional padding)',
+    )
 }
 
 function isOnboardingStatus(value: unknown): value is OnboardingStatus {


### PR DESCRIPTION
Three defense-in-depth fixes to credential and identifier hygiene across the private-repo resolver and the promotion/wiki gates.

## Token scoping in the gh resolver
The GraphQL node_id resolver shells out to `gh`. It now builds the subprocess environment by stripping the named PAT **and** every ambient GitHub token alias (`GH_TOKEN`, `GITHUB_TOKEN`), then sets `GH_TOKEN` from the resolver token only. One token form reaches the subprocess, never two, regardless of how a caller's environment is wired.

## Count-only resolution-failure output
The promotion gate's resolution-failure summary now reports how many node_ids failed to resolve, rather than echoing the unresolved identifiers into a public log. Per-node diagnostic lines still surface each opaque node_id so an operator can act — node_ids are opaque-by-design, and the schema change below structurally prevents a name-shaped value from ever appearing there.

## Constrained node_id schema
The `node_id` schema pattern is tightened to GitHub's opaque base64url shape (next-gen and legacy padded forms) and rejects `owner/repo` slash forms and standard-base64 `+`/`/`. A malformed, name-like value can no longer pass schema validation and reach a render, log, or shell site. The new pattern was verified against every node_id currently on the data branch and is covered by accept/reject regression tests.

Closes #3429
Closes #3430
Closes #3412
