### PR TITLE
feat(presence): daily digest as a gateway event, shipped dormant

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -42,6 +42,9 @@ on:
       DISCORD_WEBHOOK_URL:
         description: Discord webhook URL for social notifications (optional)
         required: false
+      GATEWAY_WEBHOOK_SECRET:
+        description: HMAC-SHA256 signing key for the gateway presence announce (optional)
+        required: false
 
 permissions:
   contents: read
@@ -335,6 +338,20 @@ jobs:
             }}
         run: node scripts/wiki-query.ts
 
+      # Overlay metadata/ from the data branch so the scheduled run can derive
+      # digest counts from live metadata/repos.yaml. Mirrors the precedented guard
+      # in reconcile-repos.yaml: tolerate a missing data branch (skip, don't fail).
+      - name: ⤵ Overlay metadata from data branch
+        if: github.event_name == 'schedule'
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code origin data >/dev/null 2>&1; then
+            git fetch --no-tags origin data
+            git checkout origin/data -- metadata/
+          else
+            echo "data branch not yet established; skipping metadata overlay."
+          fi
+
       - name: Run Fro Bot
         id: fro-bot-agent
         uses: fro-bot/agent@73501cca967b8b909812754ee29e4ab1cccf85ff # v0.58.1
@@ -374,6 +391,96 @@ jobs:
             `knowledge/schema.md`. Keep changes additive, preserve contradictions with
             dates and sources, and leave the wiki untouched when the signal is weak.
             </knowledge_persistence>
+
+      # Discover the daily report issue URL created by the agent this run.
+      # MUST run after the agent step (the agent creates the issue mid-run).
+      # Matches the EXACT title "Daily Fro Bot Report — <today-UTC> (UTC)" (em-dash U+2014).
+      # Two title families coexist — post-filter JSON for byte-equality to avoid false matches.
+      # Shape-validates the URL before use; skips the post on zero/multiple matches (fail-soft).
+      - name: 🔍 Discover daily report URL
+        id: report-url
+        if: github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+        run: |
+          set -euo pipefail
+          TODAY_UTC="$(date -u +%Y-%m-%d)"
+          EXPECTED_TITLE="Daily Fro Bot Report \u2014 ${TODAY_UTC} (UTC)"
+          # Fetch open issues, post-filter for exact title match (byte-equality).
+          MATCHES="$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --limit 50 \
+            --json number,title,url \
+            | jq --arg title "$EXPECTED_TITLE" \
+              '[.[] | select(.title == $title)]')"
+          COUNT="$(echo "$MATCHES" | jq 'length')"
+          if [ "$COUNT" -ne 1 ]; then
+            echo "report_url=" >> "$GITHUB_OUTPUT"
+            echo "::notice::daily-digest: expected 1 report issue match, got ${COUNT}; skipping announce"
+          else
+            CANDIDATE_URL="$(echo "$MATCHES" | jq -r '.[0].url')"
+            # Shape-validate: must be https://github.com/fro-bot/.github/issues/<n>
+            if echo "$CANDIDATE_URL" | grep -qE '^https://github\.com/fro-bot/\.github/issues/[0-9]+$'; then
+              echo "report_url=${CANDIDATE_URL}" >> "$GITHUB_OUTPUT"
+            else
+              echo "report_url=" >> "$GITHUB_OUTPUT"
+              echo "::notice::daily-digest: report URL failed shape validation; skipping announce"
+            fi
+          fi
+
+      # Derive repos_tracked, surveys_today, should_post, count_status from metadata/repos.yaml.
+      # Surfaces count_status=='error' as a step warning so a broken data overlay is visible.
+      - name: 📊 Derive daily digest counts
+        id: digest-counts
+        if: github.event_name == 'schedule'
+        run: |
+          set -euo pipefail
+          TODAY_UTC="$(date -u +%Y-%m-%d)"
+          export TODAY_UTC
+          RESULT="$(node scripts/daily-digest-counts.ts metadata/repos.yaml "$TODAY_UTC")"
+          REPOS_TRACKED="$(echo "$RESULT" | jq '.repos_tracked')"
+          SURVEYS_TODAY="$(echo "$RESULT" | jq '.surveys_today')"
+          SHOULD_POST="$(echo "$RESULT" | jq -r '.should_post')"
+          COUNT_STATUS="$(echo "$RESULT" | jq -r '.count_status')"
+          {
+            echo "result=${RESULT}"
+            echo "repos_tracked=${REPOS_TRACKED}"
+            echo "surveys_today=${SURVEYS_TODAY}"
+            echo "should_post=${SHOULD_POST}"
+            echo "count_status=${COUNT_STATUS}"
+          } >> "$GITHUB_OUTPUT"
+          if [ "$COUNT_STATUS" = "error" ]; then
+            echo "::warning::daily-digest-counts: count_status=error — metadata overlay may have failed; treating as quiet day"
+          fi
+
+      # Best-effort Discord presence: announce the daily digest to the gateway.
+      # DORMANT until vars.DAILY_DIGEST_ENABLED is set (default unset at merge).
+      # The dedicated step gate (not GATEWAY_ANNOUNCE_DISABLED) keeps this dormant
+      # so the two live events (survey_completed, invitation_accepted) are unaffected.
+      # Go-live: set DAILY_DIGEST_ENABLED after the gateway daily_digest variant is
+      # deployed and verified in fro-bot/agent + marcusrbrown/infra.
+      - name: 📣 Announce daily digest to gateway
+        if: >-
+          github.event_name == 'schedule' &&
+          steps.digest-counts.outputs.should_post == 'true' &&
+          vars.DAILY_DIGEST_ENABLED != ''
+        env:
+          EVENT_TYPE: daily_digest
+          REPOS_TRACKED: ${{ steps.digest-counts.outputs.repos_tracked }}
+          SURVEYS_TODAY: ${{ steps.digest-counts.outputs.surveys_today }}
+          REPORT_URL: ${{ steps.report-url.outputs.report_url }}
+          GATEWAY_PRESENCE_URL: ${{ vars.GATEWAY_PRESENCE_URL }}
+          GATEWAY_WEBHOOK_SECRET: ${{ secrets.GATEWAY_WEBHOOK_SECRET }}
+          GATEWAY_ANNOUNCE_DISABLED: ${{ vars.GATEWAY_ANNOUNCE_DISABLED }}
+        run: |
+          EVENT_CONTEXT_JSON="$(jq -nc \
+            --argjson repos_tracked "$REPOS_TRACKED" \
+            --argjson surveys_today "$SURVEYS_TODAY" \
+            --arg report_url "$REPORT_URL" \
+            '{repos_tracked: $repos_tracked, surveys_today: $surveys_today, report_url: $report_url}')"
+          export EVENT_CONTEXT_JSON
+          node scripts/gateway-announce.ts
 
       - name: Detect wiki insight changes
         id: wiki-changes

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -405,15 +405,22 @@ jobs:
         run: |
           set -euo pipefail
           TODAY_UTC="$(date -u +%Y-%m-%d)"
