### PR TITLE
feat(privacy): wire per-PR private-leak gate via trusted workflow_run

### DIFF
--- a/.github/workflows/check-private-leak.yaml
+++ b/.github/workflows/check-private-leak.yaml
@@ -1,0 +1,121 @@
+---
+# Privileged per-PR private-leak gate — trusted workflow_run topology.
+#
+# Security model:
+#   - Triggered by `workflow_run` (on: workflow_run) so this job ALWAYS runs the
+#     DEFAULT-BRANCH workflow definition, never PR-author code. The broad-scope
+#     FRO_BOT_POLL_PAT is therefore never exposed to a malicious PR rewrite.
+#   - NO checkout of the PR head. Only the default branch (main) is checked out —
+#     for the script and metadata/repos.yaml. The PR diff is fetched as pure data
+#     via the GitHub API (`gh pr diff`), never from a checked-out tree.
+#   - NO actions/cache restore. The shared setup action restores a pnpm cache that
+#     a PR workflow could poison. This job installs deps fresh with no cache.
+#   - FRO_BOT_POLL_PAT is passed ONLY as a step-level env on the scan step. The
+#     script forwards it into the resolver subprocess under a scrubbed env (no
+#     GH_TOKEN/GITHUB_TOKEN inheritance) — mirroring the --promotion gitEnv pattern.
+#   - The commit status is posted to the exact PR head SHA the scan ran against.
+#     If the status POST itself fails, the job exits non-zero (fail-closed, R5).
+#
+# Credential split:
+#   - github.token (GITHUB_TOKEN): diff fetch, PR API, commit status POST.
+#   - FRO_BOT_POLL_PAT: private node_id → owner/name resolution only (resolver subprocess).
+name: Check Private Leak
+
+on:
+  workflow_run:
+    workflows: [Private Leak Sentinel]
+    types: [completed]
+
+# Minimum permissions: read the repo (checkout + gh api), write commit statuses,
+# read PR metadata for the API fallback identity resolution.
+permissions:
+  contents: read
+  statuses: write
+  pull-requests: read
+
+# Cancel superseded runs for the same PR head SHA. cancel-in-progress: false so a
+# stale run still posts its (failure) status rather than being silently dropped.
+concurrency:
+  group: check-private-leak-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash -Eeuo pipefail {0}
+
+jobs:
+  check-private-leak:
+    name: Check Private Leak
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Checkout the DEFAULT branch (main) only — for the script + metadata/repos.yaml.
+      # NEVER checkout the PR head; the diff is fetched as data via the GitHub API.
+      - name: ⤵ Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          fetch-depth: 1
+
+      # Minimal node + pnpm setup via mise — NO cache restore (R1: no poisonable cache).
+      # Uses the same mise-action pin as .github/actions/setup but skips the
+      # actions/cache step entirely so a PR workflow cannot poison the store.
+      - name: 📦 Install mise (node + pnpm)
+        env:
+          MISE_VERSION: 2026.6.0 # renovate: datasource=github-releases packageName=jdx/mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: ${{ env.MISE_VERSION }}
+          # Disable mise's own cache so no PR-poisonable cache is restored.
+          cache: false
+
+      # Install production deps (yaml package is required by check-private-leak.ts).
+      # --prefer-offline is fine here since there is no cache to restore from.
+      # --ignore-scripts prevents lifecycle hooks from running untrusted code.
+      - name: 📦 Install dependencies (no cache)
+        run: pnpm install --prefer-offline --ignore-scripts --loglevel warn
+
+      # Run the scan. FRO_BOT_POLL_PAT is scoped to THIS STEP ONLY (R6).
+      # The script reads GITHUB_EVENT_PATH (set automatically by Actions to the
+      # workflow_run payload), resolves PR identity via the API, fetches the diff
+      # as data, and exits 0 (pass) or non-zero (fail/error).
+      # GH_TOKEN is set to github.token so gh CLI uses the default token for
+      # diff fetch and PR API — never the broad-scope PAT.
+      - id: scan
+        name: 🔒 Scan PR diff for private repo names
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FRO_BOT_POLL_PAT: ${{ secrets.FRO_BOT_POLL_PAT }}
+        run: node scripts/check-private-leak.ts
+
+      # Post the commit status to the PR head SHA (R4, R5).
+      # Runs unconditionally (if: always()) so the status is posted whether the
+      # scan passed, failed, or errored. If this POST fails, the step exits
+      # non-zero and the job fails — the PR is never left unsignaled (fail-closed).
+      #
+      # INJECTION SAFETY: head_sha is a SHA (hex-only, safe to inline). The PR
+      # title and branch are never interpolated into this run: block.
+      - name: 📋 Post commit status
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SCAN_OUTCOME: ${{ steps.scan.outcome }}
+        run: |
+          if [ "$SCAN_OUTCOME" = "success" ]; then
+            state="success"
+            description="No private repository names detected in PR diff."
+          else
+            state="failure"
+            description="Private repository name(s) detected or scan error — see run logs for file paths."
+          fi
+
+          gh api \
+            --method POST \
+            "repos/{owner}/{repo}/statuses/${HEAD_SHA}" \
+            -f state="${state}" \
+            -f context="security/check-private-leak" \
+            -f description="${description}" \
+            -f target_url="${RUN_URL}"

--- a/.github/workflows/check-private-leak.yaml
+++ b/.github/workflows/check-private-leak.yaml
@@ -7,7 +7,8 @@
 #     FRO_BOT_POLL_PAT is therefore never exposed to a malicious PR rewrite.
 #   - NO checkout of the PR head. Only the default branch (main) is checked out —
 #     for the script and metadata/repos.yaml. The PR diff is fetched as pure data
-#     via the GitHub API (`gh pr diff`), never from a checked-out tree.
+#     via the GitHub compare API pinned to the workflow_run head SHA, never from a
+#     checked-out tree.
 #   - NO actions/cache restore. The shared setup action restores a pnpm cache that
 #     a PR workflow could poison. This job installs deps fresh with no cache.
 #   - FRO_BOT_POLL_PAT is passed ONLY as a step-level env on the scan step. The

--- a/.github/workflows/private-leak-sentinel.yaml
+++ b/.github/workflows/private-leak-sentinel.yaml
@@ -1,0 +1,40 @@
+---
+# Trusted-topology trigger for the private-leak PR gate.
+#
+# This workflow does nothing sensitive — no secrets, no PAT, no checkout of
+# PR-author code. Its sole purpose is to fire on pull_request events so that
+# the privileged `check-private-leak.yaml` workflow can trigger via
+# `workflow_run`. Because `workflow_run` always runs the DEFAULT-BRANCH
+# workflow definition, the broad-scope FRO_BOT_POLL_PAT in the privileged job
+# never executes PR-author code — closing the token-exfiltration vector that
+# existed when the scan ran directly in a `pull_request` job.
+#
+# `edited` is included so a title-based [allow-private-leak] override change
+# re-fires the gate for the same head SHA (otherwise the required status goes
+# stale when the operator adds the override prefix without pushing a new commit).
+name: Private Leak Sentinel
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, edited]
+
+# No permissions needed — this workflow does nothing sensitive.
+permissions: {}
+
+jobs:
+  sentinel:
+    name: Sentinel
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # PR-derived values passed via env (not inline ${{ }}) for injection-safety
+      # consistency with the privileged job, even though SHA/number cannot carry a payload.
+      - name: 🔒 Trigger private-leak scan
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo "sentinel: triggering private-leak scan via workflow_run"
+          echo "  head_sha=${HEAD_SHA}"
+          echo "  pr=${PR_NUMBER}"

