### PR TITLE
docs(plans): reconcile plan status with shipped reality

### DIFF
--- a/docs/plans/2026-05-17-001-feat-survey-cadence-minimum-floor-plan.md
+++ b/docs/plans/2026-05-17-001-feat-survey-cadence-minimum-floor-plan.md
@@ -1,8 +1,9 @@
 ---
 title: 'feat: Survey cadence minimum-dispatch floor'
 type: feat
-status: active
+status: complete
 date: 2026-05-17
+completed: 2026-06-09
 origin: docs/brainstorms/2026-05-17-survey-cadence-minimum-floor-requirements.md
 ---
 

--- a/docs/plans/2026-06-01-001-fix-data-branch-sole-writer-plan.md
+++ b/docs/plans/2026-06-01-001-fix-data-branch-sole-writer-plan.md
@@ -1,8 +1,9 @@
 ---
 title: "fix: Make data the sole writer of metadata/repos.yaml"
 type: fix
-status: active
+status: complete
 date: 2026-06-01
+completed: 2026-06-09
 origin: docs/brainstorms/2026-06-01-data-branch-sole-writer-requirements.md
 ---
 

--- a/docs/plans/2026-06-04-001-feat-gateway-announce-presence-plan.md
+++ b/docs/plans/2026-06-04-001-feat-gateway-announce-presence-plan.md
@@ -1,8 +1,9 @@
 ---
 title: 'feat: Control-plane gateway-announce for Fro Bot Discord presence'
 type: feat
-status: active
+status: complete
 date: 2026-06-04
+completed: 2026-06-09
 origin: docs/brainstorms/2026-05-23-discord-presence-via-control-plane-events-requirements.md
 deepened: 2026-06-04
 ---
@@ -179,7 +180,7 @@ workflow step (survey-repo / poll-invitations)
 
 ## Implementation Units
 
-- [ ] **Unit 1: `scripts/gateway-announce.ts` signer + CLI**
+- [x] **Unit 1: `scripts/gateway-announce.ts` signer + CLI**
 
 **Goal:** A strip-only-safe, zero-dep module that builds the payload, signs the exact bytes, POSTs
 with the retry/kill-switch policy, and never fails the workflow.
@@ -239,7 +240,7 @@ split); `scripts/bluesky-post.ts` (env-override seams).
 **Verification:** All scenarios pass with mocked `fetch`/`sleep`; `node -e "import('./scripts/gateway-announce.ts')"`
 loads under strip-only; types + lint clean.
 
-- [ ] **Unit 2: `handle-invitation.ts` emits accepted-public-repos list**
+- [x] **Unit 2: `handle-invitation.ts` emits accepted-public-repos list**
 
 **Goal:** Expose the list of accepted public repos so `poll-invitations.yaml` can build
 `context.repos` for the announce.
@@ -275,7 +276,7 @@ pair in `scripts/handle-invitation.ts`.
 **Verification:** existing handle-invitation tests stay green; new list-output tests pass; no redacted
 identifier appears in the list.
 
-- [ ] **Unit 3: Wire `survey_completed` into `survey-repo.yaml`**
+- [x] **Unit 3: Wire `survey_completed` into `survey-repo.yaml`**
 
 **Goal:** Fire a `survey_completed` announce after a successful survey, best-effort, behind the
 existing privacy/success gate.
@@ -313,7 +314,7 @@ existing privacy/success gate.
 payload context is built from verified outputs only; secret appears only in this step's env. Live
 proof deferred to rollout (SC1).
 
-- [ ] **Unit 4: Wire `invitation_accepted` into `poll-invitations.yaml`**
+- [x] **Unit 4: Wire `invitation_accepted` into `poll-invitations.yaml`**
 
 **Goal:** Fire a single aggregated `invitation_accepted` announce when ≥1 public invitation was
 accepted.
@@ -342,7 +343,7 @@ accepted.
 **Verification:** `actionlint` clean; step fires only when count > 0; `context.repos` comes from the
 Unit 2 list output (public only); secret scoped to the step.
 
