### PR TITLE
fix(reconcile): correct contrib classification, daily digest truthfulness, and survey floor

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -471,7 +471,6 @@ jobs:
       - name: 📣 Announce daily digest to gateway
         if: >-
           (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
-          steps.digest-counts.outputs.should_post == 'true' &&
           steps.report-url.outputs.report_url != '' &&
           vars.DAILY_DIGEST_ENABLED == 'true'
         env:

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -471,6 +471,7 @@ jobs:
       - name: 📣 Announce daily digest to gateway
         if: >-
           (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+          steps.digest-counts.outputs.count_status == 'ok' &&
           steps.report-url.outputs.report_url != '' &&
           vars.DAILY_DIGEST_ENABLED == 'true'
         env:

--- a/.github/workflows/reconcile-repos.yaml
+++ b/.github/workflows/reconcile-repos.yaml
@@ -104,5 +104,8 @@ jobs:
             echo "| Closed stale issues | $(jq '.closedStaleIssues // 0' "$result") |"
             echo "| Probes failed | $(jq '.probesFailed // 0' "$result") |"
             echo "| Committed | $(jq '.committed // false' "$result") |"
+            echo "| Entries refreshed | $(jq '.summary.refreshed // 0' "$result") |"
+            echo "| Entries migrated | $(jq '.summary.migrated // 0' "$result") |"
+            echo "| Contrib tracked | $(jq '.summary.byChannel.contrib.tracked // 0' "$result") |"
           } >> "$GITHUB_STEP_SUMMARY"
         shell: bash

--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -310,6 +310,7 @@ jobs:
       # the agent made no changes) counts as success, not failure, because the agent
       # completed cleanly.
       - name: Record survey result
+        id: record-result
         if: ${{ !cancelled() && steps.survey-agent.conclusion != 'skipped' && steps.recheck.conclusion == 'success' }}
         env:
           GITHUB_TOKEN: ${{ secrets.FRO_BOT_PAT }}
@@ -351,3 +352,21 @@ jobs:
             '{owner: $owner, repo: $repo, slug: $slug, wiki_pages_changed: $pages}')"
           export EVENT_CONTEXT_JSON
           node scripts/gateway-announce.ts
+
+      # Cadence-advance safety net: if the normal "Record survey result" step did not
+      # run or did not succeed (cancelled run, hard timeout, upstream failure before
+      # recheck, etc.) record a failure result so last_survey_at / next_survey_eligible_at
+      # advance and the minimum-floor stops retargeting this repo every day.
+      # The `outcome != 'success'` guard makes this idempotent: it never fires when the
+      # normal record step already wrote a result.
+      - name: Record survey result (cancelled/timeout fallback)
+        if: ${{ (cancelled() || failure()) && steps.record-result.outcome != 'success' }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+          REPO_OWNER: ${{ steps.resolve.outputs.owner }}
+          REPO_NAME: ${{ steps.resolve.outputs.repo }}
+          REPO_NODE_ID: ${{ inputs.node_id }}
+          REPO_PRIVATE: ${{ steps.recheck.outputs.private }}
+          SURVEY_STATUS: failure
+        run: node scripts/record-survey-result.ts

--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -360,7 +360,7 @@ jobs:
       # The `outcome != 'success'` guard makes this idempotent: it never fires when the
       # normal record step already wrote a result.
       - name: Record survey result (cancelled/timeout fallback)
-        if: ${{ (cancelled() || failure()) && steps.record-result.outcome != 'success' }}
+        if: ${{ (cancelled() || failure()) && steps.record-result.outcome != 'success' && steps.resolve.outcome == 'success' }}
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.FRO_BOT_PAT }}

