### PR TITLE
fix(workflows): derive tracker state from project

### DIFF
--- a/.github/workflows/gateway-rollout-tracker.yaml
+++ b/.github/workflows/gateway-rollout-tracker.yaml
@@ -75,23 +75,15 @@ jobs:
         been detected since the last tracker comment — narrate only the
         transition that triggered this run.
 
-        Tracked issues to review:
-        - fro-bot/agent#907
-        - fro-bot/agent#929
-        - fro-bot/dashboard#24
-        - fro-bot/dashboard#25
-        - fro-bot/dashboard#26
-        - marcusrbrown/infra#579
-        - marcusrbrown/infra#580
-        - marcusrbrown/infra#581
-
-        For each tracked issue: check whether it has been closed, whether a
-        deployment has happened, or whether a supporting feature has been
-        released. Update the GitHub Project item state/fields when the evidence
-        changes readiness. Use fro-bot/.github#3512 as the routine status log;
-        comment on tracked issues only when there is issue-specific transition
-        evidence that has not already been acknowledged, and link those comments
-        back to fro-bot/.github#3512.
+        Use the preflight snapshot and Project items as the tracked rollout
+        source of truth; do not rely on a hardcoded issue list. For each tracked
+        Project item: check whether it has been closed, whether a deployment has
+        happened, or whether a supporting feature has been released. Update the
+        GitHub Project item state/fields when the evidence changes readiness.
+        Use fro-bot/.github#3512 as the routine status log; comment on tracked
+        issues only when there is issue-specific transition evidence that has
+        not already been acknowledged, and link those comments back to
+        fro-bot/.github#3512.
 
         All status comments must begin with @fro-bot or explicitly mention
         @fro-bot. Post status updates in a concise, structured format.

--- a/scripts/rollout-tracker-snapshot.test.ts
+++ b/scripts/rollout-tracker-snapshot.test.ts
@@ -56,6 +56,7 @@ function runCliFixture(params: {items: ProjectItem[]; issues: IssueState[]; comm
       ROLLOUT_TRACKER_ISSUES_JSON: JSON.stringify(params.issues),
       ROLLOUT_TRACKER_ITEMS_JSON: JSON.stringify(params.items),
     },
+    stdio: ['ignore', 'pipe', 'pipe'],
   })
 
   return JSON.parse(stdout) as CommentDecision
