### PR TITLE
feat(workflows): gate rollout tracker comments

### DIFF
--- a/.github/workflows/gateway-rollout-tracker.yaml
+++ b/.github/workflows/gateway-rollout-tracker.yaml
@@ -14,16 +14,66 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # ── Preflight: deterministic snapshot + idempotency gate ──────────────────
+  # Reads the GitHub Project and tracked issue states, builds a stable hash,
+  # and compares it to the hash embedded in the latest @fro-bot tracker comment.
+  # Outputs should_comment=true only when there is a genuine gating transition.
+  preflight:
+    name: Rollout Tracker Preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      should_comment: ${{ steps.snapshot.outputs.should_comment }}
+      reason: ${{ steps.snapshot.outputs.reason }}
+      hash: ${{ steps.snapshot.outputs.hash }}
+      snapshot: ${{ steps.snapshot.outputs.snapshot }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: 📦 Setup
+        uses: ./.github/actions/setup
+
+      - name: 🔍 Run rollout tracker snapshot preflight
+        id: snapshot
+        env:
+          GH_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+        run: |
+          set -euo pipefail
+          RESULT="$(node scripts/rollout-tracker-snapshot.ts)"
+          SHOULD_COMMENT="$(echo "$RESULT" | jq -r '.should_comment')"
+          REASON="$(echo "$RESULT" | jq -r '.reason')"
+          HASH="$(echo "$RESULT" | jq -r '.hash')"
+          SNAPSHOT="$(echo "$RESULT" | jq -c '.snapshot')"
+          {
+            echo "should_comment=${SHOULD_COMMENT}"
+            echo "reason=${REASON}"
+            echo "hash=${HASH}"
+            echo "snapshot<<SNAPSHOT_JSON"
+            echo "${SNAPSHOT}"
+            echo "SNAPSHOT_JSON"
+          } >> "$GITHUB_OUTPUT"
+          if [ "$SHOULD_COMMENT" = "false" ]; then
+            echo "::notice::rollout-tracker: no gating transition — ${REASON}"
+          else
+            echo "::notice::rollout-tracker: gating transition detected — ${REASON}"
+          fi
+
+  # ── Fro Bot agent: only runs when preflight detects a gating transition ───
   update-rollout-tracker:
+    name: Update Rollout Tracker
+    needs: preflight
+    if: needs.preflight.outputs.should_comment == 'true'
     uses: ./.github/workflows/fro-bot.yaml
     with:
       prompt: >-
         Update the Gateway operator control-surface rollout tracker at
         fro-bot/.github#3512 and the linked GitHub Project at
-        https://github.com/users/fro-bot/projects/1. Review the current
-        status of all tracked issues and post a status update comment on
-        fro-bot/.github#3512 only when there is meaningful drift since the
-        latest @fro-bot tracker status comment.
+        https://github.com/users/fro-bot/projects/1. A gating transition has
+        been detected since the last tracker comment — narrate only the
+        transition that triggered this run.
 
         Tracked issues to review:
         - fro-bot/agent#907
@@ -45,6 +95,16 @@ jobs:
 
         All status comments must begin with @fro-bot or explicitly mention
         @fro-bot. Post status updates in a concise, structured format.
+
+        IMPORTANT: End every tracker comment on fro-bot/.github#3512 with the
+        machine-readable state marker on its own line, replacing any prior
+        marker. Use this preflight hash:
+        ${{ needs.preflight.outputs.hash }}
+        And this preflight snapshot JSON:
+        ${{ needs.preflight.outputs.snapshot }}
+        Format exactly:
+        <!-- gateway-rollout-tracker:{"hash":"${{ needs.preflight.outputs.hash }}","snapshot":${{ needs.preflight.outputs.snapshot }}} -->
+        Never parse prose tables as state — always read and write the marker.
     secrets:
       FRO_BOT_PAT: ${{ secrets.FRO_BOT_PAT }}
       OPENCODE_AUTH_JSON: ${{ secrets.OPENCODE_AUTH_JSON }}

--- a/scripts/rollout-tracker-snapshot.test.ts
+++ b/scripts/rollout-tracker-snapshot.test.ts
@@ -1,0 +1,755 @@
+// Import types from the module under test
+import type {CommentDecision, IssueState, MarkerData, ProjectItem, RolloutSnapshot} from './rollout-tracker-snapshot.ts'
+import {execFileSync} from 'node:child_process'
+import {readFileSync} from 'node:fs'
+import {resolve} from 'node:path'
+import process from 'node:process'
+import {describe, expect, it, vi} from 'vitest'
+import {parse} from 'yaml'
+
+import {
+  buildSnapshot,
+  decideComment,
+  extractPreviousMarker,
+  hashSnapshot,
+  MARKER_PREFIX,
+  normaliseIssueState,
+  normaliseRawProjectItem,
+  selectLatestMarkerCommentBody,
+} from './rollout-tracker-snapshot.ts'
+
+// ─── Fixture helpers ──────────────────────────────────────────────────────────
+
+/** Minimal tracked issue state fixture */
+function makeIssueState(overrides: Partial<IssueState> = {}): IssueState {
+  return {
+    number: 907,
+    repo: 'fro-bot/agent',
+    state: 'open',
+    title: 'Test issue',
+    closed_at: null,
+    labels: [],
+    ...overrides,
+  }
+}
+
+/** Minimal project item fixture */
+function makeProjectItem(overrides: Partial<ProjectItem> = {}): ProjectItem {
+  return {
+    id: 'PVTI_1',
+    content_number: 907,
+    content_repo: 'fro-bot/agent',
+    status: 'In Progress',
+    readiness: null,
+    gate: null,
+    ...overrides,
+  }
+}
+
+function runCliFixture(params: {items: ProjectItem[]; issues: IssueState[]; commentBody?: string}): CommentDecision {
+  const scriptPath = resolve(import.meta.dirname, './rollout-tracker-snapshot.ts')
+  const stdout = execFileSync('node', [scriptPath], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ROLLOUT_TRACKER_COMMENT_BODY: params.commentBody ?? '',
+      ROLLOUT_TRACKER_ISSUES_JSON: JSON.stringify(params.issues),
+      ROLLOUT_TRACKER_ITEMS_JSON: JSON.stringify(params.items),
+    },
+  })
+
+  return JSON.parse(stdout) as CommentDecision
+}
+
+// ─── buildSnapshot ────────────────────────────────────────────────────────────
+
+describe('buildSnapshot', () => {
+  it('constructs a normalized snapshot from project items and issue states', () => {
+    const items: ProjectItem[] = [makeProjectItem()]
+    const issues: IssueState[] = [makeIssueState()]
+
+    const snapshot = buildSnapshot(items, issues)
+
+    expect(snapshot).toBeDefined()
+    expect(snapshot.items).toHaveLength(1)
+    expect(snapshot.items[0]).toMatchObject({
+      content_number: 907,
+      content_repo: 'fro-bot/agent',
+      status: 'In Progress',
+    })
+  })
+
+  it('merges issue state (closed_at, labels) into snapshot items', () => {
+    const items: ProjectItem[] = [makeProjectItem({content_number: 929, content_repo: 'fro-bot/agent'})]
+    const issues: IssueState[] = [
+      makeIssueState({
+        number: 929,
+        repo: 'fro-bot/agent',
+        state: 'closed',
+        closed_at: '2026-06-01T00:00:00Z',
+        labels: ['deployed'],
+      }),
+    ]
+
+    const snapshot = buildSnapshot(items, issues)
+
+    expect(snapshot.items[0]).toMatchObject({
+      content_number: 929,
+      issue_state: 'closed',
+      issue_closed_at: '2026-06-01T00:00:00Z',
+      issue_labels: ['deployed'],
+    })
+  })
+
+  it('sorts items deterministically by repo+number', () => {
+    const items: ProjectItem[] = [
+      makeProjectItem({content_number: 929, content_repo: 'fro-bot/agent'}),
+      makeProjectItem({content_number: 907, content_repo: 'fro-bot/agent'}),
+      makeProjectItem({content_number: 24, content_repo: 'fro-bot/dashboard'}),
+    ]
+    const issues: IssueState[] = []
+
+    const snapshot = buildSnapshot(items, issues)
+
+    expect(snapshot.items[0]?.content_number).toBe(907)
+    expect(snapshot.items[1]?.content_number).toBe(929)
+    expect(snapshot.items[2]?.content_number).toBe(24)
+  })
+
+  it('excludes volatile fields (timestamps, prose) from snapshot items', () => {
+    const items: ProjectItem[] = [makeProjectItem()]
+    const issues: IssueState[] = [makeIssueState({title: 'Some prose title that changes'})]
+
+    const snapshot = buildSnapshot(items, issues)
+
+    // title should NOT appear in snapshot items (volatile prose)
+    expect(JSON.stringify(snapshot)).not.toContain('Some prose title that changes')
+  })
+})
+
+// ─── hashSnapshot ─────────────────────────────────────────────────────────────
+
+describe('hashSnapshot', () => {
+  it('produces a stable hex string for the same snapshot', () => {
+    const snapshot: RolloutSnapshot = {
+      items: [
+        {
+          content_number: 907,
+          content_repo: 'fro-bot/agent',
+          status: 'In Progress',
+          readiness: null,
+          gate: null,
+          issue_state: 'open',
+          issue_closed_at: null,
+          issue_labels: [],
+        },
+      ],
+    }
+
+    const h1 = hashSnapshot(snapshot)
+    const h2 = hashSnapshot(snapshot)
+
+    expect(h1).toBe(h2)
+    expect(h1).toMatch(/^[0-9a-f]{64}$/) // SHA-256 hex
+  })
+
+  it('produces different hashes for different issue states', () => {
+    const base: RolloutSnapshot = {
+      items: [
+        {
+          content_number: 907,
+          content_repo: 'fro-bot/agent',
+          status: 'In Progress',
+          readiness: null,
+          gate: null,
+          issue_state: 'open',
+          issue_closed_at: null,
+          issue_labels: [],
+        },
+      ],
+    }
+    const baseItem = base.items[0] ?? {
+      content_number: 907,
+      content_repo: 'fro-bot/agent',
+      status: 'In Progress',
+      readiness: null,
+      gate: null,
+      issue_state: 'open' as const,
+      issue_closed_at: null,
+      issue_labels: [],
+    }
+    const changed: RolloutSnapshot = {
+      items: [
+        {
+          ...baseItem,
+          issue_state: 'closed',
+        },
+      ],
+    }
+
+    expect(hashSnapshot(base)).not.toBe(hashSnapshot(changed))
+  })
+
+  it('is stable regardless of object key insertion order (sorted keys)', () => {
+    const a: RolloutSnapshot = {
+      items: [
+        {
+          content_number: 907,
+          content_repo: 'fro-bot/agent',
+          status: 'In Progress',
+          readiness: null,
+          gate: null,
+          issue_state: 'open',
+          issue_closed_at: null,
+          issue_labels: [],
+        },
+      ],
+    }
+    // Same data, different key order in the object literal
+    const b: RolloutSnapshot = {
+      items: [
+        {
+          issue_state: 'open',
+          gate: null,
+          readiness: null,
+          status: 'In Progress',
+          content_repo: 'fro-bot/agent',
+          content_number: 907,
+          issue_closed_at: null,
+          issue_labels: [],
+        },
+      ],
+    }
+
+    expect(hashSnapshot(a)).toBe(hashSnapshot(b))
+  })
+
+  it('closure/state change affects hash', () => {
+    const open: RolloutSnapshot = {
+      items: [
+        {
+          content_number: 907,
+          content_repo: 'fro-bot/agent',
+          status: 'In Progress',
+          readiness: null,
+          gate: null,
+          issue_state: 'open',
+          issue_closed_at: null,
+          issue_labels: [],
+        },
+      ],
+    }
+    const openItem = open.items[0] ?? {
+      content_number: 907,
+      content_repo: 'fro-bot/agent',
+      status: 'In Progress',
+      readiness: null,
+      gate: null,
+      issue_state: 'open' as const,
+      issue_closed_at: null,
+      issue_labels: [],
+    }
+    const closed: RolloutSnapshot = {
+      items: [
+        {
+          ...openItem,
+          issue_state: 'closed',
+          issue_closed_at: '2026-06-01T00:00:00Z',
+        },
+      ],
+    }
+
+    expect(hashSnapshot(open)).not.toBe(hashSnapshot(closed))
+  })
+
+  it('does not change hash for Project field-only drift', () => {
+    const base: RolloutSnapshot = {
+      items: [
+        {
+          content_number: 24,
+          content_repo: 'fro-bot/dashboard',
+          status: 'Todo',
+          readiness: 'ready now',
+          gate: 'Unit 3',
+          issue_state: 'open',
+          issue_closed_at: null,
+          issue_labels: [],
+        },
+      ],
+    }
+    const baseItem = base.items[0]
+    if (baseItem === undefined) throw new Error('missing base item')
+    const fieldOnlyDrift: RolloutSnapshot = {
+      items: [
+        {
+          ...baseItem,
+          status: 'In Progress',
+          readiness: 'blocked',
+          gate: 'Unit 4',
+        },
+      ],
+    }
+
+    expect(hashSnapshot(base)).toBe(hashSnapshot(fieldOnlyDrift))
+  })
+
+  it('does not change hash for issue label-only drift', () => {
+    const base: RolloutSnapshot = {
+      items: [
+        {
+          content_number: 24,
+          content_repo: 'fro-bot/dashboard',
+          status: 'Todo',
+          readiness: 'ready now',
+          gate: 'Unit 3',
+          issue_state: 'open',
+          issue_closed_at: null,
+          issue_labels: [],
+        },
+      ],
+    }
+    const baseItem = base.items[0]
+    if (baseItem === undefined) throw new Error('missing base item')
+    const labelOnlyDrift: RolloutSnapshot = {
+      items: [
+        {
+          ...baseItem,
+          issue_labels: ['tracking', 'triaged'],
+        },
+      ],
+    }
+
+    expect(hashSnapshot(base)).toBe(hashSnapshot(labelOnlyDrift))
+  })
+})
+
+// ─── extractPreviousMarker ────────────────────────────────────────────────────
+
+describe('extractPreviousMarker', () => {
+  it('returns null when no marker is present', () => {
+    const body = 'Some comment body with no marker here.'
+    expect(extractPreviousMarker(body)).toBeNull()
+  })
+
+  it('extracts marker data from an HTML comment', () => {
+    const markerData: MarkerData = {hash: 'abc123', snapshot: {items: []}}
+    const body = `Some text\n<!-- ${MARKER_PREFIX}${JSON.stringify(markerData)} -->\nMore text`
+
+    const result = extractPreviousMarker(body)
+
+    expect(result).not.toBeNull()
+    expect(result?.hash).toBe('abc123')
+    expect(result?.snapshot).toEqual({items: []})
+  })
+
+  it('returns null for malformed marker JSON', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const body = `<!-- ${MARKER_PREFIX}not-valid-json -->`
+
+    const result = extractPreviousMarker(body)
+
+    expect(result).toBeNull()
+    expect(stderrSpy).toHaveBeenCalled()
+    stderrSpy.mockRestore()
+  })
+
+  it('returns null for empty string input', () => {
+    expect(extractPreviousMarker('')).toBeNull()
+  })
+
+  it('extracts the LAST marker when multiple are present (latest wins)', () => {
+    const first: MarkerData = {hash: 'first', snapshot: {items: []}}
+    const second: MarkerData = {hash: 'second', snapshot: {items: []}}
+    const body = [
+      `<!-- ${MARKER_PREFIX}${JSON.stringify(first)} -->`,
+      'Some prose in between',
+      `<!-- ${MARKER_PREFIX}${JSON.stringify(second)} -->`,
+    ].join('\n')
+
+    const result = extractPreviousMarker(body)
+
+    expect(result?.hash).toBe('second')
+  })
+})
+
+describe('selectLatestMarkerCommentBody', () => {
+  it('uses the latest fro-bot comment with a tracker marker', () => {
+    const first = `@fro-bot first\n<!-- ${MARKER_PREFIX}${JSON.stringify({hash: 'one', snapshot: {items: []}})} -->`
+    const second = `@fro-bot second\n<!-- ${MARKER_PREFIX}${JSON.stringify({hash: 'two', snapshot: {items: []}})} -->`
+
+    expect(
+      selectLatestMarkerCommentBody([
+        {author: {login: 'fro-bot'}, body: first},
+        {author: {login: 'fro-bot'}, body: '@fro-bot prose-only follow-up'},
+        {author: {login: 'marcusrbrown'}, body: second},
+        {author: {login: 'fro-bot'}, body: second},
+      ]),
+    ).toBe(second)
+  })
+
+  it('returns an empty body when no fro-bot marker exists', () => {
+    expect(
+      selectLatestMarkerCommentBody([
+        {author: {login: 'fro-bot'}, body: '@fro-bot prose-only'},
+        {author: {login: 'marcusrbrown'}, body: `<!-- ${MARKER_PREFIX}{"hash":"x","snapshot":{"items":[]}} -->`},
+      ]),
+    ).toBe('')
+  })
+})
+
+// ─── decideComment ────────────────────────────────────────────────────────────
+
+describe('decideComment', () => {
+  const baseSnapshot: RolloutSnapshot = {
+    items: [
+      {
+        content_number: 907,
+        content_repo: 'fro-bot/agent',
+        status: 'In Progress',
+        readiness: null,
+        gate: null,
+        issue_state: 'open',
+        issue_closed_at: null,
+        issue_labels: [],
+      },
+    ],
+  }
+
+  it('cold start (no prior marker) => should_comment:true to seed state', () => {
+    const hash = hashSnapshot(baseSnapshot)
+    const result = decideComment(baseSnapshot, hash, null)
+
+    expect(result.should_comment).toBe(true)
+    expect(result.reason).toMatch(/cold start/i)
+    expect(result.hash).toBe(hash)
+    expect(result.snapshot).toEqual(baseSnapshot)
+  })
+
+  it('same hash as previous marker => should_comment:false with no gating transition reason', () => {
+    const hash = hashSnapshot(baseSnapshot)
+    const previousMarker: MarkerData = {hash, snapshot: baseSnapshot}
+
+    const result = decideComment(baseSnapshot, hash, previousMarker)
+
+    expect(result.should_comment).toBe(false)
+    expect(result.reason).toMatch(/no gating transition/i)
+    expect(result.hash).toBe(hash)
+  })
+
+  it('different hash from previous marker => should_comment:true', () => {
+    const oldSnapshot: RolloutSnapshot = {
+      items: [
+        {
+          content_number: 907,
+          content_repo: 'fro-bot/agent',
+          status: 'In Progress',
+          readiness: null,
+          gate: null,
+          issue_state: 'open',
+          issue_closed_at: null,
+          issue_labels: [],
+        },
+      ],
+    }
+    const oldItem = oldSnapshot.items[0] ?? {
+      content_number: 907,
+      content_repo: 'fro-bot/agent',
+      status: 'In Progress',
+      readiness: null,
+      gate: null,
+      issue_state: 'open' as const,
+      issue_closed_at: null,
+      issue_labels: [],
+    }
+    const newSnapshot: RolloutSnapshot = {
+      items: [
+        {
+          ...oldItem,
+          status: 'Done',
+          issue_state: 'closed',
+          issue_closed_at: '2026-06-10T00:00:00Z',
+        },
+      ],
+    }
+    const oldHash = hashSnapshot(oldSnapshot)
+    const newHash = hashSnapshot(newSnapshot)
+    const previousMarker: MarkerData = {hash: oldHash, snapshot: oldSnapshot}
+
+    const result = decideComment(newSnapshot, newHash, previousMarker)
+
+    expect(result.should_comment).toBe(true)
+    expect(result.hash).toBe(newHash)
+    expect(result.snapshot).toEqual(newSnapshot)
+  })
+
+  it('returns hash and snapshot in result regardless of should_comment value', () => {
+    const hash = hashSnapshot(baseSnapshot)
+    const previousMarker: MarkerData = {hash, snapshot: baseSnapshot}
+
+    const result = decideComment(baseSnapshot, hash, previousMarker)
+
+    expect(result.hash).toBeDefined()
+    expect(result.snapshot).toBeDefined()
+  })
+})
+
+describe('rollout-tracker-snapshot CLI fixture path', () => {
+  it('gates comments only on tracked identity or issue-state transitions', () => {
+    const items = [makeProjectItem({content_number: 24, content_repo: 'fro-bot/dashboard', gate: 'Unit 3'})]
+    const issues = [makeIssueState({number: 24, repo: 'fro-bot/dashboard', state: 'open'})]
+
+    const first = runCliFixture({items, issues})
+    expect(first.should_comment).toBe(true)
+
+    const marker = `@fro-bot seeded\n<!-- ${MARKER_PREFIX}${JSON.stringify({
+      hash: first.hash,
+      snapshot: first.snapshot,
+    })} -->`
+
+    const unchanged = runCliFixture({items, issues, commentBody: marker})
+    expect(unchanged.should_comment).toBe(false)
+    expect(unchanged.reason).toContain('no gating transition')
+
+    const projectFieldAndLabelDrift = runCliFixture({
+      commentBody: marker,
+      issues: [makeIssueState({number: 24, repo: 'fro-bot/dashboard', labels: ['tracking']})],
+      items: [
+        makeProjectItem({
+          content_number: 24,
+          content_repo: 'fro-bot/dashboard',
+          gate: 'Units 4-6',
+          readiness: 'blocked',
+          status: 'In Progress',
+        }),
+      ],
+    })
+    expect(projectFieldAndLabelDrift.should_comment).toBe(false)
+
+    const issueStateTransition = runCliFixture({
+      commentBody: marker,
+      issues: [makeIssueState({number: 24, repo: 'fro-bot/dashboard', state: 'closed'})],
+      items,
+    })
+    expect(issueStateTransition.should_comment).toBe(true)
+
+    const existingItem = items[0]
+    if (existingItem === undefined) throw new Error('missing existing item')
+    const addedItemTransition = runCliFixture({
+      commentBody: marker,
+      issues,
+      items: [existingItem, makeProjectItem({content_number: 25, content_repo: 'fro-bot/dashboard'})],
+    })
+    expect(addedItemTransition.should_comment).toBe(true)
+  })
+})
+
+// ─── Live-shape regression: gate field mapping ────────────────────────────────
+
+describe('buildSnapshot — gate field from live gh project shape', () => {
+  it('maps raw "gateway Unit Gate" text field to gate on ProjectItem', () => {
+    // The gh project item-list --format json API returns the custom field as
+    // "gateway Unit Gate" (with spaces), not "gate". The normalisation layer
+    // in main() must map it before calling buildSnapshot, so ProjectItem.gate
+    // must be populated from that key.
+    //
+    // We test the normalisation contract by verifying that a ProjectItem whose
+    // gate is set (as the normaliser should produce) flows through correctly.
+    const item: ProjectItem = makeProjectItem({gate: 'Unit Gate'})
+    const snapshot = buildSnapshot([item], [])
+    expect(snapshot.items[0]?.gate).toBe('Unit Gate')
+  })
+
+  it('gate is null when raw "gateway Unit Gate" field is absent or null', () => {
+    const item: ProjectItem = makeProjectItem({gate: null})
+    const snapshot = buildSnapshot([item], [])
+    expect(snapshot.items[0]?.gate).toBeNull()
+  })
+
+  it('gate value is preserved in the snapshot but does not affect comment hash by itself', () => {
+    const withGate = buildSnapshot([makeProjectItem({gate: 'Unit Gate'})], [])
+    const withoutGate = buildSnapshot([makeProjectItem({gate: null})], [])
+    expect(withGate.items[0]?.gate).toBe('Unit Gate')
+    expect(hashSnapshot(withGate)).toBe(hashSnapshot(withoutGate))
+  })
+})
+
+// ─── Live-shape regression: normaliseRawProjectItem ──────────────────────────
+
+describe('normaliseRawProjectItem', () => {
+  it('maps "gateway Unit Gate" key to gate field', () => {
+    const raw: Record<string, unknown> = {
+      id: 'PVTI_1',
+      content: {number: 929, repository: 'fro-bot/agent'},
+      status: 'In Progress',
+      readiness: null,
+      'gateway Unit Gate': 'Unit Gate',
+    }
+    const item = normaliseRawProjectItem(raw)
+    expect(item.gate).toBe('Unit Gate')
+  })
+
+  it('gate is null when field is missing', () => {
+    const raw: Record<string, unknown> = {
+      id: 'PVTI_2',
+      content: {number: 907, repository: 'fro-bot/agent'},
+      status: null,
+      readiness: null,
+    }
+    const item = normaliseRawProjectItem(raw)
+    expect(item.gate).toBeNull()
+  })
+
+  it('gate is null when field value is null', () => {
+    const raw: Record<string, unknown> = {
+      id: 'PVTI_3',
+      content: {number: 24, repository: 'fro-bot/dashboard'},
+      status: 'Backlog',
+      readiness: null,
+      'gateway Unit Gate': null,
+    }
+    const item = normaliseRawProjectItem(raw)
+    expect(item.gate).toBeNull()
+  })
+})
+
+// ─── Live-shape regression: issue/PR state normalisation ─────────────────────
+
+describe('normaliseIssueState', () => {
+  it('maps CLOSED to "closed"', () => {
+    expect(normaliseIssueState('CLOSED')).toBe('closed')
+  })
+
+  it('maps MERGED to "merged"', () => {
+    expect(normaliseIssueState('MERGED')).toBe('merged')
+  })
+
+  it('maps OPEN to "open"', () => {
+    expect(normaliseIssueState('OPEN')).toBe('open')
+  })
+
+  it('maps unknown values to "open" (safe default)', () => {
+    expect(normaliseIssueState('SOMETHING_ELSE')).toBe('open')
+  })
+})
+
+describe('buildSnapshot — MERGED PR state', () => {
+  it('issue_state is "merged" when gh returns MERGED', () => {
+    const issue: IssueState = makeIssueState({
+      number: 929,
+      repo: 'fro-bot/agent',
+      state: 'merged',
+      closed_at: '2026-06-10T00:00:00Z',
+    })
+    const item = makeProjectItem({content_number: 929, content_repo: 'fro-bot/agent'})
+    const snapshot = buildSnapshot([item], [issue])
+    expect(snapshot.items[0]?.issue_state).toBe('merged')
+  })
+
+  it('merged state produces a different hash than open or closed', () => {
+    const base = makeProjectItem({content_number: 929, content_repo: 'fro-bot/agent'})
+    const openSnap = buildSnapshot([base], [makeIssueState({number: 929, repo: 'fro-bot/agent', state: 'open'})])
+    const closedSnap = buildSnapshot([base], [makeIssueState({number: 929, repo: 'fro-bot/agent', state: 'closed'})])
+    const mergedSnap = buildSnapshot([base], [makeIssueState({number: 929, repo: 'fro-bot/agent', state: 'merged'})])
+    expect(hashSnapshot(mergedSnap)).not.toBe(hashSnapshot(openSnap))
+    expect(hashSnapshot(mergedSnap)).not.toBe(hashSnapshot(closedSnap))
+  })
+})
+
+// ─── Workflow shape regression ────────────────────────────────────────────────
+
+interface WorkflowJob {
+  steps?: {name?: string; run?: string; id?: string; if?: string; uses?: string}[]
+  uses?: string
+  with?: Record<string, unknown>
+  if?: string
+}
+
+function assertWorkflow(value: unknown): asserts value is {jobs: Record<string, WorkflowJob>} {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    !('jobs' in value) ||
+    typeof (value as Record<string, unknown>).jobs !== 'object'
+  ) {
+    throw new TypeError('gateway-rollout-tracker.yaml does not have expected shape: missing jobs object')
+  }
+}
+
+describe('gateway-rollout-tracker.yaml workflow shape', () => {
+  const workflowPath = resolve(import.meta.dirname, '../.github/workflows/gateway-rollout-tracker.yaml')
+  const parsed: unknown = parse(readFileSync(workflowPath, 'utf8'))
+
+  assertWorkflow(parsed)
+
+  it('has a preflight job or preflight step before the fro-bot call', () => {
+    const jobs = parsed.jobs
+    // Either a dedicated preflight job or a preflight step in the tracker job
+    const hasPreflightJob = 'preflight' in jobs || 'rollout-preflight' in jobs
+    const trackerJob = jobs['update-rollout-tracker']
+    const hasPreflightStep = trackerJob?.steps?.some(
+      s =>
+        s.id === 'preflight' ||
+        s.name?.toLowerCase().includes('preflight') ||
+        s.run?.includes('rollout-tracker-snapshot'),
+    )
+    expect(hasPreflightJob || hasPreflightStep).toBe(true)
+  })
+
+  it('gates the fro-bot call so it does not run when should_comment != true', () => {
+    const jobs = parsed.jobs
+    // The fro-bot reusable call job must have an `if:` condition referencing should_comment
+    // OR the step calling fro-bot must have an `if:` condition
+    const trackerJob = jobs['update-rollout-tracker']
+    const jobIf = trackerJob?.if ?? ''
+    const froStepIf = trackerJob?.steps?.find(s => s.uses?.includes('fro-bot'))?.if ?? ''
+    const hasGate =
+      jobIf.includes('should_comment') ||
+      froStepIf.includes('should_comment') ||
+      // Could also be a separate job with needs: preflight and if: needs.preflight.outputs.should_comment == 'true'
+      Object.values(jobs).some(j => {
+        const jobIfStr = (j as {if?: string}).if ?? ''
+        return jobIfStr.includes('should_comment')
+      })
+    expect(hasGate).toBe(true)
+  })
+
+  it('logs no gating transition on no-op path', () => {
+    // The preflight step or a dedicated no-op step must log "no gating transition"
+    const jobs = parsed.jobs
+    const allSteps = Object.values(jobs).flatMap(j => (j as {steps?: {run?: string}[]}).steps ?? [])
+    const hasNoOpLog = allSteps.some(s => s.run?.includes('no gating transition'))
+    expect(hasNoOpLog).toBe(true)
+  })
+
+  it('keeps concurrency group intact', () => {
+    const wf = parsed as unknown as {concurrency?: {group?: string}}
+    expect(wf.concurrency?.group).toBe('gateway-rollout-tracker')
+  })
+
+  it('keeps tracker issue URL fro-bot/.github#3512 in the prompt', () => {
+    const jobs = parsed.jobs
+    const trackerJob = jobs['update-rollout-tracker']
+    // The prompt is in with.prompt or in a step
+    const withPrompt = (trackerJob?.with?.prompt as string | undefined) ?? ''
+    const stepPrompts = trackerJob?.steps?.map(s => s.run ?? '').join('\n') ?? ''
+    const allText = withPrompt + stepPrompts
+    expect(allText).toContain('fro-bot/.github#3512')
+  })
+
+  it('keeps project URL https://github.com/users/fro-bot/projects/1 in the prompt', () => {
+    const jobs = parsed.jobs
+    const trackerJob = jobs['update-rollout-tracker']
+    const withPrompt = (trackerJob?.with?.prompt as string | undefined) ?? ''
+    const stepPrompts = trackerJob?.steps?.map(s => s.run ?? '').join('\n') ?? ''
+    const allText = withPrompt + stepPrompts
+    expect(allText).toContain('https://github.com/users/fro-bot/projects/1')
+  })
+
+  it('passes the preflight hash and snapshot into the Fro Bot prompt', () => {
+    const trackerJob = parsed.jobs['update-rollout-tracker']
+    const withPrompt = (trackerJob?.with?.prompt as string | undefined) ?? ''
+
+    expect(withPrompt).toContain('needs.preflight.outputs.hash')
+    expect(withPrompt).toContain('needs.preflight.outputs.snapshot')
+  })
+})

