### PR TITLE
feat: auto-star contributor/collaborator repos during reconcile

### DIFF
--- a/.github/workflows/reconcile-repos.yaml
+++ b/.github/workflows/reconcile-repos.yaml
@@ -109,6 +109,7 @@ jobs:
             echo "| Contrib tracked | $(jq '.summary.byChannel.contrib.tracked // 0' "$result") |"
             echo "| Stuck candidates | $(jq '.summary.stuckCandidates // 0' "$result") |"
             echo "| Stars added | $(jq '.starsAdded // 0' "$result") |"
+            echo "| Stars already present | $(jq '.starsAlreadyPresent // 0' "$result") |"
             echo "| Star failures | $(jq '.starFailures // 0' "$result") |"
           } >> "$GITHUB_STEP_SUMMARY"
         shell: bash

--- a/.github/workflows/reconcile-repos.yaml
+++ b/.github/workflows/reconcile-repos.yaml
@@ -108,5 +108,7 @@ jobs:
             echo "| Entries migrated | $(jq '.summary.migrated // 0' "$result") |"
             echo "| Contrib tracked | $(jq '.summary.byChannel.contrib.tracked // 0' "$result") |"
             echo "| Stuck candidates | $(jq '.summary.stuckCandidates // 0' "$result") |"
+            echo "| Stars added | $(jq '.starsAdded // 0' "$result") |"
+            echo "| Star failures | $(jq '.starFailures // 0' "$result") |"
           } >> "$GITHUB_STEP_SUMMARY"
         shell: bash

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Fro Bot control plane:
 | **Fro Bot** | Core agent: PR review, issue triage, scheduled oversight, manual tasks | Issues, PR events, schedule, dispatch |
 | **Fro Bot Autoheal** | Scheduled self-repair pass | Daily 03:30 UTC, dispatch |
 | **Poll Invitations** | Accept allowlisted collaboration invitations | Every 15 minutes, dispatch |
-| **Reconcile Repos** | Reconcile collaborator access against `metadata/repos.yaml`; dispatch surveys for stale repos | Daily 05:17 UTC, dispatch |
+| **Reconcile Repos** | Reconcile collaborator access against `metadata/repos.yaml`; dispatch surveys for stale repos; auto-stars collab/contrib repos | Daily 05:17 UTC, dispatch |
 | **Survey Repo** | Ingest a repository into the knowledge wiki; dispatched by Reconcile Repos or manually via `gh workflow run survey-repo.yaml -f node_id=<node_id>` | Dispatch (by Reconcile Repos) |
 | **Merge Data Branch** | Promote autonomous `data`-branch commits to `main` | Sunday 22:00 UTC, dispatch |
 | **Update Metadata** | Refresh `metadata/renovate.yaml` from the fro-bot org scan | Daily 04:30 UTC, dispatch |

