### PR TITLE
docs: mark shipped reconcile plans complete

### DIFF
--- a/docs/plans/2026-06-09-002-feat-survey-floor-stuck-repo-observability-plan.md
+++ b/docs/plans/2026-06-09-002-feat-survey-floor-stuck-repo-observability-plan.md
@@ -1,8 +1,9 @@
 ---
 title: 'feat: Survey floor stuck-repo observability'
 type: feat
-status: active
+status: complete
 date: 2026-06-09
+completed: 2026-06-10
 origin: docs/brainstorms/2026-06-09-survey-floor-stuck-repo-observability-requirements.md
 ---
 
@@ -74,7 +75,7 @@ schema change (see origin: docs/brainstorms/2026-06-09-survey-floor-stuck-repo-o
 
 ## Implementation Units
 
-- [ ] **Unit 1: Stateless stuck-candidate detector + telemetry**
+- [x] **Unit 1: Stateless stuck-candidate detector + telemetry**
 
 **Goal:** Derive a stuck-candidate count in the reconcile engine and surface it as counts-only telemetry in the JSON summary and step summary.
 
@@ -114,7 +115,7 @@ schema change (see origin: docs/brainstorms/2026-06-09-survey-floor-stuck-repo-o
 - Step summary renders the counter; run logs contain no canonical identifiers for stuck candidates.
 - `pnpm check-types`, `pnpm lint`, `pnpm test`, and actionlint pass.
 
-- [ ] **Unit 2: Document the accepted residual**
+- [x] **Unit 2: Document the accepted residual**
 
 **Goal:** Record the cancel-before-resolve window as a known, accepted residual and the trigger for revisiting the structural fix.
 

--- a/docs/plans/2026-06-21-002-feat-reconcile-auto-star-repos-plan.md
+++ b/docs/plans/2026-06-21-002-feat-reconcile-auto-star-repos-plan.md
@@ -1,8 +1,9 @@
 ---
 title: 'feat: auto-star contributor/collaborator repos during reconcile'
 type: feat
-status: active
+status: complete
 date: 2026-06-21
+completed: 2026-06-20
 origin: operator request (auto-star repos Fro Bot is a contributor/collaborator of)
 ---
 
@@ -79,7 +80,7 @@ to keep the star set in sync.
 
 ## Implementation Units
 
-- [ ] **Unit 1: reconcile-time star sync (test-first)**
+- [x] **Unit 1: reconcile-time star sync (test-first)**
 
 **Goal:** Star collab/contrib-channel accessible repos that `@fro-bot` has not yet starred,
 during each reconcile run, idempotently and non-blocking.


### PR DESCRIPTION
Two plan docs drifted out of sync with shipped reality. The stuck-repo observability plan (#3484) and the reconcile auto-star plan (#3532) both shipped — `stuckCandidates` and `syncStars` are live in `scripts/reconcile-repos.ts` — but their docs still read as active with unchecked units.

Flip both to `complete`, check the shipped units, and record completion dates matching when each merged. Docs-only; no code change.