@@ -670,6 +671,161 @@ describe('buildSnapshot — MERGED PR state', () => {
     const mergedSnap = buildSnapshot([base], [makeIssueState({number: 929, repo: 'fro-bot/agent', state: 'merged'})])
     expect(hashSnapshot(mergedSnap)).not.toBe(hashSnapshot(openSnap))
     expect(hashSnapshot(mergedSnap)).not.toBe(hashSnapshot(closedSnap))
+  })
+})
+
+// ─── deriveTrackedIssueRefs ───────────────────────────────────────────────────
+
+describe('deriveTrackedIssueRefs', () => {
+  // Import lazily so the test file compiles even before the export exists
+  // (the import at the top of the file will fail if the export is missing)
+  it('derives refs from supported project items', async () => {
+    const {deriveTrackedIssueRefs} = await import('./rollout-tracker-snapshot.ts')
+    const items: ProjectItem[] = [
+      makeProjectItem({content_number: 931, content_repo: 'fro-bot/agent'}),
+      makeProjectItem({content_number: 907, content_repo: 'fro-bot/agent'}),
+    ]
+    const refs = deriveTrackedIssueRefs(items)
+    expect(refs).toContain('fro-bot/agent#931')
+    expect(refs).toContain('fro-bot/agent#907')
+    expect(refs).toHaveLength(2)
+  })
+
+  it('deduplicates refs when the same repo#number appears multiple times', async () => {
+    const {deriveTrackedIssueRefs} = await import('./rollout-tracker-snapshot.ts')
+    const items: ProjectItem[] = [
+      makeProjectItem({content_number: 907, content_repo: 'fro-bot/agent'}),
+      makeProjectItem({content_number: 907, content_repo: 'fro-bot/agent'}),
+    ]
+    const refs = deriveTrackedIssueRefs(items)
+    expect(refs).toHaveLength(1)
+    expect(refs[0]).toBe('fro-bot/agent#907')
+  })
+
+  it('excludes items with empty content_repo', async () => {
+    const {deriveTrackedIssueRefs} = await import('./rollout-tracker-snapshot.ts')
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const items: ProjectItem[] = [
+      makeProjectItem({content_number: 907, content_repo: ''}),
+      makeProjectItem({content_number: 929, content_repo: 'fro-bot/agent'}),
+    ]
+    const refs = deriveTrackedIssueRefs(items)
+    expect(refs).not.toContain('#907')
+    expect(refs).toContain('fro-bot/agent#929')
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('unsupported'))
+    stderrSpy.mockRestore()
+  })
+
+  it('excludes items with content_number === 0', async () => {
+    const {deriveTrackedIssueRefs} = await import('./rollout-tracker-snapshot.ts')
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const items: ProjectItem[] = [
+      makeProjectItem({content_number: 0, content_repo: 'fro-bot/agent'}),
+      makeProjectItem({content_number: 929, content_repo: 'fro-bot/agent'}),
+    ]
+    const refs = deriveTrackedIssueRefs(items)
+    expect(refs).not.toContain('fro-bot/agent#0')
+    expect(refs).toContain('fro-bot/agent#929')
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('unsupported'))
+    stderrSpy.mockRestore()
+  })
+
+  it('returns empty array when all items are unsupported', async () => {
+    const {deriveTrackedIssueRefs} = await import('./rollout-tracker-snapshot.ts')
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const items: ProjectItem[] = [makeProjectItem({content_number: 0, content_repo: ''})]
+    const refs = deriveTrackedIssueRefs(items)
+    expect(refs).toHaveLength(0)
+    expect(stderrSpy).toHaveBeenCalled()
+    stderrSpy.mockRestore()
+  })
+})
+
+// ─── Project-derived state: fro-bot/agent#931 ────────────────────────────────
+
+describe('Project-derived state: fro-bot/agent#931', () => {
+  it('agent#931 derives a tracked ref from Project items (not static list)', async () => {
+    const {deriveTrackedIssueRefs} = await import('./rollout-tracker-snapshot.ts')
+    const items: ProjectItem[] = [makeProjectItem({content_number: 931, content_repo: 'fro-bot/agent'})]
+    const refs = deriveTrackedIssueRefs(items)
+    expect(refs).toContain('fro-bot/agent#931')
+  })
+
+  it('agent#931 can receive issue_state merged without being in a static list', () => {
+    const items: ProjectItem[] = [makeProjectItem({content_number: 931, content_repo: 'fro-bot/agent'})]
+    const issues: IssueState[] = [
+      makeIssueState({number: 931, repo: 'fro-bot/agent', state: 'merged', closed_at: '2026-06-17T00:00:00Z'}),
+    ]
+    const snapshot = buildSnapshot(items, issues)
+    expect(snapshot.items[0]?.issue_state).toBe('merged')
+    expect(snapshot.items[0]?.content_number).toBe(931)
+  })
+
+  it('CLI fixture: agent#931 appears in snapshot with merged state via ROLLOUT_TRACKER_ISSUES_JSON', () => {
+    const items: ProjectItem[] = [makeProjectItem({content_number: 931, content_repo: 'fro-bot/agent'})]
+    const issues: IssueState[] = [
+      makeIssueState({number: 931, repo: 'fro-bot/agent', state: 'merged', closed_at: '2026-06-17T00:00:00Z'}),
+    ]
+    const result = runCliFixture({items, issues})
+    const item931 = result.snapshot.items.find(i => i.content_number === 931 && i.content_repo === 'fro-bot/agent')
+    expect(item931).toBeDefined()
+    expect(item931?.issue_state).toBe('merged')
+  })
+})
+
+// ─── Unsupported Project items excluded from snapshot ─────────────────────────
+
+describe('unsupported Project items excluded from snapshot', () => {
+  it('buildSnapshot excludes items with empty content_repo', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const items: ProjectItem[] = [
+      makeProjectItem({content_number: 907, content_repo: ''}),
+      makeProjectItem({content_number: 929, content_repo: 'fro-bot/agent'}),
+    ]
+    const issues: IssueState[] = [makeIssueState({number: 929, repo: 'fro-bot/agent', state: 'open'})]
+    const snapshot = buildSnapshot(items, issues)
+    // The item with empty repo must not appear in the snapshot
+    expect(snapshot.items.every(i => i.content_repo !== '')).toBe(true)
+    expect(snapshot.items).toHaveLength(1)
+    expect(snapshot.items[0]?.content_number).toBe(929)
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('unsupported'))
+    stderrSpy.mockRestore()
+  })
+
+  it('buildSnapshot excludes items with content_number === 0', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const items: ProjectItem[] = [
+      makeProjectItem({content_number: 0, content_repo: 'fro-bot/agent'}),
+      makeProjectItem({content_number: 929, content_repo: 'fro-bot/agent'}),
+    ]
+    const issues: IssueState[] = [makeIssueState({number: 929, repo: 'fro-bot/agent', state: 'open'})]
+    const snapshot = buildSnapshot(items, issues)
+    expect(snapshot.items.every(i => i.content_number !== 0)).toBe(true)
+    expect(snapshot.items).toHaveLength(1)
+    expect(snapshot.items[0]?.content_number).toBe(929)
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('unsupported'))
+    stderrSpy.mockRestore()
+  })
+
+  it('CLI fixture: unsupported items do not appear in snapshot output', () => {
+    const items: ProjectItem[] = [
+      makeProjectItem({content_number: 0, content_repo: ''}),
+      makeProjectItem({content_number: 929, content_repo: 'fro-bot/agent'}),
+    ]
+    const issues: IssueState[] = [makeIssueState({number: 929, repo: 'fro-bot/agent', state: 'open'})]
+    const result = runCliFixture({items, issues})
+    expect(result.snapshot.items.every(i => i.content_number !== 0 && i.content_repo !== '')).toBe(true)
+    expect(result.snapshot.items).toHaveLength(1)
+  })
+})
+
+// ─── Static trackedIssues removed from production code ───────────────────────
+
+describe('static trackedIssues removed from production code', () => {
+  it('production source does not contain a hardcoded trackedIssues array', () => {
+    const src = readFileSync(resolve(import.meta.dirname, './rollout-tracker-snapshot.ts'), 'utf8')
+    // The static list was defined as `const trackedIssues = [...]`
+    expect(src).not.toMatch(/const\s+trackedIssues\s*=\s*\[/)
   })
 })
 

--- a/scripts/rollout-tracker-snapshot.test.ts
+++ b/scripts/rollout-tracker-snapshot.test.ts
@@ -829,6 +829,23 @@ describe('static trackedIssues removed from production code', () => {
   })
 })
 