-- [ ] **Unit 5: Document secrets/vars in `metadata/README.md`**
+- [x] **Unit 5: Document secrets/vars in `metadata/README.md`**
 
 **Goal:** Document the three new config values and which workflows consume them.
 

--- a/docs/plans/2026-06-04-001-fix-orphan-wiki-page-guard-plan.md
+++ b/docs/plans/2026-06-04-001-fix-orphan-wiki-page-guard-plan.md
@@ -1,8 +1,9 @@
 ---
 title: 'fix: gate survey wiki-commit on an onboarded repos.yaml entry'
 type: fix
-status: active
+status: complete
 date: 2026-06-04
+completed: 2026-06-09
 ---
 
 # Gate survey wiki-commit on an onboarded repos.yaml entry
@@ -136,7 +137,7 @@ dispatch (commit `1dd3b5c`); the gate now passes. This plan prevents recurrence.
 
 ## Implementation Units
 
-- [ ] **Unit 1: `repoEntryExists` helper + tests**
+- [x] **Unit 1: `repoEntryExists` helper + tests**
 
 **Goal:** A pure, tested predicate that answers "does `metadata/repos.yaml` have
 an entry for this owner/repo?" for the survey gate to call.
@@ -173,7 +174,7 @@ an entry for this owner/repo?" for the survey gate to call.
 - Edge: malformed YAML → fail-closed (treat as not-onboarded / surface a clear
   error per the chosen wrapper contract), never a silent true.
 
-- [ ] **Unit 2: wire the onboarded gate into `survey-repo.yaml`**
+- [x] **Unit 2: wire the onboarded gate into `survey-repo.yaml`**
 
 **Goal:** Survey only commits the wiki page (and announces) when the resolved repo
 is onboarded on `data`.

--- a/docs/plans/2026-06-04-003-feat-wire-private-leak-pr-gate-plan.md
+++ b/docs/plans/2026-06-04-003-feat-wire-private-leak-pr-gate-plan.md
@@ -1,8 +1,9 @@
 ---
 title: 'feat: Wire Check Private Leak as a per-PR gate via trusted workflow_run'
 type: feat
-status: active
+status: complete
 date: 2026-06-04
+completed: 2026-06-09
 origin: 'GitHub issue #3407'
 ---
 
@@ -196,7 +197,7 @@ branch protection (once proven) requires security/check-private-leak ─┘
 
 ## Implementation Units
 
-- [ ] **Unit 1: Add a `workflow_run` / per-PR event reader + resolver wiring to `check-private-leak.ts`**
+- [x] **Unit 1: Add a `workflow_run` / per-PR event reader + resolver wiring to `check-private-leak.ts`**
 
 **Goal:** Teach `main()` to run under a `workflow_run` event: read the `workflow_run` payload, resolve
 and validate PR identity via the API, wire `FRO_BOT_POLL_PAT` into the resolver, and emit a structured
@@ -258,7 +259,7 @@ fail-closed identity-validation paths before implementing.
   silent-pass regression and fail under the fail-closed implementation.
 - The PAT never appears in the diff/git subprocess env.
 
-- [ ] **Unit 2: Add the sentinel + privileged `workflow_run` workflows and post the commit status**
+- [x] **Unit 2: Add the sentinel + privileged `workflow_run` workflows and post the commit status**
 
 **Goal:** Add the minimal `pull_request` sentinel workflow and the privileged `workflow_run` workflow
 that runs the Unit 1 scan with subprocess-scoped PAT and posts a `security/check-private-leak` commit
@@ -310,7 +311,8 @@ Unit 3. The behavioral logic is covered by Unit 1's script tests.
 - The privileged job's logs show no PAT, no PR-head checkout, no cache restore; the PAT is present only
   in the scan step's resolver subprocess.
 