--- a/docs/plans/2026-06-09-001-fix-cadence-contrib-digest-floor-plan.md
+++ b/docs/plans/2026-06-09-001-fix-cadence-contrib-digest-floor-plan.md
@@ -1,0 +1,183 @@
+---
+title: "fix: Contrib channel tracking, daily digest truthfulness, and floor retry loops"
+type: fix
+status: active
+date: 2026-06-09
+---
+
+# fix: Contrib channel tracking, daily digest truthfulness, and floor retry loops
+
+## Overview
+
+Three interacting cadence/observability defects, diagnosed from live production evidence:
+
+1. **Contrib repos mis-classified as collab.** The four `bfra-me` repos in `approved_contrib_repos` are tracked but counted under `collab`, so `byChannel.contrib.tracked` is `0` and they never get the faster 21-day contrib cadence.
+2. **Daily digest is silent and mistimed.** It suppresses on zero-survey days and counts surveys for "today (UTC)" — but it runs at `00:00 UTC`, hours before the `~08:00 UTC` reconcile produces that day's surveys, so the count is structurally near-zero. The digest should post every day with a truthful count.
+3. **Floor retry loops on hung surveys.** A dispatched survey that is cancelled or hard-timed-out never records a result, so its cadence never advances and the minimum-floor keeps retargeting the same broken repo daily.
+
+## Problem Frame
+
+The survey cadence floor is working (reconcile dispatches 2/day), but three layers above it are wrong: channel classification mis-buckets explicitly-approved contrib repos, the digest reports a misleading near-zero count and goes silent, and the floor has no guard against repeatedly retargeting a repo whose survey never completes. The fixes are independent and each is grounded in a confirmed root cause.
+
+## Requirements Trace
+
+- R1. `bfra-me` `approved_contrib_repos` are classified `contrib`, counted under `byChannel.contrib.tracked`, and surveyed on the contrib cadence (21d).
+- R2. Already-tracked entries with a stale or missing `discovery_channel` are refreshed to their live channel during reconcile, and `next_survey_eligible_at` is recomputed for the new channel's interval.
+- R3. The daily digest posts every scheduled day regardless of survey count.
+- R4. The digest's `surveys_today` reflects a settled, truthful count (the prior UTC day's completed surveys), not a structurally-empty same-day count.
+- R5. A cancelled or timed-out survey records a `failure` result so its cadence advances and the floor does not retarget it indefinitely.
+
+## Scope Boundaries
+
+- No change to the survey dispatch mechanism, the floor algorithm (`FLOOR_MIN`/`FLOOR_MIN_GAP_DAYS`), or channel interval constants.
+- No change to the gateway payload schema (`surveys_today` field name stays for gateway compatibility; only its semantics — prior-day — change, documented in code).
+- No change to the digest cron schedule (stays `0 0 * * * UTC`; the yesterday-count fix makes that timing truthful without a reschedule).
+
+### Deferred to Separate Tasks
+
+- **Stateful dispatch tracking (`last_dispatched_at` schema field + cooldown exclusion)**: deferred unless the Unit 3 workflow-hardening (Option B) proves insufficient. Adds schema surface and `data`-branch write contention; revisit only if hung surveys still cause retargeting after the failure-recording fix.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/reconcile-repos.ts` — `mergeAccessChannels` (precedence collab>owned>contrib, the bug), `classifyTracked` (no channel-refresh for tracked entries), `byChannel` summary counting (`entry.discovery_channel ?? 'collab'`), `computeNextEligibleAt` import from `repos-metadata.ts`.
+- `scripts/repos-metadata.ts` — `CHANNEL_INTERVAL_DAYS` (owned 14 / contrib 21 / collab 30), `computeNextEligibleAt` (deterministic jitter); the channel-refresh recompute must reuse this.
+- `scripts/daily-digest-counts.ts` — `deriveCounts(yamlContent, todayUtc)`: `surveysToday` matches `last_survey_at === todayUtc` (L85-86); `should_post: surveysToday > 0` (the suppression).
+- `.github/workflows/survey-repo.yaml` — `Record survey result` (L312-313) gates on `!cancelled() && ... recheck.conclusion == 'success'`; a cancelled/timed-out run skips it, never recording failure.
+- `metadata/allowlist.yaml` — `approved_contrib_repos` lists the 4 bfra-me repos (confirmed).
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/loose-then-tight-schema-migration-pattern-2026-05-05.md` — channel-refresh writes existing entries; no schema change here, but the refresh is a one-time in-place migration of `discovery_channel` values.
+- `docs/solutions/best-practices/autonomous-pipeline-minimum-progress-floor-2026-05-17.md` — the floor's retry-loop edge is the gap Unit 3 closes.
+
+## Key Technical Decisions
+
+- **Precedence flip to owned > contrib > collab**: an explicitly-approved channel (owned/contrib) must win over generic collaborator access. The bfra-me repos are collab-accessible AND contrib-approved; contrib is the intended identity.
+- **Channel-refresh in `classifyTracked`**: flipping precedence fixes the access-list channel, but already-tracked entries carry a stored `discovery_channel` (or none → defaults collab). Refresh: if stored channel differs from live channel, update it, count `summary.refreshed`, and recompute `next_survey_eligible_at` for the new interval so the cadence shift takes effect immediately.
+- **Digest counts prior UTC day**: at `00:00 UTC` the just-ended day is fully settled (its reconcile + surveys completed ~16h earlier). Counting `last_survey_at === yesterdayUtc` is truthful and race-free; same-day would always be ~0. The gateway field stays `surveys_today` (documented as "prior UTC day").
+- **Remove `should_post` suppression**: the digest is a daily character moment; 0 surveys is valid signal. `should_post` becomes `count_status === 'ok'` (still suppress on a genuine read error).
+- **Option B failure recording (not Option A schema)**: a final `if: cancelled() || failure()` cleanup step records a `failure` survey result when the normal record step didn't run, advancing cadence. Cheaper than a stateful `last_dispatched_at` field; no extra data-branch writes on the happy path.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Why is `contrib.tracked` 0? — `mergeAccessChannels` collab-first precedence + no refresh; verified the 4 entries have no `discovery_channel` on `data`.
+- Is `committed:false` a bug? — No; stateless dispatch correctly produces a no-op commit. The real edge is the hung-survey retry loop (Unit 3).
+
+### Deferred to Implementation
+
+- Exact yesterday-derivation helper (UTC date subtraction) shape — implement against the injected `todayUtc` string; pin midnight-boundary tests.
+- Whether the cleanup step in survey-repo can reuse `record-survey-result.ts` as-is with a forced `failure` status, or needs a thin guard for the "already recorded" case.
+
+## Implementation Units
+
+- [x] **Unit 1: Fix contrib channel precedence and refresh tracked entries**
+
+**Goal:** bfra-me contrib repos classify as `contrib`, count under `byChannel.contrib.tracked`, and get the 21-day cadence; existing mis-classified entries self-heal on the next reconcile.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `scripts/reconcile-repos.ts`
+- Test: `scripts/reconcile-repos.test.ts`
+
+**Approach:**
+- In `mergeAccessChannels`, reorder the merge loops to `owned` → `contrib` → `collab` (each later loop skips keys already claimed), and update the precedence doc-comment to `owned > contrib > collab`.
+- In `classifyTracked`, for a still-accessible tracked entry whose stored `discovery_channel` differs from the live `accessChannelByKey` channel: set the new channel, increment `summary.refreshed`, and recompute `next_survey_eligible_at` via `computeNextEligibleAt` for the new channel/interval. Preserve reference identity when nothing changes (no-op probe).
+
+**Patterns to follow:**
+- Existing `classifyTracked` field-refresh blocks; `computeNextEligibleAt` call sites in `repos-metadata.ts`.
+
+**Test scenarios:**
+- Happy path: a repo in both `collab` access and `approved_contrib_repos` → merged channel is `contrib`.
+- Happy path: `owned` wins over `contrib` wins over `collab` on triple overlap.
+- Edge case: a tracked entry stored `collab` but now live `contrib` → refreshed to `contrib`, `summary.refreshed` incremented, `next_survey_eligible_at` recomputed for 21d.
+- Edge case: a tracked entry with no stored `discovery_channel` (legacy) and live `contrib` → backfilled to `contrib` (not left defaulting to collab).
+- Edge case: stored channel == live channel → no change, no spurious `refreshed`, reference identity preserved.
+- Integration: full `handleReconcile` with the 4 bfra-me entries → `byChannel.contrib.tracked == 4`, `collab.tracked` reduced accordingly, metadata committed.
+
+**Verification:**
+- A reconcile against access including the bfra-me repos reports `byChannel.contrib.tracked >= 4` and recomputed eligibility on the refreshed entries.
+
+- [x] **Unit 2: Daily digest counts prior UTC day and posts every day**
+
+**Goal:** the digest fires daily with a truthful settled survey count.
+
+**Requirements:** R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `scripts/daily-digest-counts.ts`
+- Modify: `.github/workflows/fro-bot.yaml` (announce gate — drop `should_post` condition)
+- Test: `scripts/daily-digest-counts.test.ts`
+
+**Approach:**
+- In `deriveCounts`, derive `yesterdayUtc` by subtracting one day from the injected `todayUtc` (string date math, UTC-safe), and match `last_survey_at === yesterdayUtc` for `surveys_today`. Document in JSDoc that `surveys_today` is the prior UTC day's settled count (field name retained for gateway compatibility).
+- Change `should_post` to `count_status === 'ok'` (post on any successful read; suppress only on a genuine read error).
+- In `fro-bot.yaml`, remove the `steps.digest-counts.outputs.should_post == 'true'` condition from the announce `if:` — keep `report_url != ''` and `DAILY_DIGEST_ENABLED == 'true'`. (Decision: keep gating on a resolved `report_url` so we never post a digest with an empty link; revisit only if that proves too strict.)
+
+**Patterns to follow:**
+- Existing `deriveCounts` UTC-date handling and the midnight-stability tests in `daily-digest-counts.test.ts`.
+
+**Test scenarios:**
+- Happy path: surveys with `last_survey_at == yesterdayUtc` are counted; today's are NOT.
+- Happy path: zero prior-day surveys → `surveys_today: 0`, `should_post: true` (posts anyway).
+- Edge case: `todayUtc` at month/year boundary (e.g. 2026-03-01 → counts 2026-02-28) → correct yesterday derivation.
+- Edge case: malformed/missing metadata → `count_status: 'error'`, `should_post: false` (still suppress on real error).
+- Error path: non-object `repos[]` element → fail-soft `count_status: 'error'`, no throw (existing guard preserved).
+
+**Verification:**
+- `daily-digest-counts.ts` against real data with `todayUtc=2026-06-09` reports the 2026-06-08 survey count and `should_post: true`. The announce step fires on a zero-count day in a dispatch/scheduled run (given `DAILY_DIGEST_ENABLED` + resolved `report_url`).
+
+- [x] **Unit 3: Record failure on cancelled/timed-out surveys (close floor retry loop)**
+
+**Goal:** a survey that is cancelled or hard-timed-out records a `failure` result so its cadence advances and the floor stops retargeting it.
+
+**Requirements:** R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `.github/workflows/survey-repo.yaml`
+- Test: none (workflow-only; behavior verified operationally — see Verification)
+
+**Approach:**
+- Add a final cleanup step gated to run when the normal `Record survey result` step did NOT run because the job was cancelled or an earlier step failed (e.g. `if: cancelled() || (failure() && steps.record-result.outcome != 'success')`). It records a `failure` survey result for the repo (reusing `record-survey-result.ts` with `status=failure`), so `last_survey_at`/`next_survey_eligible_at` advance.
+- Guard against double-recording when the normal record step already ran (key on its `outcome`/`conclusion`).
+- The recorded node_id comes from the resolved survey inputs already present in the job (no new resolution).
+
+**Patterns to follow:**
+- The existing `Record survey result` step (L312) and its `record-survey-result.ts` invocation; the `if: always()`/`cancelled()` fail-soft patterns used elsewhere in the workflow.
+
+**Test scenarios:**
+- Test expectation: none — workflow-only orchestration change. The recording logic in `record-survey-result.ts` is already covered; this unit only adds a new trigger condition.
+
+**Verification:**
+- A manually-cancelled survey-repo run leaves the target repo with an advanced `last_survey_at`/`next_survey_eligible_at` and `last_survey_status: failure` on `data`, and the next reconcile does not immediately retarget it via the floor.
+
+## System-Wide Impact
+
+- **Interaction graph:** Unit 1 changes channel classification consumed by the floor/threshold dispatch selection and the `byChannel` summary; Unit 2 changes only the digest count + announce gate; Unit 3 adds a write-back path on abnormal survey termination.
+- **State lifecycle risks:** Unit 1's refresh recomputes `next_survey_eligible_at` — must not reset a repo that's mid-cadence into perpetual eligibility; recompute is deterministic from the new channel. Unit 3 must not double-record (idempotency on the record step outcome).
+- **API surface parity:** Unit 2 keeps the gateway `surveys_today` field name; only semantics change (documented).
+- **Unchanged invariants:** floor algorithm, channel intervals, dispatch mechanism, gateway schema, digest cron — all unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Channel-refresh resets cadence for many entries at once, bunching surveys | Recompute is deterministic per-channel with jitter; only mis-classified entries (the 4 bfra-me) refresh, bounded blast radius |
+| Removing `should_post` floods the gateway on quiet days | Digest is once-daily; one post/day is the intended character cadence |
+| Unit 3 cleanup step double-records or records on a healthy run | Gate strictly on the normal record step having NOT succeeded; key on its outcome |
+| `report_url != ''` gate still suppresses the digest if discovery fails | Accepted — better to skip than post a linkless digest; report-url discovery is fail-soft and already hardened |
+
+## Sources & References
+
+- Origin: Oracle cadence/contrib/timing diagnostic (this session), root causes verified directly against `scripts/reconcile-repos.ts`, `metadata/allowlist.yaml`, and `origin/data` metadata.
+- Related code: `scripts/reconcile-repos.ts`, `scripts/repos-metadata.ts`, `scripts/daily-digest-counts.ts`, `.github/workflows/survey-repo.yaml`, `.github/workflows/fro-bot.yaml`

