### PR TITLE
docs: rebaseline Phase 1 status and north-star roadmap to shipped reality

### DIFF
--- a/docs/brainstorms/2026-06-15-fro-bot-personal-agent-north-star-requirements.md
+++ b/docs/brainstorms/2026-06-15-fro-bot-personal-agent-north-star-requirements.md
@@ -32,6 +32,31 @@ across repos, other agents, and eventually domains beyond software.
 | **Workflows** | Systematic (`marcusrbrown/systematic`) | Durable structured workflows (brainstorm/plan/work/review/compound) | The discipline layer for cross-repo planning and durable agent learning |
 | **Dashboard** | net-new | — | The operator's window and command surface (PWA) |
 
+## Rebaseline (2026-06-21) — program is running concurrent, not serial
+
+This doc's original roadmap recommended a serial Phase 1 → 2 → 3. Reality has diverged, and
+this note rebaselines it:
+
+- **Phase 1 (read-only dashboard):** code-complete in `fro-bot/dashboard` (Units 1-6) and
+  `marcusrbrown/infra` (deploy stack, Units 7-8) — **but not yet operationally verified**
+  (live deploy, production-shaped redaction exercise, and infra security posture are owed
+  before it can be called done). The R8 cross-source leak guard is genuinely implemented.
+- **Phase 2 (S1/S2 spine):** already in **active parallel implementation** in `fro-bot/agent`
+  (operator auth/OAuth/session/CSRF/allowlist + repo-authz helper merged through "Unit 3f",
+  `v0.69.0` released; umbrella `fro-bot/agent#907`). It is no longer "design now, build later."
+- **Phase 3 (interactive dashboard):** exploratory/mock work has started (dashboard `#37`
+  typed mock operator-client merged; `#26` mock operator UI skeleton open) — but this is
+  **gated on `fro-bot/agent` owning and freezing the canonical operator API contract**. The
+  mock must remain a non-canonical fixture, never the de facto API design.
+
+So the operating truth is **concurrent workstreams**, not strict serial phases. The serial
+roadmap below is retained as the original strategic recommendation, not the current schedule.
+
+Correction to the original framing: this doc said the Phase-1 visibility slice needs "no
+spine and no auth." The shipped Phase-1 dashboard *does* use operator auth (a dedicated GitHub
+OAuth App + signed cookie) because it holds a GitHub App read key and must be operator-only.
+"No spine" still holds; "no auth" does not.
+
 ## Current state (verified 2026-06-15)
 
 Grounded against live source, not aspiration:
@@ -170,6 +195,11 @@ they reach their ceiling once some operator surface exists. Everything else — 
 push, cross-agent coordination, negotiation — truly requires the spine.
 
 ## Phased roadmap
+
+> **Historical recommendation (2026-06-15).** This serial phasing was the original strategic
+> recommendation. As of the 2026-06-21 rebaseline above, Phases 1 and 2 are being built
+> concurrently and Phase 3 mock work has begun — read this section as the strategic intent,
+> not the current schedule.
 
 The phasing leads with the operator's stated pain — *visibility into work scattered across
 repos* — rather than the agent's internal autonomy. Relief comes first; the heavier

--- a/docs/plans/2026-06-15-001-feat-monitoring-dashboard-phase-1-plan.md
+++ b/docs/plans/2026-06-15-001-feat-monitoring-dashboard-phase-1-plan.md
@@ -1,13 +1,27 @@
 ---
 title: 'feat: Fro Bot monitoring dashboard — Phase 1'
 type: feat
-status: active
+status: code-complete-pending-verification
 date: 2026-06-15
 deepened: 2026-06-15
+reconciled: 2026-06-21
 origin: docs/brainstorms/2026-06-15-monitoring-dashboard-phase-1-requirements.md
 ---
 
 # feat: Fro Bot monitoring dashboard — Phase 1