-- [ ] **Unit 3: Prove fork-head status attachment, then register the required check**
+- [x] **Unit 3: Prove fork-head status attachment, then register the required check**
+  - Same-repo attachment proven and the check is registered as required; fork-head status attachment remains an accepted, documented residual (no fork PR has exercised it).
 
 **Goal:** Empirically verify the commit status attaches and blocks for both same-repo and fork PR heads,
 then register `security/check-private-leak` as a required status check on `main`. If fork-head

--- a/docs/plans/2026-06-07-001-feat-daily-digest-presence-event-plan.md
+++ b/docs/plans/2026-06-07-001-feat-daily-digest-presence-event-plan.md
@@ -1,8 +1,9 @@
 ---
 title: "feat: Daily digest presence event (control-plane side)"
 type: feat
-status: active
+status: complete
 date: 2026-06-07
+completed: 2026-06-09
 origin: docs/brainstorms/2026-06-04-daily-digest-presence-event-requirements.md
 deepened: 2026-06-09
 ---
@@ -165,7 +166,7 @@ cron heartbeat (see origin: `docs/brainstorms/2026-06-04-daily-digest-presence-e
 
 ## Implementation Units
 
-- [ ] **Unit 1: Teach the signer the `daily_digest` event type**
+- [x] **Unit 1: Teach the signer the `daily_digest` event type**
 
 **Goal:** Extend `gateway-announce.ts` so it accepts and signs `daily_digest` without changing the
 auth/replay contract.
@@ -198,7 +199,7 @@ auth/replay contract.
 **Verification:** New tests pass; existing signer tests unchanged; `tsc --noEmit` clean; the script
 still loads under Node strip-only.
 
-- [ ] **Unit 2: Count-derivation + suppress-gate script**
+- [x] **Unit 2: Count-derivation + suppress-gate script**
 
 **Goal:** A small tested script that reads `metadata/repos.yaml` and emits the digest counts plus a
 post/skip decision.
@@ -242,7 +243,7 @@ Vitest).
 
 **Verification:** Tests pass; script loads under strip-only; `tsc --noEmit` clean.
 
-- [ ] **Unit 3: Wire the scheduled run — metadata overlay, report-URL, dormant announce**
+- [x] **Unit 3: Wire the scheduled run — metadata overlay, report-URL, dormant announce**
 
 **Goal:** In `fro-bot.yaml`, overlay `metadata/`, derive counts, discover the report URL, and post
 the `daily_digest` (shipped dormant), without touching the legacy webhook step.
@@ -295,7 +296,7 @@ the step is skipped (never calls the signer); the discovery step carries `GH_TOK
 `GATEWAY_ANNOUNCE_DISABLED` is untouched and the two live events are unaffected; the legacy webhook
 step is unchanged.
 
-- [ ] **Unit 4: Docs — event type, secrets/vars, and go-live runbook**
+- [x] **Unit 4: Docs — event type, secrets/vars, and go-live runbook**
 
 **Goal:** Document the new event type and the exact dormant→live sequence.
 

--- a/docs/plans/2026-06-09-001-fix-cadence-contrib-digest-floor-plan.md
+++ b/docs/plans/2026-06-09-001-fix-cadence-contrib-digest-floor-plan.md
@@ -1,8 +1,9 @@
 ---
 title: "fix: Contrib channel tracking, daily digest truthfulness, and floor retry loops"
 type: fix
-status: active
+status: complete
 date: 2026-06-09
+completed: 2026-06-09
 ---
 
 # fix: Contrib channel tracking, daily digest truthfulness, and floor retry loops


### PR DESCRIPTION
Marks seven implementation plans complete now that their units are live: minimum-floor, data-branch sole-writer, gateway-announce presence, orphan-wiki-page guard, private-leak PR gate, daily-digest presence, and the cadence/contrib/digest/floor fixes.

Checkboxes are flipped to match shipped code and workflows; `status` is set to `complete` with a `completed` date. The private-leak PR gate records fork-head status attachment as an accepted, documented residual (same-repo attachment is proven and the check is registered as required).

No code, tests, or workflows changed.