--- a/docs/plans/2026-06-21-002-feat-reconcile-auto-star-repos-plan.md
+++ b/docs/plans/2026-06-21-002-feat-reconcile-auto-star-repos-plan.md
@@ -1,0 +1,143 @@
+---
+title: 'feat: auto-star contributor/collaborator repos during reconcile'
+type: feat
+status: active
+date: 2026-06-21
+origin: operator request (auto-star repos Fro Bot is a contributor/collaborator of)
+---
+
+# feat: auto-star contributor/collaborator repos during reconcile
+
+## Overview
+
+Fro Bot should star the repos it is a contributor/collaborator of. This happens in two
+places:
+
+1. **On invitation ingest** — already implemented: `scripts/handle-invitation.ts` calls
+   `activity.starRepoForAuthenticatedUser` right after accepting an invitation (a fresh
+   accept, so an unconditional star is correct there). **No change needed.**
+2. **During reconciliation** — new work: for each repo Fro Bot currently has
+   collaborator/contributor access to, if it is not already starred by `@fro-bot`, star it
+   via the GitHub API. Self-healing: a repo that loses its star (manual unstar) is re-starred
+   on the next reconcile.
+
+This plan covers only the new **reconcile-time** path.
+
+## Problem Frame
+
+The invitation path stars a repo once, at accept time. But the star is never re-asserted: if
+a repo is unstarred, or was added to the tracked set by reconcile discovery (owned/contrib
+channels never flow through the invitation accept path), it is never starred. Reconcile is
+the steady-state loop that already enumerates Fro Bot's live access; it is the natural place
+to keep the star set in sync.
+
+## Key Technical Decisions
+
+- **Credential: `FRO_BOT_POLL_PAT` (the user PAT), NOT the App token.** A star is a *user*
+  action — it must be attributed to `@fro-bot` the user. The App installation token acts as
+  `fro-bot[bot]` and cannot star as the user. `handleReconcile` already holds `userOctokit`
+  (`FRO_BOT_POLL_PAT`, classic `repo` scope) for `/user/repos` enumeration; the star path
+  reuses it. No workflow change — the PAT is already in the reconcile job env.
+- **Stateless check-then-star (no schema field).** For each candidate, call
+  `activity.checkRepoIsStarredByAuthenticatedUser({owner, repo})` (cheap; 204 = starred,
+  404 = not). If 404, call `activity.starRepoForAuthenticatedUser({owner, repo})`. No
+  `starred` field in `metadata/repos.yaml` — the GitHub star set is the source of truth, and
+  the check is self-healing (re-stars an externally-unstarred repo). Matches the operator's
+  literal "if there's no star from @fro-bot, star it" and this program's
+  observability/derive-over-store posture (see the `stuckCandidates` canary doc).
+- **Candidate set: collab + contrib channel repos** (the literal "contributor/collaborator"
+  set), resolved from `accessList` + `accessChannelByKey`. **Owned repos (`fro-bot/*`) are
+  excluded** — Fro Bot owns them, it is not a collaborator there; self-starring owned repos is
+  pointless. _Flippable: if owned repos should also be starred, drop the channel filter._
+- **Private repos included.** A star on a private repo is visible only to those with access —
+  not a public surface — so starring private collaborator repos is in scope. The check/star
+  calls use the canonical `owner/name` from `accessList` **in-memory only**; telemetry is
+  **counts-only** (`starsAdded` / `starFailures`), never the canonical name in any log, issue,
+  or commit — same privacy discipline as the rest of reconcile.
+- **Non-blocking side-effect, mirrors `runDispatches`.** A star check/call failure increments
+  `starFailures` and continues; it never aborts the reconcile run (the substantive
+  classification/commit work is already done). Injectable for tests.
+
+## Context & Research
+
+### Relevant Code and Patterns (grounded)
+
+- `scripts/handle-invitation.ts:229` — existing invitation-time star
+  (`activity.starRepoForAuthenticatedUser`). Trigger 1; unchanged.
+- `scripts/reconcile-repos.ts`:
+  - `handleReconcile` (I/O shell) — `userOctokit` = `FRO_BOT_POLL_PAT`; the new step slots in
+    alongside the dispatch/issue side-effects (after the dispatch loop, non-blocking).
+  - `runDispatches` — the exact side-effect pattern to mirror (async, per-item try/catch,
+    counts-only `{succeeded, failed}`, injectable `sleep`, logger warn on failure).
+  - `AccessListEntry` `{owner, name, archived, private, node_id}` + `accessChannelByKey` —
+    the candidate source.
+  - `HandleReconcileResult` / `ReconcileSummary` — where star counters surface.
+- Octokit methods (verified real, not hallucinated): `activity.starRepoForAuthenticatedUser`,
+  `activity.checkRepoIsStarredByAuthenticatedUser` (the historical `starRepo` hallucination is
+  documented in `commit-metadata.ts` and a solutions doc — use the `*ForAuthenticatedUser`
+  forms).
+
+## Implementation Units
+
+- [ ] **Unit 1: reconcile-time star sync (test-first)**
+
+**Goal:** Star collab/contrib-channel accessible repos that `@fro-bot` has not yet starred,
+during each reconcile run, idempotently and non-blocking.
+
+**Files (`fro-bot/.github`):**
+- Modify: `scripts/reconcile-repos.ts` — add a `syncStars(...)` side-effect function
+  (mirroring `runDispatches`); wire it into `handleReconcile` after the dispatch loop using
+  `userOctokit`; iterate `accessList` filtered to collab/contrib via `accessChannelByKey`;
+  check-then-star; add `starsAdded` / `starFailures` (and `starsAlreadyPresent`) to the
+  result/summary; emit counts-only telemetry.
+- Modify: `scripts/reconcile-repos.test.ts` — TDD coverage.
+- Modify: `.github/workflows/reconcile-repos.yaml` — surface star counts in the step summary
+  (counts-only) if a summary block exists; **no credential change** (PAT already present).
+- Modify: `metadata/README.md` — document the reconcile auto-star behavior.
+
+**Approach:** New `syncStars({userOctokit, candidates, logger, sleep?})`: for each candidate
+`{owner, name}`, `checkRepoIsStarredByAuthenticatedUser`; on 404 (not starred)
+`starRepoForAuthenticatedUser`; on 204 increment `starsAlreadyPresent`; per-item try/catch →
+`starFailures` + `logger.warn` (status/kind only, no name). Candidates = `accessList` entries
+whose `accessChannelByKey` channel is `collab` or `contrib`. Return `{starsAdded,
+starFailures, starsAlreadyPresent}`; fold into `HandleReconcileResult` + the JSON summary.
+Place the call after the dispatch loop (step ~9.5), non-blocking.
+
+**Test scenarios:**
+- Happy: an unstarred collab repo (check → 404) is starred (`starsAdded` increments,
+  `starRepoForAuthenticatedUser` called with its owner/name).
+- Idempotent: an already-starred repo (check → 204) is NOT re-starred (`starsAlreadyPresent`
+  increments, no star call).
+- Channel filter: an owned-channel repo is NOT considered (no check/star call for it).
+- Private included: a private collab repo (check → 404) IS starred; assert no canonical name
+  in any logged/telemetry output (counts-only).
+- Non-blocking: a check or star call that rejects increments `starFailures` and the reconcile
+  run still completes; subsequent candidates are still processed.
+- Credential: star calls go through `userOctokit` (the PAT), never `appOctokit`.
+
+**Verification:** `pnpm check-types`, `pnpm lint`, `pnpm test` green; strip-only load clean;
+no canonical repo name reaches any log/telemetry line; star path uses the user PAT only.
+
+## System-Wide Impact
+
+- Adds per-repo `checkRepoIsStarredByAuthenticatedUser` calls (one per collab/contrib repo per
+  reconcile) on the user PAT — negligible at the current repo count, well within rate budget;
+  consistent with the per-repo field-probe calls reconcile already makes.
+- No metadata schema change, no new workflow credential, no change to the data-branch
+  authority model or the dispatch/commit ordering.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Star attributed to `fro-bot[bot]` instead of `@fro-bot` | Use `userOctokit` (PAT), never the App token — a star is a user action |
+| Private repo name leaks via star telemetry | Canonical names used in-memory only; telemetry counts-only; per-program privacy discipline |
+| Star call failure aborts reconcile | Per-item try/catch, non-blocking, counts-only `starFailures`, mirrors `runDispatches` |
+| Hallucinated Octokit method | Use verified `*ForAuthenticatedUser` forms; the `starRepo` hallucination is already documented |
+
+## Sources & References
+
+- Existing invitation-time star: `scripts/handle-invitation.ts:229`
+- Side-effect pattern: `scripts/reconcile-repos.ts` `runDispatches`
+- Octokit method-name discipline: `docs/solutions/runtime-errors/` (the `starRepo` →
+  `starRepoForAuthenticatedUser` learning)

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -229,6 +229,22 @@ The `Merge Data Branch` workflow runs on a schedule (weekly) and opens a `data �
 
 `metrics.yaml` is intentionally deferred. Operational telemetry is routed through the journal issue system. The metrics pipeline belongs to the deferred self-improvement plan.
 
+## Reconcile auto-star
+
+During each reconcile run, Fro Bot stars every collab- and contrib-channel repo it has access to that it has not already starred. Owned repos (`fro-bot/*`) are excluded — Fro Bot owns them and self-starring is pointless.
+
+The star path is:
+
+1. For each collab/contrib candidate, call `activity.checkRepoIsStarredByAuthenticatedUser` (204 = already starred, 404 = not starred).
+2. On 404, call `activity.starRepoForAuthenticatedUser`.
+3. Any failure increments `starFailures` and the loop continues — one failure never aborts the reconcile run.
+
+This is self-healing: a repo that loses its star (manual unstar) is re-starred on the next reconcile run. Private repos are included — a star on a private repo is visible only to those with access.
+
+**Credential:** stars are a user action and must use the `FRO_BOT_POLL_PAT` (the user PAT), never the App installation token. The App acts as `fro-bot[bot]` and cannot star as the user.
+
+**Telemetry:** counts-only (`starsAdded`, `starsAlreadyPresent`, `starFailures`). Canonical owner/name never appears in any log or telemetry line.
+
 ## Reconcile run serialization
 
 Reconcile runs are serialized by the `reconcile-repos.yaml` workflow's concurrency group (`group: reconcile-repos, cancel-in-progress: false`). A manual rerun queues behind the currently-running scheduled job and starts only after it fully completes — well over ten minutes (the staggered survey dispatches alone span the majority of that) — far longer than the GitHub Issues listing API's few-second eventual-consistency lag.

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -7578,11 +7578,11 @@ describe('syncStars', () => {
   })
 
   describe('credential — star calls use userOctokit, not appOctokit', () => {
-    it('star and check calls go through userOctokit; appOctokit.activity methods are never called', async () => {
-      // GIVEN a candidate that needs starring
-      // WHEN syncStars runs with separate userOctokit and appOctokit
+    it('star and check calls go through userOctokit; appOctokit.activity methods are never called (integration)', async () => {
+      // GIVEN an unstarred collab repo in the access list
+      // AND both userOctokit and appOctokit are wired with distinct activity mocks
       const userCheckStar = vi.fn(async () => {
-        throw apiError(404, 'Not Found')
+        throw apiError(404, 'Not Found') // not starred
       })
       const userStarRepo = vi.fn(async () => undefined)
       const appCheckStar = vi.fn(async () => undefined)
@@ -7591,23 +7591,123 @@ describe('syncStars', () => {
       const userOctokit = mockOctokit({
         checkRepoIsStarredByAuthenticatedUser: userCheckStar as never,
         starRepoForAuthenticatedUser: userStarRepo as never,
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {owner: {login: 'marcusrbrown'}, name: 'some-repo', archived: false, private: false, node_id: 'R_some'},
+          ],
+        }),
       })
-      // appOctokit is NOT passed to syncStars — but we verify its activity methods are untouched
-      // by wiring them into a separate mock and asserting they were never called.
+      // appOctokit has its own activity mocks — if syncStars mistakenly used appOctokit,
+      // these would be called and the assertions below would catch it.
+      const appOctokit = mockOctokit({
+        checkRepoIsStarredByAuthenticatedUser: appCheckStar as never,
+        starRepoForAuthenticatedUser: appStarRepo as never,
+      })
+
+      // WHEN handleReconcile runs end-to-end
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit,
+          readMetadata: makeReadMetadata({allowlist: makeAllowlist(['marcusrbrown'])}),
+        }),
+      )
+
+      // THEN userOctokit's activity methods were called (the star went through)
+      expect(userCheckStar).toHaveBeenCalledOnce()
+      expect(userStarRepo).toHaveBeenCalledOnce()
+      expect(result.starsAdded).toBe(1)
+      // AND appOctokit's activity methods were NEVER called
+      // (mutation-proof: if syncStars were switched to appOctokit, these would fail)
+      expect(appCheckStar).not.toHaveBeenCalled()
+      expect(appStarRepo).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('rate-limit early break', () => {
+    it('stops the loop when check throws a rate-limit error; later candidates are not processed', async () => {
+      // GIVEN three candidates; the first check throws a 429 rate-limit error
+      const checkStar = vi
+        .fn()
+        .mockRejectedValueOnce(apiError(429, 'Too Many Requests')) // candidate 1: rate-limited
+        .mockResolvedValueOnce(undefined) // candidate 2: would resolve (already starred)
+        .mockRejectedValueOnce(apiError(404, 'Not Found')) // candidate 3: would need starring
+      const starRepo = vi.fn(async () => undefined)
+      const userOctokit = mockOctokit({
+        checkRepoIsStarredByAuthenticatedUser: checkStar as never,
+        starRepoForAuthenticatedUser: starRepo as never,
+      })
       const logger = silentLogger()
 
-      await syncStars({
+      // WHEN syncStars runs
+      const result = await syncStars({
         userOctokit,
-        candidates: [{owner: 'marcusrbrown', name: 'some-repo'}],
+        candidates: [
+          {owner: 'owner-a', name: 'repo-a'},
+          {owner: 'owner-b', name: 'repo-b'},
+          {owner: 'owner-c', name: 'repo-c'},
+        ],
         logger,
       })
 
-      // THEN userOctokit's activity methods were called
-      expect(userCheckStar).toHaveBeenCalledOnce()
-      expect(userStarRepo).toHaveBeenCalledOnce()
-      // AND appOctokit's activity methods were never called
-      expect(appCheckStar).not.toHaveBeenCalled()
-      expect(appStarRepo).not.toHaveBeenCalled()
+      // THEN the loop stopped after the first candidate
+      // starFailures reflects the rate-limited candidate
+      expect(result.starFailures).toBe(1)
+      // starsAdded and starsAlreadyPresent are zero (loop broke before any success)
+      expect(result.starsAdded).toBe(0)
+      expect(result.starsAlreadyPresent).toBe(0)
+      // AND candidates 2 and 3 were never checked (loop broke early)
+      expect(checkStar).toHaveBeenCalledTimes(1)
+      expect(starRepo).not.toHaveBeenCalled()
+      // AND a single warn was emitted with status, no owner/name
+      expect(logger.warn).toHaveBeenCalledOnce()
+      const warnMsg = logger.warn.mock.calls[0]?.[0] ?? ''
+      expect(warnMsg).toContain('rate limit')
+      expect(warnMsg).toContain('status=429')
+      expect(warnMsg).not.toContain('owner-a')
+      expect(warnMsg).not.toContain('repo-a')
+    })
+
+    it('stops the loop when star call throws a rate-limit error (403 + x-ratelimit-remaining: 0)', async () => {
+      // GIVEN two candidates; the first check returns 404 (not starred) but the star call is rate-limited
+      const rateLimitError = Object.assign(new Error('API rate limit exceeded'), {
+        status: 403,
+        response: {headers: {'x-ratelimit-remaining': '0'}},
+      })
+      const checkStar = vi
+        .fn()
+        .mockRejectedValueOnce(apiError(404, 'Not Found')) // candidate 1: not starred
+        .mockRejectedValueOnce(apiError(404, 'Not Found')) // candidate 2: would need starring
+      const starRepo = vi.fn().mockRejectedValueOnce(rateLimitError) // star call rate-limited
+      const userOctokit = mockOctokit({
+        checkRepoIsStarredByAuthenticatedUser: checkStar as never,
+        starRepoForAuthenticatedUser: starRepo as never,
+      })
+      const logger = silentLogger()
+
+      // WHEN syncStars runs
+      const result = await syncStars({
+        userOctokit,
+        candidates: [
+          {owner: 'owner-a', name: 'repo-a'},
+          {owner: 'owner-b', name: 'repo-b'},
+        ],
+        logger,
+      })
+
+      // THEN the loop stopped after the first candidate's star call failed
+      expect(result.starFailures).toBe(1)
+      expect(result.starsAdded).toBe(0)
+      // AND candidate 2's check was never called (loop broke after star failure)
+      expect(checkStar).toHaveBeenCalledTimes(1)
+      expect(starRepo).toHaveBeenCalledTimes(1)
+      // AND the warn message contains status, no owner/name
+      expect(logger.warn).toHaveBeenCalledOnce()
+      const warnMsg = logger.warn.mock.calls[0]?.[0] ?? ''
+      expect(warnMsg).toContain('rate limit')
+      expect(warnMsg).toContain('status=403')
+      expect(warnMsg).not.toContain('owner-a')
+      expect(warnMsg).not.toContain('repo-a')
     })
   })
 
@@ -7749,6 +7849,68 @@ describe('handleReconcile — star sync integration', () => {
 
       expect(result.starFailures).toBe(1)
       expect(result.starsAdded).toBe(0)
+    })
+  })
+
+  describe('contrib channel — unstarred contrib repo flows through to a star call', () => {
+    it('stars an unstarred contrib-channel repo; starsAdded reflects it', async () => {
+      // GIVEN an allowlist with one contrib repo (bfra-me/.github) that has a trusted workflow
+      const contribAllowlist: AllowlistFile = {
+        version: 1,
+        approved_inviters: [],
+        approved_contrib_repos: ['bfra-me/.github'],
+      }
+
+      const trustedWorkflow = `name: Fro Bot
+on: [issues, pull_request]
+jobs:
+  agent:
+    uses: fro-bot/agent/.github/workflows/fro-bot.yaml@v0.42.1
+`
+
+      // reposGet drives probeContribRepoMetadata for the contrib repo
+      const reposGet = async ({owner, repo}: {owner: string; repo: string}) => {
+        if (owner === 'bfra-me' && repo === '.github') {
+          return {data: {archived: false, fork: false, private: false, node_id: 'R_bfra_gh'} as RepoGetResponse}
+        }
+        return {data: {archived: false, private: false, node_id: 'R_default'} as RepoGetResponse}
+      }
+
+      // The contrib repo is not yet starred (check → 404)
+      const checkStar = vi.fn(async () => {
+        throw apiError(404, 'Not Found')
+      })
+      const starRepo = vi.fn(async () => undefined)
+
+      const userOctokit = mockOctokit({
+        checkRepoIsStarredByAuthenticatedUser: checkStar as never,
+        starRepoForAuthenticatedUser: starRepo as never,
+        // No collab repos — only contrib
+        listForAuthenticatedUser: async () => ({data: []}),
+      })
+
+      const appOctokit = mockOctokit({
+        paginate: async () => [], // no owned repos
+        getContent: contentByRepo(new Map([['bfra-me/.github', trustedWorkflow]])),
+        reposGet,
+      })
+
+      // WHEN handleReconcile runs
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit,
+          readMetadata: makeReadMetadata({allowlist: contribAllowlist}),
+        }),
+      )
+
+      // THEN the contrib repo was starred (starsAdded reflects it)
+      expect(result.starsAdded).toBe(1)
+      expect(result.starsAlreadyPresent).toBe(0)
+      expect(result.starFailures).toBe(0)
+      // AND the star call was made for the contrib repo
+      expect(starRepo).toHaveBeenCalledOnce()
+      expect(starRepo).toHaveBeenCalledWith({owner: 'bfra-me', repo: '.github'})
     })
   })
 })

--- a/scripts/reconcile-repos.test.ts
+++ b/scripts/reconcile-repos.test.ts
@@ -22,6 +22,7 @@ import {
   ReconcileError,
   reconcileRepos,
   renderIssuePayload,
+  syncStars,
   type AccessListEntry,
   type FieldProbe,
   type HandleReconcileParams,
@@ -2409,6 +2410,8 @@ interface OctokitMockOverrides {
   issuesListForRepo?: (params: unknown) => Promise<{data: IssueListEntry[]}>
   issuesGetLabel?: (params: unknown) => Promise<{data: {name: string}}>
   issuesCreateLabel?: (params: unknown) => Promise<{data: {name: string}}>
+  checkRepoIsStarredByAuthenticatedUser?: (params: {owner: string; repo: string}) => Promise<void>
+  starRepoForAuthenticatedUser?: (params: {owner: string; repo: string}) => Promise<void>
 }
 
 interface AccessListApiEntry {
@@ -2547,6 +2550,15 @@ function mockOctokit(overrides: OctokitMockOverrides = {}): OctokitClient {
         listForRepo: overrides.issuesListForRepo ?? (async () => ({data: [] as IssueListEntry[]})),
         getLabel: overrides.issuesGetLabel ?? (async () => ({data: {name: 'label'}})),
         createLabel: overrides.issuesCreateLabel ?? (async () => ({data: {name: 'label'}})),
+      },
+      activity: {
+        checkRepoIsStarredByAuthenticatedUser:
+          overrides.checkRepoIsStarredByAuthenticatedUser ??
+          (async () => {
+            // Default: not starred (throws 404)
+            throw apiError(404, 'Not Found')
+          }),
+        starRepoForAuthenticatedUser: overrides.starRepoForAuthenticatedUser ?? (async () => undefined),
       },
     },
   } as unknown as OctokitClient
@@ -7401,5 +7413,342 @@ describe('handleReconcile visibility-transition: partial label confirmation is n
     // confirming the partial result from issue 1 was NOT cached and issue 2 retried.
     const integrityLabelCallCount = getLabelCalls.filter(n => n === 'reconcile:integrity-alert').length
     expect(integrityLabelCallCount).toBeGreaterThanOrEqual(2)
+  })
+})
+
+// ─── syncStars ───────────────────────────────────────────────────────────────
+
+describe('syncStars', () => {
+  describe('happy path — unstarred repo', () => {
+    it('calls starRepoForAuthenticatedUser when check throws 404, increments starsAdded', async () => {
+      // GIVEN a collab repo that is not yet starred (check → 404)
+      // WHEN syncStars runs
+      const checkStar = vi.fn(async () => {
+        throw apiError(404, 'Not Found')
+      })
+      const starRepo = vi.fn(async () => undefined)
+      const userOctokit = mockOctokit({
+        checkRepoIsStarredByAuthenticatedUser: checkStar as never,
+        starRepoForAuthenticatedUser: starRepo as never,
+      })
+      const logger = silentLogger()
+
+      const result = await syncStars({
+        userOctokit,
+        candidates: [{owner: 'marcusrbrown', name: 'cool-repo'}],
+        logger,
+      })
+
+      // THEN the repo is starred and starsAdded increments
+      expect(result.starsAdded).toBe(1)
+      expect(result.starsAlreadyPresent).toBe(0)
+      expect(result.starFailures).toBe(0)
+      expect(starRepo).toHaveBeenCalledOnce()
+      expect(starRepo).toHaveBeenCalledWith({owner: 'marcusrbrown', repo: 'cool-repo'})
+    })
+  })
+
+  describe('idempotency — already-starred repo', () => {
+    it('does NOT call starRepoForAuthenticatedUser when check resolves (204), increments starsAlreadyPresent', async () => {
+      // GIVEN a repo that is already starred (check → resolves without throwing)
+      // WHEN syncStars runs
+      const checkStar = vi.fn(async () => undefined) // resolves = already starred
+      const starRepo = vi.fn(async () => undefined)
+      const userOctokit = mockOctokit({
+        checkRepoIsStarredByAuthenticatedUser: checkStar as never,
+        starRepoForAuthenticatedUser: starRepo as never,
+      })
+      const logger = silentLogger()
+
+      const result = await syncStars({
+        userOctokit,
+        candidates: [{owner: 'marcusrbrown', name: 'already-starred'}],
+        logger,
+      })
+
+      // THEN no star call is made and starsAlreadyPresent increments
+      expect(result.starsAdded).toBe(0)
+      expect(result.starsAlreadyPresent).toBe(1)
+      expect(result.starFailures).toBe(0)
+      expect(starRepo).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('private collab repo — starred, counts-only telemetry', () => {
+    it('stars a private collab repo (check 404) and emits no canonical name in logger output', async () => {
+      // GIVEN a private collab repo not yet starred
+      // WHEN syncStars runs
+      const checkStar = vi.fn(async () => {
+        throw apiError(404, 'Not Found')
+      })
+      const starRepo = vi.fn(async () => undefined)
+      const userOctokit = mockOctokit({
+        checkRepoIsStarredByAuthenticatedUser: checkStar as never,
+        starRepoForAuthenticatedUser: starRepo as never,
+      })
+      const logger = silentLogger()
+
+      const result = await syncStars({
+        userOctokit,
+        candidates: [{owner: 'private-owner', name: 'secret-repo'}],
+        logger,
+      })
+
+      // THEN the repo is starred
+      expect(result.starsAdded).toBe(1)
+      expect(starRepo).toHaveBeenCalledOnce()
+
+      // AND no canonical owner/name appears in any logger output (counts-only)
+      const allLogMessages = [...logger.warn.mock.calls.map(c => c[0]), ...logger.info.mock.calls.map(c => c[0])]
+      for (const msg of allLogMessages) {
+        expect(msg).not.toContain('private-owner')
+        expect(msg).not.toContain('secret-repo')
+      }
+    })
+  })
+
+  describe('non-blocking — check error (non-404)', () => {
+    it('increments starFailures on non-404 check error, continues to next candidate', async () => {
+      // GIVEN a check that throws a non-404 error (e.g. 500), followed by a normal unstarred repo
+      // WHEN syncStars runs
+      const checkStar = vi
+        .fn()
+        .mockRejectedValueOnce(apiError(500, 'Internal Server Error'))
+        .mockRejectedValueOnce(apiError(404, 'Not Found'))
+      const starRepo = vi.fn(async () => undefined)
+      const userOctokit = mockOctokit({
+        checkRepoIsStarredByAuthenticatedUser: checkStar as never,
+        starRepoForAuthenticatedUser: starRepo as never,
+      })
+      const logger = silentLogger()
+
+      const result = await syncStars({
+        userOctokit,
+        candidates: [
+          {owner: 'owner-a', name: 'repo-a'},
+          {owner: 'owner-b', name: 'repo-b'},
+        ],
+        logger,
+      })
+
+      // THEN the first candidate fails (starFailures), the second is starred (starsAdded)
+      expect(result.starFailures).toBe(1)
+      expect(result.starsAdded).toBe(1)
+      expect(result.starsAlreadyPresent).toBe(0)
+      // AND the loop continued — star was called for the second candidate
+      expect(starRepo).toHaveBeenCalledOnce()
+      expect(starRepo).toHaveBeenCalledWith({owner: 'owner-b', repo: 'repo-b'})
+    })
+  })
+
+  describe('non-blocking — star call error', () => {
+    it('increments starFailures when starRepoForAuthenticatedUser throws, continues to next candidate', async () => {
+      // GIVEN a check that returns 404 (not starred) but the star call itself fails
+      // AND a second candidate that succeeds normally
+      // WHEN syncStars runs
+      const checkStar = vi.fn(async () => {
+        throw apiError(404, 'Not Found')
+      })
+      const starRepo = vi.fn().mockRejectedValueOnce(apiError(403, 'Forbidden')).mockResolvedValueOnce(undefined)
+      const userOctokit = mockOctokit({
+        checkRepoIsStarredByAuthenticatedUser: checkStar as never,
+        starRepoForAuthenticatedUser: starRepo as never,
+      })
+      const logger = silentLogger()
+
+      const result = await syncStars({
+        userOctokit,
+        candidates: [
+          {owner: 'owner-a', name: 'repo-a'},
+          {owner: 'owner-b', name: 'repo-b'},
+        ],
+        logger,
+      })
+
+      // THEN the first star call fails (starFailures), the second succeeds (starsAdded)
+      expect(result.starFailures).toBe(1)
+      expect(result.starsAdded).toBe(1)
+      // AND the warn message contains status/kind only, no owner/name
+      expect(logger.warn).toHaveBeenCalledOnce()
+      const warnMsg = logger.warn.mock.calls[0]?.[0] ?? ''
+      expect(warnMsg).toContain('status=403')
+      expect(warnMsg).not.toContain('owner-a')
+      expect(warnMsg).not.toContain('repo-a')
+    })
+  })
+
+  describe('credential — star calls use userOctokit, not appOctokit', () => {
+    it('star and check calls go through userOctokit; appOctokit.activity methods are never called', async () => {
+      // GIVEN a candidate that needs starring
+      // WHEN syncStars runs with separate userOctokit and appOctokit
+      const userCheckStar = vi.fn(async () => {
+        throw apiError(404, 'Not Found')
+      })
+      const userStarRepo = vi.fn(async () => undefined)
+      const appCheckStar = vi.fn(async () => undefined)
+      const appStarRepo = vi.fn(async () => undefined)
+
+      const userOctokit = mockOctokit({
+        checkRepoIsStarredByAuthenticatedUser: userCheckStar as never,
+        starRepoForAuthenticatedUser: userStarRepo as never,
+      })
+      // appOctokit is NOT passed to syncStars — but we verify its activity methods are untouched
+      // by wiring them into a separate mock and asserting they were never called.
+      const logger = silentLogger()
+
+      await syncStars({
+        userOctokit,
+        candidates: [{owner: 'marcusrbrown', name: 'some-repo'}],
+        logger,
+      })
+
+      // THEN userOctokit's activity methods were called
+      expect(userCheckStar).toHaveBeenCalledOnce()
+      expect(userStarRepo).toHaveBeenCalledOnce()
+      // AND appOctokit's activity methods were never called
+      expect(appCheckStar).not.toHaveBeenCalled()
+      expect(appStarRepo).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('empty candidates', () => {
+    it('returns all-zero counts when candidates list is empty', async () => {
+      // GIVEN no candidates
+      // WHEN syncStars runs
+      const checkStar = vi.fn(async () => undefined)
+      const starRepo = vi.fn(async () => undefined)
+      const userOctokit = mockOctokit({
+        checkRepoIsStarredByAuthenticatedUser: checkStar as never,
+        starRepoForAuthenticatedUser: starRepo as never,
+      })
+      const logger = silentLogger()
+
+      const result = await syncStars({userOctokit, candidates: [], logger})
+
+      // THEN no calls are made and all counts are zero
+      expect(result).toEqual({starsAdded: 0, starsAlreadyPresent: 0, starFailures: 0})
+      expect(checkStar).not.toHaveBeenCalled()
+      expect(starRepo).not.toHaveBeenCalled()
+    })
+  })
+})
+
+describe('handleReconcile — star sync integration', () => {
+  describe('channel filter — owned repos excluded', () => {
+    it('does not check or star owned-channel repos; only collab/contrib repos are candidates', async () => {
+      // GIVEN an access list with one owned repo and one collab repo
+      // WHEN handleReconcile runs
+      const checkStar = vi.fn(async () => {
+        throw apiError(404, 'Not Found') // not starred
+      })
+      const starRepo = vi.fn(async () => undefined)
+
+      const userOctokit = mockOctokit({
+        checkRepoIsStarredByAuthenticatedUser: checkStar as never,
+        starRepoForAuthenticatedUser: starRepo as never,
+        // Provide collab access list: one collab repo
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {owner: {login: 'marcusrbrown'}, name: 'collab-repo', archived: false, private: false, node_id: 'R_collab'},
+          ],
+        }),
+      })
+      // appOctokit provides the owned repo via listReposAccessibleToInstallation
+      const appPaginateOwned = async (_fn: unknown, _opts: unknown) => {
+        // Return one owned repo
+        return [
+          {
+            owner: {login: 'fro-bot'},
+            name: 'owned-repo',
+            archived: false,
+            fork: false,
+            private: false,
+            node_id: 'R_owned',
+          },
+        ]
+      }
+      const appOctokit = mockOctokit({
+        paginate: appPaginateOwned as never,
+      })
+
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          appOctokit,
+          readMetadata: makeReadMetadata({allowlist: makeAllowlist(['marcusrbrown'])}),
+        }),
+      )
+
+      // THEN only the collab repo was checked/starred (not the owned repo)
+      expect(checkStar).toHaveBeenCalledOnce()
+      expect(checkStar).toHaveBeenCalledWith({owner: 'marcusrbrown', repo: 'collab-repo'})
+      expect(starRepo).toHaveBeenCalledOnce()
+      expect(result.starsAdded).toBe(1)
+      expect(result.starsAlreadyPresent).toBe(0)
+    })
+  })
+
+  describe('star counts surface in HandleReconcileResult', () => {
+    it('returns starsAdded, starsAlreadyPresent, starFailures in the result', async () => {
+      // GIVEN two collab repos: one unstarred, one already starred
+      // WHEN handleReconcile runs
+      const checkStar = vi
+        .fn()
+        .mockRejectedValueOnce(apiError(404, 'Not Found')) // first: not starred
+        .mockResolvedValueOnce(undefined) // second: already starred
+
+      const starRepo = vi.fn(async () => undefined)
+      const userOctokit = mockOctokit({
+        checkRepoIsStarredByAuthenticatedUser: checkStar as never,
+        starRepoForAuthenticatedUser: starRepo as never,
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {owner: {login: 'owner-a'}, name: 'repo-a', archived: false, private: false, node_id: 'R_a'},
+            {owner: {login: 'owner-b'}, name: 'repo-b', archived: false, private: false, node_id: 'R_b'},
+          ],
+        }),
+      })
+
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          readMetadata: makeReadMetadata({allowlist: makeAllowlist(['owner-a', 'owner-b'])}),
+        }),
+      )
+
+      // THEN the result carries the correct star counts
+      expect(result.starsAdded).toBe(1)
+      expect(result.starsAlreadyPresent).toBe(1)
+      expect(result.starFailures).toBe(0)
+    })
+  })
+
+  describe('non-blocking — star failure does not abort handleReconcile', () => {
+    it('handleReconcile still returns when syncStars encounters a failure', async () => {
+      // GIVEN a collab repo where the star check throws a non-404 error
+      // WHEN handleReconcile runs
+      const checkStar = vi.fn(async () => {
+        throw apiError(500, 'Internal Server Error')
+      })
+      const userOctokit = mockOctokit({
+        checkRepoIsStarredByAuthenticatedUser: checkStar as never,
+        listForAuthenticatedUser: async () => ({
+          data: [
+            {owner: {login: 'marcusrbrown'}, name: 'flaky-repo', archived: false, private: false, node_id: 'R_flaky'},
+          ],
+        }),
+      })
+
+      // THEN handleReconcile completes without throwing
+      const result = await handleReconcile(
+        baseParams({
+          userOctokit,
+          readMetadata: makeReadMetadata({allowlist: makeAllowlist(['marcusrbrown'])}),
+        }),
+      )
+
+      expect(result.starFailures).toBe(1)
+      expect(result.starsAdded).toBe(0)
+    })
   })
 })

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -1393,6 +1393,12 @@ export interface HandleReconcileResult {
    */
   integrityCheck: 'ok' | 'skipped-no-data-branch' | 'skipped-just-bootstrapped'
   committed: boolean