+// ─── Shell-injection regression: issue fetch uses execFileSync argv form ──────
+
+describe('shell-injection regression: issue fetch uses execFileSync argv form', () => {
+  it('production source does not use shell-string interpolation for gh issue view', () => {
+    const src = readFileSync(resolve(import.meta.dirname, './rollout-tracker-snapshot.ts'), 'utf8')
+    // The vulnerable pattern: execSync(`gh issue view ${numStr} --repo ${repo} ...`)
+    // Any template literal containing "gh issue view" is the shell-injection risk.
+    expect(src).not.toMatch(/execSync\s*\(\s*`gh issue view/)
+  })
+
+  it('production source uses execFileSync with argv array for gh issue view', () => {
+    const src = readFileSync(resolve(import.meta.dirname, './rollout-tracker-snapshot.ts'), 'utf8')
+    // Must use execFileSync('gh', ['issue', 'view', ...]) form
+    expect(src).toMatch(/execFileSync\s*\(\s*['"]gh['"]/)
+  })
+})
+
 // ─── Workflow shape regression ────────────────────────────────────────────────
 
 interface WorkflowJob {

--- a/scripts/rollout-tracker-snapshot.ts
+++ b/scripts/rollout-tracker-snapshot.ts
@@ -118,11 +118,42 @@ export function normaliseIssueState(raw: string): 'open' | 'closed' | 'merged' {
 }
 
 /**
+ * Derive a deduplicated list of `"repo#number"` ref strings from Project items.
+ *
+ * Items with an empty `content_repo` or a `content_number` of `0` are
+ * considered unsupported (e.g. draft cards, notes, or items without a linked
+ * issue/PR). Each unsupported item emits a warning to stderr and is excluded
+ * from the returned set.
+ */
+export function deriveTrackedIssueRefs(items: ProjectItem[]): string[] {
+  const seen = new Set<string>()
+  for (const item of filterSupportedProjectItems(items)) {
+    seen.add(`${item.content_repo}#${item.content_number}`)
+  }
+  return [...seen]
+}
+
+function filterSupportedProjectItems(items: ProjectItem[]): ProjectItem[] {
+  return items.filter(item => {
+    if (item.content_repo === '' || item.content_number === 0) {
+      process.stderr.write(
+        `rollout-tracker-snapshot: warning — skipping unsupported Project item (id=${item.id}, repo="${item.content_repo}", number=${item.content_number})\n`,
+      )
+      return false
+    }
+    return true
+  })
+}
+
+/**
  * Build a normalized, deterministic snapshot from Project items and issue states.
  *
  * Volatile fields (title, body, prose) are excluded. Items are sorted by
  * repo+number for stable ordering. Issue state is merged by matching
  * content_repo+content_number to issue repo+number.
+ *
+ * Unsupported items (`content_repo === ''` or `content_number === 0`) are
+ * excluded from the snapshot with a stderr warning.
  */
 export function buildSnapshot(items: ProjectItem[], issues: IssueState[]): RolloutSnapshot {
   // Build a lookup map: "repo#number" → IssueState
@@ -131,7 +162,9 @@ export function buildSnapshot(items: ProjectItem[], issues: IssueState[]): Rollo
     issueMap.set(`${issue.repo}#${issue.number}`, issue)
   }
 
-  const snapshotItems: SnapshotItem[] = items.map(item => {
+  const supportedItems = filterSupportedProjectItems(items)
+
+  const snapshotItems: SnapshotItem[] = supportedItems.map(item => {
     const key = `${item.content_repo}#${item.content_number}`
     const issue = issueMap.get(key)
     return {
@@ -355,18 +388,8 @@ async function main(): Promise<void> {
   }
 
   if (process.env.ROLLOUT_TRACKER_ISSUES_JSON === undefined) {
-    // Fetch tracked issue states via gh CLI
-    const trackedIssues = [
-      'fro-bot/.github#3512',
-      'fro-bot/agent#907',
-      'fro-bot/agent#929',
-      'fro-bot/dashboard#24',
-      'fro-bot/dashboard#25',
-      'fro-bot/dashboard#26',
-      'marcusrbrown/infra#579',
-      'marcusrbrown/infra#580',
-      'marcusrbrown/infra#581',
-    ]
+    items = filterSupportedProjectItems(items)
+    const trackedIssues = deriveTrackedIssueRefs(items)
     issues = []
     const {execSync} = await import('node:child_process')
     for (const ref of trackedIssues) {

--- a/scripts/rollout-tracker-snapshot.ts
+++ b/scripts/rollout-tracker-snapshot.ts
@@ -391,14 +391,16 @@ async function main(): Promise<void> {
     items = filterSupportedProjectItems(items)
     const trackedIssues = deriveTrackedIssueRefs(items)
     issues = []
-    const {execSync} = await import('node:child_process')
+    const {execFileSync} = await import('node:child_process')
     for (const ref of trackedIssues) {
       const [repo, numStr] = ref.split('#')
       if (repo === undefined || numStr === undefined) continue
       try {
-        const raw = execSync(`gh issue view ${numStr} --repo ${repo} --json number,state,title,closedAt,labels`, {
-          encoding: 'utf8',
-        })
+        const raw = execFileSync(
+          'gh',
+          ['issue', 'view', numStr, '--repo', repo, '--json', 'number,state,title,closedAt,labels'],
+          {encoding: 'utf8'},
+        )
         const parsed = JSON.parse(raw) as {
           number: number
           state: string
@@ -441,10 +443,12 @@ async function main(): Promise<void> {
       process.exit(1)
     }
     try {
-      const {execSync} = await import('node:child_process')
-      const raw = execSync(`gh issue view ${trackerNumStr} --repo ${trackerRepo} --comments --json comments`, {
-        encoding: 'utf8',
-      })
+      const {execFileSync} = await import('node:child_process')
+      const raw = execFileSync(
+        'gh',
+        ['issue', 'view', trackerNumStr, '--repo', trackerRepo, '--comments', '--json', 'comments'],
+        {encoding: 'utf8'},
+      )
       const parsed = JSON.parse(raw) as {comments: TrackerComment[]}
       latestCommentBody = selectLatestMarkerCommentBody(parsed.comments)
     } catch (error) {


### PR DESCRIPTION
## Summary

Makes Project #1 the source of truth for Gateway rollout tracker state, so newly added rollout items are tracked without editing the workflow script.

## Changes

- derive issue/PR refs from Project items instead of a static list
- skip unsupported Project items with explicit warnings instead of snapshotting `issue_state: null`
- remove stale hardcoded tracked-issue guidance from the tracker workflow prompt
- add tests for Project-derived refs, unsupported items, and `fro-bot/agent#931` state coverage

## Verification

- `pnpm test scripts/rollout-tracker-snapshot.test.ts`
- live preflight reports `fro-bot/agent#931=merged//Unit 2//done`
- `pnpm exec actionlint .github/workflows/gateway-rollout-tracker.yaml .github/workflows/fro-bot.yaml`
- `pnpm bootstrap && pnpm check-types && pnpm lint && pnpm test`
