### PR TITLE
feat(ci): require the private leak scan with a readable name

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -21,6 +21,7 @@ branches:
           - Lint
           - Renovate / Renovate
           - Review Dependencies
+          - Security: Private Leak Scan
           - Test
           - Test Scripts Load
 

--- a/.github/workflows/check-private-leak.yaml
+++ b/.github/workflows/check-private-leak.yaml
@@ -117,6 +117,6 @@ jobs:
             --method POST \
             "repos/{owner}/{repo}/statuses/${HEAD_SHA}" \
             -f state="${state}" \
-            -f context="security/check-private-leak" \
+            -f context="Security: Private Leak Scan" \
             -f description="${description}" \
             -f target_url="${RUN_URL}"

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -101,7 +101,7 @@ A private repo's existence, name, or content must never reach a public surface. 
   - `github.token` (`GITHUB_TOKEN`): diff fetch, PR API identity resolution, commit status POST.
   - `FRO_BOT_POLL_PAT`: private `node_id` → `owner/name` resolution only (resolver subprocess, scrubbed env — no `GH_TOKEN`/`GITHUB_TOKEN` inheritance).
 
-  The gate posts a `security/check-private-leak` commit status to the exact PR head SHA. If the status POST itself fails, the job exits non-zero (fail-closed — the PR is never left unsignaled). Required-check registration on `main` is deferred until empirical fork-status proof exists.
+  The gate posts a `Security: Private Leak Scan` commit status to the exact PR head SHA. If the status POST itself fails, the job exits non-zero (fail-closed — the PR is never left unsignaled). It is registered as a required status check on `main`.
 
 **Operator lookup** — to map a redacted `node_id` back to its `owner/repo` (the convenience a plain `grep` of `repos.yaml` used to provide), run `GH_TOKEN=<operator-PAT> node scripts/resolve-private.ts`. It reads `repos.yaml`, resolves each private entry's `node_id` via the GitHub API, and prints a `node_id → owner/name` table to stdout. It never writes to the working tree and is invoked by no workflow.
 
@@ -202,7 +202,7 @@ All `metadata/*.yaml` files are enforced as Fro-Bot-writable-only on `main`. A C
 
 `repos.yaml` carries an additional sole-writer invariant: changes to it on `main` must originate only from the `data` promotion branch. A direct edit to `repos.yaml` on a non-promotion branch is prohibited even if fro-bot-authored. Any exception requires an explicit override and is treated as an emergency measure, not routine workflow — the invariant exists precisely to prevent the both-sides mutation that causes promotion conflicts.
 
-A companion guard, `scripts/check-private-leak.ts`, detects a private repo's canonical `owner/name` introduced in a PR's added lines (see [Privacy gates and operator tooling](#privacy-gates-and-operator-tooling)). It runs on every PR to `main` via the trusted `workflow_run` topology described above (`private-leak-sentinel.yaml` + `check-private-leak.yaml`), posting a `security/check-private-leak` commit status to the PR head SHA.
+A companion guard, `scripts/check-private-leak.ts`, detects a private repo's canonical `owner/name` introduced in a PR's added lines (see [Privacy gates and operator tooling](#privacy-gates-and-operator-tooling)). It runs on every PR to `main` via the trusted `workflow_run` topology described above (`private-leak-sentinel.yaml` + `check-private-leak.yaml`), posting a `Security: Private Leak Scan` commit status to the PR head SHA.
 
 For intentional manual edits to any metadata file (including `allowlist.yaml`), land the change on `data` directly and let the existing promotion flow land it on `main`:
 


### PR DESCRIPTION
Makes the private-leak scan a required status check on `main` and gives it a readable name on pull requests.

## What changed

- The scan's commit-status context is renamed from the slug `security/check-private-leak` to the human-readable **`Security: Private Leak Scan`**, so it reads clearly in the PR checks list. A commit status displays its context string verbatim, so this string is byte-identical in the workflow POST and in branch protection.
- `Security: Private Leak Scan` is added to the required status checks on `main`.
- Operator docs updated to the new name.

## Rollout

Branch protection is applied by the settings workflow, not on merge. After this merges, the scan begins posting the new context; the required-check registration is then applied deliberately once the new context is confirmed posting, so no in-flight PR stalls waiting on a context that has not appeared yet.

Same-repo attachment is already proven — the scan has posted a passing status on recent PRs. The status fails closed on any scan or post error.