-          EXPECTED_TITLE="Daily Fro Bot Report \u2014 ${TODAY_UTC} (UTC)"
+          EXPECTED_TITLE="Daily Fro Bot Report — ${TODAY_UTC} (UTC)"
           # Fetch open issues, post-filter for exact title match (byte-equality).
-          MATCHES="$(gh issue list \
+          # Fail-soft: any gh/jq error emits empty report_url + warning and exits 0.
+          if ! MATCHES="$(gh issue list \
             --repo "$GITHUB_REPOSITORY" \
             --state open \
             --limit 50 \
             --json number,title,url \
+            2>/tmp/discover-err \
             | jq --arg title "$EXPECTED_TITLE" \
-              '[.[] | select(.title == $title)]')"
+              '[.[] | select(.title == $title)]' \
+            2>>/tmp/discover-err)"; then
+            echo "report_url=" >> "$GITHUB_OUTPUT"
+            echo "::warning::daily-digest: report URL discovery failed: $(head -c 200 /tmp/discover-err 2>/dev/null)"
+            exit 0
+          fi
           COUNT="$(echo "$MATCHES" | jq 'length')"
           if [ "$COUNT" -ne 1 ]; then
             echo "report_url=" >> "$GITHUB_OUTPUT"
@@ -464,7 +471,8 @@ jobs:
         if: >-
           github.event_name == 'schedule' &&
           steps.digest-counts.outputs.should_post == 'true' &&
-          vars.DAILY_DIGEST_ENABLED != ''
+          steps.report-url.outputs.report_url != '' &&
+          vars.DAILY_DIGEST_ENABLED == 'true'
         env:
           EVENT_TYPE: daily_digest
           REPOS_TRACKED: ${{ steps.digest-counts.outputs.repos_tracked }}

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -346,8 +346,11 @@ jobs:
         run: |
           set -euo pipefail
           if git ls-remote --exit-code origin data >/dev/null 2>&1; then
-            git fetch --no-tags origin data
-            git checkout origin/data -- metadata/
+            overlay_err=$(
+              { git fetch --no-tags origin data && git checkout origin/data -- metadata/; } 2>&1
+            ) || {
+              echo "::warning::metadata overlay fetch/checkout failed (continuing — counts will use stale/missing metadata): $(echo "$overlay_err" | head -c 200)"
+            }
           else
             echo "data branch not yet established; skipping metadata overlay."
           fi

--- a/docs/plans/2026-06-07-001-feat-daily-digest-presence-event-plan.md
+++ b/docs/plans/2026-06-07-001-feat-daily-digest-presence-event-plan.md
@@ -4,7 +4,7 @@ type: feat
 status: active
 date: 2026-06-07
 origin: docs/brainstorms/2026-06-04-daily-digest-presence-event-requirements.md
-deepened: 2026-06-07
+deepened: 2026-06-09
 ---
 
 # Daily digest presence event (control-plane side)
