### PR TITLE
fix(ci): quote the private leak scan required-check context

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -21,7 +21,7 @@ branches:
           - Lint
           - Renovate / Renovate
           - Review Dependencies
-          - Security: Private Leak Scan
+          - 'Security: Private Leak Scan'
           - Test
           - Test Scripts Load
 


### PR DESCRIPTION
A list item containing a colon (`Security: Private Leak Scan`) parses as a YAML mapping when unquoted, so the settings sync rejected it as a non-string and the required check was never registered on `main`. Quoting it keeps it a string.

Validated: all 12 required-status contexts now parse as strings. After merge, the settings sync registers the check correctly.