--- a/scripts/daily-digest-counts.test.ts
+++ b/scripts/daily-digest-counts.test.ts
@@ -5,6 +5,8 @@ import {deriveCounts} from './daily-digest-counts.ts'
 
 // ─── Fixture helpers ──────────────────────────────────────────────────────────
 
+// TODAY is the injected "todayUtc" clock value passed to deriveCounts.
+// YESTERDAY is the prior UTC day — the window deriveCounts now counts surveys in.
 const TODAY = '2026-06-08'
 const YESTERDAY = '2026-06-07'
 
@@ -40,12 +42,14 @@ describe('deriveCounts', () => {
 
   // ─── Happy path ───────────────────────────────────────────────────────────
 
-  it('happy path: 3 public + 1 private, 2 surveyed today → repos_tracked:3, surveys_today:2, should_post:true', () => {
+  it('happy path: 3 public + 1 private, 2 surveyed yesterday → repos_tracked:3, surveys_today:2, should_post:true', () => {
+    // surveys_today counts the PRIOR UTC day (yesterdayUtc), not todayUtc.
+    // Entries with last_survey_at == YESTERDAY are the settled prior-day count.
     const yaml = makeYaml([
-      {owner: 'acme', name: 'alpha', private: false, last_survey_at: TODAY},
-      {owner: 'acme', name: 'beta', private: false, last_survey_at: TODAY},
-      {owner: 'acme', name: 'gamma', private: false, last_survey_at: YESTERDAY},
-      {owner: 'acme', name: 'private-repo', private: true, last_survey_at: TODAY},
+      {owner: 'acme', name: 'alpha', private: false, last_survey_at: YESTERDAY},
+      {owner: 'acme', name: 'beta', private: false, last_survey_at: YESTERDAY},
+      {owner: 'acme', name: 'gamma', private: false, last_survey_at: TODAY},
+      {owner: 'acme', name: 'private-repo', private: true, last_survey_at: YESTERDAY},
     ])
 
     const result = deriveCounts(yaml, TODAY)
@@ -58,12 +62,14 @@ describe('deriveCounts', () => {
     })
   })
 
-  // ─── Quiet day ────────────────────────────────────────────────────────────
+  // ─── Zero prior-day surveys still posts ───────────────────────────────────
 
-  it('quiet day: 0 surveyed today → surveys_today:0, should_post:false, count_status:ok', () => {
+  it('zero prior-day surveys → surveys_today:0, should_post:true (posts anyway on count_status:ok)', () => {
+    // should_post is now count_status === 'ok', not surveysToday > 0.
+    // A quiet day is valid signal — the digest fires regardless.
     const yaml = makeYaml([
-      {owner: 'acme', name: 'alpha', private: false, last_survey_at: YESTERDAY},
-      {owner: 'acme', name: 'beta', private: false, last_survey_at: YESTERDAY},
+      {owner: 'acme', name: 'alpha', private: false, last_survey_at: TODAY},
+      {owner: 'acme', name: 'beta', private: false, last_survey_at: TODAY},
     ])
 
     const result = deriveCounts(yaml, TODAY)
@@ -71,7 +77,7 @@ describe('deriveCounts', () => {
     expect(result).toEqual({
       repos_tracked: 2,
       surveys_today: 0,
-      should_post: false,
+      should_post: true,
       count_status: 'ok',
     })
   })
@@ -80,8 +86,8 @@ describe('deriveCounts', () => {
 
   it('private entries are excluded from repos_tracked', () => {
     const yaml = makeYaml([
-      {owner: 'acme', name: 'pub', private: false, last_survey_at: TODAY},
-      {owner: 'acme', name: 'priv', private: true, last_survey_at: TODAY},
+      {owner: 'acme', name: 'pub', private: false, last_survey_at: YESTERDAY},
+      {owner: 'acme', name: 'priv', private: true, last_survey_at: YESTERDAY},
     ])
 
     const result = deriveCounts(yaml, TODAY)
@@ -94,9 +100,9 @@ describe('deriveCounts', () => {
 
   it('entry missing `private` field is NOT counted as public (repos_tracked)', () => {
     const yaml = makeYaml([
-      {owner: 'acme', name: 'pub', private: false, last_survey_at: TODAY},
+      {owner: 'acme', name: 'pub', private: false, last_survey_at: YESTERDAY},
       // no `private` key at all
-      {owner: 'acme', name: 'unknown', last_survey_at: TODAY},
+      {owner: 'acme', name: 'unknown', last_survey_at: YESTERDAY},
     ])
 
     const result = deriveCounts(yaml, TODAY)
@@ -108,7 +114,8 @@ describe('deriveCounts', () => {
 
   // ─── Empty repos ─────────────────────────────────────────────────────────
 
-  it('empty repos list → zeros, should_post:false, no throw', () => {
+  it('empty repos list → zeros, should_post:true (count_status:ok), no throw', () => {
+    // Empty repos is a valid read — should_post:true because count_status:ok.
     const yaml = 'version: 1\nrepos: []\n'
 
     const result = deriveCounts(yaml, TODAY)
@@ -116,7 +123,7 @@ describe('deriveCounts', () => {
     expect(result).toEqual({
       repos_tracked: 0,
       surveys_today: 0,
-      should_post: false,
+      should_post: true,
       count_status: 'ok',
     })
   })
@@ -157,19 +164,22 @@ describe('deriveCounts', () => {
 
   // ─── count_status:'error' distinguishable from quiet day ─────────────────
 
-  it('count_status:error is distinguishable from a genuine quiet day (should_post:false, count_status:ok)', () => {
+  it('count_status:error is distinguishable from a genuine quiet day (should_post:true, count_status:ok)', () => {
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
 
     const errorResult = deriveCounts(null as unknown as string, TODAY)
+    // A quiet day: no surveys on YESTERDAY — but count_status is ok, so should_post:true.
     const quietResult = deriveCounts(
-      makeYaml([{owner: 'acme', name: 'pub', private: false, last_survey_at: YESTERDAY}]),
+      makeYaml([{owner: 'acme', name: 'pub', private: false, last_survey_at: TODAY}]),
       TODAY,
     )
 
-    // Both have should_post:false, but count_status differs
+    // Error path: should_post:false, count_status:error
     expect(errorResult.should_post).toBe(false)
-    expect(quietResult.should_post).toBe(false)
     expect(errorResult.count_status).toBe('error')
+
+    // Quiet day: should_post:true (posts anyway), count_status:ok
+    expect(quietResult.should_post).toBe(true)
     expect(quietResult.count_status).toBe('ok')
 
     stderrSpy.mockRestore()
@@ -177,10 +187,11 @@ describe('deriveCounts', () => {
 
   // ─── UTC date boundary ────────────────────────────────────────────────────
 
-  it('UTC date boundary: today-UTC counts, yesterday does not (fixed clock)', () => {
+  it('UTC date boundary: yesterday counts, today does NOT (fixed clock)', () => {
+    // deriveCounts(yaml, TODAY) should count last_survey_at == YESTERDAY, not TODAY.
     const yaml = makeYaml([
-      {owner: 'acme', name: 'surveyed-today', private: false, last_survey_at: TODAY},
       {owner: 'acme', name: 'surveyed-yesterday', private: false, last_survey_at: YESTERDAY},
+      {owner: 'acme', name: 'surveyed-today', private: false, last_survey_at: TODAY},
     ])
 
     const result = deriveCounts(yaml, TODAY)
@@ -189,17 +200,60 @@ describe('deriveCounts', () => {
     expect(result.should_post).toBe(true)
   })
 
-  it('UTC date boundary: when today is yesterday, neither entry counts', () => {
+  it('UTC date boundary: when clock advances, prior-day window shifts correctly', () => {
+    // When todayUtc is '2026-06-09', yesterdayUtc is '2026-06-08' (== TODAY).
+    // The entry with last_survey_at == TODAY should now be counted.
     const yaml = makeYaml([
       {owner: 'acme', name: 'surveyed-today', private: false, last_survey_at: TODAY},
       {owner: 'acme', name: 'surveyed-yesterday', private: false, last_survey_at: YESTERDAY},
     ])
 
-    // Advance "today" to a future date — neither entry matches
+    // Advance "today" by one day — TODAY becomes yesterday
     const result = deriveCounts(yaml, '2026-06-09')
 
-    expect(result.surveys_today).toBe(0)
-    expect(result.should_post).toBe(false)
+    expect(result.surveys_today).toBe(1) // TODAY entry now matches as yesterday
+    expect(result.should_post).toBe(true)
+    expect(result.count_status).toBe('ok')
+  })
+
+  // ─── Month and year boundary yesterday derivation ─────────────────────────
+
+  it('month boundary: todayUtc=2026-03-01 → yesterdayUtc=2026-02-28 (non-leap year)', () => {
+    const yaml = makeYaml([
+      {owner: 'acme', name: 'feb28', private: false, last_survey_at: '2026-02-28'},
+      {owner: 'acme', name: 'mar01', private: false, last_survey_at: '2026-03-01'},
+    ])
+
+    const result = deriveCounts(yaml, '2026-03-01')
+
+    expect(result.surveys_today).toBe(1) // only feb28 matches
+    expect(result.should_post).toBe(true)
+    expect(result.count_status).toBe('ok')
+  })
+
+  it('month boundary: todayUtc=2024-03-01 → yesterdayUtc=2024-02-29 (leap year)', () => {
+    const yaml = makeYaml([
+      {owner: 'acme', name: 'feb29', private: false, last_survey_at: '2024-02-29'},
+      {owner: 'acme', name: 'mar01', private: false, last_survey_at: '2024-03-01'},
+    ])
+
+    const result = deriveCounts(yaml, '2024-03-01')
+
+    expect(result.surveys_today).toBe(1) // only feb29 matches
+    expect(result.should_post).toBe(true)
+    expect(result.count_status).toBe('ok')
+  })
+
+  it('year boundary: todayUtc=2026-01-01 → yesterdayUtc=2025-12-31', () => {
+    const yaml = makeYaml([
+      {owner: 'acme', name: 'dec31', private: false, last_survey_at: '2025-12-31'},
+      {owner: 'acme', name: 'jan01', private: false, last_survey_at: '2026-01-01'},
+    ])
+
+    const result = deriveCounts(yaml, '2026-01-01')
+
+    expect(result.surveys_today).toBe(1) // only dec31 matches
+    expect(result.should_post).toBe(true)
     expect(result.count_status).toBe('ok')
   })
 
@@ -260,10 +314,12 @@ describe('deriveCounts', () => {
   // ─── Strengthen missing-private test (full exact result object) ───────────
 
   it('entry missing `private` field — full exact result object', () => {
+    // The explicitly-public entry has last_survey_at == YESTERDAY → counted.
+    // The unknown-private entry is excluded from repos_tracked entirely.
     const yaml = makeYaml([
-      {owner: 'acme', name: 'pub', private: false, last_survey_at: TODAY},
+      {owner: 'acme', name: 'pub', private: false, last_survey_at: YESTERDAY},
       // no `private` key at all
-      {owner: 'acme', name: 'unknown', last_survey_at: TODAY},
+      {owner: 'acme', name: 'unknown', last_survey_at: YESTERDAY},
     ])
 
     const result = deriveCounts(yaml, TODAY)

--- a/scripts/daily-digest-counts.ts
+++ b/scripts/daily-digest-counts.ts
@@ -30,6 +30,16 @@ export interface DigestCounts {
  * @param todayUtc    - Today's date in YYYY-MM-DD format (UTC). Injected for
  *                      testability so tests can pin the UTC boundary.
  * @returns DigestCounts — never throws; emits a stderr diagnostic on error.
+ *
+ * Note: `surveys_today` reflects the **prior UTC day's** settled survey count
+ * (yesterdayUtc = todayUtc − 1 day). The digest runs at 00:00 UTC, so the
+ * prior day is fully settled (~16h after its reconcile). Counting same-day
+ * surveys would always yield ~0 at that hour. The gateway field name
+ * `surveys_today` is retained for payload schema compatibility.
+ *
+ * `should_post` is `count_status === 'ok'` — the digest fires every scheduled
+ * day regardless of survey count; zero surveys is valid signal. It is only
+ * `false` on a genuine metadata read error.
  */
 export function deriveCounts(yamlContent: string, todayUtc: string): DigestCounts {
   const errorResult: DigestCounts = {
@@ -65,6 +75,11 @@ export function deriveCounts(yamlContent: string, todayUtc: string): DigestCount
     return errorResult
   }
 
+  // Derive yesterdayUtc: parse todayUtc as UTC midnight, subtract 86400000ms, reformat.
+  // This is UTC-safe: YYYY-MM-DD parsed as UTC avoids local-timezone drift.
+  const todayMs = Date.parse(`${todayUtc}T00:00:00Z`)
+  const yesterdayUtc = new Date(todayMs - 86_400_000).toISOString().slice(0, 10)
+
   let reposTracked = 0
   let surveysToday = 0
 
@@ -80,9 +95,9 @@ export function deriveCounts(yamlContent: string, todayUtc: string): DigestCount
     if (entry.private === false) {
       reposTracked++
 
-      // Count public entries whose last_survey_at (YYYY-MM-DD) equals today in UTC.
+      // Count public entries whose last_survey_at (YYYY-MM-DD) equals the prior UTC day.
       // Private repos are excluded — the gateway's public-only intent applies here too.
-      if (typeof entry.last_survey_at === 'string' && entry.last_survey_at === todayUtc) {
+      if (typeof entry.last_survey_at === 'string' && entry.last_survey_at === yesterdayUtc) {
         surveysToday++
       }
     }
@@ -91,7 +106,7 @@ export function deriveCounts(yamlContent: string, todayUtc: string): DigestCount
   return {
     repos_tracked: reposTracked,
     surveys_today: surveysToday,
-    should_post: surveysToday > 0,
+    should_post: true, // count_status === 'ok': post every day; suppress only on read error
     count_status: 'ok',
   }
 }

--- a/scripts/daily-digest-counts.ts
+++ b/scripts/daily-digest-counts.ts
@@ -81,7 +81,7 @@ export function deriveCounts(yamlContent: string, todayUtc: string): DigestCount
   const yesterdayUtc = new Date(todayMs - 86_400_000).toISOString().slice(0, 10)
 
   let reposTracked = 0
-  let surveysToday = 0
+  let surveysYesterday = 0
 
   for (const entry of data.repos) {
     // Guard: a null or non-object element is a malformed entry — treat as data error.
@@ -98,14 +98,14 @@ export function deriveCounts(yamlContent: string, todayUtc: string): DigestCount
       // Count public entries whose last_survey_at (YYYY-MM-DD) equals the prior UTC day.
       // Private repos are excluded — the gateway's public-only intent applies here too.
       if (typeof entry.last_survey_at === 'string' && entry.last_survey_at === yesterdayUtc) {
-        surveysToday++
+        surveysYesterday++
       }
     }
   }
 
   return {
     repos_tracked: reposTracked,
-    surveys_today: surveysToday,
+    surveys_today: surveysYesterday,
     should_post: true, // count_status === 'ok': post every day; suppress only on read error
     count_status: 'ok',
   }

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -1816,6 +1816,68 @@ describe('reconcileRepos', () => {
       expect(byName.get('agent')).toBe('owned')
       expect(byName.get('.github')).toBe('contrib')
     })
+
+    it('channel-refresh with malformed last_survey_at does not throw and falls back to now', () => {
+      // #given a tracked collab entry with a corrupted last_survey_at AND a live contrib upgrade
+      // A malformed date string must not crash computeNextEligibleAt via Invalid Date.toISOString().
+      const entry = makeEntry({
+        owner: 'bfra-me',
+        name: 'renovate-config',
+        onboarding_status: 'onboarded',
+        discovery_channel: 'collab',
+        last_survey_at: 'bogus', // malformed — not a valid YYYY-MM-DD
+        next_survey_eligible_at: '2026-06-01',
+      })
+
+      // #when reconciling with a live contrib channel upgrade — must not throw
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos: {version: 1, repos: [entry]},
+          accessList: [makeAccess({owner: 'bfra-me', name: 'renovate-config', node_id: 'R_bfra_ren'})],
+          accessChannelByKey: new Map([['bfra-me/renovate-config', 'contrib']]),
+        }),
+      )
+
+      // #then channel is upgraded to contrib
+      expect(result.nextRepos.repos[0]?.discovery_channel).toBe('contrib')
+
+      // #then next_survey_eligible_at is a valid ISO string (computed from `now`, not from 'bogus')
+      const nextEligible = result.nextRepos.repos[0]?.next_survey_eligible_at
+      expect(typeof nextEligible).toBe('string')
+      expect(Number.isFinite(Date.parse(nextEligible ?? ''))).toBe(true)
+    })
+
+    it('does not downgrade a tracked owned entry when live channel is contrib or collab', () => {
+      // #given a tracked owned entry
+      const entry = makeEntry({
+        owner: 'fro-bot',
+        name: 'agent',
+        onboarding_status: 'onboarded',
+        discovery_channel: 'owned',
+        next_survey_eligible_at: '2026-05-01',
+        private: false,
+        node_id: 'R_agent',
+      })
+      const currentRepos: ReposFile = {version: 1, repos: [entry]}
+
+      // #when the live channel map reports contrib (lower precedence than owned)
+      const result = reconcileRepos(
+        makeInput({
+          currentRepos,
+          accessList: [makeAccess({owner: 'fro-bot', name: 'agent', node_id: 'R_agent'})],
+          accessChannelByKey: new Map([['fro-bot/agent', 'contrib']]),
+        }),
+      )
+
+      // #then channel stays owned — downgrade is suppressed
+      expect(result.nextRepos.repos[0]?.discovery_channel).toBe('owned')
+      // #and no channel-refresh refresh bump (reference identity preserved for the channel field)
+      // The entry may be refreshed for other reasons (e.g. node_id write), but the channel
+      // must not change. We assert the channel directly rather than summary.refreshed to avoid
+      // coupling to unrelated field-drift behavior.
+      expect(result.nextRepos.repos[0]?.discovery_channel).not.toBe('contrib')
+      expect(result.nextRepos.repos[0]?.discovery_channel).not.toBe('collab')
+    })
   })
 })
 

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -29,7 +29,7 @@ import {
   type RepoStatusProbe,
   type VisibilityTransitionIssue,
 } from './reconcile-repos.ts'
-import {addRepoEntry} from './repos-metadata.ts'
+import {addRepoEntry, computeNextEligibleAt} from './repos-metadata.ts'
 import {assertReposFile} from './schemas.ts'
 
 const NOW = new Date('2026-04-17T12:00:00Z')
@@ -4807,16 +4807,28 @@ describe('mergeAccessChannels (precedence + dedup)', () => {
     expect(result.accessChannelByKey.get('bfra-me/.github')).toBe('contrib')
   })
 
-  it('collab wins over owned for the same key', () => {
+  it('owned wins over collab for the same key', () => {
     // #given the same owner/name appears in both collab and owned
     const result = mergeAccessChannels({
       collab: [entry('fro-bot', 'agent')],
       owned: [entry('fro-bot', 'agent')],
       contrib: [],
     })
-    // #then collab wins; only one entry; no duplicate keys
+    // #then owned wins (owned > collab); only one entry; no duplicate keys
     expect(result.accessList).toHaveLength(1)
-    expect(result.accessChannelByKey.get('fro-bot/agent')).toBe('collab')
+    expect(result.accessChannelByKey.get('fro-bot/agent')).toBe('owned')
+  })
+
+  it('contrib wins over collab for the same key', () => {
+    // #given the same owner/name appears in both collab and contrib
+    const result = mergeAccessChannels({
+      collab: [entry('bfra-me', '.github')],
+      owned: [],
+      contrib: [entry('bfra-me', '.github')],
+    })
+    // #then contrib wins (contrib > collab); only one entry; no duplicate keys
+    expect(result.accessList).toHaveLength(1)
+    expect(result.accessChannelByKey.get('bfra-me/.github')).toBe('contrib')
   })
 
   it('owned wins over contrib for the same key', () => {
@@ -4829,14 +4841,14 @@ describe('mergeAccessChannels (precedence + dedup)', () => {
     expect(result.accessChannelByKey.get('shared/repo')).toBe('owned')
   })
 
-  it('collab wins over both owned and contrib for the same key', () => {
+  it('owned wins over both collab and contrib for the same key (triple overlap)', () => {
     const result = mergeAccessChannels({
       collab: [entry('shared', 'repo')],
       owned: [entry('shared', 'repo')],
       contrib: [entry('shared', 'repo')],
     })
     expect(result.accessList).toHaveLength(1)
-    expect(result.accessChannelByKey.get('shared/repo')).toBe('collab')
+    expect(result.accessChannelByKey.get('shared/repo')).toBe('owned')
   })
 
   it('preserves all three channels when keys are distinct', () => {
@@ -4852,11 +4864,12 @@ describe('mergeAccessChannels (precedence + dedup)', () => {
   })
 
   it('produces an accessList that passes validateAccessList (no duplicates)', () => {
-    // #given overlapping channels
+    // #given overlapping channels (use 'eslint-config' instead of '.github' to avoid
+    // the dot in the auto-generated node_id R_bfra-me_.github failing NODE_ID_PATTERN)
     const result = mergeAccessChannels({
       collab: [entry('shared', 'repo'), entry('marcusrbrown', 'foo')],
       owned: [entry('shared', 'repo'), entry('fro-bot', 'agent')],
-      contrib: [entry('bfra-me', '.github')],
+      contrib: [entry('bfra-me', 'eslint-config')],
     })
     // #then reconcileRepos accepts it without throwing on the duplicate-key check
     expect(() =>
@@ -4946,6 +4959,195 @@ describe('reconcileRepos byChannel summary', () => {
     expect(result.summary.byChannel.owned.tracked).toBe(1)
     expect(result.summary.byChannel.contrib.tracked).toBe(1)
     expect(result.summary.byChannel.collab.tracked).toBe(0)
+  })
+})
+
+describe('classifyTracked — discovery_channel refresh', () => {
+  // Happy path: stored collab, live contrib → refreshed to contrib, summary.refreshed++,
+  // next_survey_eligible_at recomputed for 21d contrib interval.
+  it('refreshes stored collab to live contrib, increments summary.refreshed, recomputes eligibility', () => {
+    const entry = makeEntry({
+      owner: 'bfra-me',
+      name: 'eslint-config',
+      discovery_channel: 'collab',
+      last_survey_at: '2026-04-01',
+      next_survey_eligible_at: '2026-05-01', // stale collab-based date
+      private: false,
+      node_id: 'R_bfra',
+      onboarding_status: 'onboarded',
+    })
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [entry]},
+        accessList: [makeAccess({owner: 'bfra-me', name: 'eslint-config', node_id: 'R_bfra', private: false})],
+        accessChannelByKey: new Map([['bfra-me/eslint-config', 'contrib']]),
+        fieldProbes: new Map([['bfra-me/eslint-config', {has_fro_bot_workflow: false, has_renovate: false}]]),
+      }),
+    )
+
+    const next = result.nextRepos.repos[0]
+    expect(next).toBeDefined()
+    expect(next?.discovery_channel).toBe('contrib')
+    expect(result.summary.refreshed).toBe(1)
+    expect(result.summary.unchanged).toBe(0)
+    // next_survey_eligible_at must be recomputed for the contrib (21d) interval
+    const expected = computeNextEligibleAt({
+      owner: 'bfra-me',
+      repo: 'eslint-config',
+      channel: 'contrib',
+      baseDate: new Date('2026-04-01T00:00:00Z'),
+    })
+    expect(next?.next_survey_eligible_at).toBe(expected)
+  })
+
+  // Edge: tracked entry with no stored discovery_channel (legacy), live contrib → backfilled to contrib.
+  it('backfills missing discovery_channel to live contrib (not left defaulting to collab)', () => {
+    // Build a legacy entry without discovery_channel (simulate pre-schema entry)
+    const legacyEntry: RepoEntry = {
+      owner: 'bfra-me',
+      name: 'tsconfig',
+      added: '2026-01-01',
+      onboarding_status: 'onboarded',
+      last_survey_at: '2026-03-15',
+      last_survey_status: 'success',
+      has_fro_bot_workflow: false,
+      has_renovate: false,
+      next_survey_eligible_at: '2026-04-14',
+      private: false,
+      node_id: 'R_tsconfig',
+      // discovery_channel intentionally omitted (legacy entry)
+    }
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [legacyEntry]},
+        accessList: [makeAccess({owner: 'bfra-me', name: 'tsconfig', node_id: 'R_tsconfig', private: false})],
+        accessChannelByKey: new Map([['bfra-me/tsconfig', 'contrib']]),
+        fieldProbes: new Map([['bfra-me/tsconfig', {has_fro_bot_workflow: false, has_renovate: false}]]),
+      }),
+    )
+
+    const next = result.nextRepos.repos[0]
+    expect(next?.discovery_channel).toBe('contrib')
+    expect(result.summary.refreshed).toBe(1)
+    // next_survey_eligible_at recomputed for contrib interval
+    const expected = computeNextEligibleAt({
+      owner: 'bfra-me',
+      repo: 'tsconfig',
+      channel: 'contrib',
+      baseDate: new Date('2026-03-15T00:00:00Z'),
+    })
+    expect(next?.next_survey_eligible_at).toBe(expected)
+  })
+
+  // Edge: stored channel == live channel → no change, no spurious refreshed, reference identity preserved.
+  it('preserves reference identity when stored channel matches live channel (no-op)', () => {
+    const entry = makeEntry({
+      owner: 'bfra-me',
+      name: 'prettier-config',
+      discovery_channel: 'contrib',
+      last_survey_at: '2026-04-01',
+      next_survey_eligible_at: '2026-04-25',
+      private: false,
+      node_id: 'R_prettier',
+      onboarding_status: 'onboarded',
+    })
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [entry]},
+        accessList: [makeAccess({owner: 'bfra-me', name: 'prettier-config', node_id: 'R_prettier', private: false})],
+        accessChannelByKey: new Map([['bfra-me/prettier-config', 'contrib']]),
+        fieldProbes: new Map([['bfra-me/prettier-config', {has_fro_bot_workflow: false, has_renovate: false}]]),
+      }),
+    )
+
+    // Reference identity preserved (no-op path)
+    expect(result.nextRepos.repos[0]).toBe(entry)
+    expect(result.summary.refreshed).toBe(0)
+    expect(result.summary.unchanged).toBe(1)
+  })
+
+  // Integration: 4 bfra-me contrib entries → byChannel.contrib.tracked == 4, collab reduced.
+  it('integration: 4 bfra-me contrib entries count under byChannel.contrib.tracked', () => {
+    const contribRepos = [
+      makeEntry({
+        owner: 'bfra-me',
+        name: 'eslint-config',
+        discovery_channel: 'collab',
+        private: false,
+        node_id: 'R_1',
+        onboarding_status: 'onboarded',
+        last_survey_at: '2026-04-01',
+        next_survey_eligible_at: '2026-05-01',
+      }),
+      makeEntry({
+        owner: 'bfra-me',
+        name: 'tsconfig',
+        discovery_channel: 'collab',
+        private: false,
+        node_id: 'R_2',
+        onboarding_status: 'onboarded',
+        last_survey_at: '2026-04-01',
+        next_survey_eligible_at: '2026-05-01',
+      }),
+      makeEntry({
+        owner: 'bfra-me',
+        name: 'prettier-config',
+        discovery_channel: 'collab',
+        private: false,
+        node_id: 'R_3',
+        onboarding_status: 'onboarded',
+        last_survey_at: '2026-04-01',
+        next_survey_eligible_at: '2026-05-01',
+      }),
+      makeEntry({
+        owner: 'bfra-me',
+        name: '.github',
+        discovery_channel: 'collab',
+        private: false,
+        node_id: 'R_4',
+        onboarding_status: 'onboarded',
+        last_survey_at: '2026-04-01',
+        next_survey_eligible_at: '2026-05-01',
+      }),
+    ]
+    const accessList = contribRepos.map(e =>
+      makeAccess({owner: e.owner, name: e.name, node_id: e.node_id ?? `R_${e.name}`, private: false}),
+    )
+    const channelMap = new Map<string, DiscoveryChannel>(
+      contribRepos.map(e => [`${e.owner}/${e.name}`, 'contrib' as DiscoveryChannel]),
+    )
+    const fieldProbes = new Map(
+      contribRepos.map(e => [`${e.owner}/${e.name}`, {has_fro_bot_workflow: false, has_renovate: false}]),
+    )
+
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: contribRepos},
+        accessList,
+        accessChannelByKey: channelMap,
+        fieldProbes,
+      }),
+    )
+
+    // All 4 entries should now be classified as contrib
+    expect(result.summary.byChannel.contrib.tracked).toBe(4)
+    expect(result.summary.byChannel.collab.tracked).toBe(0)
+    // All 4 refreshed (stored collab → live contrib)
+    expect(result.summary.refreshed).toBe(4)
+    // All entries have contrib channel
+    for (const entry of result.nextRepos.repos) {
+      expect(entry.discovery_channel).toBe('contrib')
+    }
+    // next_survey_eligible_at recomputed for contrib (21d) interval for each
+    for (const entry of result.nextRepos.repos) {
+      const expected = computeNextEligibleAt({
+        owner: entry.owner,
+        repo: entry.name,
+        channel: 'contrib',
+        baseDate: new Date('2026-04-01T00:00:00Z'),
+      })
+      expect(entry.next_survey_eligible_at).toBe(expected)
+    }
   })
 })
 

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -860,18 +860,21 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
   // Only upgrades (lower → higher precedence) are applied. Downgrades are suppressed so a
   // genuinely `owned` entry that also appears in the collab list stays `owned`. Precedence
   // rank: owned=2 > contrib=1 > collab=0 (matches mergeAccessChannels loop order).
-  const CHANNEL_RANK: Record<DiscoveryChannel, number> = {owned: 2, contrib: 1, collab: 0}
+  const CHANNEL_RANK = {owned: 2, contrib: 1, collab: 0} as const satisfies Record<DiscoveryChannel, number>
   const liveChannel = params.accessChannelByKey.get(accessKey) ?? 'collab'
   const storedChannel = entry.discovery_channel ?? 'collab'
   let workingEntry = entry
   if (CHANNEL_RANK[liveChannel] > CHANNEL_RANK[storedChannel]) {
     // Recompute next_survey_eligible_at for the new channel's interval. Use last_survey_at
     // as the base date when available; fall back to now so the entry gets a fresh cadence
-    // window rather than becoming immediately eligible.
-    const baseDate =
+    // window rather than becoming immediately eligible. Guard against a corrupted
+    // last_survey_at (e.g. 'bogus') that would produce an Invalid Date and cause
+    // computeNextEligibleAt's .toISOString() to throw — mirror migrateRepoEntry's guard.
+    const baseMs =
       entry.last_survey_at !== null && entry.last_survey_at !== undefined
-        ? new Date(`${entry.last_survey_at}T00:00:00Z`)
-        : now
+        ? Date.parse(`${entry.last_survey_at}T00:00:00Z`)
+        : Number.NaN
+    const baseDate = Number.isFinite(baseMs) ? new Date(baseMs) : now
     const nextEligible = computeNextEligibleAt({
       owner: access.owner,
       repo: access.name,

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -851,6 +851,36 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
     dispatches.push({owner: access.owner, repo: access.name, node_id: access.node_id})
   }
 
+  // Channel refresh: if the live access-channel has higher precedence than the stored
+  // discovery_channel (including legacy entries with no stored channel, which default to
+  // 'collab'), update the channel and recompute next_survey_eligible_at for the new
+  // channel's interval. This self-heals mis-classified entries (e.g. bfra-me contrib repos
+  // stored as collab) and backfills legacy entries that predate the discovery_channel field.
+  //
+  // Only upgrades (lower → higher precedence) are applied. Downgrades are suppressed so a
+  // genuinely `owned` entry that also appears in the collab list stays `owned`. Precedence
+  // rank: owned=2 > contrib=1 > collab=0 (matches mergeAccessChannels loop order).
+  const CHANNEL_RANK: Record<DiscoveryChannel, number> = {owned: 2, contrib: 1, collab: 0}
+  const liveChannel = params.accessChannelByKey.get(accessKey) ?? 'collab'
+  const storedChannel = entry.discovery_channel ?? 'collab'
+  let workingEntry = entry
+  if (CHANNEL_RANK[liveChannel] > CHANNEL_RANK[storedChannel]) {
+    // Recompute next_survey_eligible_at for the new channel's interval. Use last_survey_at
+    // as the base date when available; fall back to now so the entry gets a fresh cadence
+    // window rather than becoming immediately eligible.
+    const baseDate =
+      entry.last_survey_at !== null && entry.last_survey_at !== undefined
+        ? new Date(`${entry.last_survey_at}T00:00:00Z`)
+        : now
+    const nextEligible = computeNextEligibleAt({
+      owner: access.owner,
+      repo: access.name,
+      channel: liveChannel,
+      baseDate,
+    })
+    workingEntry = {...entry, discovery_channel: liveChannel, next_survey_eligible_at: nextEligible}
+  }
+
   // Field refresh: apply probe results when they disagree with tracked fields,
   // and write live private/node_id from the access list when they differ.
   const probe = fieldProbes.get(key) ?? fieldProbes.get(accessKey)
@@ -859,7 +889,7 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
 
   if (probe === undefined) {
     // No field probe — but access list still has private/node_id. Apply if changed.
-    const normalized = normalizeRepoEntryForStorage(entry, storageInput)
+    const normalized = normalizeRepoEntryForStorage(workingEntry, storageInput)
     if (normalized === entry) {
       summary.unchanged += 1
       return entry
@@ -869,16 +899,17 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
   }
 
   const fieldsMatch =
-    probe.has_fro_bot_workflow === entry.has_fro_bot_workflow && probe.has_renovate === entry.has_renovate
-  const privacyMatch = entry.private === accessPrivate && entry.node_id === accessNodeId
+    probe.has_fro_bot_workflow === workingEntry.has_fro_bot_workflow && probe.has_renovate === workingEntry.has_renovate
+  const privacyMatch = workingEntry.private === accessPrivate && workingEntry.node_id === accessNodeId
+  const channelMatch = workingEntry === entry // true only when no channel refresh occurred
 
-  if (fieldsMatch && privacyMatch) {
+  if (fieldsMatch && privacyMatch && channelMatch) {
     summary.unchanged += 1
     return entry
   }
   summary.refreshed += 1
   return normalizeRepoEntryForStorage({
-    ...normalizeRepoEntryForStorage(entry, storageInput),
+    ...normalizeRepoEntryForStorage(workingEntry, storageInput),
     has_fro_bot_workflow: probe.has_fro_bot_workflow,
     has_renovate: probe.has_renovate,
   })
@@ -2122,9 +2153,14 @@ async function probeContribWorkflow(
 
 /**
  * Merge per-channel access lists into the canonical access list + channel map. Precedence
- * is `collab > owned > contrib`: when the same `owner/name` appears in multiple channels,
+ * is `owned > contrib > collab`: when the same `owner/name` appears in multiple channels,
  * the highest-precedence channel wins so `validateAccessList` (which rejects duplicate
  * keys) sees a single entry.
+ *
+ * Rationale: explicitly-approved channels (owned/contrib) must win over generic collaborator
+ * access. A bfra-me repo that is both collab-accessible AND contrib-approved must be
+ * classified as `contrib` so it gets the correct 21-day cadence and counts under
+ * `byChannel.contrib.tracked`.
  */
 export function mergeAccessChannels(input: {
   collab: AccessListEntry[]
@@ -2134,15 +2170,9 @@ export function mergeAccessChannels(input: {
   const accessByKey = new Map<string, AccessListEntry>()
   const channelByKey = new Map<string, DiscoveryChannel>()
 
-  // Order matters: collab first wins overlap with owned/contrib; owned wins over contrib.
-  for (const entry of input.collab) {
-    const key = repoKey(entry.owner, entry.name)
-    accessByKey.set(key, entry)
-    channelByKey.set(key, 'collab')
-  }
+  // Order matters: owned first wins overlap with contrib/collab; contrib wins over collab.
   for (const entry of input.owned) {
     const key = repoKey(entry.owner, entry.name)
-    if (accessByKey.has(key)) continue
     accessByKey.set(key, entry)
     channelByKey.set(key, 'owned')
   }
@@ -2151,6 +2181,12 @@ export function mergeAccessChannels(input: {
     if (accessByKey.has(key)) continue
     accessByKey.set(key, entry)
     channelByKey.set(key, 'contrib')
+  }
+  for (const entry of input.collab) {
+    const key = repoKey(entry.owner, entry.name)
+    if (accessByKey.has(key)) continue
+    accessByKey.set(key, entry)
+    channelByKey.set(key, 'collab')
   }
 
   return {accessList: Array.from(accessByKey.values()), accessChannelByKey: channelByKey}


### PR DESCRIPTION
Three interacting cadence and observability defects, fixed together.

## Contrib repos were tracked but never classified as contrib

The four `bfra-me` repos in `approved_contrib_repos` were counted under `collab` because the channel-merge precedence let generic collaborator access win over an explicitly-approved channel. They never got the faster 21-day contrib cadence. Fix: precedence is now `owned > contrib > collab`, and reconcile refreshes already-tracked entries to their live channel (upgrade-only — it never downgrades a genuinely-owned repo), recomputing the next eligibility window for the new interval.

## The daily digest was silent and mistimed

The digest runs at 00:00 UTC, hours before that day's reconcile produces any surveys — so counting "today" was structurally near-zero, and a zero count suppressed the post entirely. Fix: count the prior UTC day's settled surveys (truthful and race-free) and post every scheduled day. A genuine metadata read error still suppresses the post (fail-closed); a quiet day does not.

## A hung survey could starve the cadence floor

A survey that was cancelled or timed out never recorded a result, so its cadence never advanced and the minimum-floor kept retargeting the same broken repo every day. Fix: a fallback step records a failure result when the normal record step did not run, so the repo advances and the floor moves on.

## Hardening

- Guard a corrupted `last_survey_at` so the channel-refresh cannot crash the daily reconcile.
- Surface refresh / migrated / contrib-tracked counts in the reconcile run summary so the classification fix is observable.