--- a/docs/plans/2026-06-04-001-fix-orphan-wiki-page-guard-plan.md
+++ b/docs/plans/2026-06-04-001-fix-orphan-wiki-page-guard-plan.md
@@ -1,0 +1,259 @@
+---
+title: 'fix: gate survey wiki-commit on an onboarded repos.yaml entry'
+type: fix
+status: active
+date: 2026-06-04
+---
+
+# Gate survey wiki-commit on an onboarded repos.yaml entry
+
+## Overview
+
+A manual `survey-repo.yaml` dispatch can write a promotable wiki page to the
+`data` branch for a repository that has **no `metadata/repos.yaml` entry**. The
+resulting orphan page is `unattributable` to the privacy gate
+(`scripts/check-wiki-private-presence.ts`), which fail-closed blocks every
+`data → main` promotion until the page is removed by hand.
+
+This plan establishes the invariant: **a survey only writes a wiki page to `data`
+if the surveyed repo is already onboarded in `metadata/repos.yaml` on `data`.**
+
+## Problem Frame
+
+Triage issue #3440 (and the live incident it documents): a Merge Data Branch run
+failed at `🔒 Block private wiki pages` with one `unattributable-page`. Root cause
+(diagnosed via the gate's own exported functions, operator-side):
+
+- A manual survey of `fro-bot/tokentoilet` (an archived fork, never onboarded
+  because reconcile excludes archived repos via `archived === false` filtering)
+  wrote `knowledge/wiki/repos/fro-bot--tokentoilet.md` to `data`.
+- `fro-bot/tokentoilet` has no `repos.yaml` entry, so the page is not in the
+  public slug map and is not grandfathered on `main` → `unattributable-page`.
+- `scripts/record-survey-result.ts` already requires an entry and **silently
+  no-ops** (`RepoEntryNotFoundError` → exit 0, treated as "legitimate when a
+  manual survey dispatch runs against an un-onboarded repo"). But the wiki page is
+  committed in an **earlier** step, independent of that check, so the orphan page
+  lands regardless.
+
+The asymmetry: reconcile-driven surveys are always preceded by `addRepoEntry`
+onboarding, so they never orphan. Only **manual dispatch** can.
+
+The one-off orphan page was already removed from `data` via a Fro Bot identity
+dispatch (commit `1dd3b5c`); the gate now passes. This plan prevents recurrence.
+
+## Requirements Trace
+
+- R1. A survey of a repo with no `metadata/repos.yaml` entry on `data` must NOT
+  commit a wiki page to `data` (no orphan promotable pages).
+- R2. The guard must cover the general un-onboarded class, not just archived forks
+  (a non-archived, non-fork, public-but-not-yet-onboarded repo must also be
+  gated).
+- R3. The guard must be consistent with the existing `record-survey-result`
+  contract, which already requires an entry.
+- R4. Reconcile-driven surveys (which onboard via `addRepoEntry` first) must
+  continue to work unchanged.
+- R5. The survey run must not be marked failed when it gates out — it should skip
+  the wiki-commit + announce and exit cleanly (same fail-soft posture as the
+  existing no-op).
+
+## Scope Boundaries
+
+- Not changing reconcile's onboarding eligibility policy (archived/fork
+  exclusion stays as-is).
+- Not auto-onboarding repos during survey (explicitly rejected — would bypass
+  reconcile's eligibility policy and write entries for repos that shouldn't be
+  tracked).
+- Not changing the privacy gate (`check-wiki-private-presence.ts`) — it behaved
+  correctly (fail-closed). This plan stops the orphan from being created, not the
+  gate from catching it.
+- Not adding a dispatch-time archived/fork rejection (considered; the onboarded-
+  entry gate is strictly more general and covers the archived-fork case too).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `.github/workflows/survey-repo.yaml` — the survey job. Key steps in order:
+  `🔒 Resolve and verify` (resolves node_id → owner/repo, public-only), `Sync wiki
+  from data branch` (already does `git fetch origin data`), `Commit wiki ingest to
+  data branch` (`id: wiki-commit`, writes the page), `Record survey result`
+  (requires the entry, no-ops if missing), `📣 Announce survey to gateway`.
+- `scripts/record-survey-result.ts` — already throws/handles `RepoEntryNotFoundError`
+  and exits 0 on a missing entry. This is the existing "is it onboarded?" check —
+  the plan moves an equivalent check **earlier**, before the wiki-commit.
+- `scripts/reconcile-repos.ts:1793` — `archived === false` filtering; `addRepoEntry`
+  called before dispatch (why reconcile never orphans).
+- The `data` metadata overlay pattern: `survey-repo.yaml` already does
+  `git fetch origin data` for the wiki sync; `reconcile-repos.yaml` overlays
+  `metadata/` from `data` with `git checkout origin/data -- metadata/`. The same
+  cheap, precedented overlay gives the survey read access to the authoritative
+  `repos.yaml`.
+
+### Institutional Learnings
+
+- `docs/solutions/` (data-branch sole-writer / privacy-gate docs): `data` is the
+  authoritative writer for `knowledge/**` + `metadata/**`; `wiki-ingest.ts` is
+  additive-only (cannot delete); manual `data` writes by a human author trip
+  `DATA_BRANCH_TAMPER` in reconcile.
+- Memory: reconcile reads authoritative survey state by overlaying `metadata/`
+  from `data` before planning — the same technique applies here.
+
+## Key Technical Decisions
+
+- **Gate location: a new step before `wiki-commit`, after `resolve`.** It reads
+  the overlaid `data` `metadata/repos.yaml`, checks whether the resolved
+  owner/repo has an entry, and sets an output the `wiki-commit` and `announce`
+  steps gate on. Rationale: stops the orphan at the source (R1), covers the whole
+  un-onboarded class (R2), and mirrors `record-survey-result`'s contract (R3).
+- **Reuse the existing data overlay.** The survey already fetches `data` for the
+  wiki sync; extend it to also read `repos.yaml` (or overlay `metadata/`), so no
+  new credential or network surface is added.
+- **A small TS helper, not inline YAML/jq.** A pure, tested function
+  (`repoEntryExists(reposYaml, owner, repo)`) keeps the logic testable and
+  strip-only safe, consistent with the repo's "logic in scripts, not shell"
+  convention. The workflow calls it and gates on its output.
+- **Fail-soft skip, not failure (R5).** When the entry is absent, the run skips
+  wiki-commit + announce and exits 0 with a clear stderr note — matching the
+  existing `record-survey-result` posture so manual dispatches of un-onboarded
+  repos degrade cleanly instead of erroring.
+
+## Open Questions
+
+### Resolved During Planning
+
+- *Where to gate?* → before `wiki-commit` (the step that creates the orphan), not
+  at dispatch. Resolved per the design decision above.
+- *Archived/fork rejection too?* → no; the onboarded-entry gate is strictly more
+  general. Recorded as a scope boundary.
+- *Auto-onboard?* → rejected (scope boundary).
+
+### Deferred to Implementation
+
+- Exact mechanism to expose the "entry exists" result to later steps (a step
+  output set from the helper's stdout vs. an env var). Resolve when wiring.
+- Whether to overlay all of `metadata/` or read only `repos.yaml` — pick the
+  minimal form that the helper needs at implementation time.
+
+## Implementation Units
+
+- [ ] **Unit 1: `repoEntryExists` helper + tests**
+
+**Goal:** A pure, tested predicate that answers "does `metadata/repos.yaml` have
+an entry for this owner/repo?" for the survey gate to call.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `scripts/repos-metadata.ts` (add `repoEntryExists`, or a thin
+  CLI-friendly wrapper) — or a new small `scripts/check-repo-onboarded.ts` CLI if
+  a standalone entrypoint is cleaner for the workflow to call
+- Test: `scripts/repos-metadata.test.ts` (or the new script's `.test.ts`)
+
+**Approach:**
+- Parse the provided `repos.yaml` content and return whether an entry matches the
+  given `owner` + `repo` (case-sensitive, matching how entries are stored).
+- Pure function over parsed YAML — no I/O in the predicate. A thin CLI wrapper
+  reads the file + env (`REPO_OWNER`, `REPO_NAME`) and prints a gate-friendly
+  result (e.g. `onboarded=true|false` to `GITHUB_OUTPUT`), exiting 0 either way.
+- Reuse existing schema/parse helpers in `repos-metadata.ts`; do not hand-roll
+  YAML parsing.
+
+**Patterns to follow:**
+- `scripts/record-survey-result.ts` CLI shape (env-driven, `import.meta.url`
+  entrypoint guard, structured stderr, exit-0 posture).
+- Existing `repos-metadata.ts` pure-function + `RepoEntryNotFoundError` style.
+
+**Test scenarios:**
+- Happy path: entry present for `owner/repo` → true.
+- Edge: entry absent → false.
+- Edge: empty/missing `repos:` list → false (not a crash).
+- Edge: owner matches but name differs (and vice versa) → false.
+- Edge: malformed YAML → fail-closed (treat as not-onboarded / surface a clear
+  error per the chosen wrapper contract), never a silent true.
+
+- [ ] **Unit 2: wire the onboarded gate into `survey-repo.yaml`**
+
+**Goal:** Survey only commits the wiki page (and announces) when the resolved repo
+is onboarded on `data`.
+
+**Requirements:** R1, R2, R4, R5
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `.github/workflows/survey-repo.yaml`
+
+**Approach:**
+- After `🔒 Resolve and verify`, ensure `metadata/repos.yaml` from `data` is
+  available (reuse/extend the existing `git fetch origin data`; overlay
+  `metadata/` if needed). Add a `Check repo onboarded` step that runs the Unit 1
+  helper with `REPO_OWNER`/`REPO_NAME` and sets `steps.onboarded.outputs.onboarded`.
+- Add `&& steps.onboarded.outputs.onboarded == 'true'` to the `if:` of the
+  `Commit wiki ingest to data branch` step and the `📣 Announce survey to gateway`
+  step. (The `Record survey result` step already no-ops on a missing entry; leave
+  its behavior, but it will now agree with the wiki gate.)
+- When not onboarded: emit a clear stderr note, skip wiki-commit + announce, and
+  let the job conclude successfully (R5).
+- Confirm reconcile-driven dispatches still pass: reconcile onboards via
+  `addRepoEntry` before dispatch, so the entry exists on `data` by survey time
+  (R4).
+
+**Execution note:** Validate with `actionlint` (the repo's `Check Workflows`
+gate); workflow logic can't be unit-tested, so the helper (Unit 1) carries the
+test coverage and the workflow carries an actionlint + a live manual-dispatch
+verification.
+
+**Patterns to follow:**
+- The existing `data` fetch/overlay in `survey-repo.yaml` (wiki sync) and
+  `reconcile-repos.yaml` (`git checkout origin/data -- metadata/`).
+- The existing step-output gating pattern already used across the survey steps
+  (`steps.recheck.conclusion`, `steps.wiki-changes.outputs.changed`).
+
+**Test scenarios:**
+- Test expectation: none (workflow YAML) — covered by Unit 1 tests +
+  `actionlint` + a post-merge manual-dispatch verification (onboarded repo →
+  page commits; un-onboarded repo → no page, run succeeds).
+
+## System-Wide Impact
+
+- **Interaction graph:** Only `survey-repo.yaml`'s wiki-commit + announce gating
+  changes. `record-survey-result` already gated on the entry; this brings the
+  wiki-commit into agreement. No change to reconcile, the privacy gate, or the
+  gateway announce script.
+- **Error propagation:** Not-onboarded is a clean skip (exit 0), not a failure —
+  consistent with the existing `record-survey-result` no-op.
+- **State lifecycle risks:** Eliminates the orphan-page state that blocked
+  promotion. No new state introduced.
+- **API surface parity:** `poll-invitations.yaml` and `reconcile-repos.yaml` both
+  onboard before any wiki write, so they don't need the guard — but if a future
+  manual wiki-writing path is added, it should reuse the Unit 1 helper.
+- **Unchanged invariants:** The privacy gate, `wiki-ingest.ts` additive-only
+  behavior, and reconcile onboarding eligibility are all unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Overlaying `data` metadata adds a step that could fail and block legit surveys | Reuse the existing `git fetch origin data` already in the job; fail-closed only on the onboarded check itself, and make malformed/missing read a clear skip, not a hard error mid-job |
+| A legit brand-new public repo manual-survey now no-ops until onboarded | Documented + intended: onboard via reconcile or the allowlist first. Surfaced in the skip stderr message so the operator knows the next step |
+| Helper case-sensitivity mismatch vs. stored entries | Unit 1 tests cover owner/name exact-match; mirror how `record-survey-result` matches |
+
+## Documentation / Operational Notes
+
+- Note in `metadata/README.md` (or the survey workflow header comment) that a
+  manual survey of an un-onboarded repo will skip the wiki write by design, and
+  how to onboard first.
+- Close #3440 referencing the unblock (already done on `data`) + this guard once
+  shipped.
+
+## Sources & References
+
+- Triage issue: #3440
+- Unblock commit on `data`: `1dd3b5c` (Fro Bot identity)
+- Gate: `scripts/check-wiki-private-presence.ts` (`detectPrivateWikiLeaks`)
+- Existing entry-check precedent: `scripts/record-survey-result.ts`,
+  `scripts/repos-metadata.ts` (`RepoEntryNotFoundError`)
+- Onboarding/exclusion: `scripts/reconcile-repos.ts` (`addRepoEntry`,
+  `archived === false`)

--- a/docs/plans/2026-06-04-003-feat-wire-private-leak-pr-gate-plan.md
+++ b/docs/plans/2026-06-04-003-feat-wire-private-leak-pr-gate-plan.md
@@ -1,0 +1,393 @@
+---
+title: 'feat: Wire Check Private Leak as a per-PR gate via trusted workflow_run'
+type: feat
+status: active
+date: 2026-06-04
+origin: 'GitHub issue #3407'
+---
+
+# feat: Wire Check Private Leak as a per-PR gate via trusted workflow_run
+
+## Overview
+
+`scripts/check-private-leak.ts` carries a tested pure core that scans a PR's added lines, new-file
+paths, and rename/copy destinations for a private repo's canonical `owner/name` (and `owner--slug`
+wiki form), returning matched FILE paths only — never the resolved name. The names are resolved from
+`data`'s redacted `node_id` entries via a broad-scope classic PAT (`FRO_BOT_POLL_PAT`), the only
+credential that can read cross-account private repos.
+
+The `data→main` promotion gate (`--promotion` mode in `merge-data.yaml`) already enforces this scan on
+the autonomous promotion path (shipped via the `2026-06-03-001` plan). This plan adds the **per-PR
+defense-in-depth layer** that plan explicitly deferred: a gate that scans human/agent PRs *to `main`*
+for private names before merge — the secondary layer catching a leak introduced directly in a PR diff
+rather than through the `data` promotion path.
+
+The hard constraint is credential safety. The broad-scope PAT must **never** execute PR-author code.
+The first attempt ran the scan as a `pull_request` job that checked out `head_ref` with the PAT in
+scope — a token-exfiltration vector on this public repo (a pushed branch could rewrite the script or a
+lifecycle hook to leak the PAT). That job was removed. This plan rebuilds the gate in a **trusted
+`workflow_run` topology** where the privileged job runs only the default-branch workflow definition and
+treats the PR diff as pure data read via the GitHub API — never a checkout.
+
+## Problem Frame
+
+`check-private-leak.ts` is shipped and tested but has **no per-PR CI trigger** after the original
+`pull_request` wiring was removed for the token-exfil vector (origin: issue #3407). The promotion gate
+covers the autonomous `data→main` path, but a private name introduced directly in a PR diff to `main`
+has no automated gate. The fix is to wire the scan in a trusted context that closes the exfil vector
+while still reporting a blocking status back to the PR.
+
+This is defense-in-depth, not the sole control: `check-wiki-authority` already blocks non-Fro-Bot edits
+to `knowledge/`+`metadata/`, and on a public repo a fork PR that adds a private name has already
+disclosed it before Actions runs. This gate is a **merge blocker**, not a secrecy control — it prevents
+merging/amplifying a leak, and catches the human-PR class the promotion gate cannot see.
+
+## Requirements Trace
+
+- R1. The scan runs in a context where `FRO_BOT_POLL_PAT` never executes PR-author code (no PR-head
+  checkout, no PR artifacts, no shared cache in the PAT-bearing job).
+- R2. The privileged job runs the workflow definition from the default branch (`workflow_run` semantics).
+- R3. The PR diff and identity are treated as pure data, resolved via the GitHub API — never from a
+  checked-out tree or a PR-author-produced artifact.
+- R4. A blocking status is reported back to the PR head SHA (pass/fail + offending file paths only,
+  never the resolved private name).
+- R5. The scan fails closed: if PR identity cannot be resolved, resolution errors, **or the commit-status
+  POST itself fails**, the outcome is a blocking failure (never a silent pass and never an unsignaled PR).
+- R6. `FRO_BOT_POLL_PAT` is scoped to the node-id resolver subprocess only — never the job-level or
+  step-level `GH_TOKEN`, never ambient before setup/install. The resolver subprocess receives a **minimal
+  env** with no inherited token surface (`GH_TOKEN`/`GITHUB_TOKEN`/other creds) beyond the intended PAT.
+- R7. The blocking status uses a new context name distinct from any existing job/check name (no
+  collision), and is registered as a required status check on `main` only after the topology is proven
+  green — including for fork PRs.
+
+## Scope Boundaries
+
+- Not changing the `--promotion` gate in `merge-data.yaml` (shipped, separate path).
+- Not changing the pure scan core (`checkPrivateLeak`) — it is shipped and tested.
+- Not changing the `[allow-private-leak]` operator override semantics (already built) — only confirming
+  it still functions under the new event shape.
+- Not building fingerprint/hash detection (rejected: low-entropy repo names → guess-confirmable oracle on
+  a public branch; secret-pepper relocates the credential problem).
+- Not attempting to make fork-PR submission confidential — public PRs already disclose names; this is a
+  merge gate only.
+
+### Deferred to Separate Tasks
+
+- **Required-check registration on `main`** is the final step and is gated on empirical proof that the
+  commit status attaches and blocks for **fork** PR heads (R7). If fork-head status attachment cannot be
+  proven, registration is deferred and the gate ships as advisory-only with a tracked follow-up, rather
+  than registering a required check that silently never attaches to fork PRs.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/check-private-leak.ts` — `main()` (L567) reads `GITHUB_EVENT_PATH` and expects a
+  `pull_request` payload (`pull_request.number/.user.login/.title`, L219-223). This is the event reader
+  that must change to accept a `workflow_run` payload. **Oracle-confirmed gap:** L594 calls
+  `makeGhNodeIdResolver()` with **no PAT** — the resolver must be wired with `FRO_BOT_POLL_PAT`.
+- `scripts/check-private-leak.ts` `--promotion` path (L453-475) — the **correct pattern to mirror** for
+  PAT isolation: it reads `FRO_BOT_POLL_PAT` only for the resolver and builds a `gitEnv` that strips the
+  PAT from the git subprocess. The per-PR path must isolate the PAT identically.
+- `scripts/private-repo-resolution.ts` — `makeGhNodeIdResolver(token)` is the resolver seam; the
+  `#3429` hygiene work already strips token aliases from its subprocess env.
+- `.github/workflows/renovate.yaml` — **in-repo `workflow_run` precedent** to mirror for trigger shape.
+- `.github/workflows/merge-data.yaml` — existing `check-private-leak --promotion` wiring (the sibling
+  enforcement point) for the script-invocation and redacted-output shape.
+- `[allow-private-leak]` override (L261/589/671) — operator bypass via PR title prefix, restricted to a
+  permitted login. Title is mutable, so the sentinel `pull_request` workflow must include `edited`
+  (Oracle sharp edge) or the required status can go stale for the same head SHA.
+
+### Institutional Learnings
+
+- `docs/solutions/security-issues/` and `docs/solutions/best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md`
+  — the promotion-gate sibling, including the fail-closed and PAT-confinement patterns.
+- Memory: `FRO_BOT_POLL_PAT` is the only credential resolving cross-account private repos; App and
+  fine-grained PATs cannot. Redaction surfaces use `node_id` only, never `owner/name`.
+- The `#3429`/`#3430`/`#3412` hygiene shipped this cycle: subprocess-scoped PAT, count-only failure
+  output, tightened `node_id` schema — all directly relevant to R5/R6.
+
+### External References
+
+- Oracle topology pressure-test (this session): `workflow_run` runs the default-branch workflow
+  definition; `pull_requests[]` can be empty for forks (API fallback by head SHA required); branch
+  protection accepts commit statuses; Checks API requires a GitHub App (out of reach here) → use a
+  **commit status** set with `GITHUB_TOKEN`; fork-head required-status attachment is the genuine risk to
+  prove before registering.
+
+## Key Technical Decisions
+
+- **Two-workflow `workflow_run` topology.** A minimal `pull_request` sentinel workflow (targets `main`,
+  does nothing sensitive, exists only to fire) triggers a privileged `workflow_run` workflow that runs
+  the scan with the PAT. The privileged workflow runs the default-branch definition (R2), closing the
+  "malicious PR rewrites the workflow file" hole. Mirrors `renovate.yaml`'s precedent.
+- **Commit status, not Checks API** (Oracle). Checks API needs a GitHub App; a commit status set with
+  `GITHUB_TOKEN`/`statuses: write` integrates natively with branch-protection required-checks. Context
+  name: `security/check-private-leak` — distinct from any job name to avoid collision (R7).
+- **Target the scanned PR head SHA.** The status is posted to the exact head SHA the scan ran against —
+  never the default-branch `GITHUB_SHA`, never the `workflow_run` SHA. Stale runs post failure, not
+  success (R4, R5).
+- **PR identity resolved in code, not YAML** (Oracle). The script reads the `workflow_run` payload,
+  requires `workflow_run.event == 'pull_request'`, takes the candidate PR from
+  `workflow_run.pull_requests[]` when present, falls back to an API query by `head_sha`, then validates:
+  base repo is `fro-bot/.github`, base branch is `main`, PR head SHA matches the scanned SHA. The
+  security boundary stays in TypeScript, not spread into shell.
+- **No artifacts from the PR-author job.** The privileged job derives everything from the GitHub API and
+  the event payload — never a downloaded artifact (the classic `workflow_run` untrusted-artifact footgun).
+- **PAT subprocess-scoped only** (R6). The job's `GH_TOKEN` is the default `GITHUB_TOKEN` (for diff +
+  status). `FRO_BOT_POLL_PAT` is passed only into the resolver, mirroring the `--promotion` `gitEnv`
+  isolation. No cache/setup step runs with the PAT ambient.
+- **No `actions/cache` in the PAT-bearing job** (Oracle sharp edge). The shared `setup` action restores
+  a pnpm cache; a PR workflow could poison it. The privileged job does a minimal install (or none if the
+  script's runtime deps are already vendored) with no restored cache.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Status mechanism → **commit status via `GITHUB_TOKEN`** (Oracle: Checks API needs an App).
+- Required-check name → **`security/check-private-leak`** (new context, no collision with existing jobs).
+- Where PR-identity validation lives → **in the script** (security boundary in code, not YAML).
+- Whether to trust `workflow_run.pull_requests[]` → **use when present, API-fallback by head SHA**, then
+  validate base repo/branch + head-SHA match.
+- Fork PRs → **in-scope for merge blocking, fail-closed on unresolvable identity**; required-check
+  registration gated on proven fork-head attachment.
+
+### Deferred to Implementation
+
+- Exact pnpm/install shape in the privileged job (whether the script runs with zero install or a minimal
+  no-cache install) — resolved when wiring the job against the real runtime.
+- Whether the sentinel `pull_request` workflow needs any path filter, or fires on all PRs to `main`
+  (default: all PRs to `main`, since any file could introduce a name) — confirmed against the diff cost
+  at implementation.
+- The precise API call for the head-SHA → PR-number fallback (`gh api` search vs
+  `pulls.listAssociatedWithCommit`) — resolved against the live API shape.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation
+> specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+PR opened/synchronized/edited (-> main)
+        │
+        ▼
+[sentinel workflow]  on: pull_request   (no secrets, no PAT, does nothing sensitive)
+        │  completes
+        ▼
+on: workflow_run (completed)  ── runs the DEFAULT-BRANCH definition ──┐
+        │                                                             │ trusted context
+        ▼                                                             │
+[privileged job]  GH_TOKEN = GITHUB_TOKEN (diff + status only)        │
+  1. read workflow_run payload → require event == 'pull_request'      │
+  2. PR number := pull_requests[] || API fallback by head_sha         │
+  3. validate base = fro-bot/.github, base branch = main,             │
+     PR head SHA == scanned SHA   ── unresolvable? → FAIL CLOSED ──────┤
+  4. gh pr diff <n>  (pure data, no checkout)                         │
+  5. resolve private names: FRO_BOT_POLL_PAT → resolver subprocess    │
+     (PAT stripped from git/diff env, mirrors --promotion gitEnv)     │
+  6. scan added lines/paths/renames → matched FILE paths only         │
+  7. POST commit status `security/check-private-leak` to head SHA     │
+     pass / fail(+paths) — never the resolved name                    │
+        │                                                             │
+        ▼                                                             │
+branch protection (once proven) requires security/check-private-leak ─┘
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Add a `workflow_run` / per-PR event reader + resolver wiring to `check-private-leak.ts`**
+
+**Goal:** Teach `main()` to run under a `workflow_run` event: read the `workflow_run` payload, resolve
+and validate PR identity via the API, wire `FRO_BOT_POLL_PAT` into the resolver, and emit a structured
+result the workflow turns into a commit status. **`main()` accepts only the `workflow_run` payload** — the
+direct `pull_request` event reader is replaced (the per-PR gate is the only consumer of `main()`, and it
+now runs exclusively in the trusted `workflow_run` context). The `--promotion` path (separate entrypoint,
+`process.argv`-gated) is unaffected.
+
+**Requirements:** R3, R5, R6
+
+**Dependencies:** None (script is shipped; this extends `main()`)
+
+**Files:**
+- Modify: `scripts/check-private-leak.ts`
+- Test: `scripts/check-private-leak.test.ts`
+
+**Approach:**
+- Add a `workflow_run` payload reader: require `workflow_run.event == 'pull_request'`; take PR number
+  from `workflow_run.pull_requests[]` when present, else fall back to an API query by `head_sha`.
+- Validate base repo `fro-bot/.github`, base branch `main`, and that the PR head SHA equals the scanned
+  SHA. **Require exactly one PR to survive validation** — if the head-SHA fallback returns multiple
+  associated PRs and more than one (or none) passes validation, fail closed. Any validation failure or
+  resolution error → fail-closed result (status failure), never a pass.
+- Fix the Oracle-confirmed gap at L594: wire `makeGhNodeIdResolver(process.env.FRO_BOT_POLL_PAT)` and
+  fail closed if the PAT is absent. Mirror the `--promotion` `gitEnv` pattern (L453-475) so the PAT
+  reaches only the resolver, never the diff/git subprocess.
+- Emit a structured result (pass | fail + matched file paths) the workflow maps to the commit status —
+  paths only, never the resolved name (existing redaction).
+- Confirm the `[allow-private-leak]` override still resolves under the new identity path (title comes
+  from the validated PR JSON, not a `pull_request` event payload).
+
+**Execution note:** Test-first — add failing tests for the `workflow_run` payload reader and the
+fail-closed identity-validation paths before implementing.
+
+**Patterns to follow:**
+- `--promotion` path (L453-475) for PAT/`gitEnv` isolation.
+- Existing event-reading + redacted-output structure in `main()`.
+
+**Test scenarios:**
+- Happy path: `workflow_run` payload with a populated `pull_requests[]` → resolves PR number, validates
+  base/branch/head-SHA, scans diff (mocked), emits pass when no private name present.
+- Happy path: added line contains a resolved private `owner/name` → emits fail with the offending file
+  path, never the name.
+- Edge case: empty `pull_requests[]` → API fallback by `head_sha` resolves the PR number.
+- Error path: `workflow_run.event != 'pull_request'` → fail-closed (no scan, status failure).
+- Error path: base repo/branch mismatch, or PR head SHA != scanned SHA → fail-closed.
+- Error path: PR identity unresolvable (no `pull_requests[]`, API fallback returns nothing) → fail-closed.
+- Error path: head-SHA fallback returns multiple associated PRs, not exactly one passing validation →
+  fail-closed (ambiguous identity never resolves to a pass).
+- Error path: `FRO_BOT_POLL_PAT` absent → fail-closed (resolver cannot run; never a silent pass).
+- Integration: PAT is present in the resolver subprocess env but absent from the diff/git subprocess env
+  (mirror the `--promotion` isolation assertion).
+- Edge case: `[allow-private-leak]`-prefixed title by the permitted login → override honored under the
+  new identity path.
+
+**Verification:**
+- `main()` runs under a `workflow_run` event and produces a pass/fail result with file-path-only output.
+- All identity-resolution failure modes produce a failure result, proven by tests that would pass under a
+  silent-pass regression and fail under the fail-closed implementation.
+- The PAT never appears in the diff/git subprocess env.
+
+- [ ] **Unit 2: Add the sentinel + privileged `workflow_run` workflows and post the commit status**
+
+**Goal:** Add the minimal `pull_request` sentinel workflow and the privileged `workflow_run` workflow
+that runs the Unit 1 scan with subprocess-scoped PAT and posts a `security/check-private-leak` commit
+status to the PR head SHA.
+
+**Requirements:** R1, R2, R4, R5, R6
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `.github/workflows/private-leak-sentinel.yaml` (the `pull_request` trigger)
+- Create: `.github/workflows/check-private-leak.yaml` (the `workflow_run` privileged job)
+- Modify: `metadata/README.md` (document the credential + topology, mirroring existing gate docs)
+
+**Approach:**
+- Sentinel: `on: pull_request` to `main`, types `[opened, synchronize, reopened, edited]` (`edited` so a
+  title-based override change re-fires — Oracle sharp edge). Minimal `permissions: {}` / no secrets; it
+  exists only to trigger the privileged workflow. Mirror `renovate.yaml`'s sentinel shape.
+- Privileged: `on: workflow_run` (workflows: the sentinel name, types `[completed]`). Job permissions:
+  `contents: read`, `statuses: write`, `pull-requests: read`. `GH_TOKEN` = `GITHUB_TOKEN` for diff +
+  status. `FRO_BOT_POLL_PAT` passed only as an env on the scan step (the script isolates it to the
+  resolver subprocess). **No `actions/cache`, no PR-head checkout, no artifact download.**
+- The job runs the Unit 1 scan, captures the structured result, and posts a commit status
+  `security/check-private-leak` to the resolved PR head SHA: `success` on pass, `failure` with the
+  matched file paths in the description (never the name). On any unresolved-identity/error path, post
+  `failure` (fail-closed). **If the status POST itself fails (transient API/auth), the job exits
+  non-zero** so the PR never ends up with no blocking signal (R5).
+- The scan step passes `FRO_BOT_POLL_PAT` to the script, which forwards it into the resolver subprocess
+  under a minimal scrubbed env (no `GH_TOKEN`/`GITHUB_TOKEN` inheritance) — mirroring the `#3429`
+  subprocess hygiene (R6).
+- Use `env:`-passed values for any PR-derived strings in `run:` blocks (never inline interpolation of PR
+  title/branch/diff) to avoid shell injection (Oracle residual-exfil edge).
+
+**Execution note:** none — workflow YAML; validated via actionlint and a live dispatch/test PR.
+
+**Patterns to follow:**
+- `.github/workflows/renovate.yaml` (`workflow_run` trigger shape).
+- `.github/workflows/merge-data.yaml` (`check-private-leak` invocation + redacted-output handling, App
+  vs PAT token separation already present in repo workflows).
+
+**Test scenarios:** Test expectation: none (workflow wiring). Verified by actionlint + a live test PR in
+Unit 3. The behavioral logic is covered by Unit 1's script tests.
+
+**Verification:**
+- actionlint passes on both workflows.
+- A test PR to `main` that adds a benign line produces a `success` `security/check-private-leak` status
+  on the PR head SHA.
+- A test PR whose diff contains a known private name produces a `failure` status naming only file paths.
+- The privileged job's logs show no PAT, no PR-head checkout, no cache restore; the PAT is present only
+  in the scan step's resolver subprocess.
+
+- [ ] **Unit 3: Prove fork-head status attachment, then register the required check**
+
+**Goal:** Empirically verify the commit status attaches and blocks for both same-repo and fork PR heads,
+then register `security/check-private-leak` as a required status check on `main`. If fork-head
+attachment cannot be proven, ship advisory-only and file a tracked follow-up rather than registering a
+check that silently never attaches.
+
+**Requirements:** R7
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `.github/settings.yml` (add `security/check-private-leak` to `main` required contexts — only
+  after proof)
+
+**Approach:**
+- Same-repo proof: open a throwaway branch PR to `main`, confirm the status posts to the head SHA and
+  (after registration) blocks merge until success.
+- Fork proof: from a fork, open a PR to `main`; confirm the sentinel fires (note first-time-contributor
+  approval gating), `workflow_run` triggers, the API fallback resolves the PR by head SHA, and the
+  commit status attaches to the fork head SHA and is honored by branch protection.
+- If fork attachment holds → add the context to `.github/settings.yml` required checks. If it does not →
+  do not register; ship advisory-only and open a follow-up issue documenting the fork-head limitation.
+
+**Execution note:** none — empirical verification + a settings change.
+
+**Patterns to follow:**
+- `.github/settings.yml` existing `required_status_checks.contexts` list.
+
+**Test scenarios:** Test expectation: none (operational verification + settings change). Proof is the
+live same-repo and fork PRs.
+
+**Verification:**
+- Same-repo PR: status attaches and blocks until success (post-registration).
+- Fork PR: status attaches to the fork head SHA, or — if it cannot — registration is withheld and a
+  follow-up is filed; no required check is registered that silently never attaches.
+
+## System-Wide Impact
+
+- **Interaction graph:** New sentinel `pull_request` workflow + privileged `workflow_run` workflow. No
+  change to `merge-data.yaml` promotion gate, `fro-bot.yaml`, or reconcile. The new required context (if
+  registered) gates all PRs to `main`.
+- **Error propagation:** All identity/resolution failures → commit-status `failure` (fail-closed). A
+  failed scan blocks merge (once required), never silently passes.
+- **State lifecycle risks:** Stale runs (PR head moved after scan) must post against the scanned SHA only,
+  so a superseded run cannot mark a newer head green. Title-edit override staleness mitigated by the
+  sentinel's `edited` trigger.
+- **API surface parity:** This is the per-PR sibling of the `--promotion` gate; both use the same scan
+  core and redaction, so detection semantics stay consistent across both enforcement points.
+- **Unchanged invariants:** The pure scan core, `--promotion` gate, `check-wiki-authority`, and
+  `[allow-private-leak]` override semantics are unchanged. The PAT remains resolver-subprocess-scoped
+  everywhere (consistent with the `#3429` hygiene).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Broad PAT exposed to PR-author code (the original vector) | `workflow_run` runs default-branch def; no PR-head checkout, no artifacts, no cache; PAT subprocess-scoped only (R1, R6) |
+| Fork-head commit status not honored by branch protection | Unit 3 proves it empirically before registering; advisory-only fallback + follow-up if unproven (R7) |
+| PR-author content injected into a `run:` shell eval | PR-derived strings passed as `env:`, never inline-interpolated; diff parsed as data |
+| Stale run marks a newer head green | Status posted only against the exact scanned head SHA; mismatched SHA → fail-closed |
+| Commit-status POST fails → PR left unsignaled | Status-post failure exits the job non-zero (fail-closed), never a logged warning (R5) |
+| Ambiguous PR lookup (one head SHA → multiple PRs) | Require exactly one PR to survive base/branch/head-SHA validation; otherwise fail-closed |
+| Title-based override goes stale for the same head SHA | Sentinel includes `edited` so an override title change re-fires the gate |
+| First-time fork contributor: sentinel needs approval | Documented as expected; required status is absent/pending until the PR workflow is approved to run |
+
+## Documentation / Operational Notes
+
+- Document the topology + credential split in `metadata/README.md` next to the existing gate docs: the
+  privileged job uses `GITHUB_TOKEN` for diff/status and `FRO_BOT_POLL_PAT` only for name resolution.
+- Note the `[allow-private-leak]` operator override still applies (permitted login, title prefix).
+- Note the required-check registration is gated on fork-head proof (Unit 3).
+
+## Sources & References
+
+- **Origin document:** GitHub issue #3407 (Wire Check Private Leak in a trusted `workflow_run` topology)
+- Sibling plan: `docs/plans/2026-06-03-001-feat-wire-private-leak-guard-plan.md` (the promotion gate that
+  deferred this per-PR layer)
+- Related code: `scripts/check-private-leak.ts`, `scripts/private-repo-resolution.ts`,
+  `.github/workflows/renovate.yaml`, `.github/workflows/merge-data.yaml`
+- Related learnings: `docs/solutions/best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md`

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -16,10 +16,10 @@ approved_inviters:
     role: string
 # Optional. Empty/missing = no contrib-channel discovery.
 approved_contrib_orgs:
-  - string  # GitHub org login (e.g., "bfra-me")
+  - string # GitHub org login (e.g., "bfra-me")
 # Optional. Empty/missing = no contrib-channel direct probes.
 approved_contrib_repos:
-  - string  # "owner/name" (e.g., "bfra-me/.github")
+  - string # "owner/name" (e.g., "bfra-me/.github")
 ```
 
 - `approved_inviters` — collaboration invitations from these usernames are auto-accepted by `poll-invitations.yaml`.
@@ -91,7 +91,17 @@ A private repo's existence, name, or content must never reach a public surface. 
 - **Workflow resolution gate** — `survey-repo.yaml` takes a `node_id` input and resolves it to `owner/repo` only after verifying the repo is public; a private (or inaccessible) `node_id` aborts the run before any name reaches a log, run name, or concurrency key.
 - **Social gate** — `social-broadcast.yaml` defaults `private: true`, so a caller that omits the flag skips external posts (fail-safe).
 - **Merge-ceremony gate** — the `data → main` promotion blocks if a wiki page in `knowledge/wiki/repos/` would promote that can't be attributed to a known-public repo (by filename-slug attribution via `scripts/check-wiki-private-presence.ts`). **Known open seam:** this gate scans ONLY `knowledge/wiki/repos/` by filename slug. Non-repo wiki areas (`knowledge/wiki/topics/`, `entities/`, `comparisons/`) and free-text body mentions of a private repo name are NOT gated on the promotion path today — the companion content scan (`check-private-leak.ts`) is not yet wired into the promotion (tracked as in-progress follow-up hardening to cover a promotion-time trusted content scan). This is a known, plainly-stated limitation, not a solved problem. Because the `data` branch is publicly readable, this gate is defense-in-depth for `main`, not a first-disclosure control. The gate reads `metadata/repos.yaml` from the `data` branch it is validating (not a PR tree); the original "open a PR flipping `private:true→false` to bypass" path is moot because (a) the gate runs only on schedule/workflow_dispatch, never on a PR tree, and (b) `check-wiki-authority` blocks non-fro-bot and non-`data`-head edits to `repos.yaml`. Residual: a trusted-writer visibility downgrade on `data` (buggy reconcile probe, compromised token, direct push) could still mark a repo public; mitigated by fro-bot sole-writer + the public-attribution requirement. A `private→false` transition is worth an audit alert (future hardening).
-- **CI guard** — `scripts/check-private-leak.ts` scans a PR's added lines for any private repo's canonical `owner/name`, resolved from `data`'s `node_id` values via the GitHub API. A match reports only the offending file path, never the leaked name. Operator override: a PR titled `[allow-private-leak] …` authored by `marcusrbrown` passes with a logged transparency comment. The CI wiring that runs this guard on every PR is deferred: resolving cross-account private names requires a broad-scope credential, which must not run in a job that checks out PR-author code (token-exfiltration risk). The guard ships as a standalone, tested script; its CI integration lands separately in a trusted (`workflow_run`) topology that treats the PR diff as data.
+- **CI guard (per-PR)** — `scripts/check-private-leak.ts` scans a PR's added lines for any private repo's canonical `owner/name`, resolved from `data`'s `node_id` values via the GitHub API. A match reports only the offending file path, never the leaked name. Operator override: a PR titled `[allow-private-leak] …` authored by `marcusrbrown` passes with a logged transparency comment.
+
+  The CI wiring uses a **trusted `workflow_run` topology** to keep the broad-scope `FRO_BOT_POLL_PAT` away from PR-author code:
+  - `private-leak-sentinel.yaml` — a minimal `pull_request` workflow (no secrets, no PAT, no checkout) that fires on `opened`, `synchronize`, `reopened`, and `edited` events targeting `main`. Its only job is to trigger the privileged workflow. `edited` is included so a title-based `[allow-private-leak]` override change re-fires the gate for the same head SHA.
+  - `check-private-leak.yaml` — a `workflow_run` workflow that runs **only the default-branch workflow definition** (never PR-author code). It checks out `main` only (never the PR head), installs deps fresh with no cache restore (no poisonable pnpm store), and runs the scan with `FRO_BOT_POLL_PAT` scoped to the resolver subprocess only. The PR diff is fetched as pure data via `gh pr diff` using the default `GITHUB_TOKEN` — the broad-scope PAT never touches the diff subprocess.
+
+  Credential split in the privileged job:
+  - `github.token` (`GITHUB_TOKEN`): diff fetch, PR API identity resolution, commit status POST.
+  - `FRO_BOT_POLL_PAT`: private `node_id` → `owner/name` resolution only (resolver subprocess, scrubbed env — no `GH_TOKEN`/`GITHUB_TOKEN` inheritance).
+
+  The gate posts a `security/check-private-leak` commit status to the exact PR head SHA. If the status POST itself fails, the job exits non-zero (fail-closed — the PR is never left unsignaled). Required-check registration on `main` is gated on empirical proof that the status attaches for fork PR heads (Unit 3, not yet registered).
 
 **Operator lookup** — to map a redacted `node_id` back to its `owner/repo` (the convenience a plain `grep` of `repos.yaml` used to provide), run `GH_TOKEN=<operator-PAT> node scripts/resolve-private.ts`. It reads `repos.yaml`, resolves each private entry's `node_id` via the GitHub API, and prints a `node_id → owner/name` table to stdout. It never writes to the working tree and is invoked by no workflow.
 
@@ -139,16 +149,17 @@ PAT split summary:
 
 ### Workflow secret mapping
 
-| Workflow                | Secrets passed (explicit, not inherited)                                                |
-| ----------------------- | --------------------------------------------------------------------------------------- |
-| `fro-bot.yaml`          | `FRO_BOT_PAT`, `OPENCODE_AUTH_JSON`, `OMO_PROVIDERS`, `OPENCODE_CONFIG`                 |
-| `fro-bot-autoheal.yaml` | Same 4 (via reusable call to `fro-bot.yaml`)                                            |
-| `apply-branding.yaml`   | Same 4 (via reusable call to `fro-bot.yaml`)                                            |
-| `poll-invitations.yaml` | `FRO_BOT_POLL_PAT`, `GATEWAY_WEBHOOK_SECRET` (presence)                                 |
-| `survey-repo.yaml`      | `FRO_BOT_PAT`, `FRO_BOT_POLL_PAT`, `APPLICATION_*`, `GATEWAY_WEBHOOK_SECRET` (presence) |
-| `merge-data.yaml`       | `GITHUB_TOKEN` (auto-provisioned, job-scoped permissions)                               |
-| `reconcile-repos.yaml`  | `FRO_BOT_POLL_PAT` + `APPLICATION_ID` + `APPLICATION_PRIVATE_KEY`                       |
-| `update-metadata.yaml`  | `APPLICATION_ID` + `APPLICATION_PRIVATE_KEY`                                            |
+| Workflow                  | Secrets passed (explicit, not inherited)                                                |
+| ------------------------- | --------------------------------------------------------------------------------------- |
+| `fro-bot.yaml`            | `FRO_BOT_PAT`, `OPENCODE_AUTH_JSON`, `OMO_PROVIDERS`, `OPENCODE_CONFIG`                 |
+| `fro-bot-autoheal.yaml`   | Same 4 (via reusable call to `fro-bot.yaml`)                                            |
+| `apply-branding.yaml`     | Same 4 (via reusable call to `fro-bot.yaml`)                                            |
+| `poll-invitations.yaml`   | `FRO_BOT_POLL_PAT`, `GATEWAY_WEBHOOK_SECRET` (presence)                                 |
+| `survey-repo.yaml`        | `FRO_BOT_PAT`, `FRO_BOT_POLL_PAT`, `APPLICATION_*`, `GATEWAY_WEBHOOK_SECRET` (presence) |
+| `merge-data.yaml`         | `GITHUB_TOKEN` (auto-provisioned, job-scoped permissions)                               |
+| `check-private-leak.yaml` | `GITHUB_TOKEN` (diff + status POST) + `FRO_BOT_POLL_PAT` (resolver subprocess only)     |
+| `reconcile-repos.yaml`    | `FRO_BOT_POLL_PAT` + `APPLICATION_ID` + `APPLICATION_PRIVATE_KEY`                       |
+| `update-metadata.yaml`    | `APPLICATION_ID` + `APPLICATION_PRIVATE_KEY`                                            |
 
 ### Gateway presence (Discord)
 
@@ -168,7 +179,7 @@ All `metadata/*.yaml` files are enforced as Fro-Bot-writable-only on `main`. A C
 
 `repos.yaml` carries an additional sole-writer invariant: changes to it on `main` must originate only from the `data` promotion branch. A direct edit to `repos.yaml` on a non-promotion branch is prohibited even if fro-bot-authored. Any exception requires an explicit override and is treated as an emergency measure, not routine workflow — the invariant exists precisely to prevent the both-sides mutation that causes promotion conflicts.
 
-A companion guard, `scripts/check-private-leak.ts`, detects a private repo's canonical `owner/name` introduced in a PR's added lines (see [Privacy gates and operator tooling](#privacy-gates-and-operator-tooling)). It ships as a tested script; its always-on CI wiring is deferred to a trusted (`workflow_run`) topology so the broad-scope resolution credential never runs against PR-author code.
+A companion guard, `scripts/check-private-leak.ts`, detects a private repo's canonical `owner/name` introduced in a PR's added lines (see [Privacy gates and operator tooling](#privacy-gates-and-operator-tooling)). It runs on every PR to `main` via the trusted `workflow_run` topology described above (`private-leak-sentinel.yaml` + `check-private-leak.yaml`), posting a `security/check-private-leak` commit status to the PR head SHA.
 
 For intentional manual edits to any metadata file (including `allowlist.yaml`), land the change on `data` directly and let the existing promotion flow land it on `main`:
 

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -101,7 +101,7 @@ A private repo's existence, name, or content must never reach a public surface. 
   - `github.token` (`GITHUB_TOKEN`): diff fetch, PR API identity resolution, commit status POST.
   - `FRO_BOT_POLL_PAT`: private `node_id` → `owner/name` resolution only (resolver subprocess, scrubbed env — no `GH_TOKEN`/`GITHUB_TOKEN` inheritance).
 
-  The gate posts a `security/check-private-leak` commit status to the exact PR head SHA. If the status POST itself fails, the job exits non-zero (fail-closed — the PR is never left unsignaled). Required-check registration on `main` is gated on empirical proof that the status attaches for fork PR heads (Unit 3, not yet registered).
+  The gate posts a `security/check-private-leak` commit status to the exact PR head SHA. If the status POST itself fails, the job exits non-zero (fail-closed — the PR is never left unsignaled). Required-check registration on `main` is deferred until empirical fork-status proof exists.
 
 **Operator lookup** — to map a redacted `node_id` back to its `owner/repo` (the convenience a plain `grep` of `repos.yaml` used to provide), run `GH_TOKEN=<operator-PAT> node scripts/resolve-private.ts`. It reads `repos.yaml`, resolves each private entry's `node_id` via the GitHub API, and prints a `node_id → owner/name` table to stdout. It never writes to the working tree and is invoked by no workflow.
 

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -95,7 +95,7 @@ A private repo's existence, name, or content must never reach a public surface. 
 
   The CI wiring uses a **trusted `workflow_run` topology** to keep the broad-scope `FRO_BOT_POLL_PAT` away from PR-author code:
   - `private-leak-sentinel.yaml` — a minimal `pull_request` workflow (no secrets, no PAT, no checkout) that fires on `opened`, `synchronize`, `reopened`, and `edited` events targeting `main`. Its only job is to trigger the privileged workflow. `edited` is included so a title-based `[allow-private-leak]` override change re-fires the gate for the same head SHA.
-  - `check-private-leak.yaml` — a `workflow_run` workflow that runs **only the default-branch workflow definition** (never PR-author code). It checks out `main` only (never the PR head), installs deps fresh with no cache restore (no poisonable pnpm store), and runs the scan with `FRO_BOT_POLL_PAT` scoped to the resolver subprocess only. The PR diff is fetched as pure data via `gh pr diff` using the default `GITHUB_TOKEN` — the broad-scope PAT never touches the diff subprocess.
+  - `check-private-leak.yaml` — a `workflow_run` workflow that runs **only the default-branch workflow definition** (never PR-author code). It checks out `main` only (never the PR head), installs deps fresh with no cache restore (no poisonable pnpm store), and runs the scan with `FRO_BOT_POLL_PAT` scoped to the resolver subprocess only. The PR diff is fetched as pure data via the GitHub compare API pinned to the immutable workflow_run head SHA, using the default `GITHUB_TOKEN` — the broad-scope PAT never touches the diff subprocess.
 
   Credential split in the privileged job:
   - `github.token` (`GITHUB_TOKEN`): diff fetch, PR API identity resolution, commit status POST.

--- a/scripts/check-private-leak.test.ts
+++ b/scripts/check-private-leak.test.ts
@@ -521,9 +521,10 @@ describe('main() — fail-closed and no-name-leak (FIX #1, FIX #4)', () => {
 // Round-3 FIX #2 — access-lost skip vs error fail-closed (CLI-level, PR path)
 // ---------------------------------------------------------------------------
 
-describe('main() — access-lost skip vs error fail-closed (Round-3 FIX #2)', () => {
-  it('proceeds (no exit 1) when one resolves + one access-lost; access-lost node_id in stderr', async () => {
+describe('main() — access-lost fail-closed (Round-3 FIX #2, updated for Finding A)', () => {
+  it('fails closed (exit 1) when one resolves + one access-lost; access-lost node_id in stderr', async () => {
     // #given: two private node_ids — one resolves, one is access-lost (null node)
+    // Finding A: access-lost is now fail-closed (same as error class) — not skipped.
     const eventJson = makeWorkflowRunEvent({headSha: 'sha-fix2-a'})
     const prApiResolver = makePrApiResolver({prByNumber: makePrApiResponse({number: 42, headSha: 'sha-fix2-a'})})
     mockExecFileSync.mockReset()
@@ -532,7 +533,6 @@ describe('main() — access-lost skip vs error fail-closed (Round-3 FIX #2)', ()
       .mockReturnValueOnce(makeYamlBase64(['R_resolved', 'R_gone'])) // fetchPrivateNodeIds
       .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'acme/resolved-repo'}}})) // R_resolved → ok
       .mockReturnValueOnce(JSON.stringify({data: {node: null}})) // R_gone → access-lost
-      .mockReturnValueOnce('') // fetchPrDiff → empty diff (nothing to scan)
 
     const stderrOutput: string[] = []
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((msg: unknown) => {
@@ -547,15 +547,14 @@ describe('main() — access-lost skip vs error fail-closed (Round-3 FIX #2)', ()
     process.env.GITHUB_EVENT_PATH = '/fake/event.json'
     process.env.FRO_BOT_POLL_PAT = 'test-pat'
     try {
-      await main(makeWorkflowRunReader(eventJson), prApiResolver) // must NOT throw
-
-      // #then: no exit called
-      expect(exitSpy).not.toHaveBeenCalled()
+      // #then: access-lost → fail closed (process.exit(1))
+      await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
+      expect(exitSpy).toHaveBeenCalledWith(1)
 
       const stderrText = stderrOutput.join('')
-      // #then: access-lost node_id appears in stderr
+      // #then: access-lost node_id appears in stderr with BLOCKING message
       expect(stderrText).toContain('R_gone')
-      expect(stderrText).toContain('access-lost')
+      expect(stderrText).toContain('BLOCKING')
       // #then: the resolved canonical name does NOT appear in stderr
       expect(stderrText).not.toContain('acme/resolved-repo')
     } finally {
@@ -599,8 +598,9 @@ describe('main() — access-lost skip vs error fail-closed (Round-3 FIX #2)', ()
     }
   })
 
-  it('proceeds when ALL node_ids are access-lost (nothing to scan → guard passes)', async () => {
-    // #given: both private repos are access-lost (deleted/inaccessible)
+  it('fails closed when ALL node_ids are access-lost (Finding A: cannot guarantee complete scan)', async () => {
+    // #given: both private repos are access-lost (deleted/inaccessible or mis-scoped PAT)
+    // Finding A: access-lost is indistinguishable from no-access/mis-scoped-token → fail closed.
     const eventJson = makeWorkflowRunEvent({headSha: 'sha-fix2-c'})
     const prApiResolver = makePrApiResolver({prByNumber: makePrApiResponse({number: 42, headSha: 'sha-fix2-c'})})
     mockExecFileSync.mockReset()
@@ -609,7 +609,6 @@ describe('main() — access-lost skip vs error fail-closed (Round-3 FIX #2)', ()
       .mockReturnValueOnce(makeYamlBase64(['R_gone1', 'R_gone2'])) // fetchPrivateNodeIds
       .mockReturnValueOnce(JSON.stringify({data: {node: null}})) // R_gone1 → access-lost
       .mockReturnValueOnce(JSON.stringify({data: {node: null}})) // R_gone2 → access-lost
-      .mockReturnValueOnce('') // fetchPrDiff → empty diff
 
     const stderrOutput: string[] = []
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((msg: unknown) => {
@@ -624,15 +623,15 @@ describe('main() — access-lost skip vs error fail-closed (Round-3 FIX #2)', ()
     process.env.GITHUB_EVENT_PATH = '/fake/event.json'
     process.env.FRO_BOT_POLL_PAT = 'test-pat'
     try {
-      await main(makeWorkflowRunReader(eventJson), prApiResolver) // must NOT throw
-
-      expect(exitSpy).not.toHaveBeenCalled()
+      // #then: all access-lost → fail closed
+      await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
+      expect(exitSpy).toHaveBeenCalledWith(1)
 
       const stderrText = stderrOutput.join('')
-      // Both access-lost node_ids appear in stderr
+      // Both access-lost node_ids appear in stderr with BLOCKING message
       expect(stderrText).toContain('R_gone1')
       expect(stderrText).toContain('R_gone2')
-      expect(stderrText).toContain('access-lost')
+      expect(stderrText).toContain('BLOCKING')
     } finally {
       stderrSpy.mockRestore()
       exitSpy.mockRestore()
@@ -1479,10 +1478,7 @@ describe('runPromotionCli — Fix E: CLI-level tests via injectable seams', () =
 })
 
 // ---------------------------------------------------------------------------
-// Unit 1: main() — workflow_run event reader + resolver wiring
-// ---------------------------------------------------------------------------
-// These tests cover the new workflow_run-based main() behavior.
-// They are written BEFORE the implementation (TDD RED phase).
+// main() — workflow_run main() behavior tests
 // ---------------------------------------------------------------------------
 
 /**
@@ -1581,7 +1577,7 @@ describe('main() — workflow_run event: happy path with pull_requests[] populat
       .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
       .mockReturnValueOnce(makeYamlBase64(['R_wf_1'])) // fetchPrivateNodeIds
       .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'acme/private-repo'}}})) // resolver
-      .mockReturnValueOnce(makeDiff('docs/public.md', ['some public content'])) // fetchPrDiff
+      .mockReturnValueOnce(makeDiff('docs/public.md', ['some public content'])) // fetchDiffForSha (compare API)
 
     vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
     vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
@@ -1616,7 +1612,7 @@ describe('main() — workflow_run event: happy path with pull_requests[] populat
       .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
       .mockReturnValueOnce(makeYamlBase64(['R_wf_2'])) // fetchPrivateNodeIds
       .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'acme/private-repo'}}})) // resolver
-      .mockReturnValueOnce(makeDiff('docs/leak.md', ['See acme/private-repo for details.'])) // fetchPrDiff
+      .mockReturnValueOnce(makeDiff('docs/leak.md', ['See acme/private-repo for details.'])) // fetchDiffForSha (compare API)
 
     const stderrOutput: string[] = []
     vi.spyOn(process.stderr, 'write').mockImplementation((msg: unknown) => {
@@ -1665,7 +1661,7 @@ describe('main() — workflow_run event: empty pull_requests[] → API fallback 
       .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
       .mockReturnValueOnce(makeYamlBase64(['R_wf_fallback'])) // fetchPrivateNodeIds
       .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'acme/private-repo'}}})) // resolver
-      .mockReturnValueOnce(makeDiff('docs/public.md', ['some public content'])) // fetchPrDiff
+      .mockReturnValueOnce(makeDiff('docs/public.md', ['some public content'])) // fetchDiffForSha (compare API)
 
     vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
     vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
@@ -1898,21 +1894,21 @@ describe('main() — workflow_run event: PAT isolation (resolver vs diff subproc
 
     // We capture the env passed to execFileSync calls.
     // The resolver (gh api graphql) call should have GH_TOKEN = PAT (makeGhNodeIdResolver sets it).
-    // The diff (gh pr diff) call should NOT have FRO_BOT_POLL_PAT.
+    // The diff (gh api repos/.../compare/...) call should NOT have FRO_BOT_POLL_PAT.
     const capturedEnvs: {args: string[]; env: NodeJS.ProcessEnv | undefined}[] = []
     mockExecFileSync.mockReset()
     mockExecFileSync.mockImplementation((cmd: string, args: string[], opts: {env?: NodeJS.ProcessEnv} | undefined) => {
       capturedEnvs.push({args: [cmd, ...args], env: opts?.env})
       // fetchPrivateNodeIds: gh api repos/.../contents/...
-      if (args[0] === 'api' && String(args[1]).startsWith('repos/')) {
+      if (args[0] === 'api' && String(args[1]).startsWith('repos/') && String(args[1]).includes('/contents/')) {
         return makeYamlBase64(['R_pat_iso'])
       }
       // resolver: gh api graphql
       if (args[0] === 'api' && args[1] === 'graphql') {
         return JSON.stringify({data: {node: {nameWithOwner: 'acme/private-repo'}}})
       }
-      // fetchPrDiff: gh pr diff
-      if (args[0] === 'pr' && args[1] === 'diff') {
+      // fetchDiffForSha: gh api repos/.../compare/main...{sha} (immutable pinned diff)
+      if (args[0] === 'api' && String(args[1]).includes('/compare/')) {
         return makeDiff('docs/public.md', ['some public content'])
       }
       return ''
@@ -1929,8 +1925,8 @@ describe('main() — workflow_run event: PAT isolation (resolver vs diff subproc
     try {
       await main(makeWorkflowRunReader(eventJson), prApiResolver)
 
-      // Find the diff call (gh pr diff)
-      const diffCalls = capturedEnvs.filter(c => c.args[1] === 'pr' && c.args[2] === 'diff')
+      // Find the diff call (gh api repos/.../compare/main...{sha} — immutable pinned diff)
+      const diffCalls = capturedEnvs.filter(c => c.args[1] === 'api' && String(c.args[2]).includes('/compare/'))
       expect(diffCalls.length).toBeGreaterThan(0)
       for (const call of diffCalls) {
         // FRO_BOT_POLL_PAT must NOT be in the diff subprocess env
@@ -2086,7 +2082,7 @@ describe('main() — PR-path matched file redaction (FIX 2)', () => {
       .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
       .mockReturnValueOnce(makeYamlBase64(['R_pr_redact'])) // fetchPrivateNodeIds
       .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'synth-owner/synth_private'}}})) // resolver → resolves
-      // fetchPrDiff: diff adds a new file whose path contains the slug form
+      // fetchDiffForSha (compare API): diff adds a new file whose path contains the slug form
       .mockReturnValueOnce(
         [
           'diff --git a/knowledge/wiki/repos/synth-owner--synth_private.md b/knowledge/wiki/repos/synth-owner--synth_private.md',
@@ -2198,5 +2194,286 @@ describe('redactPathTokens — regex-metachar token (FIX 3)', () => {
 
     // #then: no match — the path does not contain the literal token
     expect(result.ok).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Finding F: regression-lock tests for Finding A (access-lost fail-closed in PR mode)
+// and Finding B (head-SHA moved → fail-closed)
+// ---------------------------------------------------------------------------
+
+describe('main() — Finding A regression lock: access-lost in PR mode → fail-closed', () => {
+  it('fails closed (process.exit(1)) when resolver returns access-lost without operator override', async () => {
+    // #given: workflow_run payload; resolver returns access-lost for the private node_id
+    // This is the critical regression lock: if access-lost goes back to being skipped,
+    // this test must fail.
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-access-lost'})
+    const prApiResolver = makePrApiResolver({
+      prByNumber: makePrApiResponse({number: 42, headSha: 'sha-access-lost'}),
+    })
+
+    mockExecFileSync.mockReset()
+    mockExecFileSync
+      .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
+      .mockReturnValueOnce(makeYamlBase64(['R_access_lost_pr'])) // fetchPrivateNodeIds
+      .mockImplementationOnce(() => {
+        // resolver: returns access-lost (simulate mis-scoped/expired PAT)
+        return JSON.stringify({data: {node: null}, errors: [{type: 'NOT_FOUND'}]})
+      })
+
+    const stderrOutput: string[] = []
+    vi.spyOn(process.stderr, 'write').mockImplementation((msg: unknown) => {
+      stderrOutput.push(String(msg))
+      return true
+    })
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      // #when: main() runs with an access-lost resolver result
+      await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
+      // #then: process.exit(1) was called — fail closed
+      expect(exitSpy).toHaveBeenCalledWith(1)
+      // #then: stderr mentions BLOCKING (not "skipping")
+      const stderrText = stderrOutput.join('')
+      expect(stderrText).toContain('BLOCKING')
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
+      mockExecFileSync.mockReset()
+    }
+  })
+
+  it('proceeds (no exit) when access-lost occurs AND operator override is active', async () => {
+    // #given: workflow_run payload; resolver returns access-lost; operator override is active
+    // Parity with the existing failedNodeIds override test.
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-access-lost-override'})
+    const prApiResolver = makePrApiResolver({
+      prByNumber: makePrApiResponse({
+        number: 42,
+        headSha: 'sha-access-lost-override',
+        title: '[allow-private-leak] operator override',
+        author: 'marcusrbrown',
+      }),
+    })
+
+    mockExecFileSync.mockReset()
+    mockExecFileSync
+      .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
+      .mockReturnValueOnce(makeYamlBase64(['R_access_lost_override'])) // fetchPrivateNodeIds
+      .mockImplementationOnce(() => {
+        // resolver: returns access-lost
+        return JSON.stringify({data: {node: null}, errors: [{type: 'NOT_FOUND'}]})
+      })
+      .mockReturnValueOnce('') // fetchDiffForSha → empty diff (no leak, compare API)
+
+    const stderrOutput: string[] = []
+    vi.spyOn(process.stderr, 'write').mockImplementation((msg: unknown) => {
+      stderrOutput.push(String(msg))
+      return true
+    })
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      // #when: main() runs with access-lost + operator override
+      await main(makeWorkflowRunReader(eventJson), prApiResolver)
+      // #then: no exit called — operator override allows proceeding
+      expect(exitSpy).not.toHaveBeenCalled()
+      // #then: override was logged
+      const stderrText = stderrOutput.join('')
+      expect(stderrText).toContain('operator override active')
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
+      mockExecFileSync.mockReset()
+    }
+  })
+})
+
+describe('main() — Finding B regression lock: diff pinned to immutable scannedHeadSha (no TOCTOU)', () => {
+  it('scans the diff for the scanned SHA even when the PR head has since moved (force-push)', async () => {
+    // #given: workflow_run payload with headSha='sha-scanned-b'; a force-push has since moved
+    // the PR head to 'sha-moved'. With the old revalidation approach this would fail-closed.
+    // With the new pinned-SHA approach, main() fetches the diff for 'sha-scanned-b' (immutable)
+    // and proceeds — the status is posted to 'sha-scanned-b' and the diff is for that exact SHA.
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-scanned-b'})
+    // readWorkflowRunContext calls fetchPrByNumber once (returns sha-scanned-b → validates OK).
+    // No second revalidation call — the pinned-SHA approach eliminates it.
+    const prApiResolver = makePrApiResolver({
+      prByNumber: makePrApiResponse({number: 42, headSha: 'sha-scanned-b'}),
+    })
+
+    // Capture which SHA the compare-API diff call uses.
+    const capturedCompareArgs: string[] = []
+    mockExecFileSync.mockReset()
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      // gh repo view
+      if (cmd === 'gh' && args[0] === 'repo') return 'fro-bot/.github'
+      // fetchPrivateNodeIds
+      if (cmd === 'gh' && args[0] === 'api' && String(args[1]).includes('/contents/')) {
+        return makeYamlBase64(['R_sha_moved'])
+      }
+      // resolver
+      if (cmd === 'gh' && args[0] === 'api' && args[1] === 'graphql') {
+        return JSON.stringify({data: {node: {nameWithOwner: 'acme/private-repo'}}})
+      }
+      // fetchDiffForSha: gh api repos/.../compare/main...{sha}
+      if (cmd === 'gh' && args[0] === 'api' && String(args[1]).includes('/compare/')) {
+        capturedCompareArgs.push(String(args[1]))
+        return makeDiff('docs/public.md', ['some public content'])
+      }
+      return ''
+    })
+
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      // #when: main() runs — even though the PR head has "moved" (no revalidation), it proceeds
+      await main(makeWorkflowRunReader(eventJson), prApiResolver)
+
+      // #then: no exit called — the scan passed (diff is clean)
+      expect(exitSpy).not.toHaveBeenCalled()
+
+      // #then: the compare-API diff call used the scanned SHA (immutable), not any "current" head
+      expect(capturedCompareArgs.length).toBeGreaterThan(0)
+      for (const compareArg of capturedCompareArgs) {
+        // The compare endpoint must reference the scanned SHA, not 'sha-moved'
+        expect(compareArg).toContain('sha-scanned-b')
+        expect(compareArg).not.toContain('sha-moved')
+      }
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
+      mockExecFileSync.mockReset()
+    }
+  })
+})
+
+describe('main() — Finding F: pull_requests[] with two validating PRs → fail-closed', () => {
+  it('fails closed when pull_requests[] contains two PRs that both pass validation', async () => {
+    // #given: workflow_run payload with two PRs in pull_requests[] that both validate
+    const eventJson = JSON.stringify({
+      workflow_run: {
+        event: 'pull_request',
+        head_sha: 'sha-two-prs',
+        pull_requests: [
+          {
+            number: 10,
+            head: {sha: 'sha-two-prs', repo: {full_name: 'fro-bot/.github'}},
+            base: {ref: 'main', repo: {full_name: 'fro-bot/.github'}},
+          },
+          {
+            number: 11,
+            head: {sha: 'sha-two-prs', repo: {full_name: 'fro-bot/.github'}},
+            base: {ref: 'main', repo: {full_name: 'fro-bot/.github'}},
+          },
+        ],
+      },
+    })
+    const prApiResolver = makePrApiResolver()
+
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      // #when: main() runs with two validating PRs
+      await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
+      // #then: fail closed — exactly-one guard triggered
+      expect(exitSpy).toHaveBeenCalledWith(1)
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
+    }
+  })
+})
+
+describe('main() — Finding F: malformed PR details → fail-closed', () => {
+  it('fails closed when fetchPrByNumber returns a PR missing the title field', async () => {
+    // #given: workflow_run payload; fetchPrByNumber returns a PR with no title
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-no-title'})
+    const prApiResolver = makePrApiResolver({
+      prByNumber: {
+        number: 42,
+        // title intentionally omitted
+        user: {login: 'some-user'},
+        head: {sha: 'sha-no-title', repo: {full_name: 'fro-bot/.github'}},
+        base: {ref: 'main', repo: {full_name: 'fro-bot/.github'}},
+      },
+    })
+
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
+    }
+  })
+
+  it('fails closed when fetchPrByNumber returns a PR missing user.login', async () => {
+    // #given: workflow_run payload; fetchPrByNumber returns a PR with no user.login
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-no-login'})
+    const prApiResolver = makePrApiResolver({
+      prByNumber: {
+        number: 42,
+        title: 'some PR',
+        // user intentionally omitted
+        head: {sha: 'sha-no-login', repo: {full_name: 'fro-bot/.github'}},
+        base: {ref: 'main', repo: {full_name: 'fro-bot/.github'}},
+      },
+    })
+
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
+    }
   })
 })

--- a/scripts/check-private-leak.test.ts
+++ b/scripts/check-private-leak.test.ts
@@ -1,4 +1,10 @@
-import type {GitDiffRunner, ReposYamlReader, ResolverFactory} from './check-private-leak.ts'
+import type {
+  GitDiffRunner,
+  PrApiResolver,
+  ReposYamlReader,
+  ResolverFactory,
+  WorkflowRunReader,
+} from './check-private-leak.ts'
 import type {NodeIdResolver} from './private-repo-resolution.ts'
 import {Buffer} from 'node:buffer'
 import process from 'node:process'
@@ -369,17 +375,6 @@ describe('checkPrivateLeak — rename/copy path detection (Round-3 FIX #1)', () 
 // Round-3 FIX #4 — no bare-name false positives (pure function)
 // ---------------------------------------------------------------------------
 
-function makeEvent(opts: {title?: string; author?: string; prNumber?: number} = {}): string {
-  return JSON.stringify({
-    pull_request: {
-      number: opts.prNumber ?? 42,
-      title: opts.title ?? 'some PR',
-      user: {login: opts.author ?? 'some-user'},
-      base: {repo: {full_name: 'fro-bot/.github'}},
-    },
-  })
-}
-
 function makeYamlBase64(nodeIds: string[]): string {
   const entries = nodeIds
     .map(
@@ -393,9 +388,11 @@ function makeYamlBase64(nodeIds: string[]): string {
 describe('main() — fail-closed and no-name-leak (FIX #1, FIX #4)', () => {
   it('exits non-zero (fail-closed) when one node_id resolves and one fails — private name NOT in stderr', async () => {
     // #given: two private node_ids; one resolves, one fails
-    mockReadFile.mockResolvedValue(makeEvent())
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-fix1-a'})
+    const prApiResolver = makePrApiResolver({prByNumber: makePrApiResponse({number: 42, headSha: 'sha-fix1-a'})})
     mockExecFileSync.mockReset()
     mockExecFileSync
+      .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
       .mockReturnValueOnce(makeYamlBase64(['R_ok', 'R_fail'])) // fetchPrivateNodeIds
       .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'acme/private-repo'}}})) // R_ok
       .mockImplementationOnce(() => {
@@ -412,8 +409,9 @@ describe('main() — fail-closed and no-name-leak (FIX #1, FIX #4)', () => {
     })
 
     process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
     try {
-      await expect(main()).rejects.toThrow('process.exit called')
+      await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
 
       const stderrText = stderrOutput.join('')
 
@@ -431,16 +429,21 @@ describe('main() — fail-closed and no-name-leak (FIX #1, FIX #4)', () => {
       stderrSpy.mockRestore()
       exitSpy.mockRestore()
       delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
       mockExecFileSync.mockReset()
     }
   })
 
   it('exits non-zero when ALL node_ids fail to resolve and no override', async () => {
-    mockReadFile.mockResolvedValue(makeEvent())
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-fix1-b'})
+    const prApiResolver = makePrApiResolver({prByNumber: makePrApiResponse({number: 42, headSha: 'sha-fix1-b'})})
     mockExecFileSync.mockReset()
-    mockExecFileSync.mockReturnValueOnce(makeYamlBase64(['R_x'])).mockImplementationOnce(() => {
-      throw new Error('server error')
-    })
+    mockExecFileSync
+      .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
+      .mockReturnValueOnce(makeYamlBase64(['R_x'])) // fetchPrivateNodeIds
+      .mockImplementationOnce(() => {
+        throw new Error('server error')
+      }) // resolver R_x — fails
 
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('process.exit called')
@@ -448,22 +451,33 @@ describe('main() — fail-closed and no-name-leak (FIX #1, FIX #4)', () => {
     vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
 
     process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
     try {
-      await expect(main()).rejects.toThrow('process.exit called')
+      await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
       expect(exitSpy).toHaveBeenCalledWith(1)
     } finally {
       exitSpy.mockRestore()
       vi.restoreAllMocks()
       delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
       mockExecFileSync.mockReset()
     }
   })
 
   it('passes with bypass log when operator override is active and resolution fails', async () => {
     // #given: operator override active + one node_id fails
-    mockReadFile.mockResolvedValue(makeEvent({title: '[allow-private-leak] my PR', author: 'marcusrbrown'}))
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-fix1-c'})
+    const prApiResolver = makePrApiResolver({
+      prByNumber: makePrApiResponse({
+        number: 42,
+        headSha: 'sha-fix1-c',
+        title: '[allow-private-leak] my PR',
+        author: 'marcusrbrown',
+      }),
+    })
     mockExecFileSync.mockReset()
     mockExecFileSync
+      .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
       .mockReturnValueOnce(makeYamlBase64(['R_y'])) // fetchPrivateNodeIds
       .mockImplementationOnce(() => {
         throw new Error('outage')
@@ -481,8 +495,9 @@ describe('main() — fail-closed and no-name-leak (FIX #1, FIX #4)', () => {
     })
 
     process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
     try {
-      await main() // should NOT throw
+      await main(makeWorkflowRunReader(eventJson), prApiResolver) // should NOT throw
 
       // #then: exit was NOT called
       expect(exitSpy).not.toHaveBeenCalled()
@@ -496,6 +511,7 @@ describe('main() — fail-closed and no-name-leak (FIX #1, FIX #4)', () => {
       exitSpy.mockRestore()
       vi.restoreAllMocks()
       delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
       mockExecFileSync.mockReset()
     }
   })
@@ -508,9 +524,11 @@ describe('main() — fail-closed and no-name-leak (FIX #1, FIX #4)', () => {
 describe('main() — access-lost skip vs error fail-closed (Round-3 FIX #2)', () => {
   it('proceeds (no exit 1) when one resolves + one access-lost; access-lost node_id in stderr', async () => {
     // #given: two private node_ids — one resolves, one is access-lost (null node)
-    mockReadFile.mockResolvedValue(makeEvent())
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-fix2-a'})
+    const prApiResolver = makePrApiResolver({prByNumber: makePrApiResponse({number: 42, headSha: 'sha-fix2-a'})})
     mockExecFileSync.mockReset()
     mockExecFileSync
+      .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
       .mockReturnValueOnce(makeYamlBase64(['R_resolved', 'R_gone'])) // fetchPrivateNodeIds
       .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'acme/resolved-repo'}}})) // R_resolved → ok
       .mockReturnValueOnce(JSON.stringify({data: {node: null}})) // R_gone → access-lost
@@ -527,8 +545,9 @@ describe('main() — access-lost skip vs error fail-closed (Round-3 FIX #2)', ()
     })
 
     process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
     try {
-      await main() // must NOT throw
+      await main(makeWorkflowRunReader(eventJson), prApiResolver) // must NOT throw
 
       // #then: no exit called
       expect(exitSpy).not.toHaveBeenCalled()
@@ -544,14 +563,17 @@ describe('main() — access-lost skip vs error fail-closed (Round-3 FIX #2)', ()
       exitSpy.mockRestore()
       vi.restoreAllMocks()
       delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
       mockExecFileSync.mockReset()
     }
   })
 
   it('fails-closed (exit 1) when one resolved + one error-class failure', async () => {
-    mockReadFile.mockResolvedValue(makeEvent())
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-fix2-b'})
+    const prApiResolver = makePrApiResolver({prByNumber: makePrApiResponse({number: 42, headSha: 'sha-fix2-b'})})
     mockExecFileSync.mockReset()
     mockExecFileSync
+      .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
       .mockReturnValueOnce(makeYamlBase64(['R_ok2', 'R_err'])) // fetchPrivateNodeIds
       .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'acme/resolved-repo'}}})) // R_ok2 → ok
       .mockImplementationOnce(() => {
@@ -564,22 +586,26 @@ describe('main() — access-lost skip vs error fail-closed (Round-3 FIX #2)', ()
     vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
 
     process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
     try {
-      await expect(main()).rejects.toThrow('process.exit called')
+      await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
       expect(exitSpy).toHaveBeenCalledWith(1)
     } finally {
       exitSpy.mockRestore()
       vi.restoreAllMocks()
       delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
       mockExecFileSync.mockReset()
     }
   })
 
   it('proceeds when ALL node_ids are access-lost (nothing to scan → guard passes)', async () => {
     // #given: both private repos are access-lost (deleted/inaccessible)
-    mockReadFile.mockResolvedValue(makeEvent())
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-fix2-c'})
+    const prApiResolver = makePrApiResolver({prByNumber: makePrApiResponse({number: 42, headSha: 'sha-fix2-c'})})
     mockExecFileSync.mockReset()
     mockExecFileSync
+      .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
       .mockReturnValueOnce(makeYamlBase64(['R_gone1', 'R_gone2'])) // fetchPrivateNodeIds
       .mockReturnValueOnce(JSON.stringify({data: {node: null}})) // R_gone1 → access-lost
       .mockReturnValueOnce(JSON.stringify({data: {node: null}})) // R_gone2 → access-lost
@@ -596,8 +622,9 @@ describe('main() — access-lost skip vs error fail-closed (Round-3 FIX #2)', ()
     })
 
     process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
     try {
-      await main() // must NOT throw
+      await main(makeWorkflowRunReader(eventJson), prApiResolver) // must NOT throw
 
       expect(exitSpy).not.toHaveBeenCalled()
 
@@ -611,6 +638,7 @@ describe('main() — access-lost skip vs error fail-closed (Round-3 FIX #2)', ()
       exitSpy.mockRestore()
       vi.restoreAllMocks()
       delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
       mockExecFileSync.mockReset()
     }
   })
@@ -623,12 +651,14 @@ describe('main() — access-lost skip vs error fail-closed (Round-3 FIX #2)', ()
 describe('main() — stderr sanitization on error-class failure (Round-3 FIX #3)', () => {
   it('never echoes raw gh stderr containing owner/name on error-class resolution failure', async () => {
     // #given: one private node_id fails with a poisoned gh stderr body containing owner/name
-    mockReadFile.mockResolvedValue(makeEvent())
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-fix3'})
+    const prApiResolver = makePrApiResolver({prByNumber: makePrApiResponse({number: 42, headSha: 'sha-fix3'})})
     mockExecFileSync.mockReset()
 
     // The gh error body contains a canonical owner/name — must NOT appear in logged output.
     const poisonedStderr = 'GraphQL error for someowner/private-repo: Not Found\n'
     mockExecFileSync
+      .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
       .mockReturnValueOnce(makeYamlBase64(['R_leak_test'])) // fetchPrivateNodeIds
       .mockImplementationOnce(() => {
         throw Object.assign(new Error('gh failed'), {stderr: poisonedStderr})
@@ -644,8 +674,9 @@ describe('main() — stderr sanitization on error-class failure (Round-3 FIX #3)
     })
 
     process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
     try {
-      await expect(main()).rejects.toThrow('process.exit called')
+      await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
 
       const stderrText = stderrOutput.join('')
 
@@ -661,6 +692,7 @@ describe('main() — stderr sanitization on error-class failure (Round-3 FIX #3)
       exitSpy.mockRestore()
       vi.restoreAllMocks()
       delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
       mockExecFileSync.mockReset()
     }
   })
@@ -1447,6 +1479,540 @@ describe('runPromotionCli — Fix E: CLI-level tests via injectable seams', () =
 })
 
 // ---------------------------------------------------------------------------
+// Unit 1: main() — workflow_run event reader + resolver wiring
+// ---------------------------------------------------------------------------
+// These tests cover the new workflow_run-based main() behavior.
+// They are written BEFORE the implementation (TDD RED phase).
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal workflow_run event payload.
+ */
+function makeWorkflowRunEvent(
+  opts: {
+    event?: string
+    headSha?: string
+    pullRequests?: {
+      number: number
+      head: {sha: string; repo: {full_name: string}}
+      base: {ref: string; repo: {full_name: string}}
+    }[]
+  } = {},
+): string {
+  return JSON.stringify({
+    workflow_run: {
+      event: opts.event ?? 'pull_request',
+      head_sha: opts.headSha ?? 'abc123',
+      pull_requests: opts.pullRequests ?? [
+        {
+          number: 42,
+          head: {sha: opts.headSha ?? 'abc123', repo: {full_name: 'fro-bot/.github'}},
+          base: {ref: 'main', repo: {full_name: 'fro-bot/.github'}},
+        },
+      ],
+    },
+  })
+}
+
+/**
+ * Build a minimal PR API response (as returned by the GitHub API).
+ */
+function makePrApiResponse(
+  opts: {
+    number?: number
+    title?: string
+    author?: string
+    headSha?: string
+    baseRef?: string
+    baseRepoFullName?: string
+    headRepoFullName?: string
+  } = {},
+): Record<string, unknown> {
+  return {
+    number: opts.number ?? 42,
+    title: opts.title ?? 'some PR',
+    user: {login: opts.author ?? 'some-user'},
+    head: {sha: opts.headSha ?? 'abc123', repo: {full_name: opts.headRepoFullName ?? 'fro-bot/.github'}},
+    base: {ref: opts.baseRef ?? 'main', repo: {full_name: opts.baseRepoFullName ?? 'fro-bot/.github'}},
+  }
+}
+
+/**
+ * Build a minimal WorkflowRunReader seam for main() tests.
+ */
+function makeWorkflowRunReader(eventJson: string): WorkflowRunReader {
+  return async (_path: string) => eventJson
+}
+
+/**
+ * Build a minimal PrApiResolver seam for main() tests.
+ * Returns a PR by number, or by head SHA (fallback).
+ */
+function makePrApiResolver(
+  opts: {
+    prByNumber?: Record<string, unknown>
+    prsByHeadSha?: Record<string, unknown>[]
+    throwOnNumber?: boolean
+    throwOnSha?: boolean
+  } = {},
+): PrApiResolver {
+  return {
+    fetchPrByNumber: async (_prNumber: number) => {
+      if (opts.throwOnNumber === true) throw new Error('API error fetching PR by number')
+      return opts.prByNumber ?? makePrApiResponse()
+    },
+    fetchPrsByHeadSha: async (_headSha: string) => {
+      if (opts.throwOnSha === true) throw new Error('API error fetching PRs by SHA')
+      return opts.prsByHeadSha ?? []
+    },
+  }
+}
+
+describe('main() — workflow_run event: happy path with pull_requests[] populated', () => {
+  it('resolves PR identity from pull_requests[], validates, scans diff, passes when no private name', async () => {
+    // #given: workflow_run payload with pull_requests[] populated; no private names in diff
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-happy'})
+    const prApiResolver = makePrApiResolver({
+      prByNumber: makePrApiResponse({number: 42, headSha: 'sha-happy'}),
+    })
+
+    mockExecFileSync.mockReset()
+    mockExecFileSync
+      .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
+      .mockReturnValueOnce(makeYamlBase64(['R_wf_1'])) // fetchPrivateNodeIds
+      .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'acme/private-repo'}}})) // resolver
+      .mockReturnValueOnce(makeDiff('docs/public.md', ['some public content'])) // fetchPrDiff
+
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      await main(makeWorkflowRunReader(eventJson), prApiResolver)
+      // #then: no exit called (pass)
+      expect(exitSpy).not.toHaveBeenCalled()
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
+      mockExecFileSync.mockReset()
+    }
+  })
+
+  it('fails with offending file path (never the name) when diff contains a private name', async () => {
+    // #given: workflow_run payload; diff adds a line with the private name
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-fail'})
+    const prApiResolver = makePrApiResolver({
+      prByNumber: makePrApiResponse({number: 42, headSha: 'sha-fail'}),
+    })
+
+    mockExecFileSync.mockReset()
+    mockExecFileSync
+      .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
+      .mockReturnValueOnce(makeYamlBase64(['R_wf_2'])) // fetchPrivateNodeIds
+      .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'acme/private-repo'}}})) // resolver
+      .mockReturnValueOnce(makeDiff('docs/leak.md', ['See acme/private-repo for details.'])) // fetchPrDiff
+
+    const stderrOutput: string[] = []
+    vi.spyOn(process.stderr, 'write').mockImplementation((msg: unknown) => {
+      stderrOutput.push(String(msg))
+      return true
+    })
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+
+      const stderrText = stderrOutput.join('')
+      // #then: file path appears in output
+      expect(stderrText).toContain('docs/leak.md')
+      // #then: the private name does NOT appear
+      expect(stderrText).not.toContain('acme/private-repo')
+      expect(stderrText).not.toContain('acme--private-repo')
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
+      mockExecFileSync.mockReset()
+    }
+  })
+})
+
+describe('main() — workflow_run event: empty pull_requests[] → API fallback by head_sha', () => {
+  it('falls back to fetchPrsByHeadSha when pull_requests[] is empty and resolves PR', async () => {
+    // #given: workflow_run payload with empty pull_requests[]; API fallback returns one PR
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-fallback', pullRequests: []})
+    const fallbackPr = makePrApiResponse({number: 99, headSha: 'sha-fallback'})
+    const prApiResolver = makePrApiResolver({
+      prsByHeadSha: [fallbackPr],
+      prByNumber: fallbackPr,
+    })
+
+    mockExecFileSync.mockReset()
+    mockExecFileSync
+      .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
+      .mockReturnValueOnce(makeYamlBase64(['R_wf_fallback'])) // fetchPrivateNodeIds
+      .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'acme/private-repo'}}})) // resolver
+      .mockReturnValueOnce(makeDiff('docs/public.md', ['some public content'])) // fetchPrDiff
+
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      await main(makeWorkflowRunReader(eventJson), prApiResolver)
+      // #then: no exit called (pass)
+      expect(exitSpy).not.toHaveBeenCalled()
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
+      mockExecFileSync.mockReset()
+    }
+  })
+})
+
+describe('main() — workflow_run event: error paths (fail-closed)', () => {
+  it('fails closed when workflow_run.event != "pull_request"', async () => {
+    // #given: workflow_run payload with event = 'push' (not pull_request)
+    const eventJson = makeWorkflowRunEvent({event: 'push'})
+    const prApiResolver = makePrApiResolver()
+
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
+    }
+  })
+
+  it('fails closed when base repo does not match fro-bot/.github', async () => {
+    // #given: workflow_run payload with a PR targeting a different base repo
+    const eventJson = makeWorkflowRunEvent({
+      headSha: 'sha-wrong-repo',
+      pullRequests: [
+        {
+          number: 42,
+          head: {sha: 'sha-wrong-repo', repo: {full_name: 'other-org/other-repo'}},
+          base: {ref: 'main', repo: {full_name: 'other-org/other-repo'}},
+        },
+      ],
+    })
+    const prApiResolver = makePrApiResolver({
+      prByNumber: makePrApiResponse({number: 42, headSha: 'sha-wrong-repo', baseRepoFullName: 'other-org/other-repo'}),
+    })
+
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
+    }
+  })
+
+  it('fails closed when base branch is not main', async () => {
+    // #given: workflow_run payload with a PR targeting a non-main branch
+    const eventJson = makeWorkflowRunEvent({
+      headSha: 'sha-wrong-branch',
+      pullRequests: [
+        {
+          number: 42,
+          head: {sha: 'sha-wrong-branch', repo: {full_name: 'fro-bot/.github'}},
+          base: {ref: 'develop', repo: {full_name: 'fro-bot/.github'}},
+        },
+      ],
+    })
+    const prApiResolver = makePrApiResolver({
+      prByNumber: makePrApiResponse({number: 42, headSha: 'sha-wrong-branch', baseRef: 'develop'}),
+    })
+
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
+    }
+  })
+
+  it('fails closed when PR head SHA does not match the scanned workflow_run head_sha', async () => {
+    // #given: workflow_run payload with head_sha that doesn't match the PR's head SHA
+    const eventJson = makeWorkflowRunEvent({
+      headSha: 'sha-scanned',
+      pullRequests: [
+        {
+          number: 42,
+          head: {sha: 'sha-different', repo: {full_name: 'fro-bot/.github'}},
+          base: {ref: 'main', repo: {full_name: 'fro-bot/.github'}},
+        },
+      ],
+    })
+    const prApiResolver = makePrApiResolver({
+      prByNumber: makePrApiResponse({number: 42, headSha: 'sha-different'}),
+    })
+
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
+    }
+  })
+
+  it('fails closed when pull_requests[] is empty and API fallback returns nothing', async () => {
+    // #given: workflow_run payload with empty pull_requests[]; API fallback returns empty array
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-no-pr', pullRequests: []})
+    const prApiResolver = makePrApiResolver({prsByHeadSha: []})
+
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
+    }
+  })
+
+  it('fails closed when head-SHA fallback returns multiple PRs and not exactly one passes validation', async () => {
+    // #given: workflow_run payload with empty pull_requests[]; API fallback returns two PRs
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-ambiguous', pullRequests: []})
+    const pr1 = makePrApiResponse({number: 10, headSha: 'sha-ambiguous'})
+    const pr2 = makePrApiResponse({number: 11, headSha: 'sha-ambiguous'})
+    const prApiResolver = makePrApiResolver({prsByHeadSha: [pr1, pr2]})
+
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
+    }
+  })
+
+  it('fails closed when FRO_BOT_POLL_PAT is absent', async () => {
+    // #given: workflow_run payload is valid; but FRO_BOT_POLL_PAT is not set
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-no-pat'})
+    const prApiResolver = makePrApiResolver({
+      prByNumber: makePrApiResponse({number: 42, headSha: 'sha-no-pat'}),
+    })
+
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    delete process.env.FRO_BOT_POLL_PAT
+    try {
+      await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+    }
+  })
+})
+
+describe('main() — workflow_run event: PAT isolation (resolver vs diff subprocess)', () => {
+  it('PAT is present in resolver subprocess env but absent from diff subprocess env', async () => {
+    // #given: workflow_run payload; FRO_BOT_POLL_PAT is set
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-pat-isolation'})
+    const prApiResolver = makePrApiResolver({
+      prByNumber: makePrApiResponse({number: 42, headSha: 'sha-pat-isolation'}),
+    })
+
+    // We capture the env passed to execFileSync calls.
+    // The resolver (gh api graphql) call should have GH_TOKEN = PAT (makeGhNodeIdResolver sets it).
+    // The diff (gh pr diff) call should NOT have FRO_BOT_POLL_PAT.
+    const capturedEnvs: {args: string[]; env: NodeJS.ProcessEnv | undefined}[] = []
+    mockExecFileSync.mockReset()
+    mockExecFileSync.mockImplementation((cmd: string, args: string[], opts: {env?: NodeJS.ProcessEnv} | undefined) => {
+      capturedEnvs.push({args: [cmd, ...args], env: opts?.env})
+      // fetchPrivateNodeIds: gh api repos/.../contents/...
+      if (args[0] === 'api' && String(args[1]).startsWith('repos/')) {
+        return makeYamlBase64(['R_pat_iso'])
+      }
+      // resolver: gh api graphql
+      if (args[0] === 'api' && args[1] === 'graphql') {
+        return JSON.stringify({data: {node: {nameWithOwner: 'acme/private-repo'}}})
+      }
+      // fetchPrDiff: gh pr diff
+      if (args[0] === 'pr' && args[1] === 'diff') {
+        return makeDiff('docs/public.md', ['some public content'])
+      }
+      return ''
+    })
+
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'super-secret-pat'
+    try {
+      await main(makeWorkflowRunReader(eventJson), prApiResolver)
+
+      // Find the diff call (gh pr diff)
+      const diffCalls = capturedEnvs.filter(c => c.args[1] === 'pr' && c.args[2] === 'diff')
+      expect(diffCalls.length).toBeGreaterThan(0)
+      for (const call of diffCalls) {
+        // FRO_BOT_POLL_PAT must NOT be in the diff subprocess env
+        expect(call.env).not.toHaveProperty('FRO_BOT_POLL_PAT')
+        if (call.env !== undefined) {
+          expect(Object.values(call.env)).not.toContain('super-secret-pat')
+        }
+      }
+
+      // Find the resolver call (gh api graphql)
+      const resolverCalls = capturedEnvs.filter(c => c.args[1] === 'api' && c.args[2] === 'graphql')
+      expect(resolverCalls.length).toBeGreaterThan(0)
+      for (const call of resolverCalls) {
+        // The resolver subprocess should have GH_TOKEN = PAT (set by makeGhNodeIdResolver)
+        // and FRO_BOT_POLL_PAT stripped (makeGhNodeIdResolver strips it)
+        expect(call.env).not.toHaveProperty('FRO_BOT_POLL_PAT')
+        if (call.env !== undefined) {
+          expect(call.env.GH_TOKEN).toBe('super-secret-pat')
+        }
+      }
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
+      mockExecFileSync.mockReset()
+    }
+  })
+})
+
+describe('main() — workflow_run event: [allow-private-leak] override honored under new identity path', () => {
+  it('honors override when title is prefixed and author is the operator (title from validated PR JSON)', async () => {
+    // #given: workflow_run payload; PR title has [allow-private-leak] prefix; author is marcusrbrown
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-override'})
+    const prApiResolver = makePrApiResolver({
+      prByNumber: makePrApiResponse({
+        number: 42,
+        headSha: 'sha-override',
+        title: '[allow-private-leak] my PR',
+        author: 'marcusrbrown',
+      }),
+    })
+
+    mockExecFileSync.mockReset()
+    mockExecFileSync
+      .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
+      .mockReturnValueOnce(makeYamlBase64(['R_override'])) // fetchPrivateNodeIds
+      .mockImplementationOnce(() => {
+        throw new Error('outage')
+      }) // resolver R_override — fails (but override should allow proceeding)
+      .mockReturnValueOnce('') // fetchPrDiff → empty diff
+
+    const stderrOutput: string[] = []
+    vi.spyOn(process.stderr, 'write').mockImplementation((msg: unknown) => {
+      stderrOutput.push(String(msg))
+      return true
+    })
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      await main(makeWorkflowRunReader(eventJson), prApiResolver)
+      // #then: no exit called (override honored)
+      expect(exitSpy).not.toHaveBeenCalled()
+      // #then: override was logged
+      const stderrText = stderrOutput.join('')
+      expect(stderrText).toContain('operator override active')
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
+      mockExecFileSync.mockReset()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
 // FIX 1 (token coverage) — buildTokensForName raw double-dash form
 // ---------------------------------------------------------------------------
 
@@ -1511,9 +2077,13 @@ describe('buildTokensForName — raw double-dash form (FIX 1)', () => {
 describe('main() — PR-path matched file redaction (FIX 2)', () => {
   it('redacts the private token from matched file paths printed to stderr on failure', async () => {
     // #given: a private repo resolves; diff adds a new file whose path contains the slug
-    mockReadFile.mockResolvedValue(makeEvent())
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-fix2-redact'})
+    const prApiResolver = makePrApiResolver({
+      prByNumber: makePrApiResponse({number: 42, headSha: 'sha-fix2-redact'}),
+    })
     mockExecFileSync.mockReset()
     mockExecFileSync
+      .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
       .mockReturnValueOnce(makeYamlBase64(['R_pr_redact'])) // fetchPrivateNodeIds
       .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'synth-owner/synth_private'}}})) // resolver → resolves
       // fetchPrDiff: diff adds a new file whose path contains the slug form
@@ -1538,8 +2108,9 @@ describe('main() — PR-path matched file redaction (FIX 2)', () => {
     })
 
     process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
     try {
-      await expect(main()).rejects.toThrow('process.exit called')
+      await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
 
       const stderrText = stderrOutput.join('')
 
@@ -1557,6 +2128,7 @@ describe('main() — PR-path matched file redaction (FIX 2)', () => {
       stderrSpy.mockRestore()
       exitSpy.mockRestore()
       delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
       mockExecFileSync.mockReset()
     }
   })

--- a/scripts/check-private-leak.test.ts
+++ b/scripts/check-private-leak.test.ts
@@ -9,7 +9,13 @@ import type {NodeIdResolver} from './private-repo-resolution.ts'
 import {Buffer} from 'node:buffer'
 import process from 'node:process'
 import {describe, expect, it, vi} from 'vitest'
-import {checkPrivateLeak, main, runPromotionCli, runPromotionScan} from './check-private-leak.ts'
+import {
+  assertCompareNotTruncated,
+  checkPrivateLeak,
+  main,
+  runPromotionCli,
+  runPromotionScan,
+} from './check-private-leak.ts'
 
 // ---------------------------------------------------------------------------
 // Module-level hoisted mocks — shared across all describe blocks.
@@ -35,6 +41,18 @@ vi.mock('node:fs/promises', async importOriginal => {
 // ---------------------------------------------------------------------------
 // Pure function: checkPrivateLeak
 // ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal compare JSON response (as returned by the GitHub compare API without
+ * a diff media type). Used to mock the truncation-check call in fetchDiffForSha.
+ * Returns a well-formed response with one file entry that has a patch field.
+ */
+function makeCompareJson(filePath = 'docs/public.md'): string {
+  return JSON.stringify({
+    total_commits: 1,
+    files: [{filename: filePath, status: 'modified', patch: '@@ -1 +1 @@\n-old\n+new'}],
+  })
+}
 
 /**
  * Build a minimal unified diff with added lines. Each line in `additions` appears
@@ -482,7 +500,8 @@ describe('main() — fail-closed and no-name-leak (FIX #1, FIX #4)', () => {
       .mockImplementationOnce(() => {
         throw new Error('outage')
       }) // resolver R_y — fails
-      .mockReturnValueOnce('') // fetchPrDiff → empty diff
+      .mockReturnValueOnce(makeCompareJson()) // fetchDiffForSha: compare JSON (truncation check)
+      .mockReturnValueOnce('') // fetchDiffForSha: raw diff → empty
 
     const stderrOutput: string[] = []
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((msg: unknown) => {
@@ -1577,7 +1596,8 @@ describe('main() — workflow_run event: happy path with pull_requests[] populat
       .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
       .mockReturnValueOnce(makeYamlBase64(['R_wf_1'])) // fetchPrivateNodeIds
       .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'acme/private-repo'}}})) // resolver
-      .mockReturnValueOnce(makeDiff('docs/public.md', ['some public content'])) // fetchDiffForSha (compare API)
+      .mockReturnValueOnce(makeCompareJson('docs/public.md')) // fetchDiffForSha: compare JSON (truncation check)
+      .mockReturnValueOnce(makeDiff('docs/public.md', ['some public content'])) // fetchDiffForSha: raw diff
 
     vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
     vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
@@ -1612,7 +1632,8 @@ describe('main() — workflow_run event: happy path with pull_requests[] populat
       .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
       .mockReturnValueOnce(makeYamlBase64(['R_wf_2'])) // fetchPrivateNodeIds
       .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'acme/private-repo'}}})) // resolver
-      .mockReturnValueOnce(makeDiff('docs/leak.md', ['See acme/private-repo for details.'])) // fetchDiffForSha (compare API)
+      .mockReturnValueOnce(makeCompareJson('docs/leak.md')) // fetchDiffForSha: compare JSON (truncation check)
+      .mockReturnValueOnce(makeDiff('docs/leak.md', ['See acme/private-repo for details.'])) // fetchDiffForSha: raw diff
 
     const stderrOutput: string[] = []
     vi.spyOn(process.stderr, 'write').mockImplementation((msg: unknown) => {
@@ -1661,7 +1682,8 @@ describe('main() — workflow_run event: empty pull_requests[] → API fallback 
       .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
       .mockReturnValueOnce(makeYamlBase64(['R_wf_fallback'])) // fetchPrivateNodeIds
       .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'acme/private-repo'}}})) // resolver
-      .mockReturnValueOnce(makeDiff('docs/public.md', ['some public content'])) // fetchDiffForSha (compare API)
+      .mockReturnValueOnce(makeCompareJson('docs/public.md')) // fetchDiffForSha: compare JSON (truncation check)
+      .mockReturnValueOnce(makeDiff('docs/public.md', ['some public content'])) // fetchDiffForSha: raw diff
 
     vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
     vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
@@ -1907,9 +1929,13 @@ describe('main() — workflow_run event: PAT isolation (resolver vs diff subproc
       if (args[0] === 'api' && args[1] === 'graphql') {
         return JSON.stringify({data: {node: {nameWithOwner: 'acme/private-repo'}}})
       }
-      // fetchDiffForSha: gh api repos/.../compare/main...{sha} (immutable pinned diff)
+      // fetchDiffForSha: gh api repos/.../compare/main...{sha}
+      // Two calls: first is the JSON truncation check (no -H header), second is the raw diff.
       if (args[0] === 'api' && String(args[1]).includes('/compare/')) {
-        return makeDiff('docs/public.md', ['some public content'])
+        if (args.includes('-H') && args.some(a => String(a).includes('application/vnd.github'))) {
+          return makeDiff('docs/public.md', ['some public content'])
+        }
+        return makeCompareJson('docs/public.md')
       }
       return ''
     })
@@ -1925,7 +1951,7 @@ describe('main() — workflow_run event: PAT isolation (resolver vs diff subproc
     try {
       await main(makeWorkflowRunReader(eventJson), prApiResolver)
 
-      // Find the diff call (gh api repos/.../compare/main...{sha} — immutable pinned diff)
+      // Find the diff calls (gh api repos/.../compare/main...{sha} — both JSON check and raw diff)
       const diffCalls = capturedEnvs.filter(c => c.args[1] === 'api' && String(c.args[2]).includes('/compare/'))
       expect(diffCalls.length).toBeGreaterThan(0)
       for (const call of diffCalls) {
@@ -1977,7 +2003,8 @@ describe('main() — workflow_run event: [allow-private-leak] override honored u
       .mockImplementationOnce(() => {
         throw new Error('outage')
       }) // resolver R_override — fails (but override should allow proceeding)
-      .mockReturnValueOnce('') // fetchPrDiff → empty diff
+      .mockReturnValueOnce(makeCompareJson()) // fetchDiffForSha: compare JSON (truncation check)
+      .mockReturnValueOnce('') // fetchDiffForSha: raw diff → empty
 
     const stderrOutput: string[] = []
     vi.spyOn(process.stderr, 'write').mockImplementation((msg: unknown) => {
@@ -2082,7 +2109,9 @@ describe('main() — PR-path matched file redaction (FIX 2)', () => {
       .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
       .mockReturnValueOnce(makeYamlBase64(['R_pr_redact'])) // fetchPrivateNodeIds
       .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'synth-owner/synth_private'}}})) // resolver → resolves
-      // fetchDiffForSha (compare API): diff adds a new file whose path contains the slug form
+      // fetchDiffForSha: compare JSON (truncation check — well-formed, under cap)
+      .mockReturnValueOnce(makeCompareJson('knowledge/wiki/repos/synth-owner--synth_private.md'))
+      // fetchDiffForSha: raw diff — adds a new file whose path contains the slug form
       .mockReturnValueOnce(
         [
           'diff --git a/knowledge/wiki/repos/synth-owner--synth_private.md b/knowledge/wiki/repos/synth-owner--synth_private.md',
@@ -2271,7 +2300,8 @@ describe('main() — Finding A regression lock: access-lost in PR mode → fail-
         // resolver: returns access-lost
         return JSON.stringify({data: {node: null}, errors: [{type: 'NOT_FOUND'}]})
       })
-      .mockReturnValueOnce('') // fetchDiffForSha → empty diff (no leak, compare API)
+      .mockReturnValueOnce(makeCompareJson()) // fetchDiffForSha: compare JSON (truncation check)
+      .mockReturnValueOnce('') // fetchDiffForSha: raw diff → empty (no leak)
 
     const stderrOutput: string[] = []
     vi.spyOn(process.stderr, 'write').mockImplementation((msg: unknown) => {
@@ -2331,9 +2361,15 @@ describe('main() — Finding B regression lock: diff pinned to immutable scanned
         return JSON.stringify({data: {node: {nameWithOwner: 'acme/private-repo'}}})
       }
       // fetchDiffForSha: gh api repos/.../compare/main...{sha}
+      // Two calls: first is the JSON truncation check (no -H header), second is the raw diff.
       if (cmd === 'gh' && args[0] === 'api' && String(args[1]).includes('/compare/')) {
         capturedCompareArgs.push(String(args[1]))
-        return makeDiff('docs/public.md', ['some public content'])
+        // If the call includes the diff Accept header, return the raw diff.
+        // Otherwise return the JSON truncation-check response.
+        if (args.includes('-H') && args.some(a => String(a).includes('application/vnd.github'))) {
+          return makeDiff('docs/public.md', ['some public content'])
+        }
+        return makeCompareJson('docs/public.md')
       }
       return ''
     })
@@ -2410,6 +2446,273 @@ describe('main() — Finding F: pull_requests[] with two validating PRs → fail
       vi.restoreAllMocks()
       delete process.env.GITHUB_EVENT_PATH
       delete process.env.FRO_BOT_POLL_PAT
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// FIX 1 (P1, fail-open): compare-API diff truncation must fail closed
+// Regression lock: a compare response at the 300-file cap (or a file with a
+// dropped patch) must cause the gate to fail closed (throw), never silently pass.
+// ---------------------------------------------------------------------------
+
+describe('assertCompareNotTruncated — truncation detection (FIX 1, P1)', () => {
+  // Scenario: files.length exactly at the 300-file cap → fail closed
+  it('throws when files.length is exactly 300 (at the API cap)', () => {
+    // #given: a compare JSON response with exactly 300 files, each with a patch field
+    const files = Array.from({length: 300}, (_, i) => ({
+      filename: `file-${i}.ts`,
+      status: 'modified',
+      patch: `@@ -1 +1 @@\n-old\n+new`,
+    }))
+    const compareJson = {total_commits: 1, files}
+
+    // #when / #then: throws because files.length >= 300 (the cap)
+    expect(() => assertCompareNotTruncated(compareJson)).toThrow(
+      /diff too large to scan completely.*300.*file.*cap.*fail closed/i,
+    )
+  })
+
+  // Scenario: files.length above the cap → fail closed
+  it('throws when files.length exceeds 300', () => {
+    // #given: 301 files (impossible in practice but validates the >= check)
+    const files = Array.from({length: 301}, (_, i) => ({
+      filename: `file-${i}.ts`,
+      status: 'modified',
+      patch: `@@ -1 +1 @@\n-old\n+new`,
+    }))
+    const compareJson = {total_commits: 1, files}
+
+    expect(() => assertCompareNotTruncated(compareJson)).toThrow(/fail closed/i)
+  })
+
+  // Scenario: a file is missing its patch field (individually too large) → fail closed
+  it('throws when any file entry is missing its patch field', () => {
+    // #given: two files, the second has no patch (API omits it for very large files)
+    const compareJson = {
+      total_commits: 1,
+      files: [
+        {filename: 'small-file.ts', status: 'modified', patch: '@@ -1 +1 @@\n-old\n+new'},
+        {filename: 'huge-file.ts', status: 'modified'}, // patch intentionally absent
+      ],
+    }
+
+    // #when / #then: throws because a file has no patch — and the filename is NOT echoed
+    // (a path could embed a private slug; the message stays redacted).
+    expect(() => assertCompareNotTruncated(compareJson)).toThrow(/file patch was omitted.*fail closed/i)
+    expect(() => assertCompareNotTruncated(compareJson)).not.toThrow(/huge-file\.ts/)
+  })
+
+  // Scenario: first file missing patch → fail closed (order doesn't matter)
+  it('throws when the first file entry is missing its patch field', () => {
+    const compareJson = {
+      total_commits: 1,
+      files: [
+        {filename: 'huge-first.ts', status: 'added'}, // no patch
+        {filename: 'normal.ts', status: 'modified', patch: '@@ -1 +1 @@\n-old\n+new'},
+      ],
+    }
+
+    // Throws on the missing-patch signal without echoing the filename.
+    expect(() => assertCompareNotTruncated(compareJson)).toThrow(/file patch was omitted.*fail closed/i)
+    expect(() => assertCompareNotTruncated(compareJson)).not.toThrow(/huge-first\.ts/)
+  })
+
+  // Scenario: well-formed response under the cap → does NOT throw
+  it('does not throw for a well-formed response with fewer than 300 files', () => {
+    // #given: 5 files, all with patch fields
+    const files = Array.from({length: 5}, (_, i) => ({
+      filename: `file-${i}.ts`,
+      status: 'modified',
+      patch: `@@ -1 +1 @@\n-old\n+new`,
+    }))
+    const compareJson = {total_commits: 1, files}
+
+    // #when / #then: no throw — response is complete
+    expect(() => assertCompareNotTruncated(compareJson)).not.toThrow()
+  })
+
+  // Scenario: empty files array → does NOT throw (zero-file diff is valid)
+  it('does not throw for an empty files array (zero-file diff)', () => {
+    const compareJson = {total_commits: 0, files: []}
+
+    expect(() => assertCompareNotTruncated(compareJson)).not.toThrow()
+  })
+
+  // Scenario: non-object JSON → fail closed
+  it('throws when compareJson is not an object', () => {
+    expect(() => assertCompareNotTruncated('not an object')).toThrow(/non-object JSON.*fail closed/i)
+    expect(() => assertCompareNotTruncated(null)).toThrow(/non-object JSON.*fail closed/i)
+    expect(() => assertCompareNotTruncated(42)).toThrow(/non-object JSON.*fail closed/i)
+  })
+
+  // Scenario: missing files array → fail closed
+  it('throws when compareJson is missing the files array', () => {
+    expect(() => assertCompareNotTruncated({total_commits: 1})).toThrow(/missing files array.*fail closed/i)
+    expect(() => assertCompareNotTruncated({total_commits: 1, files: 'not-an-array'})).toThrow(
+      /missing files array.*fail closed/i,
+    )
+  })
+
+  // Scenario: 299 files all with patches → does NOT throw (one below the cap)
+  it('does not throw for 299 files all with patch fields (one below the cap)', () => {
+    const files = Array.from({length: 299}, (_, i) => ({
+      filename: `file-${i}.ts`,
+      status: 'modified',
+      patch: `@@ -1 +1 @@\n-old\n+new`,
+    }))
+    const compareJson = {total_commits: 1, files}
+
+    expect(() => assertCompareNotTruncated(compareJson)).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// FIX 1 (P1): main() fails closed when compare JSON signals truncation
+// Integration: the truncation check is wired into fetchDiffForSha which is
+// called by main(). Verify that a truncated compare response causes process.exit(1).
+// ---------------------------------------------------------------------------
+
+describe('main() — FIX 1 (P1): truncation in compare JSON → fail closed', () => {
+  it('fails closed (process.exit(1)) when compare JSON has files.length at the 300-file cap', async () => {
+    // #given: workflow_run payload; compare JSON returns 300 files (truncated)
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-truncated-300'})
+    const prApiResolver = makePrApiResolver({
+      prByNumber: makePrApiResponse({number: 42, headSha: 'sha-truncated-300'}),
+    })
+
+    // Build a compare JSON with 300 files (all with patches — the cap itself is the signal)
+    const truncatedFiles = Array.from({length: 300}, (_, i) => ({
+      filename: `file-${i}.ts`,
+      status: 'modified',
+      patch: `@@ -1 +1 @@\n-old\n+new`,
+    }))
+    const truncatedCompareJson = JSON.stringify({total_commits: 1, files: truncatedFiles})
+
+    mockExecFileSync.mockReset()
+    mockExecFileSync
+      .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
+      .mockReturnValueOnce(makeYamlBase64(['R_trunc_300'])) // fetchPrivateNodeIds
+      .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'acme/private-repo'}}})) // resolver
+      .mockReturnValueOnce(truncatedCompareJson) // fetchDiffForSha: compare JSON (truncated)
+    // Note: the raw diff fetch is NOT reached — truncation throws before it
+
+    const stderrOutput: string[] = []
+    vi.spyOn(process.stderr, 'write').mockImplementation((msg: unknown) => {
+      stderrOutput.push(String(msg))
+      return true
+    })
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      // #when: main() runs with a truncated compare response
+      await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
+      // #then: fail closed — process.exit(1) was called
+      expect(exitSpy).toHaveBeenCalledWith(1)
+      // #then: stderr mentions the truncation (not a private name)
+      const stderrText = stderrOutput.join('')
+      expect(stderrText).toMatch(/diff too large|truncat|fail closed/i)
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
+      mockExecFileSync.mockReset()
+    }
+  })
+
+  it('fails closed (process.exit(1)) when compare JSON has a file with no patch field', async () => {
+    // #given: workflow_run payload; compare JSON has a file with no patch (too large)
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-no-patch'})
+    const prApiResolver = makePrApiResolver({
+      prByNumber: makePrApiResponse({number: 42, headSha: 'sha-no-patch'}),
+    })
+
+    // Compare JSON with one normal file and one file missing its patch
+    const compareJsonWithMissingPatch = JSON.stringify({
+      total_commits: 1,
+      files: [
+        {filename: 'normal.ts', status: 'modified', patch: '@@ -1 +1 @@\n-old\n+new'},
+        {filename: 'huge-binary.bin', status: 'modified'}, // no patch — too large
+      ],
+    })
+
+    mockExecFileSync.mockReset()
+    mockExecFileSync
+      .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
+      .mockReturnValueOnce(makeYamlBase64(['R_no_patch'])) // fetchPrivateNodeIds
+      .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'acme/private-repo'}}})) // resolver
+      .mockReturnValueOnce(compareJsonWithMissingPatch) // fetchDiffForSha: compare JSON (missing patch)
+    // Note: the raw diff fetch is NOT reached — truncation throws before it
+
+    const stderrOutput: string[] = []
+    vi.spyOn(process.stderr, 'write').mockImplementation((msg: unknown) => {
+      stderrOutput.push(String(msg))
+      return true
+    })
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      // #when: main() runs with a compare response that has a file missing its patch
+      await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
+      // #then: fail closed — process.exit(1) was called
+      expect(exitSpy).toHaveBeenCalledWith(1)
+      // #then: stderr mentions the truncation
+      const stderrText = stderrOutput.join('')
+      expect(stderrText).toMatch(/patch omitted|fail closed/i)
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
+      mockExecFileSync.mockReset()
+    }
+  })
+
+  it('proceeds normally when compare JSON is well-formed and under the cap', async () => {
+    // #given: workflow_run payload; compare JSON has 2 files, all with patches
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-not-truncated'})
+    const prApiResolver = makePrApiResolver({
+      prByNumber: makePrApiResponse({number: 42, headSha: 'sha-not-truncated'}),
+    })
+
+    mockExecFileSync.mockReset()
+    mockExecFileSync
+      .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
+      .mockReturnValueOnce(makeYamlBase64(['R_not_trunc'])) // fetchPrivateNodeIds
+      .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'acme/private-repo'}}})) // resolver
+      .mockReturnValueOnce(makeCompareJson('docs/public.md')) // fetchDiffForSha: compare JSON (ok)
+      .mockReturnValueOnce(makeDiff('docs/public.md', ['some public content'])) // fetchDiffForSha: raw diff
+
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      // #when: main() runs with a well-formed compare response
+      await main(makeWorkflowRunReader(eventJson), prApiResolver)
+      // #then: no exit called — scan passed
+      expect(exitSpy).not.toHaveBeenCalled()
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
+      mockExecFileSync.mockReset()
     }
   })
 })

--- a/scripts/check-private-leak.ts
+++ b/scripts/check-private-leak.ts
@@ -64,6 +64,26 @@ export type ReposYamlReader = (path: string) => Promise<string>
 export type ResolverFactory = (pat: string) => NodeIdResolver
 
 // ---------------------------------------------------------------------------
+// Seam types for main() workflow_run testability (Unit 1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Injectable workflow_run event reader. Reads the raw JSON from GITHUB_EVENT_PATH.
+ * Defaults to fs.readFile.
+ */
+export type WorkflowRunReader = (path: string) => Promise<string>
+
+/**
+ * Injectable GitHub API resolver for PR identity.
+ * - fetchPrByNumber: fetch a PR by its number (for validation after pull_requests[] lookup)
+ * - fetchPrsByHeadSha: fetch PRs associated with a head SHA (fallback when pull_requests[] is empty)
+ */
+export interface PrApiResolver {
+  readonly fetchPrByNumber: (prNumber: number) => Promise<Record<string, unknown>>
+  readonly fetchPrsByHeadSha: (headSha: string) => Promise<Record<string, unknown>[]>
+}
+
+// ---------------------------------------------------------------------------
 // Operator override
 // ---------------------------------------------------------------------------
 
@@ -195,35 +215,162 @@ export function checkPrivateLeak(
 // CLI helpers
 // ---------------------------------------------------------------------------
 
-async function readPullRequestContext(
+// ---------------------------------------------------------------------------
+// workflow_run event reader + PR identity resolver (Unit 1)
+// ---------------------------------------------------------------------------
+
+/**
+ * The expected base repository for PRs this gate scans.
+ * Fail-closed if the PR targets a different repo.
+ */
+const EXPECTED_BASE_REPO = 'fro-bot/.github'
+
+/**
+ * The expected base branch for PRs this gate scans.
+ * Fail-closed if the PR targets a different branch.
+ */
+const EXPECTED_BASE_BRANCH = 'main'
+
+/**
+ * Validate a PR object against the expected base repo, base branch, and head SHA.
+ * Returns true only if all three match.
+ */
+function validatePrIdentity(pr: Record<string, unknown>, expectedHeadSha: string): boolean {
+  const head = isRecord(pr.head) ? pr.head : undefined
+  const base = isRecord(pr.base) ? pr.base : undefined
+  const baseRepo = base !== undefined && isRecord(base.repo) ? base.repo : undefined
+
+  const headSha = typeof head?.sha === 'string' ? head.sha : undefined
+  const baseRef = typeof base?.ref === 'string' ? base.ref : undefined
+  const baseRepoFullName = typeof baseRepo?.full_name === 'string' ? baseRepo.full_name : undefined
+
+  return headSha === expectedHeadSha && baseRef === EXPECTED_BASE_BRANCH && baseRepoFullName === EXPECTED_BASE_REPO
+}
+
+/**
+ * Read the workflow_run event payload and resolve PR identity.
+ *
+ * Resolution order:
+ * 1. Take the first candidate from `workflow_run.pull_requests[]` that passes validation.
+ * 2. If pull_requests[] is empty, fall back to an API query by head_sha.
+ *
+ * Validation: base repo == fro-bot/.github, base branch == main, PR head SHA == workflow_run.head_sha.
+ * Requires EXACTLY ONE PR to survive validation — fail-closed otherwise.
+ *
+ * Returns the validated PR number, title, and author.
+ */
+async function readWorkflowRunContext(
   eventPath: string,
-): Promise<{prNumber: number; title: string; author: string; fullName: string | null}> {
-  const raw = await readFile(eventPath, 'utf8')
+  reader: WorkflowRunReader,
+  prApiResolver: PrApiResolver,
+): Promise<{prNumber: number; title: string; author: string}> {
+  const raw = await reader(eventPath)
   const parsed: unknown = JSON.parse(raw)
 
   if (!isRecord(parsed)) {
-    throw new Error(`check-private-leak: event payload is not an object (path=${eventPath})`)
+    throw new Error(`check-private-leak: workflow_run event payload is not an object (path=${eventPath})`)
   }
 
-  const pr = isRecord(parsed.pull_request) ? parsed.pull_request : undefined
-  const prNumber = pr === undefined ? undefined : pr.number
-  const title = pr === undefined ? undefined : pr.title
-  const user = pr !== undefined && isRecord(pr.user) ? pr.user : undefined
-  const author = typeof user?.login === 'string' ? user.login : undefined
-  const base = pr !== undefined && isRecord(pr.base) ? pr.base : undefined
-  const repo = base !== undefined && isRecord(base.repo) ? base.repo : undefined
-  const rawFullName = repo === undefined ? undefined : repo.full_name
+  const workflowRun = isRecord(parsed.workflow_run) ? parsed.workflow_run : undefined
+  if (workflowRun === undefined) {
+    throw new Error(`check-private-leak: event payload missing workflow_run field (path=${eventPath})`)
+  }
 
-  if (typeof prNumber !== 'number' || typeof author !== 'string' || author === '') {
+  // Require workflow_run.event == 'pull_request' — fail-closed otherwise.
+  const triggerEvent = workflowRun.event
+  if (triggerEvent !== 'pull_request') {
     throw new Error(
-      `check-private-leak: event payload missing pull_request.number or pull_request.user.login (path=${eventPath})`,
+      `check-private-leak: workflow_run.event is "${String(triggerEvent)}", expected "pull_request" — fail-closed`,
     )
   }
-  if (typeof title !== 'string') {
-    throw new TypeError(`check-private-leak: event payload missing pull_request.title (path=${eventPath})`)
+
+  const headSha = workflowRun.head_sha
+  if (typeof headSha !== 'string' || headSha === '') {
+    throw new Error(`check-private-leak: workflow_run.head_sha is missing or empty (path=${eventPath})`)
   }
-  const fullName = typeof rawFullName === 'string' && rawFullName.length > 0 ? rawFullName : null
-  return {prNumber, title, author, fullName}
+
+  // Resolve PR number from pull_requests[] or API fallback.
+  const pullRequests = Array.isArray(workflowRun.pull_requests) ? workflowRun.pull_requests : []
+
+  const resolvedPrNumber: number = await (async (): Promise<number> => {
+    if (pullRequests.length > 0) {
+      // Use pull_requests[] — find the one that passes validation.
+      const validCandidates: number[] = []
+      for (const pr of pullRequests) {
+        if (!isRecord(pr)) continue
+        if (validatePrIdentity(pr, headSha)) {
+          const num = pr.number
+          if (typeof num === 'number') {
+            validCandidates.push(num)
+          }
+        }
+      }
+      if (validCandidates.length !== 1) {
+        throw new Error(
+          `check-private-leak: expected exactly 1 valid PR in pull_requests[], found ${validCandidates.length} — fail-closed`,
+        )
+      }
+      const prNum = validCandidates[0]
+      if (prNum === undefined) throw new Error('check-private-leak: internal: validCandidates[0] undefined')
+      return prNum
+    }
+
+    // Fallback: query by head_sha.
+    const prs = await prApiResolver.fetchPrsByHeadSha(headSha)
+    const validCandidates: number[] = []
+    for (const pr of prs) {
+      if (!isRecord(pr)) continue
+      if (validatePrIdentity(pr, headSha)) {
+        const num = pr.number
+        if (typeof num === 'number') {
+          validCandidates.push(num)
+        }
+      }
+    }
+    if (validCandidates.length !== 1) {
+      throw new Error(
+        `check-private-leak: head-SHA fallback returned ${validCandidates.length} valid PR(s), expected exactly 1 — fail-closed`,
+      )
+    }
+    const prNum = validCandidates[0]
+    if (prNum === undefined) throw new Error('check-private-leak: internal: validCandidates[0] undefined')
+    return prNum
+  })()
+
+  // Fetch the validated PR's details (number, title, author).
+  const prDetails = await prApiResolver.fetchPrByNumber(resolvedPrNumber)
+
+  const title = prDetails.title
+  const user = isRecord(prDetails.user) ? prDetails.user : undefined
+  const author = typeof user?.login === 'string' ? user.login : undefined
+
+  if (typeof title !== 'string') {
+    throw new TypeError(`check-private-leak: PR #${resolvedPrNumber} missing title field`)
+  }
+  if (author === undefined || author === '') {
+    throw new Error(`check-private-leak: PR #${resolvedPrNumber} missing user.login field`)
+  }
+
+  return {prNumber: resolvedPrNumber, title, author}
+}
+
+// ---------------------------------------------------------------------------
+// Default seam implementations for main() (Unit 1)
+// ---------------------------------------------------------------------------
+
+const defaultWorkflowRunReader: WorkflowRunReader = async (path: string): Promise<string> => readFile(path, 'utf8')
+
+const defaultPrApiResolver: PrApiResolver = {
+  fetchPrByNumber: async (prNumber: number): Promise<Record<string, unknown>> => {
+    const raw = execFileSync('gh', ['api', `repos/{owner}/{repo}/pulls/${prNumber}`, '--jq', '.'], {encoding: 'utf8'})
+    return JSON.parse(raw) as Record<string, unknown>
+  },
+  fetchPrsByHeadSha: async (headSha: string): Promise<Record<string, unknown>[]> => {
+    const raw = execFileSync('gh', ['api', `repos/{owner}/{repo}/commits/${headSha}/pulls`, '--jq', '.'], {
+      encoding: 'utf8',
+    })
+    return JSON.parse(raw) as Record<string, unknown>[]
+  },
 }
 
 /**
@@ -249,9 +396,11 @@ function fetchPrivateNodeIds(fullName: string): string[] {
 
 /**
  * Fetch unified diff text for a pull request.
+ * Accepts an explicit env so FRO_BOT_POLL_PAT never reaches the gh subprocess
+ * (mirrors the --promotion gitEnv isolation pattern).
  */
-function fetchPrDiff(prNumber: number): string {
-  return execFileSync('gh', ['pr', 'diff', String(prNumber)], {encoding: 'utf8'})
+function fetchPrDiff(prNumber: number, env: NodeJS.ProcessEnv): string {
+  return execFileSync('gh', ['pr', 'diff', String(prNumber)], {encoding: 'utf8', env})
 }
 
 /**
@@ -564,19 +713,41 @@ export async function runPromotionCli(
 // CLI entrypoint
 // ---------------------------------------------------------------------------
 
-export async function main(): Promise<void> {
+export async function main(
+  workflowRunReader: WorkflowRunReader = defaultWorkflowRunReader,
+  prApiResolver: PrApiResolver = defaultPrApiResolver,
+): Promise<void> {
   const eventPath = process.env.GITHUB_EVENT_PATH
   if (eventPath === undefined || eventPath === '') {
     process.stderr.write(
-      'check-private-leak: GITHUB_EVENT_PATH not set. This script must run inside a GitHub Actions pull_request event.\n',
+      'check-private-leak: GITHUB_EVENT_PATH not set. This script must run inside a GitHub Actions workflow_run event.\n',
     )
     process.exit(1)
   }
 
-  const {prNumber, title, author, fullName: eventFullName} = await readPullRequestContext(eventPath)
-  const fullName =
-    eventFullName ??
-    execFileSync('gh', ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'], {encoding: 'utf8'}).trim()
+  // Fail-closed if FRO_BOT_POLL_PAT is absent — resolver cannot run without it.
+  const pat = process.env.FRO_BOT_POLL_PAT
+  if (pat === undefined || pat === '') {
+    process.stderr.write(
+      'check-private-leak: FRO_BOT_POLL_PAT not set. This is required to resolve private repo names.\n',
+    )
+    process.exit(1)
+  }
+
+  // Read workflow_run payload and resolve PR identity (fail-closed on any error).
+  let prNumber: number
+  let title: string
+  let author: string
+  try {
+    ;({prNumber, title, author} = await readWorkflowRunContext(eventPath, workflowRunReader, prApiResolver))
+  } catch (error) {
+    process.stderr.write(`check-private-leak: ${error instanceof Error ? error.message : String(error)}\n`)
+    process.exit(1)
+  }
+
+  const fullName = execFileSync('gh', ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'], {
+    encoding: 'utf8',
+  }).trim()
 
   // Resolve private node_ids from data branch.
   const privateNodeIds = fetchPrivateNodeIds(fullName)
@@ -590,8 +761,15 @@ export async function main(): Promise<void> {
   const isOperator = author === OPERATOR_LOGIN
   const override: OverrideOptions = {titlePrefixed, isOperator}
 
-  // Resolve each node_id → nameWithOwner, tracking successes and failures separately.
-  const resolver = makeGhNodeIdResolver()
+  // Build a sanitized env that excludes FRO_BOT_POLL_PAT before passing to gh pr diff.
+  // The PAT must reach ONLY makeGhNodeIdResolver — never the diff subprocess.
+  // Mirrors the --promotion gitEnv isolation pattern (Fix C in runPromotionCli).
+  const diffEnv: NodeJS.ProcessEnv = {...process.env}
+  delete diffEnv.FRO_BOT_POLL_PAT
+
+  // Wire FRO_BOT_POLL_PAT ONLY to the resolver — never the diff or any other call.
+  // Mirror the --promotion gitEnv isolation: the PAT must reach ONLY makeGhNodeIdResolver.
+  const resolver = makeGhNodeIdResolver(pat)
   const resolvedNames: string[] = []
   const failedNodeIds: string[] = []
 
@@ -637,8 +815,9 @@ export async function main(): Promise<void> {
     privateTokens.push(...buildTokensForName(nameWithOwner))
   }
 
-  // Fetch diff and evaluate.
-  const diff = fetchPrDiff(prNumber)
+  // Fetch diff via gh pr diff — no PAT needed (uses ambient GITHUB_TOKEN).
+  // Pass diffEnv (PAT-stripped) so FRO_BOT_POLL_PAT never reaches the gh subprocess.
+  const diff = fetchPrDiff(prNumber, diffEnv)
   const result = checkPrivateLeak(privateTokens, diff, override)
 
   if (result.ok) {

--- a/scripts/check-private-leak.ts
+++ b/scripts/check-private-leak.ts
@@ -64,7 +64,7 @@ export type ReposYamlReader = (path: string) => Promise<string>
 export type ResolverFactory = (pat: string) => NodeIdResolver
 
 // ---------------------------------------------------------------------------
-// Seam types for main() workflow_run testability (Unit 1)
+// Seam types for main() workflow_run testability
 // ---------------------------------------------------------------------------
 
 /**
@@ -216,7 +216,7 @@ export function checkPrivateLeak(
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// workflow_run event reader + PR identity resolver (Unit 1)
+// workflow_run event reader + PR identity resolver
 // ---------------------------------------------------------------------------
 
 /**
@@ -263,7 +263,7 @@ async function readWorkflowRunContext(
   eventPath: string,
   reader: WorkflowRunReader,
   prApiResolver: PrApiResolver,
-): Promise<{prNumber: number; title: string; author: string}> {
+): Promise<{prNumber: number; title: string; author: string; headSha: string}> {
   const raw = await reader(eventPath)
   const parsed: unknown = JSON.parse(raw)
 
@@ -351,11 +351,11 @@ async function readWorkflowRunContext(
     throw new Error(`check-private-leak: PR #${resolvedPrNumber} missing user.login field`)
   }
 
-  return {prNumber: resolvedPrNumber, title, author}
+  return {prNumber: resolvedPrNumber, title, author, headSha}
 }
 
 // ---------------------------------------------------------------------------
-// Default seam implementations for main() (Unit 1)
+// Default seam implementations for main()
 // ---------------------------------------------------------------------------
 
 const defaultWorkflowRunReader: WorkflowRunReader = async (path: string): Promise<string> => readFile(path, 'utf8')
@@ -363,13 +363,21 @@ const defaultWorkflowRunReader: WorkflowRunReader = async (path: string): Promis
 const defaultPrApiResolver: PrApiResolver = {
   fetchPrByNumber: async (prNumber: number): Promise<Record<string, unknown>> => {
     const raw = execFileSync('gh', ['api', `repos/{owner}/{repo}/pulls/${prNumber}`, '--jq', '.'], {encoding: 'utf8'})
-    return JSON.parse(raw) as Record<string, unknown>
+    const parsed: unknown = JSON.parse(raw)
+    if (!isRecord(parsed)) {
+      throw new TypeError(`check-private-leak: fetchPrByNumber returned non-object for PR #${prNumber}`)
+    }
+    return parsed
   },
   fetchPrsByHeadSha: async (headSha: string): Promise<Record<string, unknown>[]> => {
     const raw = execFileSync('gh', ['api', `repos/{owner}/{repo}/commits/${headSha}/pulls`, '--jq', '.'], {
       encoding: 'utf8',
     })
-    return JSON.parse(raw) as Record<string, unknown>[]
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) {
+      throw new TypeError(`check-private-leak: fetchPrsByHeadSha returned non-array for SHA ${headSha}`)
+    }
+    return parsed.filter(isRecord)
   },
 }
 
@@ -395,12 +403,28 @@ function fetchPrivateNodeIds(fullName: string): string[] {
 }
 
 /**
- * Fetch unified diff text for a pull request.
+ * Fetch the unified diff for an immutable, pinned head SHA against the base branch.
+ *
+ * Uses the GitHub compare API with the diff media type so the result is a standard
+ * unified diff — the same format as `git diff main...data` used on the promotion path.
+ * Pinning to scannedHeadSha (the workflow_run head_sha) closes the force-push TOCTOU:
+ * the diff is for exactly the SHA the commit status is posted to, regardless of any
+ * subsequent force-push to the PR branch.
+ *
  * Accepts an explicit env so FRO_BOT_POLL_PAT never reaches the gh subprocess
  * (mirrors the --promotion gitEnv isolation pattern).
  */
-function fetchPrDiff(prNumber: number, env: NodeJS.ProcessEnv): string {
-  return execFileSync('gh', ['pr', 'diff', String(prNumber)], {encoding: 'utf8', env})
+function fetchDiffForSha(headSha: string, env: NodeJS.ProcessEnv): string {
+  return execFileSync(
+    'gh',
+    [
+      'api',
+      `repos/{owner}/{repo}/compare/${EXPECTED_BASE_BRANCH}...${headSha}`,
+      '-H',
+      'Accept: application/vnd.github.v3.diff',
+    ],
+    {encoding: 'utf8', env},
+  )
 }
 
 /**
@@ -738,8 +762,14 @@ export async function main(
   let prNumber: number
   let title: string
   let author: string
+  let scannedHeadSha: string
   try {
-    ;({prNumber, title, author} = await readWorkflowRunContext(eventPath, workflowRunReader, prApiResolver))
+    ;({
+      prNumber,
+      title,
+      author,
+      headSha: scannedHeadSha,
+    } = await readWorkflowRunContext(eventPath, workflowRunReader, prApiResolver))
   } catch (error) {
     process.stderr.write(`check-private-leak: ${error instanceof Error ? error.message : String(error)}\n`)
     process.exit(1)
@@ -761,7 +791,7 @@ export async function main(
   const isOperator = author === OPERATOR_LOGIN
   const override: OverrideOptions = {titlePrefixed, isOperator}
 
-  // Build a sanitized env that excludes FRO_BOT_POLL_PAT before passing to gh pr diff.
+  // Build a sanitized env that excludes FRO_BOT_POLL_PAT before passing to the compare-API diff fetch.
   // The PAT must reach ONLY makeGhNodeIdResolver — never the diff subprocess.
   // Mirrors the --promotion gitEnv isolation pattern (Fix C in runPromotionCli).
   const diffEnv: NodeJS.ProcessEnv = {...process.env}
@@ -778,9 +808,13 @@ export async function main(
     if ('nameWithOwner' in result) {
       resolvedNames.push(result.nameWithOwner)
     } else if (result.error === 'access-lost') {
-      // access-lost = repo gone = no current content to leak; safe to skip.
-      // transient error = unknown state = must fail closed.
-      process.stderr.write(`check-private-leak: node_id=${nodeId} access-lost (deleted/no-access), skipping\n`)
+      // access-lost is indistinguishable between "deleted" and "no-access/mis-scoped-token".
+      // Treating it as skip would make a mis-scoped PAT silently pass everything — fail closed.
+      // Mirror runPromotionScan's Fix A: push to failedNodeIds so the fail-closed block catches it.
+      failedNodeIds.push(nodeId)
+      process.stderr.write(
+        `check-private-leak: node_id=${nodeId} access-lost (deleted or token cannot see it) — BLOCKING\n`,
+      )
     } else {
       // 'error' class: transient/auth/rate-limit/unknown — fail closed.
       // Log only node_id + coarse error class; never echo raw gh stderr (may contain owner/name).
@@ -815,9 +849,12 @@ export async function main(
     privateTokens.push(...buildTokensForName(nameWithOwner))
   }
 
-  // Fetch diff via gh pr diff — no PAT needed (uses ambient GITHUB_TOKEN).
+  // Fetch the diff pinned to the immutable scannedHeadSha via the GitHub compare API.
+  // This closes the force-push TOCTOU (Finding B): the diff is for exactly the SHA the
+  // commit status is posted to — a force-push after the workflow_run fires cannot desync
+  // the scanned diff from the status target. No extra round-trip needed (no revalidation).
   // Pass diffEnv (PAT-stripped) so FRO_BOT_POLL_PAT never reaches the gh subprocess.
-  const diff = fetchPrDiff(prNumber, diffEnv)
+  const diff = fetchDiffForSha(scannedHeadSha, diffEnv)
   const result = checkPrivateLeak(privateTokens, diff, override)
 
   if (result.ok) {

--- a/scripts/check-private-leak.ts
+++ b/scripts/check-private-leak.ts
@@ -403,18 +403,86 @@ function fetchPrivateNodeIds(fullName: string): string[] {
 }
 
 /**
+ * The maximum number of files the GitHub compare API returns in a single JSON response.
+ * If `files.length` reaches this cap, the response is truncated and we cannot guarantee
+ * a complete scan — fail closed.
+ */
+const COMPARE_API_FILE_CAP = 300
+
+/**
+ * Check the compare JSON response for truncation signals.
+ * Exported for unit testing.
+ *
+ * GitHub's compare API caps `files` at 300 per response. Two truncation signals:
+ * 1. `files.length >= 300` — the cap was hit; additional files may be missing.
+ * 2. Any file entry missing its `patch` field — the API omits `patch` for very large
+ *    individual files; we cannot scan a file whose patch was dropped.
+ *
+ * Throws with a redacted message if truncation is detected so the caller (main()'s
+ * try/catch) exits non-zero — fail closed.
+ */
+export function assertCompareNotTruncated(compareJson: unknown): void {
+  if (!isRecord(compareJson)) {
+    throw new TypeError('check-private-leak: compare API returned non-object JSON — fail closed')
+  }
+
+  const files = compareJson.files
+  if (!Array.isArray(files)) {
+    throw new TypeError('check-private-leak: compare API response missing files array — fail closed')
+  }
+
+  // Signal 1: file count at or above the API cap.
+  if (files.length >= COMPARE_API_FILE_CAP) {
+    throw new Error(
+      `check-private-leak: diff too large to scan completely (${files.length} files >= ${COMPARE_API_FILE_CAP}-file cap) — fail closed`,
+    )
+  }
+
+  // Signal 2: any file missing its patch field (individually too large for the API to include).
+  // The filename is intentionally NOT echoed — a path under knowledge/wiki/repos/ could embed a
+  // private slug. Fail closed with a count-only message.
+  for (const file of files) {
+    if (!isRecord(file)) continue
+    if (!('patch' in file)) {
+      throw new Error(
+        'check-private-leak: a file patch was omitted by the compare API (file too large to diff) — fail closed',
+      )
+    }
+  }
+}
+
+/**
  * Fetch the unified diff for an immutable, pinned head SHA against the base branch.
  *
- * Uses the GitHub compare API with the diff media type so the result is a standard
- * unified diff — the same format as `git diff main...data` used on the promotion path.
- * Pinning to scannedHeadSha (the workflow_run head_sha) closes the force-push TOCTOU:
- * the diff is for exactly the SHA the commit status is posted to, regardless of any
- * subsequent force-push to the PR branch.
+ * Uses the GitHub compare API pinned to the workflow_run head SHA, never from a
+ * checked-out tree. Pinning to scannedHeadSha (the workflow_run head_sha) closes the
+ * force-push TOCTOU: the diff is for exactly the SHA the commit status is posted to,
+ * regardless of any subsequent force-push to the PR branch.
+ *
+ * Truncation guard (fail-closed): before fetching the raw diff, queries the compare
+ * endpoint as JSON (no diff media type) to check for truncation. GitHub caps the
+ * `files` array at 300 entries and omits `patch` for individually-too-large files.
+ * Either signal means we cannot guarantee a complete scan → throws so main()'s
+ * try/catch exits non-zero (fail closed). The raw diff fetch is skipped on truncation.
  *
  * Accepts an explicit env so FRO_BOT_POLL_PAT never reaches the gh subprocess
- * (mirrors the --promotion gitEnv isolation pattern).
+ * (mirrors the --promotion gitEnv isolation pattern). The PAT-stripped env is used
+ * for BOTH the JSON truncation check and the raw diff fetch.
  */
 function fetchDiffForSha(headSha: string, env: NodeJS.ProcessEnv): string {
+  // Step 1: fetch the compare JSON to detect truncation before scanning.
+  // No diff media type — returns { total_commits, files: [...] } with per-file patch fields.
+  const compareJsonRaw = execFileSync(
+    'gh',
+    ['api', `repos/{owner}/{repo}/compare/${EXPECTED_BASE_BRANCH}...${headSha}`],
+    {encoding: 'utf8', env},
+  )
+  const compareJson: unknown = JSON.parse(compareJsonRaw)
+  // Throws if truncated — fail closed. main()'s try/catch maps this to process.exit(1).
+  assertCompareNotTruncated(compareJson)
+
+  // Step 2: fetch the raw unified diff for the actual scan content.
+  // Only reached when the JSON check confirms the diff is complete.
   return execFileSync(
     'gh',
     [
@@ -854,7 +922,14 @@ export async function main(
   // commit status is posted to — a force-push after the workflow_run fires cannot desync
   // the scanned diff from the status target. No extra round-trip needed (no revalidation).
   // Pass diffEnv (PAT-stripped) so FRO_BOT_POLL_PAT never reaches the gh subprocess.
-  const diff = fetchDiffForSha(scannedHeadSha, diffEnv)
+  // fetchDiffForSha also performs a truncation check (fail-closed) before fetching the raw diff.
+  let diff: string
+  try {
+    diff = fetchDiffForSha(scannedHeadSha, diffEnv)
+  } catch (error) {
+    process.stderr.write(`check-private-leak: ${error instanceof Error ? error.message : String(error)}\n`)
+    process.exit(1)
+  }
   const result = checkPrivateLeak(privateTokens, diff, override)
 
   if (result.ok) {


### PR DESCRIPTION
Wires the private-leak scan as a per-PR gate using a trusted `workflow_run` topology, so the broad-scope token that resolves private repo names never executes PR-author code.

## Why

The scan already gates the `data→main` promotion path. This adds the per-PR layer: a PR to `main` that introduces a private repository's name in its diff is now caught before merge. The first attempt at this ran the scan in a `pull_request` job that checked out PR-author code with the resolution token in scope — a token-exfiltration vector on a public repo. That wiring was removed; this rebuilds it safely.

## How

- A no-op `pull_request` sentinel fires a privileged `workflow_run` job. Because `workflow_run` always runs the default-branch workflow definition, the privileged job never executes PR-author code.
- The privileged job checks out `main` only (never the PR head), installs with no restored cache, and scopes the resolution token to the scan step alone. `github.token` handles the diff and the commit status; the resolution token is confined to the name-resolver subprocess.
- The scan resolves PR identity from the `workflow_run` payload (with a head-SHA API fallback), validates the base repo/branch and that exactly one PR matches the scanned SHA, fetches the diff pinned to that immutable SHA, and posts a `security/check-private-leak` commit status to it.
- It fails closed throughout: unresolvable identity, a private repo the token can't resolve, a scan error, or a status-post failure all block rather than pass. The `[allow-private-leak]` operator override (title prefix, permitted login) still applies.

Required-check registration is deferred until the commit status is proven to attach and block for fork PR heads.

Closes #3407