@@ -121,8 +121,14 @@ cron heartbeat (see origin: `docs/brainstorms/2026-06-04-daily-digest-presence-e
 - **Suppress-on-quiet gate is `surveys_today > 0`** for v1 (invitations omitted). On a quiet day the
   announce step is skipped entirely; the oversight issue is still created.
 - **Report URL via deterministic `gh issue list`** after the agent step — match the agent's
-  deterministic title (`Daily Fro Bot Report — YYYY-MM-DD (UTC)`) for today's UTC date. The agent
+  **exact** title `Daily Fro Bot Report — <today-UTC> (UTC)` (em-dash `—`, U+2014). The agent
   creates the issue mid-run; the workflow rediscovers it rather than parsing agent output.
+  **Hazard (verified in live data):** two title families coexist on the repo — `Daily Fro Bot
+  Report — …` (current) and the older `Daily Autohealing Report — …` / `Daily Org Oversight
+  Report — …`. A loose/substring match could grab the wrong issue. Discovery MUST anchor on the
+  full exact title for today's UTC date and select the single newest open match (`--search` by
+  title is not exact, so post-filter the JSON titles for byte-equality), then shape-validate the
+  resulting URL before signing. On zero or multiple matches → skip the post (fail-soft).
 - **Ship dormant via a dedicated `DAILY_DIGEST_ENABLED` step gate**, NOT the global
   `GATEWAY_ANNOUNCE_DISABLED` kill switch. The announce step's `if:` requires `vars.DAILY_DIGEST_ENABLED`
   to be truthy; it is unset at merge, so the step is skipped entirely (never even calls the signer)
@@ -258,9 +264,13 @@ the `daily_digest` (shipped dormant), without touching the legacy webhook step.
   **validate** the result is an `https://github.com/<owner>/<repo>/issues/<number>` URL for the
   expected repo before it is used; on no-match or shape-mismatch, skip the post (fail-soft).
 - Add a step that runs `scripts/daily-digest-counts.ts`, then a `📣 Announce daily digest to gateway`
-  step that builds `EVENT_CONTEXT_JSON` (`repos_tracked`, `surveys_today`, validated `report_url`) via
-  `jq -nc` and runs `node scripts/gateway-announce.ts` with `EVENT_TYPE=daily_digest` and the
-  `GATEWAY_*` env (mirror the env block in the two existing announce steps).
+  step that builds `EVENT_CONTEXT_JSON` and runs `node scripts/gateway-announce.ts` with
+  `EVENT_TYPE=daily_digest` and the `GATEWAY_*` env (mirror the env block in the two existing announce
+  steps). **Build the context with `jq -nc --argjson repos_tracked "$REPOS_TRACKED" --argjson
+  surveys_today "$SURVEYS_TODAY" --arg report_url "$REPORT_URL" '{repos_tracked:$repos_tracked,
+  surveys_today:$surveys_today, report_url:$report_url}'`** — the two counts MUST be `--argjson`
+  (JSON numbers) to satisfy the gateway's strict `Schema.Number`; the URL is `--arg` (string). This
+  mirrors the verified `--argjson pages` pattern at `survey-repo.yaml:350`.
 - **Dormancy is a dedicated step gate, not the global kill switch.** Gate the announce step's `if:` on
   `github.event_name == 'schedule'` **and** `should_post == true` **and** `vars.DAILY_DIGEST_ENABLED`
   truthy. `DAILY_DIGEST_ENABLED` is unset at merge, so the step is skipped entirely and never calls
@@ -332,7 +342,8 @@ step is unchanged.
 | Report-URL discovery step has no token | Set `GH_TOKEN: ${{ secrets.FRO_BOT_PAT }}` on the step (the action's `with: github-token` does not reach sibling shell steps). |
 | Untrusted `report_url` flows into the signed, gateway-rendered message | Validate the discovered URL is an `https://github.com/<owner>/<repo>/issues/<n>` shape for the expected repo before signing; skip on mismatch. |
 | Broken `data` overlay silently looks like a quiet day | Count script emits `count_status:'error'` distinct from `should_post:false`; the workflow surfaces an error as a step warning. |
-| Context shape drifts from the gateway-side schema | Pin the exact `{repos_tracked, surveys_today, report_url}` shape against `fro-bot/agent` #765 before enabling. |
+| Context shape drifts from the gateway-side schema | Pin the exact `{repos_tracked, surveys_today, report_url}` shape against `fro-bot/agent` #765 before enabling. **Verified 2026-06-09:** gateway `DailyDigest` schema (`packages/gateway/src/http/announce-schema.ts`) requires exactly these three fields; excess props are stripped (Effect `decodeUnknownEither`), so extras are safe but **types are strict**. |
+| Counts emitted as JSON **strings** → gateway `Schema.Number` rejects with `malformed_body` (400) post-go-live | Build `EVENT_CONTEXT_JSON` with `jq --argjson` for `repos_tracked`/`surveys_today` (numbers) and `--arg` for `report_url` (string) — mirroring the verified `--argjson pages` precedent in `survey-repo.yaml`. A quoted `"3"` count would fail the strict schema. |
 | Report URL not found (agent issue-title format changes) | Discovery step tolerates "not found" and skips the post (fail-soft), never fails the run. |
 | Metadata overlay adds run cost / `data` branch absent | Reuse the precedented, guarded overlay from `reconcile-repos.yaml`; tolerate missing `data`. |
 | Counts wrong at UTC date boundary | UTC-explicit date logic, pinned with a fixed-clock test (Unit 2). |

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -165,12 +165,12 @@ PAT split summary:
 
 `survey-repo.yaml`, `poll-invitations.yaml`, and the scheduled `fro-bot.yaml` run post in-character event announcements to the Fro Bot gateway, which relays them into Fronomenal Discord as the Fro Bot user. These steps are best-effort: they never fail the workflow, and they stay silent unless the gateway is configured.
 
-| Name                        | Type     | Purpose                                                                                 |
-| --------------------------- | -------- | --------------------------------------------------------------------------------------- |
-| `GATEWAY_WEBHOOK_SECRET`    | secret   | HMAC-SHA256 signing key for the announce payload                                        |
-| `GATEWAY_PRESENCE_URL`      | variable | Gateway `POST /v1/announce` endpoint URL                                                |
-| `GATEWAY_ANNOUNCE_DISABLED` | variable | Kill switch — any truthy value mutes all announce POSTs                                 |
-| `DAILY_DIGEST_ENABLED`      | variable | Go-live gate for the `daily_digest` event. Unset = the daily digest step is skipped     |
+| Name | Type | Purpose |
+| --- | --- | --- |
+| `GATEWAY_WEBHOOK_SECRET` | secret | HMAC-SHA256 signing key for the announce payload |
+| `GATEWAY_PRESENCE_URL` | variable | Gateway `POST /v1/announce` endpoint URL |
+| `GATEWAY_ANNOUNCE_DISABLED` | variable | Kill switch — any truthy value mutes all announce POSTs |
+| `DAILY_DIGEST_ENABLED` | variable | Go-live gate for the `daily_digest` event. Must be set to `true` to enable; unset or any other value = step is skipped |
 
 The gateway endpoint is opt-in: it accepts announcements only when the gateway deployment itself has both its webhook secret and presence channel configured. Until `GATEWAY_PRESENCE_URL` and `GATEWAY_WEBHOOK_SECRET` are set here, the announce steps log a skip and exit cleanly.
 
@@ -178,11 +178,11 @@ The gateway endpoint is opt-in: it accepts announcements only when the gateway d
 
 Each event carries a small, fixed context the gateway renders into a Discord message. All three post as the Fro Bot user.
 
-| Event                  | Source                  | Context shape                                                  |
-| ---------------------- | ----------------------- | ------------------------------------------------------------- |
-| `survey_completed`     | `survey-repo.yaml`      | `{ owner, repo, slug, wiki_pages_changed }`                   |
-| `invitation_accepted`  | `poll-invitations.yaml` | `{ count, repos: [{ owner, name }] }`                         |
-| `daily_digest`         | `fro-bot.yaml`          | `{ repos_tracked: number, surveys_today: number, report_url }` |
+| Event                 | Source                  | Context shape                                                  |
+| --------------------- | ----------------------- | -------------------------------------------------------------- |
+| `survey_completed`    | `survey-repo.yaml`      | `{ owner, repo, slug, wiki_pages_changed }`                    |
+| `invitation_accepted` | `poll-invitations.yaml` | `{ count, repos: [{ owner, name }] }`                          |
+| `daily_digest`        | `fro-bot.yaml`          | `{ repos_tracked: number, surveys_today: number, report_url }` |
 
 `daily_digest` posts on scheduled runs only, and only on days with at least one survey — quiet days are suppressed (the oversight report issue is still created either way). `repos_tracked` counts public tracked repos; `surveys_today` counts repos surveyed that UTC day; `report_url` links that day's oversight report.
 
@@ -191,7 +191,7 @@ Each event carries a small, fixed context the gateway renders into a Discord mes
 The `daily_digest` step ships dormant. To enable it:
 
 1. Confirm the gateway `daily_digest` variant is deployed and serving (gateway support lives in `fro-bot/agent` and is deployed via `marcusrbrown/infra`).
-2. Set the `DAILY_DIGEST_ENABLED` repository variable to any non-empty value.
+2. Set the `DAILY_DIGEST_ENABLED` repository variable to `true`.
 3. Verify one live post appears in Discord as the Fro Bot user with a working report link.
 
 The legacy daily-oversight Discord webhook keeps running until a separate follow-up removes it after go-live, so there is no coverage gap and no double-post while `DAILY_DIGEST_ENABLED` is unset.

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -163,15 +163,38 @@ PAT split summary:
 
 ### Gateway presence (Discord)
 
-`survey-repo.yaml` and `poll-invitations.yaml` post in-character event announcements to the Fro Bot gateway, which relays them into Fronomenal Discord as the Fro Bot user. These steps are best-effort: they never fail the workflow, and they stay silent unless the gateway is configured.
+`survey-repo.yaml`, `poll-invitations.yaml`, and the scheduled `fro-bot.yaml` run post in-character event announcements to the Fro Bot gateway, which relays them into Fronomenal Discord as the Fro Bot user. These steps are best-effort: they never fail the workflow, and they stay silent unless the gateway is configured.
 
-| Name                        | Type     | Purpose                                                 |
-| --------------------------- | -------- | ------------------------------------------------------- |
-| `GATEWAY_WEBHOOK_SECRET`    | secret   | HMAC-SHA256 signing key for the announce payload        |
-| `GATEWAY_PRESENCE_URL`      | variable | Gateway `POST /v1/announce` endpoint URL                |
-| `GATEWAY_ANNOUNCE_DISABLED` | variable | Kill switch — any truthy value mutes all announce POSTs |
+| Name                        | Type     | Purpose                                                                                 |
+| --------------------------- | -------- | --------------------------------------------------------------------------------------- |
+| `GATEWAY_WEBHOOK_SECRET`    | secret   | HMAC-SHA256 signing key for the announce payload                                        |
+| `GATEWAY_PRESENCE_URL`      | variable | Gateway `POST /v1/announce` endpoint URL                                                |
+| `GATEWAY_ANNOUNCE_DISABLED` | variable | Kill switch — any truthy value mutes all announce POSTs                                 |
+| `DAILY_DIGEST_ENABLED`      | variable | Go-live gate for the `daily_digest` event. Unset = the daily digest step is skipped     |
 
 The gateway endpoint is opt-in: it accepts announcements only when the gateway deployment itself has both its webhook secret and presence channel configured. Until `GATEWAY_PRESENCE_URL` and `GATEWAY_WEBHOOK_SECRET` are set here, the announce steps log a skip and exit cleanly.
+
+#### Events
+
+Each event carries a small, fixed context the gateway renders into a Discord message. All three post as the Fro Bot user.
+
+| Event                  | Source                  | Context shape                                                  |
+| ---------------------- | ----------------------- | ------------------------------------------------------------- |
+| `survey_completed`     | `survey-repo.yaml`      | `{ owner, repo, slug, wiki_pages_changed }`                   |
+| `invitation_accepted`  | `poll-invitations.yaml` | `{ count, repos: [{ owner, name }] }`                         |
+| `daily_digest`         | `fro-bot.yaml`          | `{ repos_tracked: number, surveys_today: number, report_url }` |
+
+`daily_digest` posts on scheduled runs only, and only on days with at least one survey — quiet days are suppressed (the oversight report issue is still created either way). `repos_tracked` counts public tracked repos; `surveys_today` counts repos surveyed that UTC day; `report_url` links that day's oversight report.
+
+#### Daily digest go-live
+
+The `daily_digest` step ships dormant. To enable it:
+
+1. Confirm the gateway `daily_digest` variant is deployed and serving (gateway support lives in `fro-bot/agent` and is deployed via `marcusrbrown/infra`).
+2. Set the `DAILY_DIGEST_ENABLED` repository variable to any non-empty value.
+3. Verify one live post appears in Discord as the Fro Bot user with a working report link.
+
+The legacy daily-oversight Discord webhook keeps running until a separate follow-up removes it after go-live, so there is no coverage gap and no double-post while `DAILY_DIGEST_ENABLED` is unset.
 
 ## Editing metadata files
 

--- a/scripts/daily-digest-counts.test.ts
+++ b/scripts/daily-digest-counts.test.ts
@@ -1,0 +1,205 @@
+import process from 'node:process'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {deriveCounts} from './daily-digest-counts.ts'
+
+// ─── Fixture helpers ──────────────────────────────────────────────────────────
+
+const TODAY = '2026-06-08'
+const YESTERDAY = '2026-06-07'
+
+function makeYaml(repos: object[]): string {
+  const lines = ['version: 1', 'repos:']
+  for (const repo of repos) {
+    const entries = Object.entries(repo as Record<string, unknown>)
+    if (entries.length === 0) {
+      lines.push('  - {}')
+      continue
+    }
+    const [first, ...rest] = entries
+    if (first !== undefined) {
+      lines.push(`  - ${first[0]}: ${JSON.stringify(first[1])}`)
+    }
+    for (const [k, v] of rest) {
+      lines.push(`    ${k}: ${JSON.stringify(v)}`)
+    }
+  }
+  return lines.join('\n')
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('deriveCounts', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // ─── Happy path ───────────────────────────────────────────────────────────
+
+  it('happy path: 3 public + 1 private, 2 surveyed today → repos_tracked:3, surveys_today:2, should_post:true', () => {
+    const yaml = makeYaml([
+      {owner: 'acme', name: 'alpha', private: false, last_survey_at: TODAY},
+      {owner: 'acme', name: 'beta', private: false, last_survey_at: TODAY},
+      {owner: 'acme', name: 'gamma', private: false, last_survey_at: YESTERDAY},
+      {owner: 'acme', name: 'private-repo', private: true, last_survey_at: TODAY},
+    ])
+
+    const result = deriveCounts(yaml, TODAY)
+
+    expect(result).toEqual({
+      repos_tracked: 3,
+      surveys_today: 2,
+      should_post: true,
+      count_status: 'ok',
+    })
+  })
+
+  // ─── Quiet day ────────────────────────────────────────────────────────────
+
+  it('quiet day: 0 surveyed today → surveys_today:0, should_post:false, count_status:ok', () => {
+    const yaml = makeYaml([
+      {owner: 'acme', name: 'alpha', private: false, last_survey_at: YESTERDAY},
+      {owner: 'acme', name: 'beta', private: false, last_survey_at: YESTERDAY},
+    ])
+
+    const result = deriveCounts(yaml, TODAY)
+
+    expect(result).toEqual({
+      repos_tracked: 2,
+      surveys_today: 0,
+      should_post: false,
+      count_status: 'ok',
+    })
+  })
+
+  // ─── Private excluded from repos_tracked ─────────────────────────────────
+
+  it('private entries are excluded from repos_tracked', () => {
+    const yaml = makeYaml([
+      {owner: 'acme', name: 'pub', private: false, last_survey_at: TODAY},
+      {owner: 'acme', name: 'priv', private: true, last_survey_at: TODAY},
+    ])
+
+    const result = deriveCounts(yaml, TODAY)
+
+    expect(result.repos_tracked).toBe(1)
+    expect(result.count_status).toBe('ok')
+  })
+
+  // ─── Missing `private` not counted as public ──────────────────────────────
+
+  it('entry missing `private` field is NOT counted as public (repos_tracked)', () => {
+    const yaml = makeYaml([
+      {owner: 'acme', name: 'pub', private: false, last_survey_at: TODAY},
+      // no `private` key at all
+      {owner: 'acme', name: 'unknown', last_survey_at: TODAY},
+    ])
+
+    const result = deriveCounts(yaml, TODAY)
+
+    // Only the explicitly-public entry counts
+    expect(result.repos_tracked).toBe(1)
+    expect(result.count_status).toBe('ok')
+  })
+
+  // ─── Empty repos ─────────────────────────────────────────────────────────
+
+  it('empty repos list → zeros, should_post:false, no throw', () => {
+    const yaml = 'version: 1\nrepos: []\n'
+
+    const result = deriveCounts(yaml, TODAY)
+
+    expect(result).toEqual({
+      repos_tracked: 0,
+      surveys_today: 0,
+      should_post: false,
+      count_status: 'ok',
+    })
+  })
+
+  // ─── Missing/malformed file → count_status:'error' ───────────────────────
+
+  it('null/undefined input → count_status:error, should_post:false, no throw', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    const result = deriveCounts(null as unknown as string, TODAY)
+
+    expect(result.count_status).toBe('error')
+    expect(result.should_post).toBe(false)
+    expect(result.repos_tracked).toBe(0)
+    expect(result.surveys_today).toBe(0)
+    expect(stderrSpy).toHaveBeenCalled()
+  })
+
+  it('malformed YAML → count_status:error, should_post:false, no throw', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    const result = deriveCounts('{not: valid: yaml: [}', TODAY)
+
+    expect(result.count_status).toBe('error')
+    expect(result.should_post).toBe(false)
+    expect(stderrSpy).toHaveBeenCalled()
+  })
+
+  it('YAML with no repos key → count_status:error, should_post:false, no throw', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    const result = deriveCounts('version: 1\n', TODAY)
+
+    expect(result.count_status).toBe('error')
+    expect(result.should_post).toBe(false)
+    expect(stderrSpy).toHaveBeenCalled()
+  })
+
+  // ─── count_status:'error' distinguishable from quiet day ─────────────────
+
+  it('count_status:error is distinguishable from a genuine quiet day (should_post:false, count_status:ok)', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    const errorResult = deriveCounts(null as unknown as string, TODAY)
+    const quietResult = deriveCounts(
+      makeYaml([{owner: 'acme', name: 'pub', private: false, last_survey_at: YESTERDAY}]),
+      TODAY,
+    )
+
+    // Both have should_post:false, but count_status differs
+    expect(errorResult.should_post).toBe(false)
+    expect(quietResult.should_post).toBe(false)
+    expect(errorResult.count_status).toBe('error')
+    expect(quietResult.count_status).toBe('ok')
+
+    stderrSpy.mockRestore()
+  })
+
+  // ─── UTC date boundary ────────────────────────────────────────────────────
+
+  it('UTC date boundary: today-UTC counts, yesterday does not (fixed clock)', () => {
+    const yaml = makeYaml([
+      {owner: 'acme', name: 'surveyed-today', private: false, last_survey_at: TODAY},
+      {owner: 'acme', name: 'surveyed-yesterday', private: false, last_survey_at: YESTERDAY},
+    ])
+
+    const result = deriveCounts(yaml, TODAY)
+
+    expect(result.surveys_today).toBe(1)
+    expect(result.should_post).toBe(true)
+  })
+
+  it('UTC date boundary: when today is yesterday, neither entry counts', () => {
+    const yaml = makeYaml([
+      {owner: 'acme', name: 'surveyed-today', private: false, last_survey_at: TODAY},
+      {owner: 'acme', name: 'surveyed-yesterday', private: false, last_survey_at: YESTERDAY},
+    ])
+
+    // Advance "today" to a future date — neither entry matches
+    const result = deriveCounts(yaml, '2026-06-09')
+
+    expect(result.surveys_today).toBe(0)
+    expect(result.should_post).toBe(false)
+    expect(result.count_status).toBe('ok')
+  })
+})