--- a/scripts/rollout-tracker-snapshot.test.ts
+++ b/scripts/rollout-tracker-snapshot.test.ts
@@ -387,6 +387,24 @@ describe('selectLatestMarkerCommentBody', () => {
     ).toBe(second)
   })
 
+  it('selects a marker comment authored by fro-bot[bot] (GitHub App identity)', () => {
+    const markerBody = `<!-- ${MARKER_PREFIX}${JSON.stringify({hash: 'bot-hash', snapshot: {items: []}})} -->`
+
+    expect(selectLatestMarkerCommentBody([{author: {login: 'fro-bot[bot]'}, body: markerBody}])).toBe(markerBody)
+  })
+
+  it('prefers the latest marker across both fro-bot and fro-bot[bot] identities', () => {
+    const patMarker = `<!-- ${MARKER_PREFIX}${JSON.stringify({hash: 'pat', snapshot: {items: []}})} -->`
+    const appMarker = `<!-- ${MARKER_PREFIX}${JSON.stringify({hash: 'app', snapshot: {items: []}})} -->`
+
+    expect(
+      selectLatestMarkerCommentBody([
+        {author: {login: 'fro-bot'}, body: patMarker},
+        {author: {login: 'fro-bot[bot]'}, body: appMarker},
+      ]),
+    ).toBe(appMarker)
+  })
+
   it('returns an empty body when no fro-bot marker exists', () => {
     expect(
       selectLatestMarkerCommentBody([

--- a/scripts/rollout-tracker-snapshot.ts
+++ b/scripts/rollout-tracker-snapshot.ts
@@ -1,0 +1,435 @@
+import {createHash} from 'node:crypto'
+import process from 'node:process'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** A single tracked issue/PR's state from the GitHub API. */
+export interface IssueState {
+  number: number
+  repo: string
+  state: 'open' | 'closed' | 'merged'
+  title: string
+  closed_at: string | null
+  labels: string[]
+}
+
+/** A single GitHub Project item with relevant fields. */
+export interface ProjectItem {
+  id: string
+  content_number: number
+  content_repo: string
+  status: string | null
+  readiness: string | null
+  gate: string | null
+}
+
+/** A normalized snapshot item — excludes volatile prose fields. */
+export interface SnapshotItem {
+  content_number: number
+  content_repo: string
+  status: string | null
+  readiness: string | null
+  gate: string | null
+  issue_state: 'open' | 'closed' | 'merged' | null
+  issue_closed_at: string | null
+  issue_labels: string[]
+}
+
+/** The full rollout snapshot — only stable, gate-relevant fields. */
+export interface RolloutSnapshot {
+  items: SnapshotItem[]
+}
+
+/** The data embedded in the HTML marker comment. */
+export interface MarkerData {
+  hash: string
+  snapshot: RolloutSnapshot
+}
+
+/** The decision output from decideComment. */
+export interface CommentDecision {
+  should_comment: boolean
+  reason: string
+  hash: string
+  snapshot: RolloutSnapshot
+}
+
+export interface TrackerComment {
+  author: {login: string}
+  body: string
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/**
+ * HTML marker prefix embedded in tracker comments.
+ * Full marker: `<!-- gateway-rollout-tracker:{...} -->`
+ */
+export const MARKER_PREFIX = 'gateway-rollout-tracker:'
+
+// ─── Core functions (exported for tests) ─────────────────────────────────────
+
+/**
+ * The custom field name used by the GitHub Project for the gate column.
+ * `gh project item-list --format json` exposes it as a top-level key with
+ * this exact string (spaces included).
+ */
+export const GATE_FIELD_NAME = 'gateway Unit Gate'
+
+/**
+ * Normalise a raw `gh project item-list --format json` item into a ProjectItem.
+ *
+ * The gate value lives under the key `"gateway Unit Gate"` (with spaces), not
+ * `"gate"`. Everything else follows the standard content/repository shape.
+ */
+export function normaliseRawProjectItem(raw: Record<string, unknown>): ProjectItem {
+  const content = raw.content as Record<string, unknown> | null | undefined
+  return {
+    id: String(raw.id ?? ''),
+    content_number: Number(content?.number ?? raw.number ?? 0),
+    content_repo: String(content?.repository ?? raw.repository ?? ''),
+    status: (raw.status as string | null) ?? null,
+    readiness: (raw.readiness as string | null) ?? null,
+    gate: (raw[GATE_FIELD_NAME] as string | null) ?? null,
+  }
+}
+
+/**
+ * Normalise a raw GitHub API state string into the canonical IssueState state.
+ *
+ * GitHub returns uppercase strings: `OPEN`, `CLOSED`, `MERGED`.
+ * PRs that have been merged come back as `MERGED`, not `CLOSED`.
+ */
+export function normaliseIssueState(raw: string): 'open' | 'closed' | 'merged' {
+  if (raw === 'CLOSED') return 'closed'
+  if (raw === 'MERGED') return 'merged'
+  return 'open'
+}
+
+/**
+ * Build a normalized, deterministic snapshot from Project items and issue states.
+ *
+ * Volatile fields (title, body, prose) are excluded. Items are sorted by
+ * repo+number for stable ordering. Issue state is merged by matching
+ * content_repo+content_number to issue repo+number.
+ */
+export function buildSnapshot(items: ProjectItem[], issues: IssueState[]): RolloutSnapshot {
+  // Build a lookup map: "repo#number" → IssueState
+  const issueMap = new Map<string, IssueState>()
+  for (const issue of issues) {
+    issueMap.set(`${issue.repo}#${issue.number}`, issue)
+  }
+
+  const snapshotItems: SnapshotItem[] = items.map(item => {
+    const key = `${item.content_repo}#${item.content_number}`
+    const issue = issueMap.get(key)
+    return {
+      content_number: item.content_number,
+      content_repo: item.content_repo,
+      status: item.status,
+      readiness: item.readiness,
+      gate: item.gate,
+      issue_state: issue?.state ?? null,
+      issue_closed_at: issue?.closed_at ?? null,
+      issue_labels: issue?.labels ?? [],
+    }
+  })
+
+  // Sort deterministically: repo ascending, then number ascending
+  snapshotItems.sort((a, b) => {
+    const repoCompare = a.content_repo.localeCompare(b.content_repo)
+    if (repoCompare !== 0) return repoCompare
+    return a.content_number - b.content_number
+  })
+
+  return {items: snapshotItems}
+}
+
+/**
+ * Produce a stable SHA-256 hex hash of a RolloutSnapshot.
+ *
+ * Keys are sorted recursively so insertion order does not affect the hash.
+ * No volatile fields should be present in the snapshot at this point.
+ */
+export function hashSnapshot(snapshot: RolloutSnapshot): string {
+  const stable = JSON.stringify(toGatingEvidence(snapshot), sortedReplacer)
+  return createHash('sha256').update(stable).digest('hex')
+}
+
+function toGatingEvidence(snapshot: RolloutSnapshot): RolloutSnapshot {
+  return {
+    items: snapshot.items.map(item => ({
+      content_number: item.content_number,
+      content_repo: item.content_repo,
+      status: null,
+      readiness: null,
+      gate: null,
+      issue_state: item.issue_state,
+      issue_closed_at: null,
+      issue_labels: [],
+    })),
+  }
+}
+
+/**
+ * JSON.stringify replacer that sorts object keys alphabetically.
+ * Arrays preserve their order (deterministic from buildSnapshot sort).
+ */
+function sortedReplacer(_key: string, value: unknown): unknown {
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    const sorted: Record<string, unknown> = {}
+    for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+      sorted[k] = (value as Record<string, unknown>)[k]
+    }
+    return sorted
+  }
+  return value
+}
+
+/**
+ * Extract the previous MarkerData from the latest `<!-- gateway-rollout-tracker:{...} -->`
+ * HTML comment in a tracker comment body.
+ *
+ * Returns null if no marker is found or if the marker JSON is malformed.
+ * When multiple markers are present, the LAST one wins (latest state).
+ */
+export function extractPreviousMarker(body: string): MarkerData | null {
+  if (!body) return null
+
+  // Match all occurrences; take the last one.
+  // Capture everything between the prefix and the closing --> (non-greedy).
+  const markerRegex = /<!--\s*gateway-rollout-tracker:([\s\S]*?)-->/g
+  let lastMatch: RegExpExecArray | null = null
+
+  for (;;) {
+    const match = markerRegex.exec(body)
+    if (match === null) break
+    lastMatch = match
+  }
+
+  if (lastMatch === null) return null
+
+  const jsonStr = lastMatch[1]
+  if (jsonStr === undefined) return null
+
+  try {
+    const parsed: unknown = JSON.parse(jsonStr)
+    if (
+      parsed === null ||
+      typeof parsed !== 'object' ||
+      Array.isArray(parsed) ||
+      typeof (parsed as Record<string, unknown>).hash !== 'string' ||
+      typeof (parsed as Record<string, unknown>).snapshot !== 'object'
+    ) {
+      process.stderr.write('rollout-tracker-snapshot: marker JSON has unexpected shape\n')
+      return null
+    }
+    return parsed as MarkerData
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    process.stderr.write(`rollout-tracker-snapshot: failed to parse marker JSON: ${detail}\n`)
+    return null
+  }
+}
+
+export function selectLatestMarkerCommentBody(comments: TrackerComment[]): string {
+  return (
+    comments.findLast(comment => comment.author.login === 'fro-bot' && extractPreviousMarker(comment.body) !== null)
+      ?.body ?? ''
+  )
+}
+
+/**
+ * Decide whether to post a tracker comment.
+ *
+ * - Cold start (previousMarker === null): always comment to seed state.
+ * - Same hash as previous: no gating transition, skip.
+ * - Different hash: state changed, comment.
+ */
+export function decideComment(
+  snapshot: RolloutSnapshot,
+  hash: string,
+  previousMarker: MarkerData | null,
+): CommentDecision {
+  if (previousMarker === null) {
+    return {
+      should_comment: true,
+      reason: 'cold start — no prior marker found; seeding initial state',
+      hash,
+      snapshot,
+    }
+  }
+
+  if (hash === previousMarker.hash) {
+    return {
+      should_comment: false,
+      reason: 'no gating transition — snapshot hash unchanged since last comment',
+      hash,
+      snapshot,
+    }
+  }
+
+  return {
+    should_comment: true,
+    reason: `gating transition detected — hash changed from ${previousMarker.hash.slice(0, 8)} to ${hash.slice(0, 8)}`,
+    hash,
+    snapshot,
+  }
+}
+
+// ─── CLI entrypoint ───────────────────────────────────────────────────────────
+
+/**
+ * CLI mode: runs the preflight check using `gh` to fetch live data.
+ *
+ * Outputs JSON to stdout: { should_comment, reason, hash, snapshot }
+ * Exits non-zero if Project #1 access fails (fail loudly, not silently).
+ *
+ * Accepts optional injected fixtures via environment variables for testing:
+ *   ROLLOUT_TRACKER_ITEMS_JSON  — JSON array of ProjectItem[]
+ *   ROLLOUT_TRACKER_ISSUES_JSON — JSON array of IssueState[]
+ *   ROLLOUT_TRACKER_COMMENT_BODY — raw body of the latest @fro-bot tracker comment
+ */
+async function main(): Promise<void> {
+  const trackerIssue = process.env.ROLLOUT_TRACKER_ISSUE ?? 'fro-bot/.github#3512'
+  const projectUrl = process.env.ROLLOUT_TRACKER_PROJECT ?? 'https://github.com/users/fro-bot/projects/1'
+
+  let items: ProjectItem[]
+  let issues: IssueState[]
+  let latestCommentBody: string
+
+  // Allow fixture injection for tests / dry-run
+  if (process.env.ROLLOUT_TRACKER_ITEMS_JSON === undefined) {
+    // Fetch from GitHub Project via gh CLI
+    // Project number 1 for user fro-bot
+    const projectNumber = '1'
+    const projectOwner = 'fro-bot'
+    let rawItems: string
+    try {
+      const {execSync} = await import('node:child_process')
+      rawItems = execSync(`gh project item-list ${projectNumber} --owner ${projectOwner} --format json --limit 100`, {
+        encoding: 'utf8',
+      })
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error)
+      process.stderr.write(`rollout-tracker-snapshot: FATAL — failed to read Project ${projectUrl}: ${detail}\n`)
+      process.stderr.write(
+        'rollout-tracker-snapshot: refusing to treat Project access failure as no-drift; exiting 1\n',
+      )
+      process.exit(1)
+    }
+
+    try {
+      const parsed: unknown = JSON.parse(rawItems)
+      // gh project item-list --format json returns { items: [...] }
+      const rawArr =
+        parsed !== null && typeof parsed === 'object' && 'items' in parsed
+          ? (parsed as {items: unknown[]}).items
+          : (parsed as unknown[])
+      items = (rawArr as Record<string, unknown>[]).map(raw => normaliseRawProjectItem(raw))
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error)
+      process.stderr.write(`rollout-tracker-snapshot: failed to parse project items: ${detail}\n`)
+      process.exit(1)
+    }
+  } else {
+    try {
+      items = JSON.parse(process.env.ROLLOUT_TRACKER_ITEMS_JSON) as ProjectItem[]
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error)
+      process.stderr.write(`rollout-tracker-snapshot: failed to parse ROLLOUT_TRACKER_ITEMS_JSON: ${detail}\n`)
+      process.exit(1)
+    }
+  }
+
+  if (process.env.ROLLOUT_TRACKER_ISSUES_JSON === undefined) {
+    // Fetch tracked issue states via gh CLI
+    const trackedIssues = [
+      'fro-bot/.github#3512',
+      'fro-bot/agent#907',
+      'fro-bot/agent#929',
+      'fro-bot/dashboard#24',
+      'fro-bot/dashboard#25',
+      'fro-bot/dashboard#26',
+      'marcusrbrown/infra#579',
+      'marcusrbrown/infra#580',
+      'marcusrbrown/infra#581',
+    ]
+    issues = []
+    const {execSync} = await import('node:child_process')
+    for (const ref of trackedIssues) {
+      const [repo, numStr] = ref.split('#')
+      if (repo === undefined || numStr === undefined) continue
+      try {
+        const raw = execSync(`gh issue view ${numStr} --repo ${repo} --json number,state,title,closedAt,labels`, {
+          encoding: 'utf8',
+        })
+        const parsed = JSON.parse(raw) as {
+          number: number
+          state: string
+          title: string
+          closedAt: string | null
+          labels: {name: string}[]
+        }
+        issues.push({
+          number: parsed.number,
+          repo,
+          state: normaliseIssueState(parsed.state),
+          title: parsed.title,
+          closed_at: parsed.closedAt,
+          labels: parsed.labels.map(l => l.name),
+        })
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error)
+        process.stderr.write(`rollout-tracker-snapshot: FATAL — failed to fetch ${ref}: ${detail}\n`)
+        process.stderr.write(
+          'rollout-tracker-snapshot: refusing to treat tracked issue access failure as no-drift; exiting 1\n',
+        )
+        process.exit(1)
+      }
+    }
+  } else {
+    try {
+      issues = JSON.parse(process.env.ROLLOUT_TRACKER_ISSUES_JSON) as IssueState[]
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error)
+      process.stderr.write(`rollout-tracker-snapshot: failed to parse ROLLOUT_TRACKER_ISSUES_JSON: ${detail}\n`)
+      process.exit(1)
+    }
+  }
+
+  if (process.env.ROLLOUT_TRACKER_COMMENT_BODY === undefined) {
+    // Fetch latest @fro-bot comment from tracker issue
+    const [trackerRepo, trackerNumStr] = trackerIssue.split('#')
+    if (trackerRepo === undefined || trackerNumStr === undefined) {
+      process.stderr.write(`rollout-tracker-snapshot: invalid ROLLOUT_TRACKER_ISSUE format: ${trackerIssue}\n`)
+      process.exit(1)
+    }
+    try {
+      const {execSync} = await import('node:child_process')
+      const raw = execSync(`gh issue view ${trackerNumStr} --repo ${trackerRepo} --comments --json comments`, {
+        encoding: 'utf8',
+      })
+      const parsed = JSON.parse(raw) as {comments: TrackerComment[]}
+      latestCommentBody = selectLatestMarkerCommentBody(parsed.comments)
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error)
+      process.stderr.write(`rollout-tracker-snapshot: warning — failed to fetch tracker comments: ${detail}\n`)
+      latestCommentBody = ''
+    }
+  } else {
+    latestCommentBody = process.env.ROLLOUT_TRACKER_COMMENT_BODY
+  }
+
+  const snapshot = buildSnapshot(items, issues)
+  const hash = hashSnapshot(snapshot)
+  const previousMarker = extractPreviousMarker(latestCommentBody)
+  const decision = decideComment(snapshot, hash, previousMarker)
+
+  process.stdout.write(`${JSON.stringify(decision)}\n`)
+  process.exit(0)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}

