### PR TITLE
fix(survey): re-mint gate token before recheck; document App-install precondition

### DIFF
--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -229,12 +229,25 @@ jobs:
         id: ts
         run: echo "now=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
+      # Re-mint the gate token immediately before the visibility recheck. The initial
+      # gate-token is minted at job start, but the survey agent can run for up to the job
+      # timeout before this point; a fresh token here keeps the recheck well clear of the
+      # ~1h installation-token lifetime even if survey durations grow.
+      - name: Re-mint App token for recheck
+        id: recheck-token
+        if: ${{ !cancelled() && steps.survey-agent.conclusion != 'skipped' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: 🔒 Recheck visibility
         id: recheck
         if: ${{ !cancelled() && steps.survey-agent.conclusion != 'skipped' }}
         env:
           NODE_ID: ${{ inputs.node_id }}
-          GH_TOKEN: ${{ steps.gate-token.outputs.token }}
+          GH_TOKEN: ${{ steps.recheck-token.outputs.token }}
         run: |
           if ! printf '%s' "$NODE_ID" | grep -qE '^[A-Za-z0-9_=-]+$'; then
             printf 'Aborting: dispatch input shape invalid\n' >&2

--- a/.github/workflows/update-metadata.yaml
+++ b/.github/workflows/update-metadata.yaml
@@ -19,6 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      # App-install precondition: APPLICATION_ID / APPLICATION_PRIVATE_KEY must be the
+      # fro-bot GitHub App, installed on the github.repository_owner (fro-bot) account with
+      # access to the target repos. Four workflows depend on this: update-metadata.yaml,
+      # dispatch-renovate.yaml, reconcile-repos.yaml, survey-repo.yaml. The `owner:` input
+      # scopes the minted installation token to that owner; without the install (or with a
+      # wrong owner) cross-repo reads and dispatches fail with 403/401.
       - id: get-workflow-app-token
         name: Get Workflow Access Token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0


### PR DESCRIPTION
Two forward-looking hardening items on the Survey Repo privacy gate, both deferred from the cross-org survey fix.

- **Re-mint the gate token before the visibility recheck.** The App token is minted once at job start, but the survey agent runs between mint and recheck (up to the 30-minute job timeout). Installation tokens live ~1h, so today's envelope is safe — but if survey durations ever grow past ~50 minutes, the recheck could race token expiry and fail with a misleading 401. A fresh token minted immediately before the recheck keeps it well clear of the token lifetime regardless of survey duration. The early resolve-and-verify step keeps using the original mint.
- **Document the App-install precondition.** Four workflows depend on `APPLICATION_ID` / `APPLICATION_PRIVATE_KEY` being the fro-bot GitHub App installed on the `fro-bot` owner (`update-metadata.yaml`, `dispatch-renovate.yaml`, `reconcile-repos.yaml`, `survey-repo.yaml`). A comment block in `update-metadata.yaml` — the first cross-org App-token consumer — records the dependency.

actionlint clean. No behavior change on today's path.

Closes #3349