--- a/scripts/daily-digest-counts.test.ts
+++ b/scripts/daily-digest-counts.test.ts
@@ -239,6 +239,24 @@ describe('deriveCounts', () => {
     expect(stderrSpy).toHaveBeenCalled()
   })
 
+  it('repos:[[...]] (array element) → count_status:error (not a silent quiet day)', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    // YAML where a repos element is itself an array — typeof [] === 'object' so the
+    // old guard missed this; the Array.isArray() addition closes the gap.
+    const yaml = 'version: 1\nrepos:\n  - - owner: acme\n    - name: alpha\n'
+
+    const result = deriveCounts(yaml, TODAY)
+
+    expect(result).toEqual({
+      repos_tracked: 0,
+      surveys_today: 0,
+      should_post: false,
+      count_status: 'error',
+    })
+    expect(stderrSpy).toHaveBeenCalled()
+  })
+
   // ─── Strengthen missing-private test (full exact result object) ───────────
 
   it('entry missing `private` field — full exact result object', () => {

--- a/scripts/daily-digest-counts.test.ts
+++ b/scripts/daily-digest-counts.test.ts
@@ -202,4 +202,59 @@ describe('deriveCounts', () => {
     expect(result.should_post).toBe(false)
     expect(result.count_status).toBe('ok')
   })
+
+  // ─── Malformed repos[] elements → count_status:'error' (Fix B) ───────────
+
+  it('repos:[null] → count_status:error (malformed entry, not silent skip)', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    // Raw YAML with a null element in repos array
+    const yaml = 'version: 1\nrepos:\n  - ~\n'
+
+    const result = deriveCounts(yaml, TODAY)
+
+    expect(result).toEqual({
+      repos_tracked: 0,
+      surveys_today: 0,
+      should_post: false,
+      count_status: 'error',
+    })
+    expect(stderrSpy).toHaveBeenCalled()
+  })
+
+  it('repos:["x"] (scalar string element) → count_status:error (malformed entry)', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    // Raw YAML with a scalar string element in repos array
+    const yaml = 'version: 1\nrepos:\n  - "x"\n'
+
+    const result = deriveCounts(yaml, TODAY)
+
+    expect(result).toEqual({
+      repos_tracked: 0,
+      surveys_today: 0,
+      should_post: false,
+      count_status: 'error',
+    })
+    expect(stderrSpy).toHaveBeenCalled()
+  })
+
+  // ─── Strengthen missing-private test (full exact result object) ───────────
+
+  it('entry missing `private` field — full exact result object', () => {
+    const yaml = makeYaml([
+      {owner: 'acme', name: 'pub', private: false, last_survey_at: TODAY},
+      // no `private` key at all
+      {owner: 'acme', name: 'unknown', last_survey_at: TODAY},
+    ])
+
+    const result = deriveCounts(yaml, TODAY)
+
+    expect(result).toEqual({
+      repos_tracked: 1,
+      surveys_today: 1,
+      should_post: true,
+      count_status: 'ok',
+    })
+  })
 })