+
+> **Reconciliation (2026-06-21).** All 8 units are CODE-COMPLETE and merged — Units 1-6 in
+> `fro-bot/dashboard`, Units 7-8 in `marcusrbrown/infra` — with the R8 cross-source leak
+> guard genuinely implemented (denylist-before-query + fail-closed). This is **not yet
+> operationally complete.** Owed before "done": (A) live-deploy verification
+> (`dashboard.fro.bot` TLS/`healthz`, OAuth E2E, protected-route denial, cookie/logout);
+> (B) production-shaped R8 verification (exercise the aggregator against real redacted data —
+> zero private name/`node_id` in SSR/api/logs/cache; fail-closed on metadata failure);
+> (C) infra security posture (App key file-mounted, container hardening, no secrets in logs,
+> revocation runbook); (D) a post-merge security review if Units 1-6 shipped without one.
+> Those verification steps are owned by the dedicated dashboard + infra sessions; this plan
+> stays `code-complete-pending-verification` until they pass. The unit checkboxes below
+> reflect code-merged status, not operational sign-off.
 
 **Target repos:** `fro-bot/dashboard` (net-new, the app) and `marcusrbrown/infra`
 (deploy wiring as `apps/dashboard`). Both need creating. This plan doc lives in
@@ -247,7 +261,7 @@ the `fro-bot/dashboard` build (Units 1-6) is handed to a separate parallel devel
 working against this plan; orchestration/planning stays in the originating session. Units 7-8
 (infra deploy) coordinate back.
 
-- [ ] **Unit 0: Provision prerequisites (one-time, manual)**
+- [x] **Unit 0: Provision prerequisites (one-time, manual)**
 
 **Goal:** All external resources that Units 1-6 depend on are created and secrets are
 provisioned before any code is written.
@@ -271,7 +285,7 @@ provisioned before any code is written.
 tests against real GitHub require the real key. Droplet provisioning is a one-time step here;
 Unit 7 owns the Compose/Caddy/deploy files.
 
-- [ ] **Unit 1: Bootstrap `fro-bot/dashboard` repo + Hono skeleton**
+- [x] **Unit 1: Bootstrap `fro-bot/dashboard` repo + Hono skeleton**
 
 **Goal:** Stand up the new repo with a minimal Hono server, TS/Node-24 config, pnpm, vitest,
 and a `/healthz` route.
@@ -298,7 +312,7 @@ shape; Hono node-server quickstart.
 
 **Verification:** server starts on Node 24, `/healthz` responds, vitest + lint green.
 
-- [ ] **Unit 2: Agent App client (second key) + installation enumeration**
+- [x] **Unit 2: Agent App client (second key) + installation enumeration**
 
 **Goal:** Octokit App client authenticating with the second Agent App private key; enumerate
 installations → read-only-scoped tokens → accessible repos.
@@ -347,7 +361,7 @@ Octokit-derived typing convention (`as unknown as` boundary casts, no `any`).
 **Verification:** with mocked Octokit, enumeration returns the unioned repo set; key never
 appears in any log line; every minted token carries a read-only permissions object.
 
-- [ ] **Unit 3: Collaborator-repo metadata reader (redaction-safe)**
+- [x] **Unit 3: Collaborator-repo metadata reader (redaction-safe)**
 
 **Goal:** Read collaborator repos from `metadata/repos.yaml` on the control plane `data`
 branch, preserving redactions and exporting a denylist of redacted node_ids for the aggregator.
