### PR TITLE
feat(privacy): local-only operator-report mode for the wiki privacy gate

### DIFF
--- a/scripts/check-wiki-private-presence.test.ts
+++ b/scripts/check-wiki-private-presence.test.ts
@@ -8,8 +8,10 @@ import {
   detectPrivateWikiLeaks,
   findStructuralViolations,
   formatLeakReport,
+  formatOperatorReport,
   loadWikiPages,
   requireGrandfatherDir,
+  runCli,
   type WikiPageSnapshot,
 } from './check-wiki-private-presence.ts'
 import {computeRepoSlug} from './wiki-slug.ts'
@@ -1423,5 +1425,224 @@ describe('present-sources key is authoritative regardless of content — no subs
     })
     expect(result).toHaveLength(1)
     expect(result[0]).toMatchObject({filename: 'acme--widget.md', reason: 'unattributable-page'})
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatOperatorReport (local-only unredacted output)
+// ---------------------------------------------------------------------------
+
+describe('formatOperatorReport (local-only unredacted output)', () => {
+  const twoLeaks = [
+    {filename: 'marcusrbrown--cart.md', reason: 'unattributable-page' as const},
+    {filename: 'acme--secret.md', reason: 'ambiguous-public-slug' as const},
+  ]
+
+  it('includes the offending filename in the output', () => {
+    // #given two leaks with known filenames
+    // #when formatOperatorReport is called
+    // #then each filename appears verbatim in the output
+    const report = formatOperatorReport(twoLeaks)
+    expect(report).toContain('marcusrbrown--cart.md')
+    expect(report).toContain('acme--secret.md')
+  })
+
+  it('includes each reason alongside the filename', () => {
+    // #given two leaks with distinct reasons
+    // #when formatOperatorReport is called
+    // #then each reason appears in the output
+    const report = formatOperatorReport(twoLeaks)
+    expect(report).toContain('unattributable-page')
+    expect(report).toContain('ambiguous-public-slug')
+  })
+
+  it('includes the BLOCKED header with the leak count', () => {
+    // #given two leaks
+    // #when formatOperatorReport is called
+    // #then the header contains BLOCKED and the count
+    const report = formatOperatorReport(twoLeaks)
+    expect(report).toContain('BLOCKED')
+    expect(report).toContain('2')
+  })
+
+  it('includes the remediation header', () => {
+    // #given any leaks
+    // #when formatOperatorReport is called
+    // #then a Remediation section is present
+    const report = formatOperatorReport(twoLeaks)
+    expect(report).toContain('Remediation')
+  })
+
+  it('includes the LOCAL OPERATOR OUTPUT warning label', () => {
+    // #given any leaks
+    // #when formatOperatorReport is called
+    // #then the output contains the local-operator warning so operators know not to paste it publicly
+    const report = formatOperatorReport(twoLeaks)
+    expect(report).toContain('LOCAL OPERATOR OUTPUT')
+  })
+
+  it('empty leaks array → no filename lines, still has header', () => {
+    // #given no leaks
+    // #when formatOperatorReport is called
+    // #then no filename lines appear but the header is still present
+    const report = formatOperatorReport([])
+    expect(report).toContain('check-wiki-private-presence')
+    expect(report).not.toContain('marcusrbrown')
+    expect(report).not.toContain('acme')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// runCli — testable seam for --operator-report and normal mode
+// ---------------------------------------------------------------------------
+
+describe('runCli — CI-refusal (critical privacy gate)', () => {
+  it('refuses with exitCode 2 when GITHUB_ACTIONS is set, regardless of leaks', async () => {
+    // #given GITHUB_ACTIONS=true in env (simulating CI)
+    // #when runCli is called with --operator-report
+    // #then exitCode is 2 and stderr contains the refusal message
+    // The refusal must short-circuit BEFORE any detection or file I/O
+    const result = await runCli(['--operator-report'], {GITHUB_ACTIONS: 'true'})
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('local-only')
+    expect(result.stderr).toContain('refusing to run in CI')
+  })
+
+  it('refuses with exitCode 2 when CI=true in env', async () => {
+    // #given CI=true in env (simulating CI)
+    // #when runCli is called with --operator-report
+    // #then exitCode is 2
+    const result = await runCli(['--operator-report'], {CI: 'true'})
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('refusing to run in CI')
+  })
+
+  it('CI-refusal stdout contains NO filename substring (short-circuits before detection)', async () => {
+    // #given GITHUB_ACTIONS=true
+    // #when runCli is called with --operator-report
+    // #then stdout is empty — the refusal must not print any leak detail
+    // This is the critical privacy assertion: even if leaks exist, CI must see nothing
+    const result = await runCli(['--operator-report'], {GITHUB_ACTIONS: 'true'})
+    expect(result.stdout).toBe('')
+    // No owner--repo .md filename shape in either stream
+    // Use literal check: the separator '--' followed by a word and '.md' must not appear
+    const combined = result.stdout + result.stderr
+    expect(combined).not.toContain('.md')
+  })
+
+  it('CI-refusal stderr contains NO filename substring', async () => {
+    // #given GITHUB_ACTIONS=true
+    // #when runCli is called with --operator-report
+    // #then stderr contains only the refusal message, no filenames
+    const result = await runCli(['--operator-report'], {GITHUB_ACTIONS: 'true'})
+    // The refusal message must not contain any .md filename
+    expect(result.stderr).not.toContain('.md')
+  })
+
+  it('GITHUB_ACTIONS=true WITHOUT --operator-report flag runs normally (redacted gate still works in CI)', async () => {
+    // #given GITHUB_ACTIONS=true but no --operator-report flag
+    // #when runCli is called without the flag
+    // #then it does NOT refuse — the normal redacted gate must still work in CI
+    // Set up mocks so the normal path can complete: no wiki pages, no leaks → exits 0
+    const enoent = Object.assign(new Error('ENOENT'), {code: 'ENOENT'})
+    mockReaddir.mockRejectedValue(enoent)
+    mockReadFile.mockResolvedValue('version: 1\nrepos: []\n')
+
+    const result = await runCli([], {GITHUB_ACTIONS: 'true', GRANDFATHER_WIKI_REPOS_DIR: '/tmp/grandfather'})
+    expect(result.exitCode).not.toBe(2)
+    expect(result.stderr).not.toContain('refusing to run in CI')
+  })
+})
+
+describe('runCli — local operator path (no CI env)', () => {
+  it('exits 0 and prints "no private wiki leaks detected" when no leaks found', async () => {
+    // #given a clean environment with no CI vars and a valid GRANDFATHER_WIKI_REPOS_DIR
+    // #when runCli is called with --operator-report and readdir returns empty (no wiki pages)
+    // #then exitCode 0 and stdout contains the clean message
+    // We use the mocked readdir/readFile from the top-level vi.mock — reset to ENOENT for both dirs
+    const enoent = Object.assign(new Error('ENOENT'), {code: 'ENOENT'})
+    mockReaddir.mockRejectedValue(enoent)
+    mockReadFile.mockResolvedValue('version: 1\nrepos: []\n')
+
+    const result = await runCli(['--operator-report'], {GRANDFATHER_WIKI_REPOS_DIR: '/tmp/empty-grandfather'})
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('no private wiki leaks detected')
+  })
+
+  it('exits 1 and stdout contains the offending filename when leaks are found', async () => {
+    // #given a local env with a known leak (a page not in publicSlugMap, not grandfathered)
+    // #when runCli is called with --operator-report
+    // #then exitCode 1 and stdout contains the offending filename
+    const enoentGrandfather = Object.assign(new Error('ENOENT'), {code: 'ENOENT'})
+
+    // readdir: first call = structural check (knowledge/wiki/repos), second = loadWikiPages, third = grandfather ENOENT
+    mockReaddir
+      .mockResolvedValueOnce([dirent('acme--secret.md')]) // findStructuralViolations
+      .mockResolvedValueOnce([dirent('acme--secret.md')]) // loadWikiPages
+      .mockRejectedValueOnce(enoentGrandfather) // grandfather dir ENOENT
+
+    mockReadFile
+      .mockResolvedValueOnce('version: 1\nrepos: []\n') // metadata/repos.yaml
+      .mockResolvedValueOnce('private content') // acme--secret.md content
+
+    const result = await runCli(['--operator-report'], {GRANDFATHER_WIKI_REPOS_DIR: '/tmp/empty-grandfather'})
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain('acme--secret.md')
+  })
+
+  it('operator report stdout does NOT contain redacted leak-N labels (uses unredacted format)', async () => {
+    // #given a local env with a known leak
+    // #when runCli is called with --operator-report
+    // #then stdout does NOT use the redacted "leak-1" format — it uses the operator format
+    const enoentGrandfather = Object.assign(new Error('ENOENT'), {code: 'ENOENT'})
+
+    mockReaddir
+      .mockResolvedValueOnce([dirent('acme--secret.md')])
+      .mockResolvedValueOnce([dirent('acme--secret.md')])
+      .mockRejectedValueOnce(enoentGrandfather)
+
+    mockReadFile.mockResolvedValueOnce('version: 1\nrepos: []\n').mockResolvedValueOnce('private content')
+
+    const result = await runCli(['--operator-report'], {GRANDFATHER_WIKI_REPOS_DIR: '/tmp/empty-grandfather'})
+    // Should NOT use the redacted format
+    expect(result.stdout).not.toMatch(/leak-\d+:/)
+    // Should contain the filename
+    expect(result.stdout).toContain('acme--secret.md')
+  })
+})
+
+describe('runCli — normal mode (no --operator-report flag)', () => {
+  it('normal mode with leaks exits 1 and stderr contains redacted report (no filenames)', async () => {
+    // #given a local env with a known leak and no --operator-report flag
+    // #when runCli is called without the flag
+    // #then exitCode 1 and stderr contains the redacted report (no filenames)
+    const enoentGrandfather = Object.assign(new Error('ENOENT'), {code: 'ENOENT'})
+
+    mockReaddir
+      .mockResolvedValueOnce([dirent('acme--secret.md')])
+      .mockResolvedValueOnce([dirent('acme--secret.md')])
+      .mockRejectedValueOnce(enoentGrandfather)
+
+    mockReadFile.mockResolvedValueOnce('version: 1\nrepos: []\n').mockResolvedValueOnce('private content')
+
+    const result = await runCli([], {GRANDFATHER_WIKI_REPOS_DIR: '/tmp/empty-grandfather'})
+    expect(result.exitCode).toBe(1)
+    // Redacted format: no filename in stderr
+    expect(result.stderr).not.toContain('acme--secret.md')
+    // Contains the redacted leak label
+    expect(result.stderr).toContain('leak-1')
+  })
+
+  it('normal mode with no leaks exits 0 and stdout contains clean message', async () => {
+    // #given a clean env with no leaks and no --operator-report flag
+    // #when runCli is called without the flag
+    // #then exitCode 0 and stdout contains the clean message
+    const enoent = Object.assign(new Error('ENOENT'), {code: 'ENOENT'})
+    mockReaddir.mockRejectedValue(enoent)
+    mockReadFile.mockResolvedValue('version: 1\nrepos: []\n')
+
+    const result = await runCli([], {GRANDFATHER_WIKI_REPOS_DIR: '/tmp/empty-grandfather'})
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('no private wiki leaks detected')
   })
 })

--- a/scripts/check-wiki-private-presence.ts
+++ b/scripts/check-wiki-private-presence.ts
@@ -416,7 +416,51 @@ export function formatLeakReport(leaks: readonly PrivateWikiLeak[]): string {
   ].join('\n')}\n`
 }
 
-async function main(): Promise<void> {
+/**
+ * Format the BLOCKED failure report WITH full page identities for local operator use.
+ *
+ * **LOCAL-ONLY OUTPUT — do not wire this into any workflow or paste into public logs.**
+ *
+ * Unlike `formatLeakReport`, this function includes each leak's `filename` and `reason`
+ * so an operator or local agent can identify and remediate offending pages without
+ * reverse-engineering the redacted gate output.
+ *
+ * This function MUST only be called from the `--operator-report` branch of `runCli`,
+ * which hard-refuses to run when `GITHUB_ACTIONS` or `CI=true` is set. It must never
+ * be wired into a GitHub Actions workflow step.
+ *
+ * Exported for testing only.
+ */
+export function formatOperatorReport(leaks: readonly PrivateWikiLeak[]): string {
+  const lines: string[] = [
+    `check-wiki-private-presence: BLOCKED — ${leaks.length} unattributable wiki repo page(s).`,
+    '',
+    'Offending pages (LOCAL OPERATOR OUTPUT — do not paste into public logs):',
+    ...leaks.map(leak => `  - knowledge/wiki/repos/${leak.filename}  (${leak.reason})`),
+    '',
+    'Remediation:',
+    '  1. Inspect each page on the data branch; if its repo is private, the page must not be promoted.',
+    '  2. Redact via a fro-bot[bot] write to data (dispatch fro-bot.yaml) — never a human-authored PR (wiki authority guard).',
+    '  3. If the repo is actually public, ensure its metadata/repos.yaml entry has `private: false` so the slug is admitted.',
+    '  4. Re-run the promotion (Merge Data Branch) once data is clean.',
+  ]
+  return `${lines.join('\n')}\n`
+}
+
+// ---------------------------------------------------------------------------
+// collectLeaks — shared detection pipeline (used by both normal and operator paths)
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the full leak-detection pipeline and return all detected leaks.
+ *
+ * Reads `metadata/repos.yaml` from CWD, scans `knowledge/wiki/repos`, and loads
+ * grandfather pages from the path in `env.GRANDFATHER_WIKI_REPOS_DIR`.
+ *
+ * Extracted as a shared helper so the normal (redacted) path and the operator
+ * (unredacted) path use ONE detection implementation with no drift risk.
+ */
+async function collectLeaks(env: Record<string, string | undefined>): Promise<PrivateWikiLeak[]> {
   // 1. Read and validate data branch's own metadata/repos.yaml (CWD = data-branch-check).
   //    Fail closed: throws on read/parse error.
   const reposRaw = await readFile('metadata/repos.yaml', 'utf8')
@@ -438,23 +482,65 @@ async function main(): Promise<void> {
   // 5. Load grandfather pages from main's wiki dir.
   //    Fail closed: GRANDFATHER_WIKI_REPOS_DIR MUST be supplied by the workflow.
   //    An unset var → throw loudly; misconfiguration must not silently pass or over-block.
-  const grandfatherDir = requireGrandfatherDir(process.env.GRANDFATHER_WIKI_REPOS_DIR)
+  const grandfatherDir = requireGrandfatherDir(env.GRANDFATHER_WIKI_REPOS_DIR)
   const grandfatherPages = await loadWikiPages(grandfatherDir)
 
   // 6. Detect content-attribution leaks — pure function, no GraphQL.
   const contentLeaks = detectPrivateWikiLeaks({dataWikiPages, publicSlugMap, grandfatherPages})
 
   // 7. Merge structural and content leaks.
-  const leaks = [...structuralLeaks, ...contentLeaks]
+  return [...structuralLeaks, ...contentLeaks]
+}
 
-  // 8. Report — redacted: the failure goes to a public Actions log, so it must
-  //    never echo the leaked owner--repo.md filenames (see formatLeakReport).
-  if (leaks.length > 0) {
-    process.stderr.write(formatLeakReport(leaks))
-    process.exit(1)
+// ---------------------------------------------------------------------------
+// runCli — testable seam (no process.exit / process.env / process.argv reads)
+// ---------------------------------------------------------------------------
+
+/**
+ * Testable CLI entry point. Does NOT call `process.exit` or read `process.env`/`process.argv`
+ * directly — all inputs are injected so tests can assert on exit codes and output without
+ * spawning a subprocess.
+ *
+ * `main()` calls this and maps the result to `process.stdout`/`process.stderr`/`process.exit`.
+ */
+export async function runCli(
+  argv: string[],
+  env: Record<string, string | undefined>,
+): Promise<{exitCode: number; stdout: string; stderr: string}> {
+  const operatorMode = argv.includes('--operator-report')
+
+  if (operatorMode) {
+    // Hard-refuse BEFORE loading or printing ANYTHING sensitive.
+    // Any value for GITHUB_ACTIONS, or CI === 'true', means we are in CI.
+    if (env.GITHUB_ACTIONS !== undefined || env.CI === 'true') {
+      return {
+        exitCode: 2,
+        stdout: '',
+        stderr: 'check-wiki-private-presence: --operator-report is local-only; refusing to run in CI\n',
+      }
+    }
+
+    // Local operator path — run detection and emit unredacted report.
+    const leaks = await collectLeaks(env)
+    if (leaks.length > 0) {
+      return {exitCode: 1, stdout: formatOperatorReport(leaks), stderr: ''}
+    }
+    return {exitCode: 0, stdout: 'no private wiki leaks detected\n', stderr: ''}
   }
 
-  process.stdout.write('no private wiki leaks detected\n')
+  // Normal (redacted) path — used in CI and locally without the flag.
+  const leaks = await collectLeaks(env)
+  if (leaks.length > 0) {
+    return {exitCode: 1, stdout: '', stderr: formatLeakReport(leaks)}
+  }
+  return {exitCode: 0, stdout: 'no private wiki leaks detected\n', stderr: ''}
+}
+
+async function main(): Promise<void> {
+  const result = await runCli(process.argv.slice(2), process.env as Record<string, string | undefined>)
+  if (result.stdout) process.stdout.write(result.stdout)
+  if (result.stderr) process.stderr.write(result.stderr)
+  if (result.exitCode !== 0) process.exit(result.exitCode)
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {


### PR DESCRIPTION
When the promotion-time privacy gate blocks, its public output is redacted to per-run `leak-N` labels — canonical `owner--repo` page names must never reach the public Actions log. But that left the remediation path under-specified: an operator or agent had to reverse-engineer the gate to find which pages to fix.

This adds a local-only `--operator-report` mode that prints the offending page paths and a remediation sequence, while keeping the public CI output redacted.

- **Hard CI-refusal.** `--operator-report` refuses to run when `GITHUB_ACTIONS` is set or `CI=true` — it returns exit 2 with a short message **before any detection runs**, so no canonical name can ever reach a public log. Verified against a real leak fixture: under CI it refuses with zero filename output; locally it lists the offending page; the normal redacted gate is unchanged.
- **Single detection path.** Both the redacted gate and the operator report share one `collectLeaks` helper, so the two outputs cannot drift.
- **Testable seam.** A `runCli(argv, env)` seam makes the CI-refusal and both output paths directly testable without spawning a process. 16 new tests, including the CI short-circuit and the local actionable path.

Closes #3408