--- a/scripts/daily-digest-counts.ts
+++ b/scripts/daily-digest-counts.ts
@@ -69,6 +69,12 @@ export function deriveCounts(yamlContent: string, todayUtc: string): DigestCount
   let surveysToday = 0
 
   for (const entry of data.repos) {
+    // Guard: a null or non-object element is a malformed entry — treat as data error.
+    if (entry === null || typeof entry !== 'object') {
+      process.stderr.write('daily-digest-counts: malformed repos[] element (null or non-object)\n')
+      return errorResult
+    }
+
     // Only entries with explicit `private: false` count as public.
     // Entries missing `private` or with `private: true` are NOT counted.
     if (entry.private === false) {
@@ -116,7 +122,21 @@ async function main(): Promise<void> {
     process.exit(0)
   }
 
-  const result = deriveCounts(yamlContent, todayUtc)
+  let result: DigestCounts
+  try {
+    result = deriveCounts(yamlContent, todayUtc)
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    process.stderr.write(`daily-digest-counts: unexpected error in deriveCounts: ${detail}\n`)
+    const errorResult: DigestCounts = {
+      repos_tracked: 0,
+      surveys_today: 0,
+      should_post: false,
+      count_status: 'error',
+    }
+    process.stdout.write(`${JSON.stringify(errorResult)}\n`)
+    process.exit(0)
+  }
   process.stdout.write(`${JSON.stringify(result)}\n`)
   process.exit(0)
 }

--- a/scripts/daily-digest-counts.ts
+++ b/scripts/daily-digest-counts.ts
@@ -70,8 +70,8 @@ export function deriveCounts(yamlContent: string, todayUtc: string): DigestCount
 
   for (const entry of data.repos) {
     // Guard: a null or non-object element is a malformed entry — treat as data error.
-    if (entry === null || typeof entry !== 'object') {
-      process.stderr.write('daily-digest-counts: malformed repos[] element (null or non-object)\n')
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+      process.stderr.write('daily-digest-counts: malformed repos[] element (null, non-object, or array)\n')
       return errorResult
     }
 

--- a/scripts/daily-digest-counts.ts
+++ b/scripts/daily-digest-counts.ts
@@ -1,0 +1,129 @@
+import {readFileSync} from 'node:fs'
+import process from 'node:process'
+
+import {parse as parseYaml} from 'yaml'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface RepoEntry {
+  private?: boolean
+  last_survey_at?: string | null
+}
+
+interface ReposYaml {
+  repos?: RepoEntry[]
+}
+
+export interface DigestCounts {
+  repos_tracked: number
+  surveys_today: number
+  should_post: boolean
+  count_status: 'ok' | 'error'
+}
+
+// ─── Core derivation (exported for tests) ────────────────────────────────────
+
+/**
+ * Derive digest counts from a repos.yaml file's raw YAML content string.
+ *
+ * @param yamlContent - Raw YAML string (the contents of metadata/repos.yaml).
+ * @param todayUtc    - Today's date in YYYY-MM-DD format (UTC). Injected for
+ *                      testability so tests can pin the UTC boundary.
+ * @returns DigestCounts — never throws; emits a stderr diagnostic on error.
+ */
+export function deriveCounts(yamlContent: string, todayUtc: string): DigestCounts {
+  const errorResult: DigestCounts = {
+    repos_tracked: 0,
+    surveys_today: 0,
+    should_post: false,
+    count_status: 'error',
+  }
+
+  if (yamlContent === null || yamlContent === undefined) {
+    process.stderr.write('daily-digest-counts: metadata content is null/undefined\n')
+    return errorResult
+  }
+
+  let parsed: unknown
+  try {
+    parsed = parseYaml(yamlContent)
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    process.stderr.write(`daily-digest-counts: failed to parse YAML: ${detail}\n`)
+    return errorResult
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    process.stderr.write('daily-digest-counts: YAML root is not an object\n')
+    return errorResult
+  }
+
+  const data = parsed as ReposYaml
+
+  if (!Array.isArray(data.repos)) {
+    process.stderr.write('daily-digest-counts: metadata/repos.yaml missing `repos` array\n')
+    return errorResult
+  }
+
+  let repos_tracked = 0
+  let surveys_today = 0
+
+  for (const entry of data.repos) {
+    // Only entries with explicit `private: false` count as public.
+    // Entries missing `private` or with `private: true` are NOT counted.
+    if (entry.private === false) {
+      repos_tracked++
+
+      // Count public entries whose last_survey_at (YYYY-MM-DD) equals today in UTC.
+      // Private repos are excluded — the gateway's public-only intent applies here too.
+      if (typeof entry.last_survey_at === 'string' && entry.last_survey_at === todayUtc) {
+        surveys_today++
+      }
+    }
+  }
+
+  return {
+    repos_tracked,
+    surveys_today,
+    should_post: surveys_today > 0,
+    count_status: 'ok',
+  }
+}
+
+// ─── CLI entrypoint ───────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  // Accept file path as first arg, defaulting to 'metadata/repos.yaml'.
+  const filePath = process.argv[2] ?? 'metadata/repos.yaml'
+
+  // Accept today's UTC date as second arg or TODAY_UTC env var (for testing/CI override).
+  // Default: derive from the current UTC clock.
+  const todayUtc =
+    process.argv[3] ??
+    process.env.TODAY_UTC ??
+    new Date().toISOString().slice(0, 10) // YYYY-MM-DD
+
+  let yamlContent: string
+  try {
+    yamlContent = readFileSync(filePath, 'utf8')
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    process.stderr.write(`daily-digest-counts: failed to read ${filePath}: ${detail}\n`)
+    const errorResult: DigestCounts = {
+      repos_tracked: 0,
+      surveys_today: 0,
+      should_post: false,
+      count_status: 'error',
+    }
+    process.stdout.write(`${JSON.stringify(errorResult)}\n`)
+    process.exit(0)
+  }
+
+  const result = deriveCounts(yamlContent, todayUtc)
+  process.stdout.write(`${JSON.stringify(result)}\n`)
+  process.exit(0)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}

--- a/scripts/daily-digest-counts.ts
+++ b/scripts/daily-digest-counts.ts
@@ -65,27 +65,27 @@ export function deriveCounts(yamlContent: string, todayUtc: string): DigestCount
     return errorResult
   }
 