@@ -383,7 +397,7 @@ cross-source denylist. Handle `data` missing/behind (warn + degrade, don't crash
 **Verification:** redacted entries stay redacted end-to-end; `redactedNodeIds` populated;
 unexpected schema version fails closed; missing `data` degrades gracefully.
 
-- [ ] **Unit 4: Status aggregator + in-memory cache**
+- [x] **Unit 4: Status aggregator + in-memory cache**
 
 **Goal:** For the unioned repo set, fetch the bounded Phase-1 signal set via GraphQL and cache
 it with a 60s background refresh — without leaking redacted private repos through the
@@ -446,7 +460,7 @@ flag. Sort attention-first. Cap per-repo summary to a small N (R2 fixed set).
 **Verification:** aggregator returns labeled, attention-sorted status; cache refreshes; partial
 failures isolated; redacted repos absent from all output.
 
-- [ ] **Unit 5: Operator auth (GitHub OAuth + signed cookie, allowlist)**
+- [x] **Unit 5: Operator auth (GitHub OAuth + signed cookie, allowlist)**
 
 **Goal:** Lock the app to one operator via a dedicated GitHub OAuth App; deny-by-default.
 
@@ -489,7 +503,7 @@ if `OPERATOR_LOGIN` is unset or whitespace-only. Per-IP rate limiting (Hono midd
 unauthenticated/invalid/expired requests; unset or whitespace allowlist fails closed; weak
 cookie key rejected at boot.
 
-- [ ] **Unit 6: Dashboard view (SSR) + status API**
+- [x] **Unit 6: Dashboard view (SSR) + status API**
 
 **Goal:** Glanceable SSR view + `/api/status` JSON, behind auth, with manual refresh.
 
@@ -519,7 +533,7 @@ Stale-cache banner when set.
 **Verification:** authed operator sees a glanceable attention-sorted view; unauth denied;
 empty/stale states render cleanly.
 
-- [ ] **Unit 7: Infra `apps/dashboard` deploy stack**
+- [x] **Unit 7: Infra `apps/dashboard` deploy stack**
 
 **Goal:** Deployable Compose + Caddy + deploy scripts, mirroring `apps/umami`.
 
@@ -551,7 +565,7 @@ exactly.
 **Verification:** `docker compose config` valid; secret is file-mounted not argv; Caddyfile
 targets `dashboard.fro.bot`.
 
-- [ ] **Unit 8: Infra deploy workflow + CLI registration**
+- [x] **Unit 8: Infra deploy workflow + CLI registration**
 
 **Goal:** Wire `apps/dashboard` into the deploy router + CLI.
 


### PR DESCRIPTION
Reconciles the Phase 1 plan and the north-star roadmap with what's actually been built, so the planning docs reflect shipped reality rather than the original sequencing.

## Phase 1 plan

All eight units of the monitoring dashboard are code-complete and merged — Units 1-6 in `fro-bot/dashboard`, Units 7-8 in `marcusrbrown/infra` — including the cross-source redaction leak guard (denylist-before-query, fail-closed on denylist unavailability). This is **not yet operationally complete**, so the plan moves to `code-complete-pending-verification` with an explicit gate for the work still owed:

- Live-deploy verification (`dashboard.fro.bot` TLS + `/healthz`, OAuth end-to-end, protected-route denial, cookie/logout).
- Production-shaped redaction verification (exercise the aggregator against real redacted data; confirm no private name or `node_id` reaches the view, API, logs, or cache; fail-closed on metadata failure).
- Infra security posture (App key file-mounted, container hardening, no secrets in logs, key-revocation runbook).
- A post-merge security review if the dashboard units shipped without one.

The unit checkboxes now reflect code-merged status; operational sign-off waits on the gate above (owned by the dashboard + infra sessions).

## North-star roadmap

The original doc recommended a strictly serial Phase 1 → 2 → 3. Reality has moved to **concurrent workstreams**, and the doc is rebaselined to say so:

- Phase 1 (read-only dashboard): code-complete, pending verification.
- Phase 2 (the gateway web control surface + operator auth): already in active parallel implementation, not a future-only phase.
- Phase 3 (interactive dashboard): mock/exploratory work has started, but it is gated on the gateway owning and freezing the canonical operator API contract — the mock stays a non-canonical fixture.

The original serial roadmap is retained as the historical strategic recommendation. Also corrects the earlier framing that the Phase-1 visibility slice needs "no auth": the shipped dashboard uses operator OAuth because it holds a GitHub App read key and must be operator-only.
