### PR TITLE
feat(workflows): automate gateway rollout tracking

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -198,7 +198,7 @@ env:
     8. GATEWAY OPERATOR CONTROL-SURFACE ROLLOUT TRACKER
        Review awareness only. Check whether the Gateway operator control-surface
        rollout tracker at fro-bot/.github#3512 or the linked GitHub Project at
-       https://github.com/users/marcusrbrown/projects/2 has obvious drift, and
+       https://github.com/users/fro-bot/projects/1 has obvious drift, and
        summarize drift in the Daily Org Oversight Report if found. Do not post
        tracker comments or edit Project fields from this daily report path; the
        dedicated Gateway Rollout Tracker workflow owns tracker writes.

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -46,6 +46,9 @@ on:
 permissions:
   contents: read
 
+# FRO_BOT_PAT carries cross-repo write-tier authority for the agent. It must
+# include repo access, read:org for organization queries, and project scope for
+# tracker Project updates when called by Gateway Rollout Tracker.
 concurrency:
   group: >-
     fro-bot-${{
@@ -190,7 +193,16 @@ env:
        package.json (ESLint, Prettier, TypeScript, Vitest more than a minor
        behind), missing or degraded CI jobs, convention drift from
        copilot-instructions.md, and stale TODO/FIXME annotations. Report under
-       "Progressive Improvement"; make no changes here.
+        "Progressive Improvement"; make no changes here.
+
+    8. GATEWAY OPERATOR CONTROL-SURFACE ROLLOUT TRACKER
+       Review awareness only. Check whether the Gateway operator control-surface
+       rollout tracker at fro-bot/.github#3512 or the linked GitHub Project at
+       https://github.com/users/marcusrbrown/projects/2 has obvious drift, and
+       summarize drift in the Daily Org Oversight Report if found. Do not post
+       tracker comments or edit Project fields from this daily report path; the
+       dedicated Gateway Rollout Tracker workflow owns tracker writes.
+
 
     HARD BOUNDARIES
     - Never force-push, rewrite history, delete branches, merge PRs, submit
@@ -250,6 +262,7 @@ jobs:
   fro-bot:
     name: Fro Bot
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: >-
       (
         github.event.pull_request == null ||
@@ -399,7 +412,9 @@ jobs:
       # Shape-validates the URL before use; skips the post on zero/multiple matches (fail-soft).
       - name: 🔍 Discover daily report URL
         id: report-url
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        if: >-
+          (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+          inputs.prompt == ''
         env:
           GH_TOKEN: ${{ secrets.FRO_BOT_PAT }}
         run: |
@@ -440,7 +455,9 @@ jobs:
       # Surfaces count_status=='error' as a step warning so a broken data overlay is visible.
       - name: 📊 Derive daily digest counts
         id: digest-counts
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        if: >-
+          (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+          inputs.prompt == ''
         run: |
           set -euo pipefail
           TODAY_UTC="$(date -u +%Y-%m-%d)"
@@ -471,6 +488,7 @@ jobs:
       - name: 📣 Announce daily digest to gateway
         if: >-
           (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+          inputs.prompt == '' &&
           steps.digest-counts.outputs.count_status == 'ok' &&
           steps.report-url.outputs.report_url != '' &&
           vars.DAILY_DIGEST_ENABLED == 'true'

--- a/.github/workflows/gateway-rollout-tracker.yaml
+++ b/.github/workflows/gateway-rollout-tracker.yaml
@@ -1,0 +1,52 @@
+---
+name: Gateway Rollout Tracker
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gateway-rollout-tracker
+  cancel-in-progress: false
+
+jobs:
+  update-rollout-tracker:
+    uses: ./.github/workflows/fro-bot.yaml
+    with:
+      prompt: >-
+        Update the Gateway operator control-surface rollout tracker at
+        fro-bot/.github#3512 and the linked GitHub Project at
+        https://github.com/users/marcusrbrown/projects/2. Review the current
+        status of all tracked issues and post a status update comment on
+        fro-bot/.github#3512 only when there is meaningful drift since the
+        latest @fro-bot tracker status comment.
+
+        Tracked issues to review:
+        - fro-bot/agent#907
+        - fro-bot/agent#929
+        - fro-bot/dashboard#24
+        - fro-bot/dashboard#25
+        - fro-bot/dashboard#26
+        - marcusrbrown/infra#579
+        - marcusrbrown/infra#580
+        - marcusrbrown/infra#581
+
+        For each tracked issue: check whether it has been closed, whether a
+        deployment has happened, or whether a supporting feature has been
+        released. Update the GitHub Project item state/fields when the evidence
+        changes readiness. Use fro-bot/.github#3512 as the routine status log;
+        comment on tracked issues only when there is issue-specific transition
+        evidence that has not already been acknowledged, and link those comments
+        back to fro-bot/.github#3512.
+
+        All status comments must begin with @fro-bot or explicitly mention
+        @fro-bot. Post status updates in a concise, structured format.
+    secrets:
+      FRO_BOT_PAT: ${{ secrets.FRO_BOT_PAT }}
+      OPENCODE_AUTH_JSON: ${{ secrets.OPENCODE_AUTH_JSON }}
+      OMO_PROVIDERS: ${{ secrets.OMO_PROVIDERS }}
+      OPENCODE_CONFIG: ${{ secrets.OPENCODE_CONFIG }}

--- a/.github/workflows/gateway-rollout-tracker.yaml
+++ b/.github/workflows/gateway-rollout-tracker.yaml
@@ -20,7 +20,7 @@ jobs:
       prompt: >-
         Update the Gateway operator control-surface rollout tracker at
         fro-bot/.github#3512 and the linked GitHub Project at
-        https://github.com/users/marcusrbrown/projects/2. Review the current
+        https://github.com/users/fro-bot/projects/1. Review the current
         status of all tracked issues and post a status update comment on
         fro-bot/.github#3512 only when there is meaningful drift since the
         latest @fro-bot tracker status comment.

--- a/docs/solutions/workflow-issues/autonomous-rollout-tracker-workflow-2026-06-17.md
+++ b/docs/solutions/workflow-issues/autonomous-rollout-tracker-workflow-2026-06-17.md
@@ -1,9 +1,12 @@
 ---
+title: Autonomous rollout tracker workflows
 module: gateway-rollout-tracker
 date: 2026-06-17
+last_updated: 2026-06-17
 problem_type: workflow_issue
 component: development_workflow
 severity: medium
+verified: true
 applies_when:
   - a cross-repo rollout needs ongoing autonomous status tracking
   - a reusable agent workflow is called from a dedicated scheduled workflow

--- a/docs/solutions/workflow-issues/autonomous-rollout-tracker-workflow-2026-06-17.md
+++ b/docs/solutions/workflow-issues/autonomous-rollout-tracker-workflow-2026-06-17.md
@@ -1,0 +1,114 @@
+---
+module: gateway-rollout-tracker
+date: 2026-06-17
+problem_type: workflow_issue
+component: development_workflow
+severity: medium
+applies_when:
+  - a cross-repo rollout needs ongoing autonomous status tracking
+  - a reusable agent workflow is called from a dedicated scheduled workflow
+  - tracker comments and project fields can be updated by the same agent workflow
+related_components:
+  - fro-bot-workflow
+  - github-projects
+  - daily-digest
+tags:
+  - github-actions
+  - fro-bot
+  - rollout-tracking
+  - projects
+  - reusable-workflows
+---
+
+# Autonomous rollout tracker workflows
+
+## Context
+
+The Gateway operator control-surface rollout spans `fro-bot/agent`, `fro-bot/dashboard`,
+`marcusrbrown/infra`, and this control-plane repository. A static tracker issue is not enough: as
+agent units land, deployment topology changes, and dashboard issues close, the matrix needs a
+routine updater that can post status and keep the `fro-bot` user-owned GitHub Project fields
+current.
+
+The first implementation added a dedicated scheduled workflow that calls the reusable Fro Bot
+workflow with a focused tracker prompt. Review found two important hazards before the PR was ready:
+reusable calls could accidentally run daily-digest side effects, and overlapping tracker runs could
+race on comments and Project state.
+
+## Guidance
+
+Use a dedicated caller workflow for autonomous tracker updates, and keep the general daily prompt
+awareness-only:
+
+```yaml
+concurrency:
+  group: gateway-rollout-tracker
+  cancel-in-progress: false
+
+jobs:
+  update-rollout-tracker:
+    uses: ./.github/workflows/fro-bot.yaml
+    with:
+      prompt: >-
+        Update the rollout tracker and linked GitHub Project only when tracked
+        state changed since the latest @fro-bot tracker status comment.
+    secrets:
+      FRO_BOT_PAT: ${{ secrets.FRO_BOT_PAT }}
+      OPENCODE_AUTH_JSON: ${{ secrets.OPENCODE_AUTH_JSON }}
+      OMO_PROVIDERS: ${{ secrets.OMO_PROVIDERS }}
+      OPENCODE_CONFIG: ${{ secrets.OPENCODE_CONFIG }}
+```
+
+When the reusable workflow also supports daily reports or digest announcements, gate those
+daily-only steps away from custom-prompt reusable calls:
+
+```yaml
+if: >-
+  (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+  inputs.prompt == ''
+```
+
+The dedicated tracker prompt should be explicit about idempotency:
+
+- use the tracker issue as the routine status log
+- compare against the latest `@fro-bot` tracker comment before posting
+- update Project fields when readiness evidence changes
+- comment on tracked issues only for issue-specific transitions that were not already acknowledged
+- link transition comments back to the tracker issue
+
+## Why This Matters
+
+Reusable workflow calls keep the caller's `github` context. A scheduled tracker workflow that calls
+the generic Fro Bot workflow still looks like `github.event_name == 'schedule'` inside the reusable
+workflow. Without an extra `inputs.prompt == ''` guard, daily-report discovery, digest counting, and
+gateway announcements can run from the tracker path.
+
+Tracker updates are also write operations against shared state: one issue thread and one GitHub
+Project. Without a caller-level concurrency group, a manual dispatch can overlap the scheduled run
+and both agents can decide the same state transition needs a comment.
+
+Explicit secret mapping keeps the caller aligned with least-privilege workflow conventions and avoids
+spreading unrelated repository secrets into reusable workflow calls.
+
+## When to Apply
+
+Apply this pattern when a Fro Bot scheduled workflow is responsible for tracking progress across
+multiple repositories, especially when it updates both GitHub issues and Projects.
+
+Do not use the general daily oversight prompt as the primary tracker writer. It can report drift, but
+the dedicated workflow should own comments and Project mutations so duplicate update paths do not
+fight each other.
+
+## Examples
+
+Good split:
+
+- daily oversight: notices tracker drift and reports it in the daily issue
+- dedicated tracker: updates Project fields and posts `@fro-bot` status comments when state changed
+
+Bad split:
+
+- daily oversight and dedicated tracker both post routine tracker comments
+- reusable tracker calls inherit every repository secret
+- tracker runs have no concurrency group
+- daily-digest announce steps run during custom tracker prompts


### PR DESCRIPTION
## Summary

Adds an automated Gateway rollout tracker path for the cross-repo operator control surface work.

## Changes

- Adds a scheduled/manual `Gateway Rollout Tracker` workflow that calls the reusable Fro Bot workflow with a focused tracker prompt.
- Keeps the daily Fro Bot pass awareness-only for the rollout tracker so routine org oversight does not duplicate tracker comments or project writes.
- Prevents tracker runs from triggering daily-digest discovery/count/announce side effects.
- Adds bounded runtime and documents required PAT scopes for tracker Project updates.

## Verification

- `pnpm exec actionlint .github/workflows/fro-bot.yaml .github/workflows/gateway-rollout-tracker.yaml`
- `pnpm bootstrap && pnpm check-types && pnpm lint && pnpm test`

## Notes

Tracker project: https://github.com/users/fro-bot/projects/1