-  let repos_tracked = 0
-  let surveys_today = 0
+  let reposTracked = 0
+  let surveysToday = 0
 
   for (const entry of data.repos) {
     // Only entries with explicit `private: false` count as public.
     // Entries missing `private` or with `private: true` are NOT counted.
     if (entry.private === false) {
-      repos_tracked++
+      reposTracked++
 
       // Count public entries whose last_survey_at (YYYY-MM-DD) equals today in UTC.
       // Private repos are excluded — the gateway's public-only intent applies here too.
       if (typeof entry.last_survey_at === 'string' && entry.last_survey_at === todayUtc) {
-        surveys_today++
+        surveysToday++
       }
     }
   }
 
   return {
-    repos_tracked,
-    surveys_today,
-    should_post: surveys_today > 0,
+    repos_tracked: reposTracked,
+    surveys_today: surveysToday,
+    should_post: surveysToday > 0,
     count_status: 'ok',
   }
 }
@@ -98,10 +98,7 @@ async function main(): Promise<void> {
 
   // Accept today's UTC date as second arg or TODAY_UTC env var (for testing/CI override).
   // Default: derive from the current UTC clock.
-  const todayUtc =
-    process.argv[3] ??
-    process.env.TODAY_UTC ??
-    new Date().toISOString().slice(0, 10) // YYYY-MM-DD
+  const todayUtc = process.argv[3] ?? process.env.TODAY_UTC ?? new Date().toISOString().slice(0, 10) // YYYY-MM-DD
 
   let yamlContent: string
   try {

--- a/scripts/gateway-announce.test.ts
+++ b/scripts/gateway-announce.test.ts
@@ -652,7 +652,8 @@ describe('runCli', () => {
     const result = await runCli(
       {
         EVENT_TYPE: 'daily_digest',
-        EVENT_CONTEXT_JSON: '{"repos_tracked":3,"surveys_today":2,"report_url":"https://github.com/fro-bot/.github/issues/1"}',
+        EVENT_CONTEXT_JSON:
+          '{"repos_tracked":3,"surveys_today":2,"report_url":"https://github.com/fro-bot/.github/issues/1"}',
       },
       {announceImpl: spy as unknown as typeof announce},
     )

--- a/scripts/gateway-announce.test.ts
+++ b/scripts/gateway-announce.test.ts
@@ -162,6 +162,31 @@ describe('announce', () => {
     expect(body.context).toEqual(ctx)
   })
 
+  it('payload shape (daily_digest): event_type is daily_digest, rendered_text null, context verbatim', async () => {
+    const fetchImpl = makeOkFetch(200)
+    const ctx = {repos_tracked: 3, surveys_today: 2, report_url: 'https://github.com/fro-bot/.github/issues/1'}
+
+    const result = await announce({
+      eventType: 'daily_digest',
+      context: ctx,
+      now: () => TEST_TS,
+      secret: TEST_SECRET,
+      url: TEST_URL,
+      fetchImpl,
+      sleep: noSleep,
+    })
+
+    expect(result).toEqual({posted: true, status: 200})
+
+    const [, init] = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string) as Record<string, unknown>
+
+    expect(body.v).toBe(1)
+    expect(body.event_type).toBe('daily_digest')
+    expect(body.rendered_text).toBeNull()
+    expect(body.context).toEqual(ctx)
+  })
+
   // ─── 503 then 200 → one retry ─────────────────────────────────────────────
 
   it('503 then 200: retries once, sleep called exactly once, returns posted:true', async () => {
@@ -493,6 +518,7 @@ describe('announce', () => {
   it('isEventType: accepts valid event types', () => {
     expect(isEventType('survey_completed')).toBe(true)
     expect(isEventType('invitation_accepted')).toBe(true)
+    expect(isEventType('daily_digest')).toBe(true)
   })
 
   it('isEventType: rejects invalid event types', () => {
@@ -618,6 +644,24 @@ describe('runCli', () => {
 
     expect(result).toEqual({posted: false, failure: 'invalid-event-type'})
     expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('daily_digest EVENT_TYPE: accepted (not invalid-event-type), announceImpl called with parsed context', async () => {
+    const spy = vi.fn(async () => ({posted: true, status: 200}) as AnnounceResult)
+
+    const result = await runCli(
+      {
+        EVENT_TYPE: 'daily_digest',
+        EVENT_CONTEXT_JSON: '{"repos_tracked":3,"surveys_today":2,"report_url":"https://github.com/fro-bot/.github/issues/1"}',
+      },
+      {announceImpl: spy as unknown as typeof announce},
+    )
+
+    expect(result).toEqual({posted: true, status: 200})
+    expect(spy).toHaveBeenCalledWith({
+      eventType: 'daily_digest',
+      context: {repos_tracked: 3, surveys_today: 2, report_url: 'https://github.com/fro-bot/.github/issues/1'},
+    })
   })
 
   // ─── EVENT_CONTEXT_JSON validation ───────────────────────────────────────

--- a/scripts/gateway-announce.ts
+++ b/scripts/gateway-announce.ts
@@ -1,9 +1,11 @@
 import {createHmac} from 'node:crypto'
 import process from 'node:process'
 
-export type EventType = 'survey_completed' | 'invitation_accepted' | 'daily_digest'
+const EVENT_TYPES = ['survey_completed', 'invitation_accepted', 'daily_digest'] as const
 
-const VALID_EVENT_TYPES = new Set<string>(['survey_completed', 'invitation_accepted', 'daily_digest'])
+export type EventType = (typeof EVENT_TYPES)[number]
+
+const VALID_EVENT_TYPES = new Set<string>(EVENT_TYPES)
 
 export function isEventType(value: string): value is EventType {
   return VALID_EVENT_TYPES.has(value)

--- a/scripts/gateway-announce.ts
+++ b/scripts/gateway-announce.ts
@@ -1,9 +1,9 @@
 import {createHmac} from 'node:crypto'
 import process from 'node:process'
 
-export type EventType = 'survey_completed' | 'invitation_accepted'
+export type EventType = 'survey_completed' | 'invitation_accepted' | 'daily_digest'
 
-const VALID_EVENT_TYPES = new Set<string>(['survey_completed', 'invitation_accepted'])
+const VALID_EVENT_TYPES = new Set<string>(['survey_completed', 'invitation_accepted', 'daily_digest'])
 
 export function isEventType(value: string): value is EventType {
   return VALID_EVENT_TYPES.has(value)


### PR DESCRIPTION
Migrates the daily oversight Discord post off the legacy webhook and onto the gateway presence pipeline as a new `daily_digest` event, so it posts **as the Fro Bot user** like `survey_completed` and `invitation_accepted` — reframed as a character moment that only speaks up on days with real activity.

## What's here

- **Signer** learns `daily_digest` (`gateway-announce.ts`) — flows through the identical HMAC/payload path; event literals now single-sourced from one const tuple.
- **`daily-digest-counts.ts`** derives `repos_tracked` (public repos) and `surveys_today` from `metadata/repos.yaml`, with a `should_post` suppress gate (quiet days stay silent) and a `count_status` field that distinguishes a genuine quiet day from a metadata-read failure. Fail-soft: malformed input returns `count_status:error` and never throws.
- **Scheduled run** (`fro-bot.yaml`) overlays `metadata/` from the data branch, discovers that day's oversight report URL by exact title match, and posts the digest — all fail-soft, so nothing can fail the oversight run.
- **Context shape** `{ repos_tracked, surveys_today, report_url }` matches the deployed gateway schema exactly.

## Ships dormant

The announce step is gated on `DAILY_DIGEST_ENABLED == 'true'` (unset at merge), so it's skipped entirely until go-live. The legacy daily-oversight webhook keeps running untouched until a separate follow-up removes it after the new path is verified live — no coverage gap, no double-post.

Go-live: confirm the gateway `daily_digest` variant is serving, set `DAILY_DIGEST_ENABLED`, verify one live post. Documented in `metadata/README.md`.
