### PR TITLE
fix(ci): fail loud on unexpected cache-delete errors

### DIFF
--- a/.github/workflows/manage-cache.yaml
+++ b/.github/workflows/manage-cache.yaml
@@ -50,6 +50,8 @@ jobs:
             # benign and must not abort the loop. Any OTHER failure (auth, API, scope) is
             # unexpected and must fail the step loudly rather than silently delete nothing.
             if ! delete_output="$(gh cache delete "$key" -R "${{ github.repository }}" 2>&1)"; then
+              # Matches gh's human-readable error text. If gh rewords this, the guard
+              # flips to fail-loud on the benign race -- noisy but safe (never silent).
               if printf '%s' "$delete_output" | grep -q 'Could not find a cache matching'; then
                 echo "::notice::cache key already evicted, skipping: $key"
               else

--- a/.github/workflows/manage-cache.yaml
+++ b/.github/workflows/manage-cache.yaml
@@ -44,10 +44,20 @@ jobs:
         run: |
           CACHE_KEYS="$(gh cache list -R "${{ github.repository }}" --ref "${{ env.REF }}" --limit 100 --order asc --sort last_accessed_at | cut -f 2 | tr '\n' ' ')"
           for key in $CACHE_KEYS; do
-            # A cache listed above can be evicted or re-keyed before we delete it,
-            # making `gh cache delete` exit non-zero. Cleanup is best-effort, so a
-            # missing entry must not abort the loop (the default shell uses `set -e`).
-            gh cache delete "$key" -R "${{ github.repository }}" || echo "::notice::cache key already gone, skipping: $key"
+            # A listed cache can be evicted or re-keyed before we delete it (a TOCTOU
+            # race against GitHub's async cache eviction), making `gh cache delete` exit
+            # non-zero with "Could not find a cache matching ...". That specific case is
+            # benign and must not abort the loop. Any OTHER failure (auth, API, scope) is
+            # unexpected and must fail the step loudly rather than silently delete nothing.
+            if ! delete_output="$(gh cache delete "$key" -R "${{ github.repository }}" 2>&1)"; then
+              if printf '%s' "$delete_output" | grep -q 'Could not find a cache matching'; then
+                echo "::notice::cache key already evicted, skipping: $key"
+              else
+                printf '%s\n' "$delete_output" >&2
+                echo "::error::unexpected failure deleting cache key: $key"
+                exit 1
+              fi
+            fi
           done
 
   setup-cache:


### PR DESCRIPTION
Narrows the cache-cleanup error tolerance so the job fails loudly on unexpected errors instead of silently swallowing them.

## Root cause

The `Manage Cache` cleanup loop lists up to 100 cache keys, then deletes them one by one. A key can be evicted by GitHub's async LRU (or re-keyed by a concurrent workflow) between the `list` and the `delete` — a genuine TOCTOU race. `gh cache delete` on a now-missing key exits non-zero, and under `set -e` that aborted the whole loop. That's the failure that occurred (`Could not find a cache matching opencode-storage-...` → exit 1).

## Why the previous tolerance was too broad

The earlier fix used a blanket `|| echo ::notice::`, which tolerated the race but also swallowed *every* other `gh cache delete` failure — auth, API outage, token scope. In those cases the job would go green while silently deleting nothing, hiding a real regression.

## What changed

The loop now captures the delete output and discriminates:
- benign `Could not find a cache matching` → `::notice::` and continue (the race, which is the desired end state — the key is gone)
- any other failure → print the output and `exit 1` (fail the step loudly)

This keeps the race tolerance while restoring fail-loud behavior for unexpected errors.

## Verification

The `if ! var="$(cmd)"` construct is well-defined under `set -e` (a command in an `if` condition does not trigger the errexit abort). All three paths were exercised locally:
- benign missing-cache output → notice + loop completes, exit 0
- auth-style error output → error printed, exit 1
- success → silent continue, exit 0

actionlint clean.