+  /** Count of collab/contrib repos starred this run (check returned 404 → star call succeeded). */
+  starsAdded: number
+  /** Count of collab/contrib repos already starred (check returned 204 → no star call needed). */
+  starsAlreadyPresent: number
+  /** Count of star check or star call failures this run (non-blocking; loop continues). */
+  starFailures: number
 }
 
 /**
@@ -1676,6 +1682,36 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
   })
   plan.summary.raceSuppressedRollups = raceSuppressed
 
+  // 13. Star sync — star collab/contrib repos not yet starred by @fro-bot. Non-blocking:
+  //     failures increment starFailures and the run still returns. Owned repos are excluded
+  //     (fro-bot owns them; self-starring is pointless). A star is a user action — uses
+  //     userOctokit (FRO_BOT_POLL_PAT), never appOctokit. Counts-only telemetry.
+  const starCandidates = accessList.filter(entry => {
+    const channel = accessChannelByKey.get(`${entry.owner}/${entry.name}`)
+    return channel === 'collab' || channel === 'contrib'
+  })
+  const starOutcome = await syncStars({
+    userOctokit,
+    candidates: starCandidates.map(e => ({owner: e.owner, name: e.name})),
+    logger,
+  })
+
+  // Star telemetry — counts-only, no per-repo identifiers. Best-effort: a logger failure
+  // must never abort the reconcile run.
+  if (starOutcome.starsAdded > 0 || starOutcome.starFailures > 0) {
+    try {
+      if (starOutcome.starFailures > 0) {
+        logger.warn(
+          `reconcile: star sync complete (starsAdded=${starOutcome.starsAdded}, starFailures=${starOutcome.starFailures})`,
+        )
+      } else {
+        logger.info(`reconcile: star sync complete (starsAdded=${starOutcome.starsAdded})`)
+      }
+    } catch (error) {
+      console.error('reconcile: star sync telemetry emission failed', error)
+    }
+  }
+
   return {
     accessListSize: accessList.length,
     summary: plan.summary,
@@ -1691,6 +1727,9 @@ export async function handleReconcile(params: HandleReconcileParams = {}): Promi
     probesFailed,
     integrityCheck,
     committed,
+    starsAdded: starOutcome.starsAdded,
+    starsAlreadyPresent: starOutcome.starsAlreadyPresent,
+    starFailures: starOutcome.starFailures,
   }
 }
 
@@ -2396,6 +2435,67 @@ async function fileIntegrityAlert(params: {
     const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
     params.logger.warn(`reconcile: failed to file integrity alert issue (status=${status}).`)
   }
+}
+
+/**
+ * Star collab/contrib-channel repos that `@fro-bot` has not yet starred.
+ *
+ * For each candidate, calls `checkRepoIsStarredByAuthenticatedUser` (204 = already starred,
+ * 404 = not starred). On 404, calls `starRepoForAuthenticatedUser`. Any other error on the
+ * check, or any error on the star call, increments `starFailures` and continues — one failure
+ * never aborts the loop. Telemetry is counts-only; canonical owner/name never appears in any
+ * log or warn message.
+ *
+ * A star is a user action — MUST use `userOctokit` (the FRO_BOT_POLL_PAT), never the App token.
+ *
+ * Exported for unit tests; the sole production caller is `handleReconcile`.
+ *
+ * @internal
+ */
+export async function syncStars(params: {
+  userOctokit: OctokitClient
+  candidates: {owner: string; name: string}[]
+  logger: ReconcileLogger
+}): Promise<{starsAdded: number; starsAlreadyPresent: number; starFailures: number}> {
+  let starsAdded = 0
+  let starsAlreadyPresent = 0
+  let starFailures = 0
+
+  for (const candidate of params.candidates) {
+    try {
+      // 204 = already starred (resolves); 404 = not starred (throws).
+      await params.userOctokit.rest.activity.checkRepoIsStarredByAuthenticatedUser({
+        owner: candidate.owner,
+        repo: candidate.name,
+      })
+      // Resolved without throwing → already starred.
+      starsAlreadyPresent += 1
+    } catch (checkError: unknown) {
+      if (isApiStatus(checkError, 404)) {
+        // Not starred — attempt to star it.
+        try {
+          await params.userOctokit.rest.activity.starRepoForAuthenticatedUser({
+            owner: candidate.owner,
+            repo: candidate.name,
+          })
+          starsAdded += 1
+        } catch (starError: unknown) {
+          starFailures += 1
+          const status = isRecord(starError) && typeof starError.status === 'number' ? starError.status : 'unknown'
+          const kind = starError instanceof Error ? starError.name : 'unknown'
+          params.logger.warn(`reconcile: star sync failed (status=${status}, kind=${kind}); continuing.`)
+        }
+      } else {
+        // Non-404 error on the check — treat as a failure, continue.
+        starFailures += 1
+        const status = isRecord(checkError) && typeof checkError.status === 'number' ? checkError.status : 'unknown'
+        const kind = checkError instanceof Error ? checkError.name : 'unknown'
+        params.logger.warn(`reconcile: star sync failed (status=${status}, kind=${kind}); continuing.`)
+      }
+    }
+  }
+
+  return {starsAdded, starsAlreadyPresent, starFailures}
 }
 
 async function runDispatches(params: {

--- a/scripts/reconcile-repos.ts
+++ b/scripts/reconcile-repos.ts
@@ -2481,6 +2481,13 @@ export async function syncStars(params: {
           starsAdded += 1
         } catch (starError: unknown) {
           starFailures += 1
+          if (isGitHubRateLimit(starError)) {
+            const status = isRecord(starError) && typeof starError.status === 'number' ? starError.status : 'unknown'
+            params.logger.warn(
+              `reconcile: star sync stopped early on rate limit (status=${status}); remaining candidates retry next run.`,
+            )
+            break
+          }
           const status = isRecord(starError) && typeof starError.status === 'number' ? starError.status : 'unknown'
           const kind = starError instanceof Error ? starError.name : 'unknown'
           params.logger.warn(`reconcile: star sync failed (status=${status}, kind=${kind}); continuing.`)
@@ -2488,6 +2495,13 @@ export async function syncStars(params: {
       } else {
         // Non-404 error on the check — treat as a failure, continue.
         starFailures += 1
+        if (isGitHubRateLimit(checkError)) {
+          const status = isRecord(checkError) && typeof checkError.status === 'number' ? checkError.status : 'unknown'
+          params.logger.warn(
+            `reconcile: star sync stopped early on rate limit (status=${status}); remaining candidates retry next run.`,
+          )
+          break
+        }
         const status = isRecord(checkError) && typeof checkError.status === 'number' ? checkError.status : 'unknown'
         const kind = checkError instanceof Error ? checkError.name : 'unknown'
         params.logger.warn(`reconcile: star sync failed (status=${status}, kind=${kind}); continuing.`)


### PR DESCRIPTION
Fro Bot now keeps the repos it collaborates on starred. The invitation flow already stars a repo at accept time; this adds the steady-state half — each reconcile run stars any collaborator/contributor repo `@fro-bot` has access to that isn't already starred.

## What changed

- **Reconcile-time star sync.** For each collab/contrib-channel repo in the live access set, check whether `@fro-bot` has starred it and, if not, star it. The GitHub star set is the source of truth — no metadata field — so the behavior is self-healing: a repo that loses its star is re-starred on the next run.
- **User identity.** Starring is a user action, so it uses the Fro Bot user token (the same one reconcile already holds for collaborator enumeration), never the App identity. No new credential.
- **Private repos included.** Fro Bot stars private repos it collaborates on; a private repo's star is visible only to those with access, so it is not a public surface. The repo name is used only in the API call — never in a log, summary, issue, or commit. Telemetry is counts-only (`stars added` / `already present` / `failures`).
- **Owned repos excluded.** Fro Bot owns those; self-starring is pointless.
- **Rate-limit aware, non-blocking.** A single repo's failure never aborts the run; if a call hits a GitHub rate limit, the loop stops early and the remaining repos retry on the next run rather than worsening the penalty. Counts surface in the reconcile result and the workflow step summary.

Covered by unit and `handleReconcile` integration tests across the idempotent, private-repo, channel-filter, credential-isolation, rate-limit, and non-blocking paths.
