### PR TITLE
feat: format-independent database_id denylist guard for redacted repos

### DIFF
--- a/docs/plans/2026-06-21-001-feat-redacted-database-id-denylist-guard-plan.md
+++ b/docs/plans/2026-06-21-001-feat-redacted-database-id-denylist-guard-plan.md
@@ -1,0 +1,319 @@
+---
+title: 'feat: format-independent database_id denylist guard for redacted repos'
+type: feat
+status: active
+date: 2026-06-21
+origin: https://github.com/fro-bot/.github/issues/3525
+---
+
+# feat: format-independent database_id denylist guard for redacted repos
+
+## Overview
+
+The dashboard's redaction denylist protects a redacted/private repo from being queried via two
+guards: a primary string match on `node_id` and a secondary, format-independent match on the
+numeric `database_id`. The secondary guard is inert today because the redacted entries in
+`metadata/repos.yaml` carry a new-format (`R_…`) `node_id` and no `database_id`, and
+`deriveDatabaseId()` correctly returns `null` for new-format node_ids. Only the primary
+`node_id` string match stands between those repos and the dashboard's working set.
+
+This plan makes the secondary guard effective by adding an explicit numeric `database_id` to
+redacted entries — fixed at the **write site** so new private repos are format-independent by
+construction, not just by a one-time backfill. The dashboard needs no code change; its
+dual-guard logic already consumes `database_id` once the data provides it.
+
+## Problem Frame
+
+(Origin: issue #3525 + Fro Bot triage.) GitHub has migrated its node_id format once already
+(legacy base64 `MDEw…==` → next-gen `R_kgDO…`; both forms are documented in
+`scripts/schemas.ts` around the `NODE_ID_PATTERN`). If GitHub migrates again, a redacted entry
+written under the old format would no longer match the `node_id` the API returns. With no
+`database_id` fallback, the redacted repo would enter the working set, get queried, and surface
+on the dashboard. The numeric `repository.id` (`database_id`) is stable across both node_id
+formats, so it is the durable anchor. This is defense-in-depth: today's single-API-version
+path is safe; the fix protects against a future format drift.
+
+## Requirements Trace
+
+- R1. `RepoEntry` accepts an optional, validated `database_id` (positive integer), omittable
+  during the rollout window (mirroring how `node_id`/`private` were tightened). (origin: "Schema")
+- R2. The metadata writer persists `database_id` on redacted/private entries at redaction time,
+  so new private repos carry the numeric anchor by construction. (origin: "Writer")
+- R3. The reconcile field probe captures the numeric `repository.id` for tracked repos via the
+  existing GraphQL probe (extended with `databaseId`), so the writer has the value to persist.
+  (origin: "Writer"/probe)
+- R4. The two existing redacted entries on the `data` branch are backfilled with their numeric
+  `database_id`, resolved from the probe — never guessed by decoding the node_id binary.
+  (origin: "Backfill")
+- R5. `database_id` is treated with the same redaction discipline as `node_id`: written only to
+  `data`, never echoed to a public render/log site. (origin: "Notes" caveat)
+- R6. `deriveDatabaseId()` stays conservative (returns `null` for unrecognized formats) — the
+  explicit field is the fix, not a binary-decode guess. (origin: "Fix")
+
+## Scope Boundaries
+
+- No dashboard code change. The dashboard's `deriveDatabaseId()` and dual-guard logic are
+  already correct; they only need the data to feed the secondary guard.
+- No change to `deriveDatabaseId()`'s conservative null-on-unrecognized behavior.
+- No change to `main`. `database_id` lives only on `data`, behind the same redaction that
+  already covers `node_id`; it never promotes to `main` for private repos.
+- Not a fix for an active leak — verified safe today; this is future-drift hardening.
+
+### Deferred to Separate Tasks
+
+- None. The schema + writer + backfill land together so the field does not round-trip silently
+  or reset the clock.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Schema** — `scripts/schemas.ts`: `RepoEntry` interface (the `node_id?: string` field is the
+  pattern to mirror for `database_id?: number`); `isRepoEntry` / `assertRepoEntry` guards (the
+  `node_id` optional+validated branches show exactly where the `database_id` validation slots
+  in); `NODE_ID_PATTERN` block documents the two node_id formats that motivate this change.
+- **Writer** — `scripts/repos-metadata.ts`: `RepoIdentityInput` (carries `private?` / `node_id?`
+  today), `assertPrivateNodeId` (enforces node_id presence for private repos), and
+  `definedPrivacyFields` (the function that copies privacy fields onto the entry) — the natural
+  seam to thread `database_id` alongside `node_id`. These are pure, idempotent writers.
+- **Probe** — `scripts/reconcile-repos.ts`: `RepoStatusProbe` union and the field-probe pass
+  that resolves `private` / `node_id` per tracked repo. Extending the existing GraphQL query
+  with `databaseId` is the chosen capture path (one round-trip, no new failure mode).
+- **Consumer (no change, for reference)** — the dashboard's `deriveDatabaseId()` and
+  `redactedDatabaseIds` denylist in `fro-bot/dashboard`.
+
+### Institutional Learnings
+
+- Loose-then-tight schema migration (the established repo pattern): new field is optional during
+  rollout; the writer populates it; tightening (if ever) ships atomically with a migrator. For
+  `database_id`, optional is likely the permanent shape — older entries may legitimately lack it.
+- Private-repo identifiers (`node_id`, and now `database_id`) must never reach a public render or
+  log site; render sites embed identifiers in shell/issue text (see the visibility-transition
+  issue renderer in `scripts/reconcile-repos.ts`).
+
+## Key Technical Decisions
+
+- **Optional `database_id?: number`, validated as a positive integer.** Mirrors the
+  `node_id?`/`private?` optional-and-validated treatment. Permanently optional — legacy/public
+  entries need not carry it, and a redacted entry written before this change is still protected
+  by the primary `node_id` guard until reconcile refreshes it.
+- **Capture via the existing GraphQL probe's `databaseId` field.** The field probe already
+  resolves `isPrivate`/`node_id` per repo in one GraphQL query; adding `databaseId` to that
+  selection set yields the numeric id with no extra API call or failure path. (User decision.)
+- **Write-site fix, not just backfill.** The durable fix populates `database_id` where redacted
+  entries are constructed (`repos-metadata.ts` via the probe value), so the next private repo
+  is format-independent by construction. Backfilling the two current entries without teaching
+  the writer would only reset the clock.
+- **Same redaction discipline as `node_id`.** `database_id` is data-branch-only and must never
+  be rendered/logged publicly. Schema validation rejects non-positive-integer values; the writer
+  treats it like `node_id`.
+- **`deriveDatabaseId()` stays conservative.** The explicit persisted field is the fix; no
+  attempt to decode the node_id binary to guess the numeric id.
+
+## Open Questions
+
+### Resolved During Planning
+
+- How to capture the numeric id? → Extend the existing reconcile GraphQL probe with `databaseId`
+  (user decision), avoiding a separate REST read.
+- Optional vs required field? → Optional (positive integer when present); permanently omittable
+  so legacy/public entries and pre-refresh redacted entries remain valid.
+- Dashboard change needed? → No; the consumer already handles `database_id` when present.
+
+### Deferred to Implementation
+
+- Exact GraphQL selection-set edit and the probe's result-type field name for `databaseId`
+  (`RepoStatusProbe` shape) — settle against the real query when implementing Unit 2.
+- Whether `assertPrivateNodeId` should also assert `database_id` presence for private repos, or
+  leave it optional (a private repo whose probe failed to return `databaseId` should still be
+  redactable on `node_id` alone — lean optional, confirm during Unit 2).
+- The exact numeric `database_id` values for the two existing redacted entries — resolved from
+  the probe at backfill time (Unit 4), never guessed.
+
+## Implementation Units
+
+Sequenced: schema first (the field must exist before the writer/probe populate it or the data
+backfill validates), then probe capture, then writer persistence, then the data backfill.
+
+- [ ] **Unit 1: Add `database_id` to the `RepoEntry` schema**
+
+**Goal:** `RepoEntry` accepts an optional, validated `database_id` (positive integer).
+
+**Requirements:** R1, R5.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `scripts/schemas.ts` (`RepoEntry` interface, `isRepoEntry`, `assertRepoEntry`)
+- Test: `scripts/schemas.test.ts`
+
+**Approach:** Add `database_id?: number` to `RepoEntry`, documented as the stable numeric REST
+`repository.id` and the format-independent denylist anchor for redacted entries. Extend
+`isRepoEntry` and `assertRepoEntry` with an optional branch mirroring `node_id`: when present,
+require a positive integer (reject `0`, negatives, non-integers, non-numbers); when omitted,
+valid. Note in the field doc that it is data-branch-only and must not be rendered/logged publicly.
+
+**Execution note:** test-first (the schema guard is the contract every downstream unit relies on).
+
+**Patterns to follow:** the `node_id?` optional+validated branches in `isRepoEntry` /
+`assertRepoEntry`; the field-doc style of the existing privacy fields.
+
+**Test scenarios:**
+- Happy path: entry with `database_id: 1234567` (positive int) → accepted.
+- Happy path: entry omitting `database_id` → accepted (optional).
+- Edge: `database_id: 0` → rejected (not positive).
+- Error: `database_id: -5` → rejected.
+- Error: `database_id: 12.5` → rejected (not integer).
+- Error: `database_id: "1234"` (string) → rejected (not number).
+
+**Verification:** schema guards accept positive-integer or omitted `database_id`, reject all
+invalid shapes; `pnpm check-types` + `pnpm test` green.
+
+- [ ] **Unit 2: Capture `databaseId` in the reconcile field probe**
+
+**Goal:** The field probe resolves the numeric `repository.id` per tracked repo alongside
+`private`/`node_id`, via the existing GraphQL query.
+
+**Requirements:** R3.
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `scripts/reconcile-repos.ts` (the GraphQL probe query + `RepoStatusProbe` result shape)
+- Test: `scripts/reconcile-repos.test.ts`
+
+**Approach:** Add `databaseId` to the existing per-repo GraphQL selection set (the query that
+already returns `isPrivate` and the GraphQL id). Surface it on the probe result type
+(`still-accessible` and any tracked-state variant that carries `private`/`node_id`). Handle the
+`databaseId` being absent/null defensively (treat as "not captured" — do not crash; the entry
+remains protected by `node_id`). Keep the `malformed` classification logic intact (a missing
+`databaseId` alone is not malformed, since it's optional downstream).
+
+**Execution note:** test-first for the probe-shape change (mocked GraphQL responses).
+
+**Patterns to follow:** the existing `private`/`node_id` resolution in the field probe;
+`RepoStatusProbe` union shape and its sticky-preserve semantics.
+
+**Test scenarios:**
+- Happy path: GraphQL returns `isPrivate`, node_id, and `databaseId` → probe result carries the
+  numeric id.
+- Edge: GraphQL returns no/`null` `databaseId` (but valid private/node_id) → probe result has no
+  database_id; not classified malformed; no crash.
+- Integration: the probe value flows to where redacted entries are written (asserted in Unit 3).
+
+**Verification:** the probe surfaces `databaseId` when present, degrades gracefully when absent;
+existing probe tests still pass.
+
+- [ ] **Unit 3: Persist `database_id` on redacted entries at the write site**
+
+**Goal:** New/updated redacted entries carry `database_id` from the probe, so private repos are
+format-independent by construction.
+
+**Requirements:** R2, R5.
+
+**Dependencies:** Units 1, 2.
+
+**Files:**
+- Modify: `scripts/repos-metadata.ts` (`RepoIdentityInput`, `definedPrivacyFields`, and the
+  redaction-entry construction; the reconcile call site that builds the identity input from the
+  probe)
+- Test: `scripts/repos-metadata.test.ts`
+
+**Approach:** Add `database_id?: number` to `RepoIdentityInput`. In `definedPrivacyFields` (or
+the equivalent privacy-field copier), copy `database_id` onto the entry when present, alongside
+`node_id`/`private`. At the reconcile call site, pass the probe's captured `databaseId` into the
+identity input. Keep `database_id` optional for private repos (lean: do NOT make
+`assertPrivateNodeId` require it — a private repo whose probe didn't return `databaseId` is still
+redactable on `node_id`; confirm during implementation). Treat `database_id` with the same
+redaction discipline as `node_id` (data-branch-only; never logged).
+
+**Execution note:** test-first for the writer field-copy behavior (pure function over inputs).
+
+**Patterns to follow:** how `node_id`/`private` flow through `RepoIdentityInput` →
+`definedPrivacyFields` → entry; the idempotent, non-mutating writer contract.
+
+**Test scenarios:**
+- Happy path: redacting a private repo with a probe `database_id` → entry carries `database_id`
+  (positive int), `node_id`, `private:true`, `owner:[REDACTED]`, `name:<node_id>`.
+- Edge: redacting a private repo with no probe `database_id` → entry has `node_id`/`private` but
+  no `database_id`; still valid, still redacted (no leak).
+- Edge: re-running the writer on an entry that already has `database_id` → idempotent (no change).
+- Security: the constructed entry never contains the canonical `owner/name`; `database_id`
+  appears only as the numeric field, never in a render/log-shaped string.
+
+**Verification:** redacted entries gain `database_id` when the probe provides it; the writer
+stays idempotent and pure; no canonical identifier leaks.
+
+- [ ] **Unit 4: Backfill `database_id` into the two existing redacted entries on `data`**
+
+**Goal:** The two current redacted entries (`R_kgDOSVJgdw`, `R_kgDOSZ9x-w`) carry their numeric
+`database_id`, resolved from the probe.
+
+**Requirements:** R4, R6.
+
+**Dependencies:** Units 1-3 (the field must validate and the writer/probe must resolve the ids).
+
+**Files:**
+- Data: `metadata/repos.yaml` on the `data` branch (the two `private:true` entries) — written via
+  the Fro Bot / data-branch authority path, NOT a human-authored `main` PR.
+
+**Approach:** Resolve the two numeric ids from the reconcile probe (or an equivalent
+authenticated lookup of `repository.id` for each node_id) — never by decoding the node_id binary.
+Add `database_id: <int>` to each redacted entry on `data`. Because `metadata/*.yaml` is
+data-branch sole-writer and wiki-authority-guarded, this write is performed under Fro Bot
+identity (e.g. a reconcile run that now captures `databaseId`, or a `fro-bot.yaml` dispatch),
+not a human PR to `main`. A normal reconcile run after Units 1-3 ship will populate the field
+naturally on the next field-probe refresh of those entries — prefer that over a manual backfill
+if the refresh cadence is acceptable.
+
+**Test scenarios:**
+- Test expectation: none (data change). Verify post-write that both redacted entries on `data`
+  validate against the updated schema and carry a positive-integer `database_id`, with no
+  canonical owner/name present.
+
+**Verification:** both redacted `data` entries have `database_id`; schema validation passes; the
+dashboard's `redactedDatabaseIds` is now non-empty (secondary guard effective); no private name
+on `main` or in any log.
+
+## System-Wide Impact
+
+- **Interaction graph:** the reconcile field probe gains one GraphQL field; the metadata writer
+  gains one optional field. Consumers: the dashboard denylist (already handles `database_id`),
+  and the schema guards (validate it). No new workflow or API surface.
+- **State lifecycle:** `database_id` is populated on the next reconcile field-probe refresh of an
+  entry; entries refreshed before this ships simply lack it and stay protected by `node_id`.
+  Loose/optional field = no migration break.
+- **API surface parity:** the field probe is the single resolver of `private`/`node_id`/now
+  `database_id` — no other code path constructs redacted entries, so there is one place to keep
+  consistent.
+- **Unchanged invariants:** `main` never receives private-repo `database_id` (data-branch-only,
+  behind existing redaction); `deriveDatabaseId()` behavior unchanged; the primary `node_id`
+  guard is untouched and remains the first line of defense.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `database_id` (numeric repo id) leaks to a public surface | Treated with the same data-branch-only redaction discipline as `node_id`; schema doc + writer keep it off render/log sites; it never promotes to `main`. The numeric id is a weak identifier (small int, not a secret), but discipline is kept regardless. |
+| Probe doesn't return `databaseId` for some repo | Field is optional; entry stays protected by the primary `node_id` guard; no crash, not classified malformed. |
+| Backfill guesses wrong ids by decoding node_id | Explicitly forbidden — ids come from the probe/authenticated lookup only; `deriveDatabaseId()` stays conservative. |
+| Field round-trips silently and breaks on a future strict-parse change | Schema (Unit 1) validates the field from the start, so it is a known field, not silent passthrough. |
+| Data write to `metadata/repos.yaml` via a human `main` PR trips the wiki-authority guard | Backfill is performed under Fro Bot / data-branch authority (reconcile run or `fro-bot.yaml`), never a human `main` PR. |
+
+## Documentation / Operational Notes
+
+- `metadata/README.md` documents the `metadata/repos.yaml` entry shape — add `database_id` to the
+  field list with its data-branch-only/redaction note, so the auto-managed-metadata contract
+  stays accurate.
+- After this ships, the cleanest backfill is a normal reconcile run (now capturing `databaseId`)
+  re-probing the two redacted entries; a manual Fro Bot dispatch is the fallback if the cadence
+  is too slow.
+
+## Sources & References
+
+- **Origin:** issue #3525 (https://github.com/fro-bot/.github/issues/3525) + Fro Bot triage.
+- Schema: `scripts/schemas.ts` (`RepoEntry`, `isRepoEntry`/`assertRepoEntry`, `NODE_ID_PATTERN`).
+- Writer: `scripts/repos-metadata.ts` (`RepoIdentityInput`, `assertPrivateNodeId`,
+  `definedPrivacyFields`).
+- Probe: `scripts/reconcile-repos.ts` (`RepoStatusProbe`, field-probe pass).
+- Consumer (no change): `fro-bot/dashboard` `deriveDatabaseId()` / `redactedDatabaseIds`.

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -2319,6 +2319,74 @@ describe('fetchFieldProbes — database_id capture', () => {
     expect(result.summary.unchanged).toBe(1)
     expect(result.summary.refreshed).toBe(0)
   })
+
+  it('sticky: stored database_id + transient probe (no database_id) → NOT refreshed, stored value preserved', () => {
+    // GIVEN an entry that already has a stored database_id
+    const entry = makeEntry({
+      name: 'sticky-repo',
+      onboarding_status: 'onboarded',
+      has_fro_bot_workflow: false,
+      has_renovate: false,
+      private: false,
+      node_id: 'R_sticky',
+      database_id: 123,
+    })
+    // AND a probe that transiently returns no database_id (e.g. repos.get hiccup)
+    const transientProbe: FieldProbe = {
+      has_fro_bot_workflow: false,
+      has_renovate: false,
+      // database_id absent — simulates a transient sub-probe failure
+    }
+
+    // WHEN reconciling
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [entry]},
+        accessList: [makeAccess({name: 'sticky-repo', private: false, node_id: 'R_sticky'})],
+        fieldProbes: new Map([['fro-bot/sticky-repo', transientProbe]]),
+      }),
+    )
+
+    // THEN the entry is NOT counted as refreshed — absent probe must not signal drift
+    expect(result.summary.refreshed).toBe(0)
+    expect(result.summary.unchanged).toBe(1)
+    // AND the stored database_id is preserved in the output
+    expect(result.nextRepos.repos[0]).toMatchObject({database_id: 123})
+  })
+
+  it('backfill: stored database_id absent + probe returns a number → entry IS refreshed and gains database_id', () => {
+    // GIVEN an entry with no stored database_id (first-time capture scenario)
+    const entry = makeEntry({
+      name: 'backfill-repo',
+      onboarding_status: 'onboarded',
+      has_fro_bot_workflow: false,
+      has_renovate: false,
+      private: false,
+      node_id: 'R_backfill',
+      // database_id intentionally absent
+    })
+    // AND a probe that returns a numeric database_id for the first time
+    const backfillProbe: FieldProbe = {
+      has_fro_bot_workflow: false,
+      has_renovate: false,
+      database_id: 456,
+    }
+
+    // WHEN reconciling
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [entry]},
+        accessList: [makeAccess({name: 'backfill-repo', private: false, node_id: 'R_backfill'})],
+        fieldProbes: new Map([['fro-bot/backfill-repo', backfillProbe]]),
+      }),
+    )
+
+    // THEN the entry IS refreshed — a present probe value that differs from stored triggers capture
+    expect(result.summary.refreshed).toBe(1)
+    expect(result.summary.unchanged).toBe(0)
+    // AND the new database_id is written to the output entry
+    expect(result.nextRepos.repos[0]).toMatchObject({database_id: 456})
+  })
 })
 
 //

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -2253,13 +2253,38 @@ describe('fetchFieldProbes — database_id capture', () => {
     // WHEN probing
     const result = await fetchFieldProbes(userOctokit, currentRepos, accessList, logger)
 
-    // THEN the probe result carries database_id that a downstream writer (Unit 3) can read
+    // THEN the probe result carries database_id that a downstream writer can read
     const probe = result.probes.get('fro-bot/private-repo')
     expect(probe).toBeDefined()
     // Verify the field is accessible and has the correct type
     const databaseId: number | undefined = probe?.database_id
     expect(databaseId).toBe(1234567)
     expect(typeof databaseId).toBe('number')
+  })
+
+  it('API error from repos.get → probe has no database_id, failed/error count unaffected, no exception', async () => {
+    // GIVEN a tracked repo where repos.get throws an API error
+    const currentRepos: ReposFile = {
+      version: 1,
+      repos: [makeEntry({owner: 'fro-bot', name: 'error-repo', node_id: 'R_error'})],
+    }
+    const accessList: AccessListEntry[] = [makeAccess({owner: 'fro-bot', name: 'error-repo', node_id: 'R_error'})]
+    const reposGet = vi.fn(async () => {
+      throw apiError(500, 'Internal Server Error')
+    })
+    const userOctokit = makeFieldProbeOctokit({reposGet: reposGet as never})
+    const logger = silentLogger()
+
+    // WHEN probing — should not throw
+    const result = await fetchFieldProbes(userOctokit, currentRepos, accessList, logger)
+
+    // THEN the probe result has no database_id
+    const probe = result.probes.get('fro-bot/error-repo')
+    expect(probe).toBeDefined()
+    expect(probe).not.toHaveProperty('database_id')
+    // AND the failed/error count is unaffected (0) — API errors on the database_id sub-probe
+    // are non-fatal; the probe still succeeds for the other fields
+    expect(result.failed).toBe(0)
   })
 
   it('missing databaseId alone does not cause the entry to be classified as malformed in reconcileRepos', () => {

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -8,6 +8,7 @@ import {describe, expect, it, vi} from 'vitest'
 import {
   containsFroBotAgentReference,
   DISPATCH_DEFAULTS,
+  fetchFieldProbes,
   fetchPerRepoStatus,
   formatCommitMessage,
   formatFloorTelemetry,
@@ -22,6 +23,7 @@ import {
   reconcileRepos,
   renderIssuePayload,
   type AccessListEntry,
+  type FieldProbe,
   type HandleReconcileParams,
   type IssuePayload,
   type OctokitClient,
@@ -2121,6 +2123,181 @@ describe('fetchPerRepoStatus 5-state classification', () => {
 
 //
 // ─────────────────────────────────────────────────────────────────────────────
+// fetchFieldProbes — database_id capture unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+//
+
+interface FieldProbeRepoGetResponse {
+  private?: boolean
+  node_id?: string
+  id?: number
+}
+
+/**
+ * Build a minimal OctokitClient mock for fetchFieldProbes.
+ * fetchFieldProbes calls repos.getContent (for workflow/renovate probes) and
+ * repos.get (for database_id). We stub both here.
+ */
+function makeFieldProbeOctokit(
+  overrides: {
+    reposGet?: (params: {owner: string; repo: string}) => Promise<{data: FieldProbeRepoGetResponse}>
+    getContent?: (params: {owner: string; repo: string; path: string}) => Promise<unknown>
+  } = {},
+): OctokitClient {
+  return {
+    rest: {
+      repos: {
+        get:
+          overrides.reposGet ??
+          (async () => ({
+            data: {private: false, node_id: 'R_default', id: 12345} satisfies FieldProbeRepoGetResponse,
+          })),
+        getContent:
+          overrides.getContent ??
+          (async () => {
+            throw Object.assign(new Error('Not Found'), {status: 404})
+          }),
+      },
+    },
+  } as unknown as OctokitClient
+}
+
+describe('fetchFieldProbes — database_id capture', () => {
+  it('happy path: GraphQL/REST returns databaseId → probe result carries numeric database_id', async () => {
+    // GIVEN a tracked repo in the access list with a known numeric id
+    const currentRepos: ReposFile = {
+      version: 1,
+      repos: [makeEntry({owner: 'fro-bot', name: 'test-repo', node_id: 'R_test'})],
+    }
+    const accessList: AccessListEntry[] = [makeAccess({owner: 'fro-bot', name: 'test-repo', node_id: 'R_test'})]
+    const reposGet = vi.fn(async () => ({
+      data: {private: false, node_id: 'R_test', id: 987654} satisfies FieldProbeRepoGetResponse,
+    }))
+    const userOctokit = makeFieldProbeOctokit({reposGet: reposGet as never})
+    const logger = silentLogger()
+
+    // WHEN probing
+    const result = await fetchFieldProbes(userOctokit, currentRepos, accessList, logger)
+
+    // THEN the probe result carries the numeric database_id
+    const probe = result.probes.get('fro-bot/test-repo')
+    expect(probe).toBeDefined()
+    expect(probe?.database_id).toBe(987654)
+    expect(result.failed).toBe(0)
+  })
+
+  it('edge: REST returns null/undefined id → probe result has no database_id; not malformed; no crash', async () => {
+    // GIVEN a tracked repo where the REST response has no numeric id
+    const currentRepos: ReposFile = {
+      version: 1,
+      repos: [makeEntry({owner: 'fro-bot', name: 'test-repo', node_id: 'R_test'})],
+    }
+    const accessList: AccessListEntry[] = [makeAccess({owner: 'fro-bot', name: 'test-repo', node_id: 'R_test'})]
+    const reposGet = vi.fn(async () => ({
+      // id is absent — simulates a response where databaseId is not returned
+      data: {private: false, node_id: 'R_test'} as FieldProbeRepoGetResponse,
+    }))
+    const userOctokit = makeFieldProbeOctokit({reposGet: reposGet as never})
+    const logger = silentLogger()
+
+    // WHEN probing
+    const result = await fetchFieldProbes(userOctokit, currentRepos, accessList, logger)
+
+    // THEN the probe result has no database_id but is otherwise valid (not failed)
+    const probe = result.probes.get('fro-bot/test-repo')
+    expect(probe).toBeDefined()
+    expect(probe).not.toHaveProperty('database_id')
+    expect(result.failed).toBe(0)
+    // AND the probe is not classified as malformed (no warn about malformed)
+    expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('malformed'))
+  })
+
+  it('edge: REST returns id: null → probe result has no database_id; not malformed; no crash', async () => {
+    // GIVEN a tracked repo where the REST response has id: null
+    const currentRepos: ReposFile = {
+      version: 1,
+      repos: [makeEntry({owner: 'fro-bot', name: 'test-repo', node_id: 'R_test'})],
+    }
+    const accessList: AccessListEntry[] = [makeAccess({owner: 'fro-bot', name: 'test-repo', node_id: 'R_test'})]
+    const reposGet = vi.fn(async () => ({
+      data: {private: false, node_id: 'R_test', id: null} as unknown as FieldProbeRepoGetResponse,
+    }))
+    const userOctokit = makeFieldProbeOctokit({reposGet: reposGet as never})
+    const logger = silentLogger()
+
+    // WHEN probing
+    const result = await fetchFieldProbes(userOctokit, currentRepos, accessList, logger)
+
+    // THEN the probe result has no database_id but is otherwise valid
+    const probe = result.probes.get('fro-bot/test-repo')
+    expect(probe).toBeDefined()
+    expect(probe).not.toHaveProperty('database_id')
+    expect(result.failed).toBe(0)
+  })
+
+  it('integration: captured database_id is available on the probe result for downstream consumption', async () => {
+    // GIVEN a tracked repo with a known numeric id
+    const currentRepos: ReposFile = {
+      version: 1,
+      repos: [makeEntry({owner: 'fro-bot', name: 'private-repo', node_id: 'R_private', private: true})],
+    }
+    const accessList: AccessListEntry[] = [
+      makeAccess({owner: 'fro-bot', name: 'private-repo', node_id: 'R_private', private: true}),
+    ]
+    const reposGet = vi.fn(async () => ({
+      data: {private: true, node_id: 'R_private', id: 1234567} satisfies FieldProbeRepoGetResponse,
+    }))
+    const userOctokit = makeFieldProbeOctokit({reposGet: reposGet as never})
+    const logger = silentLogger()
+
+    // WHEN probing
+    const result = await fetchFieldProbes(userOctokit, currentRepos, accessList, logger)
+
+    // THEN the probe result carries database_id that a downstream writer (Unit 3) can read
+    const probe = result.probes.get('fro-bot/private-repo')
+    expect(probe).toBeDefined()
+    // Verify the field is accessible and has the correct type
+    const databaseId: number | undefined = probe?.database_id
+    expect(databaseId).toBe(1234567)
+    expect(typeof databaseId).toBe('number')
+  })
+
+  it('missing databaseId alone does not cause the entry to be classified as malformed in reconcileRepos', () => {
+    // GIVEN a tracked repo with a field probe that has no database_id
+    const entry = makeEntry({
+      name: 'no-db-id-repo',
+      onboarding_status: 'onboarded',
+      has_fro_bot_workflow: false,
+      has_renovate: false,
+      private: false,
+      node_id: 'R_default',
+    })
+    // A FieldProbe without database_id (the optional field is absent)
+    const probeWithoutDatabaseId: FieldProbe = {
+      has_fro_bot_workflow: false,
+      has_renovate: false,
+      // database_id intentionally absent
+    }
+
+    // WHEN reconciling with this probe
+    const result = reconcileRepos(
+      makeInput({
+        currentRepos: {version: 1, repos: [entry]},
+        accessList: [makeAccess({name: 'no-db-id-repo', private: false, node_id: 'R_default'})],
+        fieldProbes: new Map([['fro-bot/no-db-id-repo', probeWithoutDatabaseId]]),
+      }),
+    )
+
+    // THEN the entry is NOT classified as malformed — missing database_id alone is not malformed
+    expect(result.summary.malformed).toBe(0)
+    // AND the entry is unchanged (no field drift)
+    expect(result.summary.unchanged).toBe(1)
+    expect(result.summary.refreshed).toBe(0)
+  })
+})
+
+//
+// ─────────────────────────────────────────────────────────────────────────────
 // Unit 3 — I/O shell tests for `handleReconcile`
 // ─────────────────────────────────────────────────────────────────────────────
 //
@@ -2153,6 +2330,7 @@ interface RepoGetResponse {
   archived?: boolean
   private?: boolean
   node_id?: string
+  id?: number
 }
 
 interface BranchResponse {

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -136,8 +136,10 @@ export interface FieldProbe {
    * field probe alongside `isPrivate`/`node_id`. Optional: absent when the probe did not
    * return a positive integer (e.g. the API response omitted the field or returned null).
    *
-   * Data-branch-only: must never be rendered/logged publicly. Unit 3 writes this onto
-   * redacted entries so the denylist secondary guard is format-independent.
+   * Like node_id, this promotes to main with the entry but must NEVER be embedded in a
+   * rendered/logged public surface (issue text, commit message, log line). The metadata
+   * writer persists this onto redacted entries so the denylist secondary guard is
+   * format-independent.
    */
   database_id?: number
 }

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -988,7 +988,7 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
   const fieldsMatch =
     probe.has_fro_bot_workflow === workingEntry.has_fro_bot_workflow && probe.has_renovate === workingEntry.has_renovate
   const privacyMatch = workingEntry.private === accessPrivate && workingEntry.node_id === accessNodeId
-  const databaseIdMatch = workingEntry.database_id === probe.database_id
+  const databaseIdMatch = probe.database_id === undefined || workingEntry.database_id === probe.database_id
   const channelMatch = workingEntry === entry // true only when no channel refresh occurred
 
   if (fieldsMatch && privacyMatch && databaseIdMatch && channelMatch) {

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -131,6 +131,15 @@ export type RepoStatusProbe =
 export interface FieldProbe {
   has_fro_bot_workflow: boolean
   has_renovate: boolean
+  /**
+   * Numeric REST `repository.id` (GitHub's `databaseId`). Captured from the per-repo
+   * field probe alongside `isPrivate`/`node_id`. Optional: absent when the probe did not
+   * return a positive integer (e.g. the API response omitted the field or returned null).
+   *
+   * Data-branch-only: must never be rendered/logged publicly. Unit 3 writes this onto
+   * redacted entries so the denylist secondary guard is format-independent.
+   */
+  database_id?: number
 }
 
 export interface ReconcileInput {
@@ -969,18 +978,24 @@ function classifyTracked(params: ClassifyTrackedParams): RepoEntry {
     return normalized
   }
 
+  // Include database_id from the probe so redacted entries carry the format-independent
+  // denylist anchor. Optional: absent when the probe did not return a positive integer.
+  const storageInputWithProbe =
+    probe.database_id === undefined ? storageInput : {...storageInput, database_id: probe.database_id}
+
   const fieldsMatch =
     probe.has_fro_bot_workflow === workingEntry.has_fro_bot_workflow && probe.has_renovate === workingEntry.has_renovate
   const privacyMatch = workingEntry.private === accessPrivate && workingEntry.node_id === accessNodeId
+  const databaseIdMatch = workingEntry.database_id === probe.database_id
   const channelMatch = workingEntry === entry // true only when no channel refresh occurred
 
-  if (fieldsMatch && privacyMatch && channelMatch) {
+  if (fieldsMatch && privacyMatch && databaseIdMatch && channelMatch) {
     summary.unchanged += 1
     return entry
   }
   summary.refreshed += 1
   return normalizeRepoEntryForStorage({
-    ...normalizeRepoEntryForStorage(workingEntry, storageInput),
+    ...normalizeRepoEntryForStorage(workingEntry, storageInputWithProbe),
     has_fro_bot_workflow: probe.has_fro_bot_workflow,
     has_renovate: probe.has_renovate,
   })
@@ -1898,7 +1913,14 @@ export async function fetchPerRepoStatus(
   return map
 }
 
-async function fetchFieldProbes(
+/**
+ * Probe still-accessible tracked repos for field values (`has_fro_bot_workflow`,
+ * `has_renovate`, `database_id`). Exported for unit tests; the sole production caller
+ * is `handleReconcile` in this same file.
+ *
+ * @internal
+ */
+export async function fetchFieldProbes(
   userOctokit: OctokitClient,
   currentRepos: ReposFile,
   accessList: AccessListEntry[],
@@ -1926,11 +1948,43 @@ async function fetchFieldProbes(
 }
 
 async function probeSingleRepo(userOctokit: OctokitClient, owner: string, name: string): Promise<FieldProbe> {
-  const [hasWorkflow, hasRenovate] = await Promise.all([
+  const [hasWorkflow, hasRenovate, databaseId] = await Promise.all([
     probeFroBotWorkflow(userOctokit, owner, name),
     probeRenovateConfig(userOctokit, owner, name),
+    probeRepoDatabaseId(userOctokit, owner, name),
   ])
-  return {has_fro_bot_workflow: hasWorkflow, has_renovate: hasRenovate}
+  const probe: FieldProbe = {has_fro_bot_workflow: hasWorkflow, has_renovate: hasRenovate}
+  if (databaseId !== undefined) {
+    probe.database_id = databaseId
+  }
+  return probe
+}
+
+/**
+ * Fetch the numeric `repository.id` (GitHub's `databaseId`) for a repo via `repos.get`.
+ * Returns `undefined` when the response omits or nulls the field — a missing `databaseId`
+ * is not an error; the entry remains protected by the primary `node_id` guard.
+ *
+ * Only positive integers are accepted. Zero, negatives, and non-integers are treated as
+ * absent (same validation as `RepoEntry.database_id` in the schema).
+ */
+async function probeRepoDatabaseId(
+  userOctokit: OctokitClient,
+  owner: string,
+  name: string,
+): Promise<number | undefined> {
+  try {
+    const response = await userOctokit.rest.repos.get({owner, repo: name})
+    const id = (response.data as {id?: unknown}).id
+    if (typeof id === 'number' && Number.isInteger(id) && id > 0) {
+      return id
+    }
+    return undefined
+  } catch {
+    // Non-blocking: a failed databaseId probe does not fail the field probe.
+    // The entry remains protected by the primary node_id guard.
+    return undefined
+  }
 }
 
 async function probeFroBotWorkflow(userOctokit: OctokitClient, owner: string, name: string): Promise<boolean> {

--- a/scripts/repos-metadata.test.ts
+++ b/scripts/repos-metadata.test.ts
@@ -1488,6 +1488,32 @@ describe('normalizeRepoEntryForStorage — database_id propagation', () => {
     expect(result).toBe(entry)
   })
 
+  // FIX 1 regression: public entry without database_id + input carrying database_id → new entry returned with it
+  it('returns a new entry (not the original) when a public entry gains a new database_id from the input', () => {
+    // GIVEN a public entry with no database_id
+    const entry = repoEntry({
+      owner: 'alice',
+      name: 'public-repo',
+      private: false,
+      node_id: PUBLIC_NODE_ID,
+      // database_id intentionally absent
+    })
+
+    // WHEN normalizing with an input that carries a database_id
+    const result = normalizeRepoEntryForStorage(entry, {
+      owner: 'alice',
+      repo: 'public-repo',
+      private: false,
+      node_id: PUBLIC_NODE_ID,
+      database_id: DB_ID,
+    })
+
+    // THEN the returned entry is NOT the original reference (the identity shortcut must not fire)
+    expect(result).not.toBe(entry)
+    // AND the new database_id is persisted on the returned entry
+    expect(result.database_id).toBe(DB_ID)
+  })
+
   // Edge: database_id changes → new entry returned with updated database_id
   it('returns a new entry when database_id differs from the stored value', () => {
     const entry = repoEntry({

--- a/scripts/repos-metadata.test.ts
+++ b/scripts/repos-metadata.test.ts
@@ -4,6 +4,7 @@ import {describe, expect, it} from 'vitest'
 import {
   addRepoEntry,
   computeNextEligibleAt,
+  normalizeRepoEntryForStorage,
   publicRepoEntryExists,
   recordSurveyResult,
   RepoEntryNotFoundError,
@@ -1320,5 +1321,192 @@ describe('publicRepoEntryExists', () => {
     const snapshot = structuredClone(current)
     publicRepoEntryExists(current, 'alice', 'project')
     expect(current).toEqual(snapshot)
+  })
+})
+
+describe('addRepoEntry — database_id on redacted entries', () => {
+  const DB_ID = 987654321
+
+  // Happy path: private repo WITH probe database_id → entry carries database_id, node_id, private:true, owner:[REDACTED]
+  it('persists database_id on a new private entry when provided', () => {
+    const result = addRepoEntry(EMPTY_REPOS, {
+      owner: 'private-owner',
+      repo: 'secret-repo',
+      now: NOW,
+      private: true,
+      node_id: PRIVATE_NODE_ID,
+      database_id: DB_ID,
+    })
+
+    expect(result.repos[0]).toMatchObject({
+      owner: '[REDACTED]',
+      name: PRIVATE_NODE_ID,
+      private: true,
+      node_id: PRIVATE_NODE_ID,
+      database_id: DB_ID,
+    })
+    // Security: canonical owner/name must not appear anywhere in the serialized output
+    expect(JSON.stringify(result)).not.toContain('private-owner')
+    expect(JSON.stringify(result)).not.toContain('secret-repo')
+    // Security: database_id appears only as the numeric field, not in any string
+    expect(typeof result.repos[0]?.database_id).toBe('number')
+  })
+
+  // Edge: private repo with NO probe database_id → entry has node_id/private but no database_id
+  it('omits database_id when not provided — entry is still valid and redacted', () => {
+    const result = addRepoEntry(EMPTY_REPOS, {
+      owner: 'private-owner',
+      repo: 'secret-repo',
+      now: NOW,
+      private: true,
+      node_id: PRIVATE_NODE_ID,
+    })
+
+    expect(result.repos[0]).toMatchObject({
+      owner: '[REDACTED]',
+      name: PRIVATE_NODE_ID,
+      private: true,
+      node_id: PRIVATE_NODE_ID,
+    })
+    expect(result.repos[0]?.database_id).toBeUndefined()
+    expect(JSON.stringify(result)).not.toContain('private-owner')
+    expect(JSON.stringify(result)).not.toContain('secret-repo')
+  })
+
+  // Edge: re-running the writer on an entry that already has database_id → idempotent (returns same ref)
+  it('is idempotent when re-adding a private entry that already has database_id', () => {
+    const existingEntry = repoEntry({
+      owner: '[REDACTED]',
+      name: PRIVATE_NODE_ID,
+      private: true,
+      node_id: PRIVATE_NODE_ID,
+      database_id: DB_ID,
+    })
+    const current: ReposFile = {version: 1, repos: [existingEntry]}
+
+    const result = addRepoEntry(current, {
+      owner: 'private-owner',
+      repo: 'secret-repo',
+      now: NOW,
+      private: true,
+      node_id: PRIVATE_NODE_ID,
+      database_id: DB_ID,
+    })
+
+    expect(result).toBe(current)
+    expect(result.repos[0]).toBe(existingEntry)
+  })
+
+  // Security: database_id on a public entry is NOT treated as a redacted field
+  it('does not redact owner/name for a public entry even when database_id is provided', () => {
+    const result = addRepoEntry(EMPTY_REPOS, {
+      owner: 'alice',
+      repo: 'public-project',
+      now: NOW,
+      private: false,
+      node_id: PUBLIC_NODE_ID,
+      database_id: DB_ID,
+    })
+
+    expect(result.repos[0]).toMatchObject({
+      owner: 'alice',
+      name: 'public-project',
+      private: false,
+      node_id: PUBLIC_NODE_ID,
+    })
+    // database_id is not a privacy field for public repos — it may or may not be present
+    // depending on implementation, but owner/name must be canonical
+  })
+})
+
+describe('normalizeRepoEntryForStorage — database_id propagation', () => {
+  const DB_ID = 123456789
+
+  // Happy path: normalizing a private entry with database_id in the input → entry carries it
+  it('copies database_id onto a private entry when present in the identity input', () => {
+    const entry = repoEntry({
+      owner: 'private-owner',
+      name: 'secret-repo',
+      private: false,
+      node_id: PRIVATE_NODE_ID,
+    })
+
+    const result = normalizeRepoEntryForStorage(entry, {
+      owner: 'private-owner',
+      repo: 'secret-repo',
+      private: true,
+      node_id: PRIVATE_NODE_ID,
+      database_id: DB_ID,
+    })
+
+    expect(result).toMatchObject({
+      owner: '[REDACTED]',
+      name: PRIVATE_NODE_ID,
+      private: true,
+      node_id: PRIVATE_NODE_ID,
+      database_id: DB_ID,
+    })
+  })
+
+  // Edge: normalizing without database_id → no database_id on the result
+  it('does not add database_id when not present in the identity input', () => {
+    const entry = repoEntry({
+      owner: 'private-owner',
+      name: 'secret-repo',
+      private: false,
+      node_id: PRIVATE_NODE_ID,
+    })
+
+    const result = normalizeRepoEntryForStorage(entry, {
+      owner: 'private-owner',
+      repo: 'secret-repo',
+      private: true,
+      node_id: PRIVATE_NODE_ID,
+    })
+
+    expect(result.database_id).toBeUndefined()
+  })
+
+  // Edge: idempotent — re-normalizing an already-redacted entry with same database_id returns same ref
+  it('returns the same entry reference when database_id already matches (idempotent)', () => {
+    const entry = repoEntry({
+      owner: '[REDACTED]',
+      name: PRIVATE_NODE_ID,
+      private: true,
+      node_id: PRIVATE_NODE_ID,
+      database_id: DB_ID,
+    })
+
+    const result = normalizeRepoEntryForStorage(entry, {
+      owner: 'private-owner',
+      repo: 'secret-repo',
+      private: true,
+      node_id: PRIVATE_NODE_ID,
+      database_id: DB_ID,
+    })
+
+    expect(result).toBe(entry)
+  })
+
+  // Edge: database_id changes → new entry returned with updated database_id
+  it('returns a new entry when database_id differs from the stored value', () => {
+    const entry = repoEntry({
+      owner: '[REDACTED]',
+      name: PRIVATE_NODE_ID,
+      private: true,
+      node_id: PRIVATE_NODE_ID,
+      database_id: 111,
+    })
+
+    const result = normalizeRepoEntryForStorage(entry, {
+      owner: 'private-owner',
+      repo: 'secret-repo',
+      private: true,
+      node_id: PRIVATE_NODE_ID,
+      database_id: DB_ID,
+    })
+
+    expect(result).not.toBe(entry)
+    expect(result.database_id).toBe(DB_ID)
   })
 })

--- a/scripts/repos-metadata.ts
+++ b/scripts/repos-metadata.ts
@@ -29,8 +29,9 @@ export interface RepoIdentityInput {
   node_id?: string
   /**
    * Numeric REST `repository.id` (GitHub's `databaseId`). Optional: absent when the probe
-   * did not return a positive integer. Data-branch-only — must never be rendered/logged
-   * publicly. Written onto redacted entries so the denylist secondary guard is
+   * did not return a positive integer. Like `node_id`, this promotes to main with the entry
+   * but must NEVER be embedded in a rendered/logged public surface (issue text, commit
+   * message, log line). Written onto redacted entries so the denylist secondary guard is
    * format-independent.
    */
   database_id?: number
@@ -126,7 +127,8 @@ export function normalizeRepoEntryForStorage(entry: RepoEntry, input: Partial<Re
     nextEntry.owner === entry.owner &&
     nextEntry.name === entry.name &&
     nextEntry.private === entry.private &&
-    nextEntry.node_id === entry.node_id
+    nextEntry.node_id === entry.node_id &&
+    nextEntry.database_id === entry.database_id
   ) {
     return entry
   }
@@ -207,8 +209,9 @@ export interface AddRepoEntryInput {
   node_id?: string
   /**
    * Numeric REST `repository.id` (GitHub's `databaseId`). Optional: absent when the probe
-   * did not return a positive integer. Data-branch-only — must never be rendered/logged
-   * publicly. Written onto redacted entries so the denylist secondary guard is
+   * did not return a positive integer. Like `node_id`, this promotes to main with the entry
+   * but must NEVER be embedded in a rendered/logged public surface (issue text, commit
+   * message, log line). Written onto redacted entries so the denylist secondary guard is
    * format-independent.
    */
   database_id?: number

--- a/scripts/repos-metadata.ts
+++ b/scripts/repos-metadata.ts
@@ -27,6 +27,13 @@ export interface RepoIdentityInput {
   repo: string
   private?: boolean
   node_id?: string
+  /**
+   * Numeric REST `repository.id` (GitHub's `databaseId`). Optional: absent when the probe
+   * did not return a positive integer. Data-branch-only — must never be rendered/logged
+   * publicly. Written onto redacted entries so the denylist secondary guard is
+   * format-independent.
+   */
+  database_id?: number
 }
 
 function assertPrivateNodeId(input: Pick<RepoIdentityInput, 'private' | 'node_id'>): void {
@@ -35,7 +42,9 @@ function assertPrivateNodeId(input: Pick<RepoIdentityInput, 'private' | 'node_id
   }
 }
 
-function definedPrivacyFields(input: Pick<RepoIdentityInput, 'private' | 'node_id'>): Partial<RepoEntry> {
+function definedPrivacyFields(
+  input: Pick<RepoIdentityInput, 'private' | 'node_id' | 'database_id'>,
+): Partial<RepoEntry> {
   const fields: Partial<RepoEntry> = {}
 
   if (input.private !== undefined) {
@@ -44,6 +53,10 @@ function definedPrivacyFields(input: Pick<RepoIdentityInput, 'private' | 'node_i
 
   if (input.node_id !== undefined) {
     fields.node_id = input.node_id
+  }
+
+  if (input.database_id !== undefined) {
+    fields.database_id = input.database_id
   }
 
   return fields
@@ -68,6 +81,7 @@ function findRepoEntryIndex(repos: readonly RepoEntry[], input: RepoIdentityInpu
 export function normalizeRepoEntryForStorage(entry: RepoEntry, input: Partial<RepoIdentityInput> = {}): RepoEntry {
   const nextPrivate = input.private ?? entry.private
   const nextNodeId = input.node_id ?? entry.node_id ?? (entry.owner === REDACTED_OWNER ? entry.name : undefined)
+  const nextDatabaseId = input.database_id ?? entry.database_id
 
   if (nextPrivate === true) {
     assertPrivateNodeId({private: true, node_id: nextNodeId})
@@ -80,18 +94,23 @@ export function normalizeRepoEntryForStorage(entry: RepoEntry, input: Partial<Re
       entry.owner === REDACTED_OWNER &&
       entry.name === redactedName &&
       entry.private === true &&
-      entry.node_id === redactedName
+      entry.node_id === redactedName &&
+      entry.database_id === nextDatabaseId
     ) {
       return entry
     }
 
-    return {
+    const redacted: RepoEntry = {
       ...entry,
       owner: REDACTED_OWNER,
       name: redactedName,
       private: true,
       node_id: redactedName,
     }
+    if (nextDatabaseId !== undefined) {
+      redacted.database_id = nextDatabaseId
+    }
+    return redacted
   }
 
   const nextOwner = input.private === false && input.owner !== undefined ? input.owner : entry.owner
@@ -100,7 +119,7 @@ export function normalizeRepoEntryForStorage(entry: RepoEntry, input: Partial<Re
     ...entry,
     owner: nextOwner,
     name: nextName,
-    ...definedPrivacyFields({private: input.private, node_id: nextNodeId}),
+    ...definedPrivacyFields({private: input.private, node_id: nextNodeId, database_id: input.database_id}),
   }
 
   if (
@@ -186,6 +205,13 @@ export interface AddRepoEntryInput {
   private?: boolean
   /** GitHub GraphQL global node ID. Required when `private` is true. */
   node_id?: string
+  /**
+   * Numeric REST `repository.id` (GitHub's `databaseId`). Optional: absent when the probe
+   * did not return a positive integer. Data-branch-only — must never be rendered/logged
+   * publicly. Written onto redacted entries so the denylist secondary guard is
+   * format-independent.
+   */
+  database_id?: number
   /**
    * Onboarding status for the new entry. Defaults to `'pending'` to match the original
    * invitation-acceptance path. Reconcile passes `'pending-review'` when the repo owner is

--- a/scripts/schemas.test.ts
+++ b/scripts/schemas.test.ts
@@ -729,6 +729,149 @@ describe('schemas — rejection cases', () => {
     }
   })
 
+  it('accepts entry with database_id: 1234567 (positive integer)', () => {
+    const ok = {
+      version: 1,
+      repos: [
+        {
+          owner: '[REDACTED]',
+          name: 'R_kgDOSVJgdw',
+          added: '2026-05-05',
+          onboarding_status: 'onboarded',
+          last_survey_at: '2026-05-06',
+          last_survey_status: 'success',
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: '2026-06-08',
+          private: true,
+          node_id: 'R_kgDOSVJgdw',
+          database_id: 1234567,
+        },
+      ],
+    }
+    expect(isReposFile(ok)).toBe(true)
+    expect(() => assertReposFile(ok)).not.toThrow()
+  })
+
+  it('accepts entry omitting database_id (optional field)', () => {
+    const ok = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
+        },
+      ],
+    }
+    expect(isReposFile(ok)).toBe(true)
+    expect(() => assertReposFile(ok)).not.toThrow()
+  })
+
+  it('rejects database_id: 0 (not positive)', () => {
+    const bad = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
+          database_id: 0,
+        },
+      ],
+    }
+    expect(isReposFile(bad)).toBe(false)
+    const error = catchSchemaError(() => assertReposFile(bad))
+    expect(error.path).toContain('database_id')
+  })
+
+  it('rejects database_id: -5 (negative)', () => {
+    const bad = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
+          database_id: -5,
+        },
+      ],
+    }
+    expect(isReposFile(bad)).toBe(false)
+    const error = catchSchemaError(() => assertReposFile(bad))
+    expect(error.path).toContain('database_id')
+  })
+
+  it('rejects database_id: 12.5 (not an integer)', () => {
+    const bad = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
+          database_id: 12.5,
+        },
+      ],
+    }
+    expect(isReposFile(bad)).toBe(false)
+    const error = catchSchemaError(() => assertReposFile(bad))
+    expect(error.path).toContain('database_id')
+  })
+
+  it('rejects database_id: "1234" (string, not number)', () => {
+    const bad = {
+      version: 1,
+      repos: [
+        {
+          owner: 'fro-bot',
+          name: 'test',
+          added: '2026-04-17',
+          onboarding_status: 'pending',
+          last_survey_at: null,
+          last_survey_status: null,
+          has_fro_bot_workflow: false,
+          has_renovate: false,
+          discovery_channel: 'collab',
+          next_survey_eligible_at: null,
+          database_id: '1234',
+        },
+      ],
+    }
+    expect(isReposFile(bad)).toBe(false)
+    const error = catchSchemaError(() => assertReposFile(bad))
+    expect(error.path).toContain('database_id')
+  })
+
   it('rejects non-string entry in with-renovate list', () => {
     const bad = {repositories: {'with-renovate': ['valid', 42]}}
     expect(isRenovateFile(bad)).toBe(false)

--- a/scripts/schemas.ts
+++ b/scripts/schemas.ts
@@ -79,6 +79,16 @@ export interface RepoEntry {
    * Optional during the rollout window for the same reason as `private`. Tightened later.
    */
   node_id?: string
+  /**
+   * Stable numeric GitHub REST `repository.id`. The format-independent denylist anchor for
+   * redacted entries: unlike `node_id`, this value does not change when GitHub migrates its
+   * node_id format (legacy base64 → next-gen `R_…`). Populated by reconcile's field probe.
+   *
+   * DATA-BRANCH-ONLY. Must never be rendered or logged publicly — treat with the same
+   * redaction discipline as `node_id`. Optional: legacy and public entries need not carry it;
+   * a redacted entry without `database_id` remains protected by the primary `node_id` guard.
+   */
+  database_id?: number
 }
 
 export type OnboardingStatus = 'pending' | 'onboarded' | 'failed' | 'lost-access' | 'pending-review'
@@ -234,7 +244,9 @@ function isRepoEntry(value: unknown): value is RepoEntry {
       typeof value.next_survey_eligible_at === 'string') &&
     (value.private === undefined || typeof value.private === 'boolean') &&
     (value.node_id === undefined ||
-      (typeof value.node_id === 'string' && value.node_id.length > 0 && NODE_ID_PATTERN.test(value.node_id)))
+      (typeof value.node_id === 'string' && value.node_id.length > 0 && NODE_ID_PATTERN.test(value.node_id))) &&
+    (value.database_id === undefined ||
+      (typeof value.database_id === 'number' && Number.isInteger(value.database_id) && value.database_id > 0))
   )
 }
 
@@ -274,6 +286,14 @@ function assertRepoEntry(value: unknown, path: string): asserts value is RepoEnt
     throw new SchemaValidationError(
       `${path}.node_id`,
       'expected safe GitHub node_id (no slash; base64url body with optional padding)',
+    )
+  if (
+    value.database_id !== undefined &&
+    (typeof value.database_id !== 'number' || !Number.isInteger(value.database_id) || value.database_id <= 0)
+  )
+    throw new SchemaValidationError(
+      `${path}.database_id`,
+      'expected positive integer (stable numeric GitHub repository.id) or omitted',
     )
 }
 

--- a/scripts/schemas.ts
+++ b/scripts/schemas.ts
@@ -84,9 +84,10 @@ export interface RepoEntry {
    * redacted entries: unlike `node_id`, this value does not change when GitHub migrates its
    * node_id format (legacy base64 → next-gen `R_…`). Populated by reconcile's field probe.
    *
-   * DATA-BRANCH-ONLY. Must never be rendered or logged publicly — treat with the same
-   * redaction discipline as `node_id`. Optional: legacy and public entries need not carry it;
-   * a redacted entry without `database_id` remains protected by the primary `node_id` guard.
+   * Like `node_id`, this promotes to main with the entry but must NEVER be embedded in a
+   * rendered/logged public surface (issue text, commit message, log line). Optional: legacy
+   * and public entries need not carry it; a redacted entry without `database_id` remains
+   * protected by the primary `node_id` guard.
    */
   database_id?: number
 }


### PR DESCRIPTION
Hardens the redaction denylist that keeps private repos off the dashboard. Today a redacted entry is protected by a single anchor — its `node_id` — and `metadata/repos.yaml` carries no numeric fallback. GitHub has migrated the `node_id` format once already (legacy base64 → next-gen `R_…`); if it migrates again, a redacted entry written under the old format would stop matching the id the API returns, and with no fallback the repo could drift into the dashboard's working set. The numeric `repository.id` is stable across both formats, so this adds it as a format-independent secondary anchor.

## What changed

- **Schema** — `RepoEntry` gains an optional, validated `database_id` (positive integer). Optional by design: legacy and public entries need not carry it, and a redacted entry without it stays protected by the primary `node_id` guard.
- **Probe** — the reconcile field probe now captures the numeric `repository.id` per tracked repo and surfaces it on the probe result. Capture is defensive: a missing or unreadable id yields no `database_id` (never a crash, never a "malformed" classification).
- **Writer** — redacted entries persist `database_id` at write time, so new private repos are format-independent by construction rather than relying on a one-time backfill. The writer stays pure and idempotent; `database_id` is never required for redaction.

The dashboard needs no change — its denylist already consumes `database_id` when present.

## Privacy

`database_id` carries the same discipline as `node_id`: it is never embedded in any rendered or logged public surface (issue text, commit message, log line). Like `node_id`, it does travel to `main` with the entry on the weekly data merge; the numeric id is a non-sensitive small integer and never reveals the canonical owner/name. Verified across the diff that no render/log/issue path carries it.

## Notes

- The field probe is REST-based, so the numeric id is read from `repos.get` (`repository.id`) — one additional call per tracked repo per reconcile, negligible against the rate budget at the current repo count.
- Backfilling the two existing redacted entries is not part of this change: the next reconcile run captures and writes their `database_id` naturally, through the data-branch authority path.

Tests cover the schema validation, probe capture (including the absent-id and API-error paths), and writer persistence (including idempotency, the public-entry refresh path, and that no canonical identifier leaks).

Closes #3525
