### PR TITLE
chore(survey): stop opening wiki-ingest notice issues

### DIFF
--- a/.github/workflows/survey-repo.yaml
+++ b/.github/workflows/survey-repo.yaml
@@ -37,6 +37,7 @@ env:
     - Modify only `knowledge/wiki/**`, `knowledge/index.md`, and `knowledge/log.md` in this repository.
     - Keep wikilinks valid and frontmatter complete.
     - If the target repo appears to lack a Fro Bot workflow, note that in the repo page so a follow-up draft PR can be proposed separately.
+    - Record the ingest summary only in `knowledge/log.md`. Do not open, comment on, or update a GitHub issue as a run notice; the log entry is the canonical per-survey summary.
 
     Required outcomes:
     1. Update or create the repo page at `knowledge/wiki/repos/$TARGET_SLUG.md`.

--- a/docs/brainstorms/2026-06-14-suppress-wiki-ingest-notice-issues-requirements.md
+++ b/docs/brainstorms/2026-06-14-suppress-wiki-ingest-notice-issues-requirements.md
@@ -1,0 +1,68 @@
+---
+title: Suppress agent-authored wiki-ingest notice issues
+date: 2026-06-14
+status: ready
+scope: lightweight
+---
+
+# Suppress agent-authored wiki-ingest notice issues
+
+## Problem
+
+Every survey cycle, the Survey Repo agent opens a GitHub issue summarizing the wiki
+ingest it just performed (titles like `Wiki ingest: <repo>`, `[wiki-ingest] <repo>`,
+`Wiki Ingest: <repo>`). These accumulate as board noise and require periodic manual
+sweeping — 13 had piled up between 2026-06-05 and 2026-06-12.
+
+The inconsistent title formats confirm these are **emergent agent behavior**, not a
+control-plane feature: the survey workflow never asks for an issue.
+
+## Root cause
+
+`survey-repo.yaml`'s `INGEST_PROMPT` lists required outcomes as wiki-file updates only
+(repo page, topic/entity pages, `knowledge/index.md`, `knowledge/log.md`). It does **not**
+instruct the agent to open an issue. The agent self-elects to post a run-summary issue as
+part of its default "report what I did" disposition.
+
+Two facts make this a clean, single-site fix:
+
+- The `fro-bot.yaml` ingest path runs `scripts/wiki-ingest.ts` directly (scripted commit,
+  no agent prompt) — it does not post issues.
+- The persona and `knowledge/schema.md` contain no instruction to post ingest issues.
+
+So the only source is the survey agent driven by `INGEST_PROMPT`.
+
+## Goal
+
+Stop the per-survey notice issues at the source, with zero new machinery. The durable
+ingest summary already lives in `knowledge/log.md`; the GitHub issue is pure duplication.
+
+## Requirements
+
+- **R1**: `survey-repo.yaml`'s `INGEST_PROMPT` gains an explicit constraint: record the
+  ingest summary only in `knowledge/log.md`; do **not** open, comment on, or update a
+  GitHub issue as a run notice.
+- **R2**: The existing wiki-file required outcomes are unchanged — the log entry remains
+  the canonical per-survey summary.
+- **R3**: No scheduled sweep, no perpetual-issue machinery, no script changes. The change
+  is confined to the prompt text.
+
+## Non-goals
+
+- No change to `fro-bot.yaml`'s scripted ingest path (it does not post issues).
+- No retroactive cleanup automation — already-open notices were swept manually; future
+  ones simply won't be created.
+- No change to the daily report's perpetual-single-issue behavior (that is a deliberate,
+  separate heartbeat).
+- No agent-side (`fro-bot/agent`) changes — the constraint belongs in this repo's prompt,
+  which is the authoritative instruction for the survey run.
+
+## Success criteria
+
+- **SC1**: After the change, a survey dispatch completes its wiki ingest (log entry
+  written, wiki pages committed) and opens **no** GitHub issue.
+- **SC2**: The `knowledge/log.md` entry still captures the survey summary.
+
+## Open questions
+
+None — mechanism, site, and scope are settled.


### PR DESCRIPTION
Stops the survey agent from opening a GitHub issue to summarize each wiki ingest.

## Why

Every survey cycle, the agent self-elected to open a "Wiki ingest" notice issue (inconsistent titles — `Wiki ingest:`, `[wiki-ingest]`, `Wiki Ingest:`, `[bot] Wiki ingest:` — confirm it's emergent agent behavior, not a workflow feature). These accumulate as board noise: 13 had piled up between 2026-06-05 and 2026-06-12 and needed manual sweeping. The survey prompt never asked for an issue, and the durable per-survey summary already lives in `knowledge/log.md`.

## What changed

One constraint added to `survey-repo.yaml`'s `INGEST_PROMPT`: record the ingest summary only in `knowledge/log.md`, and do not open, comment on, or update a GitHub issue as a run notice. The existing required outcomes (wiki page, topic pages, index, log entry) are unchanged — the log entry stays the canonical summary.

No new machinery: no scheduled sweep, no perpetual-issue logic, no script changes. The fix is at the source. The `fro-bot.yaml` ingest path runs the wiki-ingest script directly (no agent prompt) and never posted issues, so it's untouched.

## Validation

After merge, the next survey dispatch should complete its ingest (log entry written, wiki pages committed) and open **no** issue. I'll watch the next run to confirm.
