### PR TITLE
fix(reconcile): defensive polish on the data-branch metadata overlay

### DIFF
--- a/.github/workflows/reconcile-repos.yaml
+++ b/.github/workflows/reconcile-repos.yaml
@@ -54,7 +54,8 @@ jobs:
       - name: ⤵ Overlay metadata from data branch
         run: |
           set -euo pipefail
-          if git fetch --no-tags origin data 2>/dev/null; then
+          if git ls-remote --exit-code origin data >/dev/null 2>&1; then
+            git fetch --no-tags origin data
             git checkout origin/data -- metadata/
           else
             echo "data branch not yet established; reconcile will bootstrap it."

--- a/.github/workflows/reconcile-repos.yaml
+++ b/.github/workflows/reconcile-repos.yaml
@@ -44,13 +44,21 @@ jobs:
       # branch, but the workflow's checkout pulls scripts from the default branch (`main`).
       # Overlay the authoritative `metadata/` tree from `data` so reconcile plans against
       # live state instead of whatever `main` last reflected.
+      # git authenticates via the credentials actions/checkout persisted on origin, so no
+      # explicit token env is needed here. The fetch is guarded: when `data` does not yet
+      # exist (first run, fresh clone, fork, accidental deletion) reconcile bootstraps it,
+      # so a missing branch must not hard-fail this step under `set -euo pipefail`.
+      # NOTE: `git checkout origin/data -- metadata/` leaves metadata/ staged in the index.
+      # Reconcile commits via Octokit (not git CLI), so this is fine. Any future step in this
+      # job that depends on a clean index must `git reset HEAD metadata/` first.
       - name: ⤵ Overlay metadata from data branch
-        env:
-          GH_TOKEN: ${{ steps.get-workflow-app-token.outputs.token }}
         run: |
           set -euo pipefail
-          git fetch --no-tags origin data
-          git checkout origin/data -- metadata/
+          if git fetch --no-tags origin data 2>/dev/null; then
+            git checkout origin/data -- metadata/
+          else
+            echo "data branch not yet established; reconcile will bootstrap it."
+          fi
 
       - name: 🔁 Reconcile repos
         env:


### PR DESCRIPTION
Three defensive-polish fixes to the `metadata/` overlay step in the reconcile workflow. None are load-bearing on the live repo today; all three harden the step for first-run, fork, and transplant scenarios.

- **Drop the ornamental `GH_TOKEN` env.** The step only runs `git fetch` / `git checkout`, which authenticate via the credentials `actions/checkout` already persisted on `origin`. The env var had no effect.
- **Guard the data-branch fetch.** `git fetch origin data` exits non-zero when `data` does not exist (first run, fresh clone, fork, accidental deletion). Under `set -euo pipefail` that failed the step before reconcile could bootstrap the branch. The fetch is now guarded so the bootstrap recovery path can recreate it.
- **Document the staged-index invariant.** `git checkout origin/data -- metadata/` leaves the files staged. Reconcile commits via Octokit, not the git CLI, so this is harmless today — a comment records that any future git-CLI step in this job must reset the index first.

actionlint clean. The next reconcile cron exercises the new shape.

Closes #3343