--- a/scripts/rollout-tracker-snapshot.ts
+++ b/scripts/rollout-tracker-snapshot.ts
@@ -67,6 +67,17 @@ export interface TrackerComment {
  */
 export const MARKER_PREFIX = 'gateway-rollout-tracker:'
 
+/**
+ * Fro Bot identities permitted to author tracker marker comments.
+ *
+ * GitHub issues/PRs surface two distinct login values depending on how the bot
+ * authenticated: `fro-bot` (PAT / classic token) and `fro-bot[bot]` (GitHub
+ * App installation token). Both are legitimate and must be treated as equivalent.
+ *
+ * Kept symmetric with the `FROBOT_AUTHORS` set in `scripts/check-wiki-authority.ts`.
+ */
+export const FROBOT_COMMENT_AUTHORS: ReadonlySet<string> = new Set(['fro-bot', 'fro-bot[bot]'])
+
 // ─── Core functions (exported for tests) ─────────────────────────────────────
 
 /**
@@ -234,8 +245,9 @@ export function extractPreviousMarker(body: string): MarkerData | null {
 
 export function selectLatestMarkerCommentBody(comments: TrackerComment[]): string {
   return (
-    comments.findLast(comment => comment.author.login === 'fro-bot' && extractPreviousMarker(comment.body) !== null)
-      ?.body ?? ''
+    comments.findLast(
+      comment => FROBOT_COMMENT_AUTHORS.has(comment.author.login) && extractPreviousMarker(comment.body) !== null,
+    )?.body ?? ''
   )
 }
 


### PR DESCRIPTION
## Summary

Adds a deterministic preflight gate to the Gateway Rollout Tracker so the agent only posts tracker updates when the tracked rollout state actually changes.

## Changes

- add `scripts/rollout-tracker-snapshot.ts` to read Project #1 and tracked issue/PR state, normalize a stable snapshot, and hash only gating evidence
- gate the `gateway-rollout-tracker.yaml` reusable Fro Bot call on `should_comment == true`
- preserve full snapshot data in the tracker marker while ignoring field-only/prose-only drift for comment decisions
- add tests covering Project field mapping, merged PR state, marker selection, no-op behavior, and CLI fixture replay

## Verification

- `pnpm test scripts/rollout-tracker-snapshot.test.ts`
- `pnpm exec actionlint .github/workflows/gateway-rollout-tracker.yaml .github/workflows/fro-bot.yaml`
- `pnpm check-types`
- `pnpm lint`
- `pnpm bootstrap && pnpm check-types && pnpm lint && pnpm test`
