### PR TITLE
feat: consult prior learnings during Fro Bot runs

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -348,6 +348,24 @@ jobs:
             }}
         run: node scripts/wiki-query.ts
 
+      # Overlay metadata/ from the data branch so the scheduled run can derive
+      # digest counts from live metadata/repos.yaml. Mirrors the precedented guard
+      # in reconcile-repos.yaml: tolerate a missing data branch (skip, don't fail).
+      # Runs BEFORE solutions-query so the privacy scan reads the freshest repos.yaml.
+      - name: ⤵ Overlay metadata from data branch
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code origin data >/dev/null 2>&1; then
+            overlay_err=$(
+              { git fetch --no-tags origin data && git checkout origin/data -- metadata/; } 2>&1
+            ) || {
+              echo "::warning::metadata overlay fetch/checkout failed (continuing — counts will use stale/missing metadata): $(echo "$overlay_err" | head -c 200)"
+            }
+          else
+            echo "data branch not yet established; skipping metadata overlay."
+          fi
+
       - name: Query solutions context
         id: solutions-query
         env:
@@ -369,23 +387,6 @@ jobs:
               ''
             }}
         run: node scripts/solutions-query.ts
-
-      # Overlay metadata/ from the data branch so the scheduled run can derive
-      # digest counts from live metadata/repos.yaml. Mirrors the precedented guard
-      # in reconcile-repos.yaml: tolerate a missing data branch (skip, don't fail).
-      - name: ⤵ Overlay metadata from data branch
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        run: |
-          set -euo pipefail
-          if git ls-remote --exit-code origin data >/dev/null 2>&1; then
-            overlay_err=$(
-              { git fetch --no-tags origin data && git checkout origin/data -- metadata/; } 2>&1
-            ) || {
-              echo "::warning::metadata overlay fetch/checkout failed (continuing — counts will use stale/missing metadata): $(echo "$overlay_err" | head -c 200)"
-            }
-          else
-            echo "data branch not yet established; skipping metadata overlay."
-          fi
 
       - name: Run Fro Bot
         id: fro-bot-agent

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -348,6 +348,28 @@ jobs:
             }}
         run: node scripts/wiki-query.ts
 
+      - name: Query solutions context
+        id: solutions-query
+        env:
+          SOLUTIONS_QUERY_EVENT_NAME: ${{ github.event_name }}
+          SOLUTIONS_QUERY_OWNER: ${{ github.repository_owner }}
+          SOLUTIONS_QUERY_REPO: ${{ github.event.repository.name }}
+          SOLUTIONS_QUERY_TITLE: >-
+            ${{
+              github.event.pull_request.title ||
+              github.event.issue.title ||
+              github.event.discussion.title ||
+              ''
+            }}
+          SOLUTIONS_QUERY_BODY: >-
+            ${{
+              github.event.pull_request.body ||
+              github.event.issue.body ||
+              github.event.comment.body ||
+              ''
+            }}
+        run: node scripts/solutions-query.ts
+
       # Overlay metadata/ from the data branch so the scheduled run can derive
       # digest counts from live metadata/repos.yaml. Mirrors the precedented guard
       # in reconcile-repos.yaml: tolerate a missing data branch (skip, don't fail).
@@ -372,6 +394,7 @@ jobs:
           OPENCODE_PROMPT_ARTIFACT: 'true'
           PERSONA: ${{ steps.persona.outputs.content }}
           WIKI_CONTEXT: ${{ steps.wiki-query.outputs.excerpt }}
+          SOLUTIONS_CONTEXT: ${{ steps.solutions-query.outputs.excerpt }}
           TASK_PROMPT: >-
             ${{
               (github.event_name == 'workflow_dispatch' && github.event.inputs.prompt)
@@ -397,8 +420,15 @@ jobs:
             ${{ env.WIKI_CONTEXT }}
             </wiki_context>
 
+            <solutions_context>
+            ${{ env.SOLUTIONS_CONTEXT }}
+            </solutions_context>
+
             <knowledge_persistence>
             Use the wiki context when it materially improves the response.
+            Consult the solutions context for prior learnings relevant to this work;
+            when one applies, follow it and cite its `Path:` in your reasoning. Treat
+            entries marked as candidate suggestions as hints to verify, not settled facts.
             If this interaction surfaces durable knowledge worth keeping, update only
             `knowledge/wiki/**`, `knowledge/index.md`, and `knowledge/log.md` following
             `knowledge/schema.md`. Keep changes additive, preserve contradictions with

--- a/docs/brainstorms/2026-06-22-skill-saving-grow-and-learn-requirements.md
+++ b/docs/brainstorms/2026-06-22-skill-saving-grow-and-learn-requirements.md
@@ -1,0 +1,293 @@
+---
+title: 'A1 — Skill saving / grow-and-learn (autonomous compounding loop)'
+type: feat
+date: 2026-06-22
+status: requirements
+epic: docs/brainstorms/2026-06-15-fro-bot-personal-agent-north-star-requirements.md
+---
+
+# A1 — Skill saving / grow-and-learn
+
+## Purpose
+
+Make Fro Bot *grow and learn*: a compounding loop where it reliably retrieves and applies
+saved learnings in every run, captures new reusable learnings from cohorts of prior runs,
+and grounds itself in the surveyed wiki for whatever repo it is working in. This is the
+Tier-2 **A1** capability from the personal-agent north-star — the most control-plane-native
+capability, requiring nothing from the operator spine, so it runs in parallel with the
+operator rollout.
+
+## Problem frame
+
+Fro Bot already produces and stores knowledge, but the loop is open in three places:
+
+1. **Retrieval is unreliable (lead problem).** The 22 existing `docs/solutions/` compound
+   docs represent hard-won, hand-curated learnings — but a saved learning helps a later run
+   only if that run happens to search for it. There is no reliable consultation step, so the
+   compounding value of the existing corpus is largely unrealized. This is the dominant gap:
+   the demand side is broken before the supply side.
+2. **Capture is human-triggered.** Reusable learnings reach `docs/solutions/` only when an
+   operator invokes `ce:compound` after solving something. Fro Bot's own runs — which now
+   number in the thousands across surveys, reconciles, autoheal, reviews, and fixes —
+   generate reusable judgment that is never captured unless a human notices and acts.
+3. **Wiki grounding is shallow.** The survey builds extensive wiki pages per repo, and
+   `fro-bot.yaml` already injects a single page of wiki context (`scripts/wiki-query.ts`,
+   ~5KB budget). But Fro Bot cannot *deepen* that context by following wikilinks to related
+   repo, topic, or entity pages — so it works with a thin slice of what it actually knows.
+
+The result: Fro Bot's knowledge does not compound. Each run starts roughly as capable as
+the last, instead of standing on what prior runs learned.
+
+## Goals
+
+- **G1** — Fro Bot reliably retrieves and applies relevant saved learnings when a run hits a
+  similar situation, making the existing 22-doc corpus earn its keep before new captures are
+  added.
+- **G2** — Fro Bot autonomously captures reusable learnings from cohorts of its own prior
+  runs, without an operator triggering each capture.
+- **G3** — Fro Bot grounds itself in the surveyed wiki for the repo it is working in, and
+  can deepen that context on demand by traversing wikilinks.
+- **G4** — The loop is observable: Fro Bot maintains an internal audit trail of what it has
+  compounded. Operator-web surfacing and a formal improvement metric are later-phase
+  observability, not v1 goals.
+
+## Non-goals
+
+- **Not new storage.** The three substrates exist (`docs/solutions/` compound docs,
+  `knowledge/wiki/` Karpathy wiki, `.agents/skills/`). A1 closes the loop over them; it does
+  not invent a new store.
+- **Not the operator spine.** S1/S2 web control surface and operator auth are the
+  agent/dashboard sessions' work. A1 depends on none of it.
+- **Not executable/runnable skills.** A "skill" here is durable knowledge (a compound doc or
+  wiki page Fro Bot reads and applies), not a generated runnable tool or plugin.
+- **Not a broad-net run sweep in v1.** General scheduled/manual-dispatch run cohorts are
+  low-signal-per-run; deferred until the high-signal triggers are proven.
+- **v1/early phases explicitly exclude:** C4 cross-run synthesis, C-deep wiki traversal, and
+  operator-web decision-log surfacing. These are Phase 3 scope.
+
+## Capability A — Autonomous capture (retrospective, batch)
+
+A dedicated compounding run that retrospectively examines **cohorts of prior Fro Bot runs**
+and distills reusable learnings, rather than detecting a learnable moment mid-run. Seeing a
+collection of runs lets it find patterns invisible in any single run.
+
+> **Identity bet:** the existing 22 `docs/solutions/` docs are hand-curated and high-signal.
+> Autonomous capture must not pollute this corpus. All autonomous captures land in a
+> **quarantine lane** (separately labeled, not in the canonical `docs/solutions/` set) until
+> precision is proven. Only clearly high-confidence captures promote to canonical. This
+> protects the hand-curated corpus as the authoritative signal source.
+
+### Triggers (v1 — the high-signal set, Phase 2)
+
+- **C1 — Multi-round-review PRs.** PRs that needed several review rounds /
+  changes-requested before merging encode a mistake-then-correction — the richest learning
+  shape. Lead trigger.
+- **C2 — Failed-then-fixed runs.** Runs/PRs whose first attempt failed CI or was wrong and
+  then got corrected. The delta between broken and fixed *is* the learning. (This is the
+  shape of the strongest existing compound docs — the `jq //` trap, the Octokit method
+  hallucinations, the strip-only TypeScript failures.)
+- **C3 — Issue triages.** The daily oversight+autoheal run triages issues with fix/skip/defer
+  rationale. That judgment is reusable and teaches future triage.
+- **C4 — Recurring patterns across runs (cross-run synthesis). DEFERRED to Phase 3.** When
+  the *same kind* of issue recurs across multiple runs (repeated rate-limit failures, repeated
+  privacy-gate catches), compound the **pattern**. This is materially harder (clustering,
+  temporal comparison, sameness judgment) and is out of scope for v1.
+
+### Harvest → redact → publish pipeline (privacy-first)
+
+Raw artifact harvesting may contain private-repo content (repo names, org identifiers, issue
+titles, PR descriptions). The pipeline enforces a hard separation:
+
+1. **Harvest (private control-plane state).** Raw run artifacts are written to the `data`
+   branch as private operational state. They are never directly published.
+2. **Redact / extract.** The capture run extracts only the reusable, non-attributable
+   learning from the raw artifact. Private-repo identifiers, org names, and any content that
+   would identify a private repo are stripped at this step.
+3. **Gate.** Before any extracted learning reaches `docs/solutions/` or any public surface,
+   it MUST pass through the existing promotion-time gates:
+   - `scripts/check-private-leak.ts` — scans for private-repo names on the `data → main`
+     path.
+   - `scripts/check-wiki-private-presence.ts` — wiki promotion gate semantics.
+   Both gates must pass. Failure blocks promotion; the capture stays in quarantine.
+
+This pipeline is a first-class requirement, not an assertion. Capture that cannot be cleanly
+redacted must be discarded, not published with caveats.
+
+### Capture mechanics
+
+- **Rides Systematic `ce:compound`.** Systematic is present in the agent workspace
+  (`src/services/setup/systematic-config.ts` in `fro-bot/agent`), so capture can use the
+  existing compound-doc authoring rather than new machinery. _Open question O3: confirm
+  Systematic is enabled (not merely present) in the relevant run surface._
+- **Quarantine lane first.** Autonomous captures land in a quarantine lane (separately
+  labeled, not in the canonical `docs/solutions/` set) until precision is proven. Only
+  clearly high-confidence, gate-passed captures promote to canonical.
+- **Autonomous write → data branch → promotion PR.** Captures (quarantine and promoted) are
+  written under Fro Bot identity to the `data` branch and promoted to `main` via the existing
+  conditional promotion PR. _Open question O2: `docs/solutions/` is today human-authored on
+  `main`; A1 brings it onto the data-branch authority path. This is an architectural change
+  for planning to resolve._
+- **Quality gate (specified).** Capture must avoid noise and duplication:
+  - **Dedup:** similarity check against existing docs; prefer updating an existing doc over
+    creating a near-duplicate (the `ce:compound` overlap behavior already does this for human
+    runs).
+  - **Genuine reusable delta:** the learning must be applicable beyond the specific run that
+    generated it — not a one-off fix for a unique situation.
+  - **Evidence threshold:** the capture must cite the run cohort and the pattern it
+    generalizes; unsupported assertions are rejected.
+  - **Quarantine path:** ambiguous captures (borderline dedup, unclear generalizability) go
+    to quarantine, not canonical. They are not discarded — they wait for human review or
+    additional evidence.
+
+### Decision log (G4 — internal audit trail)
+
+Fro Bot maintains a durable decision log of what it has compounded: which run cohorts it
+examined, what learnings it captured or updated, and what it deliberately skipped and why.
+This lets it (a) avoid re-compounding the same thing, and (b) provide an internal audit
+trail for later metric definition. The decision log is **operational metadata / control-plane
+state on the `data` branch** — it is not a fourth knowledge substrate, and it is not
+published to the operator web in early phases. Operator-web surfacing is Phase 3 scope.
+
+## Capability B — Retrieve + apply
+
+Fro Bot reliably consults its saved learnings when a run hits a similar situation, instead
+of only by chance. **This is Phase 1 — the first thing built, before the capture pipeline.**
+It is lower-risk, immediately testable against the existing 22 docs, and proves compounding
+value before the harvest pipeline is built.
+
+- **B1** — Before acting on a class of work that has prior learnings (e.g. autoheal before
+  fixing, a review before flagging, a survey before ingesting), Fro Bot consults
+  `docs/solutions/` for relevant prior learnings and applies them.
+- **B2** — Retrieval is relevance-ranked (the compound docs already carry frontmatter:
+  `module`, `tags`, `problem_type`) so the consulted set is small and on-point, not a dump.
+- **B3** — Applied learnings should be visible in the run's reasoning (so the decision log
+  and the operator can see that a prior learning shaped the run) — closing the loop with G4.
+- **B4 — Freshness / staleness.** Saved learnings carry freshness/validity metadata.
+  Retrieval suppresses or down-ranks stale items. For low-confidence matches (stale learning,
+  weak relevance signal), the agent surfaces the learning as a **candidate suggestion** rather
+  than applying it directly — a stale learning applied confidently is worse than none.
+
+## Capability C — Wiki grounding (tiered)
+
+- **C-baseline (exists, stays always-on).** The single-page wiki-context injection in
+  `fro-bot.yaml` (`scripts/wiki-query.ts`, ~5KB) continues to ground every run cheaply.
+- **C-deep (new, Phase 3).** Deep wikilink **traversal** becomes a capability the agent
+  invokes on its own judgment when it needs more context — following wikilinks from the
+  repo's page to related repo, topic, entity, and comparison pages. Callers may also enable
+  it for heavier missions. **C-deep is deferred to Phase 3** — it is out of scope for v1.
+- **C-guardrails (Phase 3, when C-deep is planned).** Traversal is bounded. Concrete numeric
+  caps (depth, breadth, page count, token budget) and a stop condition must be defined when
+  C-deep is planned — not hand-waved. The agent decides *when* to go deeper; the guardrails
+  bound *how far*.
+- **C-deep privacy.** Deep traversal must only read already-gate-passed wiki content (content
+  that has cleared `scripts/check-wiki-private-presence.ts` semantics). Traversal fails
+  closed on private or unattributable pages — it does not surface content that has not passed
+  the wiki privacy gate.
+- **Surfacing across entry points.** The tiered model applies uniformly across the three
+  entry points Fro Bot acts through: the gateway operator flow, the Discord mention loop, and
+  the action. Baseline grounding is on for all; deep traversal (Phase 3) is agent-invoked on
+  its own judgment, with callers able to enable it for heavier missions.
+
+## How the loop compounds (text diagram)
+
+```
+   prior Fro Bot runs (prompt artifacts, harvested durably to data branch)
+            │
+            │  ┌─────────────────────────────────────────────────────────┐
+            │  │  PHASE 1 (first): retrieve + apply                      │
+            │  │  B. consult docs/solutions/ (22 existing docs)          │
+            │  │     relevance-ranked · freshness-gated · candidate-mode │
+            │  │     for low-confidence matches                          │
+            │  └─────────────────────────────────────────────────────────┘
+            │
+   ┌────────▼─────────┐   PHASE 2: triggers C1 · C2 · C3
+   │ A. capture run   │   harvest (private) → redact → gate → quarantine
+   │ (ce:compound)    │   → promote (high-confidence, gate-passed only)
+   └────────┬─────────┘
+            │ autonomous write → data branch → promotion PR
+            │ gates: check-private-leak.ts · check-wiki-private-presence.ts
+            ▼
+   quarantine lane  →  (proven) →  docs/solutions/ canonical
+            │                              │
+            │                    decision log (internal audit trail,
+            │                    data branch, NOT operator web in v1)
+   ┌────────▼─────────┐
+   │ C. wiki grounding│  baseline always-on
+   │ (C-deep: Ph. 3)  │  deep traversal: Phase 3, gate-passed content only
+   └────────┬─────────┘
+            │ better-grounded run
+            ▼
+       next Fro Bot run  ──────────────► (becomes input to the next capture cohort)
+```
+
+## Open questions (resolve at planning)
+
+- **O1 — Durable run harvest.** Verified: `OPENCODE_PROMPT_ARTIFACT='true'` is set in
+  `fro-bot.yaml` (line 372) and honored by the agent runtime, **but the artifacts are
+  ephemeral and inconsistent** — of three recent runs, only one had an artifact, and GitHub
+  artifacts expire. Capture cannot rely on artifacts still being present. Planning must
+  decide how run data is durably harvested (harvest-as-you-go into the data branch vs.
+  best-effort read of unexpired artifacts vs. another channel).
+- **O2 — `docs/solutions/` authority path.** Today human-authored on `main`; A1 brings
+  autonomous captures onto the data-branch authority + promotion path. Resolve the promotion
+  model (auto-merge vs. human-reviewed for captured learnings) and how human-authored and
+  Fro-Bot-authored docs coexist. **Note:** this is a bigger change than it appears —
+  `scripts/check-wiki-authority.ts` today guards only `knowledge/wiki/` and `metadata/`
+  paths, not `docs/solutions/`; `scripts/commit-metadata.ts` is path-restricted to
+  `metadata/*.yaml`. Bringing `docs/solutions/` onto the data-authority path requires new
+  guard logic and new promotion behavior, not just a config change.
+- **O3 — Systematic in the run surface.** Confirm Systematic `ce:compound` is *enabled* (not
+  just present) in the surface that runs capture, and whether capture is its own scheduled
+  workflow or rides the existing daily oversight run.
+- **O4 — Retrieval injection mechanism.** How the consulted learnings reach the agent's
+  working context (extend the existing `wiki-query` injection step, a new retrieval step, or
+  an agent-invoked tool) — parallels the wiki-traversal tool decision.
+- **O5 — Improvement metric.** What "compounding is improving outcomes" concretely measures
+  (fewer repeat failures of a compounded class, fewer review rounds on a learned pattern,
+  etc.) so the decision log's G4 claim is testable, not narrative. Metric definition is Phase
+  3 scope; early phases need only the internal audit trail.
+
+## Success criteria
+
+- **SC1** — Fro Bot reliably consults `docs/solutions/` before acting on a class of work
+  with prior learnings, and the applied learning is visible in the run's reasoning. (Phase 1)
+- **SC2** — A capture run examines a cohort of prior Fro Bot runs and produces at least one
+  genuine, deduplicated learning via the quarantine lane and data-branch promotion path, with
+  no operator invoking `ce:compound`. (Phase 2)
+- **SC3** — A later run of a class with a relevant prior learning demonstrably consults and
+  applies it (or surfaces it as a candidate for low-confidence matches), visible in the run's
+  reasoning/decision log. (Phase 2)
+- **SC4** — An agent run grounds itself from the repo's wiki page and, when it judges it
+  needs more, traverses at least one wikilink to a related page within the guardrail budget,
+  reading only gate-passed wiki content. (Phase 3)
+- **SC5** — Capture produces no private-repo identifiers in any public surface. All
+  autonomous writes pass through `scripts/check-private-leak.ts` and
+  `scripts/check-wiki-private-presence.ts` before promotion to `main`. Raw harvest artifacts
+  remain private control-plane state on the `data` branch and are never directly published.
+- **SC6** — The decision log records what was compounded (and what was skipped and why) as
+  internal operational metadata on the `data` branch.
+
+## Phasing (directional — planning refines)
+
+- **Phase 1 — Retrieve + apply.** Capability B over the existing 22 `docs/solutions/` docs:
+  reliable consultation before acting, relevance-ranked, freshness-gated, candidate-mode for
+  low-confidence matches. Lower-risk, immediately testable, proves compounding value before
+  the harvest pipeline is built.
+- **Phase 2 — Autonomous capture, narrow.** Durable run harvest (O1) + a capture run over
+  the two highest-signal triggers (C1 multi-round-review, C2 failed-then-fixed), with the
+  full harvest→redact→gate→quarantine→promote pipeline, the quality gate, and the decision
+  log. Add C3 (issue triages) once C1/C2 precision is proven.
+- **Phase 3 — Wiki traversal + observability.** Capability C-deep (agent-invoked wikilink
+  traversal with concrete numeric guardrails, gate-passed content only), C4 cross-run
+  synthesis, and operator-web surfacing of the decision log + improvement metric definition.
+
+## Dependencies & relationships
+
+- **Depends on:** nothing in the operator spine (control-plane-native). Builds on existing
+  `docs/solutions/`, `knowledge/wiki/`, `scripts/wiki-query.ts`,
+  `scripts/check-private-leak.ts`, `scripts/check-wiki-private-presence.ts`, the
+  data-branch authority model, and Systematic `ce:compound`.
+- **Soft relationship to operator web:** G4's decision-log surfacing is Phase 3 scope. A1's
+  core loop does not block on the dashboard — the internal audit trail is durable
+  control-plane state regardless of whether the web view exists yet.
+- **Epic:** Tier-2 A1 in `docs/brainstorms/2026-06-15-fro-bot-personal-agent-north-star-requirements.md`.

--- a/docs/plans/2026-06-22-001-feat-solutions-retrieval-injection-plan.md
+++ b/docs/plans/2026-06-22-001-feat-solutions-retrieval-injection-plan.md
@@ -1,0 +1,344 @@
+---
+title: 'feat: solutions retrieval — inject relevant prior learnings into the agent prompt'
+type: feat
+status: active
+date: 2026-06-22
+origin: docs/brainstorms/2026-06-22-skill-saving-grow-and-learn-requirements.md
+---
+
+# feat: solutions retrieval — inject relevant prior learnings into the agent prompt
+
+## Overview
+
+Make Fro Bot reliably consult its existing `docs/solutions/` learnings during a run.
+Today those 22 docs help a run only if it happens to search them; the
+`.github/copilot-instructions.md` "search docs/solutions/" directive is prompt-only and
+not mechanized anywhere. This plan adds a retrieval step that selects the most relevant
+prior learnings for the current run and injects them into the agent prompt — exactly
+mirroring the production wiki-context injection — so Fro Bot applies what it already knows
+instead of relearning it.
+
+This is **Phase 1** of the A1 grow-and-learn loop (see origin). It deliberately ships the
+*retrieve-and-apply* half first: it consumes the existing curated corpus, with no
+autonomous capture, no wiki traversal, and no decision log (those are Phase 2/3).
+
+## Problem Frame
+
+Fro Bot's knowledge does not compound because reuse is not surfaced at decision time. The
+dominant gap is retrieval, not capture: 22 high-quality, hand-curated learnings sit in
+`docs/solutions/`, but a run only benefits by chance. Mechanizing retrieval — selecting the
+relevant subset and injecting it into the prompt — is the lowest-risk, highest-leverage
+first move, and the production wiki-query injection path already proves the mechanism.
+
+## Requirements Trace
+
+- R1. (origin B1) Before acting on a class of work that has prior learnings, Fro Bot
+  consults `docs/solutions/` and applies the relevant ones.
+- R2. (origin B2) Retrieval is relevance-ranked via the docs' frontmatter so the injected
+  set is small and on-point, not a dump.
+- R3. (origin B3) Applied learnings are visible in the run's reasoning — the agent cites the
+  consulted doc path when it applies one.
+- R4. (origin B4) Stale learnings are handled: freshness metadata is surfaced and low-
+  confidence/stale matches are presented as candidate suggestions, not asserted facts.
+- R5. (origin SC5) Injection introduces no private-repo identifier into any public surface;
+  the retrieval path honors the repo's no-private-leak discipline.
+
+## Scope Boundaries
+
+- Retrieval and injection only. No autonomous capture/writing of new learnings (Phase 2).
+- No agentic wiki traversal (origin C-deep, Phase 3).
+- No decision log / improvement metric / operator-web surfacing (origin G4, Phase 3).
+- No new frontmatter fields on `docs/solutions/` docs — v1 uses the fields that already
+  exist on all 22 docs.
+- No learned/ML ranker — deterministic scoring only.
+
+### Deferred to Separate Tasks
+
+- Autonomous capture from run cohorts (origin Capability A): Phase 2, separate plan.
+- Wiki-link traversal (origin C-deep) and decision log (origin G4): Phase 3, separate plan.
+- A `docs/solutions/` index file, if the corpus grows enough to need one: future, only if
+  the per-run directory scan becomes a cost.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `.github/workflows/fro-bot.yaml` — the **injection pattern to mirror**. The `Query wiki
+  context` step (`id: wiki-query`) runs `node scripts/wiki-query.ts`; its
+  `outputs.excerpt` flows into the agent prompt via `WIKI_CONTEXT` and is rendered inside a
+  `<wiki_context>` block alongside `<persona>` and the `TASK_PROMPT`. The new solutions
+  step is a sibling of this, injected as a `<solutions_context>` block.
+- `scripts/wiki-query.ts` — the **script to mirror structurally**: env-driven inputs
+  (event name, owner, repo, title, body), a category-dir loader, `splitFrontmatter`
+  (`---\n…\n---` + `yaml.parse`), a deterministic `scorePage` token-overlap scorer with
+  per-field weights, event-aware base type-weighting, a byte-budget greedy packer with
+  multi-byte-safe truncation, and a `GITHUB_OUTPUT` writer (multi-line `excerpt` via hex
+  delimiter, `selected-paths` JSON, `byte-length` scalar). Its colocated
+  `scripts/wiki-query.test.ts` is the **test template** (repo-priority, hard cap, topical
+  match, empty-on-no-match, multi-byte truncation).
+- `scripts/check-private-leak.ts` — the **leak-token source** for R5. Its private-identifier
+  token set (canonical `owner/name`, sanitized `owner--slug`, raw `owner--name`) is reused
+  to body-scan candidate docs before injection.
+- `docs/solutions/` — the corpus: 22 docs in 6 category dirs
+  (`best-practices`, `documentation-gaps`, `integration-issues`, `runtime-errors`,
+  `security-issues`, `workflow-issues`). No index file. On `main` directly (not the `data`
+  branch), so no sync step is needed — simpler than the wiki.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md` —
+  injected context is a direct leak vector: **scan content not just identifiers**, **fail
+  closed on ambiguous**, **enforce at a trusted chokepoint**. Drives R5's body-scan design.
+- `docs/solutions/security-issues/survey-workflow-side-privacy-gate-2026-05-16.md` +
+  `private-repo-dispatch-visibility-gate-2026-05-08.md` — use **opaque identifiers in logs**
+  (the doc's file path, never a resolved private name) and **fail-closed on unknown**.
+- `docs/solutions/runtime-errors/node-strip-only-typescript-2026-04-18.md` — the new script
+  must be Node 24 strip-only safe (no parameter properties, enums, namespaces). `Test
+  Scripts Load` CI + `erasableSyntaxOnly` lint catch this.
+- `docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md` — if
+  retrieval becomes a gating step, the success predicate must cover it; but here retrieval
+  is **best-effort and non-gating** (a failed/empty retrieval must never fail the agent
+  run), which sidesteps the silent-failure trap by design.
+- `docs/solutions/best-practices/observability-before-structural-change-2026-06-09.md` — do
+  not add a `relevance_score` field or `last_retrieved_at` counter; derive everything from
+  existing frontmatter. No new persisted state in v1.
+
+## Key Technical Decisions
+
+- **New sibling step + new `scripts/solutions-query.ts`, mirroring `wiki-query.ts`** (origin
+  O4 resolved). Lowest-risk: the precedent is in production. An agent-invoked retrieval tool
+  is Phase 3 territory, consistent with the C-deep traversal decision.
+- **All run types get retrieval.** The script early-returns an empty excerpt on no match, so
+  the marginal cost on comment/issue events with no relevant docs is ~zero, and the byte
+  budget bounds the rest. One step on all paths is simpler than gating per event.
+- **Deterministic token-overlap scorer.** Mirror `wiki-query.ts` scoring: token overlap over
+  `tags` + `title` + `module` + body, with `problem_type` giving event-aware weight (e.g.
+  weight `security_issue` higher on security-flavored PR titles) and `applies_when` boosted
+  where present. `module` is **free-form** (file paths, identifiers, comma/`+`-joined lists),
+  so it is matched as a multi-token text field via substring/token overlap, never equality.
+  No learned ranker.
+- **Fail-closed body privacy scan (R5).** Before injecting a doc, scan its **body** (not just
+  frontmatter) for private-repo identifiers using the `check-private-leak.ts` token set. Any
+  hit excludes that doc fail-closed. Logs/outputs reference docs by **path only**, never a
+  resolved private name. This is defense-in-depth: the corpus is already on public `main` and
+  passed the merge-time gate, but the injection point is re-gated as the trusted chokepoint.
+- **Freshness via existing `last_updated` (R4).** `last_updated` is present on all 22 docs
+  (YYYY-MM-DD). The script surfaces it in each injected entry and applies a configurable
+  staleness threshold (default 60 days) to down-rank/flag stale matches as candidate
+  suggestions. `verified: true` (one doc, boolean not date) is treated as "valid as of
+  authoring, do not time-demote." No new frontmatter, no schema migration.
+- **Best-effort, non-gating.** Retrieval never fails the agent run. A parse error, empty
+  result, or privacy exclusion yields an empty/partial `<solutions_context>` and the run
+  proceeds. This avoids the autonomous-pipeline silent-failure class by not making retrieval
+  load-bearing for run success.
+- **Smaller byte budget than wiki.** Use a tighter cap (≈3–4KB vs the wiki's 5KB) because the
+  solutions corpus is denser and R2 wants "small and on-point" — configurable via env.
+
+## Open Questions
+
+### Resolved During Planning
+
+- O4 (origin) injection mechanism: new sibling step + `solutions-query.ts`. Resolved above.
+- Run-type scope: all run types. Resolved above.
+- Scorer sophistication: deterministic token-overlap. Resolved above.
+- Privacy posture: fail-closed body scan reusing `check-private-leak.ts`. Resolved above.
+
+### Deferred to Implementation
+
+- Exact per-field score weights and the staleness-threshold default — start from the
+  `wiki-query.ts` weights and tune against real fixtures; final values are an
+  implementation-time calibration, not a planning decision.
+- Whether `applies_when` (12/22 docs) is matched as free text or as discrete clauses — try
+  free-text token overlap first; refine only if precision is poor.
+- Reuse shape of the `check-private-leak.ts` token logic (import a shared helper vs.
+  replicate the token-set construction) — depends on what that module currently exports;
+  prefer extracting a shared helper if it is cheap, otherwise replicate the small token set.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not
+> implementation specification. The implementing agent should treat it as context, not code
+> to reproduce.*
+
+```
+fro-bot.yaml run (any event)
+   │
+   ├─ Query wiki context        → WIKI_CONTEXT       (existing)
+   ├─ Query solutions context   → SOLUTIONS_CONTEXT  (new, this plan)
+   │     node scripts/solutions-query.ts
+   │       1. load docs/solutions/**.md  (6 category dirs, from main checkout)
+   │       2. splitFrontmatter + parse   (title, module, tags, problem_type,
+   │                                       applies_when, last_updated, verified)
+   │       3. score vs event {title, body, owner, repo, event_name}
+   │            token overlap: tags · title · module(substring) · body
+   │            + problem_type event-weight + applies_when boost
+   │       4. privacy body-scan (check-private-leak token set) → drop fail-closed
+   │       5. freshness: surface last_updated; stale>threshold ⇒ candidate-flag
+   │       6. greedy pack into byte budget (multi-byte-safe truncate)
+   │       7. GITHUB_OUTPUT: excerpt (each entry cites Path: <doc-path>),
+   │                          selected-paths[], byte-length
+   │
+   └─ agent prompt:
+        <persona>…</persona>
+        {TASK_PROMPT}
+        <wiki_context>{WIKI_CONTEXT}</wiki_context>
+        <solutions_context>{SOLUTIONS_CONTEXT}</solutions_context>   ← new
+        <knowledge_persistence>
+          …consult <solutions_context>; apply relevant learnings and
+          cite "Path: <doc-path>" in your reasoning when you do…       ← R3
+        </knowledge_persistence>
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: `scripts/solutions-query.ts` — retrieval engine (test-first)**
+
+**Goal:** A script that loads `docs/solutions/**`, scores docs against the current run's
+event context, applies the privacy body-scan and freshness handling, packs the top matches
+into a byte budget, and writes the excerpt + metadata to `GITHUB_OUTPUT`.
+
+**Requirements:** R1, R2, R4, R5.
+
+**Dependencies:** None (reads the working tree; reuses `check-private-leak.ts` token logic).
+
+**Files:**
+- Create: `scripts/solutions-query.ts`
+- Test: `scripts/solutions-query.test.ts`
+- Possibly modify: `scripts/check-private-leak.ts` (only if extracting a shared token-set
+  helper is the clean reuse path — see deferred question)
+
+**Approach:**
+- Mirror `scripts/wiki-query.ts` structure: env-driven inputs
+  (`SOLUTIONS_QUERY_EVENT_NAME`, `_OWNER`, `_REPO`, `_TITLE`, `_BODY`, falling back to
+  `GITHUB_EVENT_NAME`), a category-dir loader over the 6 `docs/solutions/` subdirs,
+  `splitFrontmatter` + `yaml.parse`, a deterministic scorer, byte-budget packer, and the
+  `GITHUB_OUTPUT` writer shape.
+- Scorer: token overlap on `tags`, `title`, `module` (free-form → substring/token match),
+  and body; `problem_type` event-weighting; `applies_when` boost where present. Start from
+  the `wiki-query.ts` weights.
+- Privacy: for each candidate, body-scan with the `check-private-leak.ts` token set; any hit
+  excludes the doc fail-closed. Never emit a resolved private name; reference docs by path.
+- Freshness: parse `last_updated`; if `now - last_updated > threshold` (default 60d, env-
+  overridable), flag the entry as a candidate suggestion in the excerpt; treat `verified:
+  true` as non-time-demotable. Handle the `created:`-only / missing-`date` edge cases without
+  throwing.
+- Each emitted entry includes `Path: <doc-path>` (for R3) and its `last_updated` (for R4).
+- Best-effort: on any parse/IO error, emit an empty excerpt and exit 0 — never throw in a
+  way that would fail the workflow step.
+
+**Execution note:** Implement test-first, mirroring `scripts/wiki-query.test.ts`.
+
+**Patterns to follow:**
+- `scripts/wiki-query.ts` (structure, byte budget, `GITHUB_OUTPUT` shape, multi-byte-safe
+  truncation), `scripts/wiki-query.test.ts` (test shape).
+- `scripts/check-private-leak.ts` (token-set construction for the body scan).
+- Node 24 strip-only constraints (no parameter properties/enums/namespaces); `node:` import
+  prefixes; `.js`-extension TS imports.
+
+**Test scenarios:**
+- Happy path: a PR event whose title/body match a doc's `module`/`tags` selects that doc;
+  excerpt contains its title + `Path:` + `last_updated`.
+- Edge case: no matching docs → empty excerpt, `selected-paths: []`, exit 0.
+- Edge case: hard byte-budget cap enforced; an over-budget candidate is truncated with the
+  marker, multi-byte/emoji boundary safe.
+- Edge case: event-aware weighting — a security-flavored PR title ranks a `problem_type:
+  security_issue` doc above an unrelated `best_practice` doc.
+- Edge case: free-form `module` matches via substring (e.g. event token `reconcile-repos`
+  matches `module: scripts/reconcile-repos.ts`).
+- Error path (privacy, R5): a fixture doc whose **body** contains a private-identifier token
+  is excluded fail-closed; assert it is NOT in the excerpt and that no resolved private name
+  appears in any output/log (path-only references).
+- Edge case (freshness, R4): a doc with `last_updated` older than the threshold is flagged as
+  a candidate suggestion; a `verified: true` doc is not time-demoted; a doc missing `date`
+  does not throw.
+- Edge case: malformed frontmatter on one doc does not crash the run; that doc is skipped,
+  others still returned.
+
+**Verification:** `pnpm check-types`, `pnpm lint`, `pnpm test` green; the script loads under
+Node strip-only (`Test Scripts Load` semantics); no resolved private identifier appears in
+any output for the privacy fixture; excerpt respects the byte budget.
+
+- [ ] **Unit 2: wire the retrieval step + injection into `fro-bot.yaml`**
+
+**Goal:** Run `solutions-query.ts` on every Fro Bot run and inject its excerpt into the
+agent prompt as a `<solutions_context>` block, with a prompt instruction to consult and cite
+applied learnings.
+
+**Requirements:** R1, R3.
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `.github/workflows/fro-bot.yaml`
+
+**Approach:**
+- Add a `Query solutions context` step (`id: solutions-query`) as a sibling of `Query wiki
+  context`, passing the same event-derived env (`event_name`, owner, repo, title, body).
+- Add `SOLUTIONS_CONTEXT: ${{ steps.solutions-query.outputs.excerpt }}` to the agent step env
+  and render a `<solutions_context>${{ env.SOLUTIONS_CONTEXT }}</solutions_context>` block in
+  the prompt, adjacent to `<wiki_context>`.
+- Add a one-line instruction in the `<knowledge_persistence>` block (and a short mention in
+  the `SCHEDULE_PROMPT` / `PR_REVIEW_PROMPT` near the existing dedup/consult guidance):
+  consult `<solutions_context>`, apply relevant learnings, and cite `Path: <doc-path>` in
+  reasoning when applied (R3).
+- The step is best-effort: a non-zero exit must not fail the run (mirror how the wiki step is
+  treated; do not make the agent step depend on retrieval success).
+
+**Execution note:** none (workflow wiring; validated by actionlint + a live dispatch).
+
+**Patterns to follow:** the existing `Query wiki context` step and the `WIKI_CONTEXT`
+injection in the same file; keep the App-token / permissions shape unchanged.
+
+**Test scenarios:** `Test expectation: none -- workflow wiring; validated by actionlint and a
+manual dispatch that shows the `<solutions_context>` block populated and the agent citing a
+`Path:` it applied.`
+
+**Verification:** actionlint clean; a manual `workflow_dispatch` (or a real PR/schedule run)
+shows the solutions step ran, the `<solutions_context>` block is populated when relevant docs
+exist, the block is empty (not erroring) when none match, and the agent cites an applied doc
+path in its reasoning. Confirm no private identifier appears in the run log/step output.
+
+## System-Wide Impact
+
+- **Interaction graph:** adds one step to every `fro-bot.yaml` run type; the agent prompt
+  gains one context block. No change to the App-token flow, permissions, persona injection,
+  wiki injection, or the autonomous-write/data-branch paths.
+- **Error propagation:** retrieval is best-effort and non-gating — failures yield an empty
+  context block, never a failed run. This is deliberate to avoid the silent-failure trap
+  (a non-load-bearing step cannot mask a downstream failure in the run's success predicate).
+- **State lifecycle risks:** none — no persisted state, no new frontmatter, reads the working
+  tree only.
+- **API surface parity:** the wiki-context injection is the parallel surface; this mirrors it
+  without changing it.
+- **Unchanged invariants:** the no-private-leak discipline (the body scan strengthens it at a
+  new chokepoint), the data-branch authority model (untouched — `docs/solutions/` is on
+  `main`), and run success semantics (retrieval cannot fail a run).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Injected doc body leaks a private identifier into a public surface | Fail-closed body scan with the `check-private-leak.ts` token set at the injection chokepoint; path-only references in logs |
+| Retrieval failure breaks an agent run | Best-effort, non-gating: empty excerpt + exit 0 on any error; agent step does not depend on retrieval success |
+| New script crashes prod under Node 24 strip-only despite green tests | Strip-only-safe constructs only; `Test Scripts Load` CI + `erasableSyntaxOnly` lint cover it |
+| Free-form `module` makes scoring miss or over-match | Token-overlap/substring matching (never equality); calibrate weights against real fixtures; tune in implementation |
+| Context bloat / irrelevant dump | Tight byte budget (≈3–4KB) + relevance ranking; "small and on-point" is R2 |
+
+## Documentation / Operational Notes
+
+- After the feature lands, capture the retrieval-injection pattern as a new `docs/solutions/`
+  learning (the learnings research noted this surface is net-new territory with no prior
+  doc) — including the byte-budget truncation and the body-scan privacy chokepoint. (This is
+  itself a small dogfood of the grow-and-learn loop.)
+- Update `metadata/README.md` only if it documents the agent context-injection surface;
+  otherwise no doc change is required for v1.
+
+## Sources & References
+
+- **Origin document:** docs/brainstorms/2026-06-22-skill-saving-grow-and-learn-requirements.md
+- Pattern to mirror: `.github/workflows/fro-bot.yaml` (`Query wiki context` step + injection),
+  `scripts/wiki-query.ts`, `scripts/wiki-query.test.ts`
+- Privacy token source: `scripts/check-private-leak.ts`
+- Key learnings: `docs/solutions/best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md`,
+  `docs/solutions/security-issues/survey-workflow-side-privacy-gate-2026-05-16.md`,
+  `docs/solutions/runtime-errors/node-strip-only-typescript-2026-04-18.md`

--- a/docs/plans/2026-06-22-001-feat-solutions-retrieval-injection-plan.md
+++ b/docs/plans/2026-06-22-001-feat-solutions-retrieval-injection-plan.md
@@ -191,7 +191,7 @@ fro-bot.yaml run (any event)
 
 ## Implementation Units
 
-- [ ] **Unit 1: `scripts/solutions-query.ts` — retrieval engine (test-first)**
+- [x] **Unit 1: `scripts/solutions-query.ts` — retrieval engine (test-first)**
 
 **Goal:** A script that loads `docs/solutions/**`, scores docs against the current run's
 event context, applies the privacy body-scan and freshness handling, packs the top matches
@@ -258,7 +258,7 @@ into a byte budget, and writes the excerpt + metadata to `GITHUB_OUTPUT`.
 Node strip-only (`Test Scripts Load` semantics); no resolved private identifier appears in
 any output for the privacy fixture; excerpt respects the byte budget.
 
-- [ ] **Unit 2: wire the retrieval step + injection into `fro-bot.yaml`**
+- [x] **Unit 2: wire the retrieval step + injection into `fro-bot.yaml`**
 
 **Goal:** Run `solutions-query.ts` on every Fro Bot run and inject its excerpt into the
 agent prompt as a `<solutions_context>` block, with a prompt instruction to consult and cite

--- a/scripts/check-private-leak.ts
+++ b/scripts/check-private-leak.ts
@@ -7,7 +7,7 @@ import process from 'node:process'
 import {parse as parseYaml} from 'yaml'
 import {isRecord, makeGhNodeIdResolver} from './private-repo-resolution.ts'
 import {assertReposFile} from './schemas.ts'
-import {computeRepoSlug} from './wiki-slug.ts'
+import {buildPrivateNameTokens} from './wiki-slug.ts'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -682,21 +682,7 @@ function postOverrideComment(prNumber: number, author: string): void {
  * Duplicate forms are collapsed via a Set round-trip.
  */
 function buildTokensForName(nameWithOwner: string): string[] {
-  const slashIndex = nameWithOwner.indexOf('/')
-  if (slashIndex < 1) return []
-  const owner = nameWithOwner.slice(0, slashIndex)
-  const name = nameWithOwner.slice(slashIndex + 1)
-  if (owner === '' || name === '') return []
-  // Raw double-dash form — original chars, no sanitization. Always added first.
-  const rawDoubleDash = `${owner}--${name}`
-  const tokens: string[] = [nameWithOwner, rawDoubleDash]
-  try {
-    tokens.push(computeRepoSlug(owner, name))
-  } catch {
-    // computeRepoSlug throws on empty segments — skip slug form
-  }
-  // Dedup: identical forms (e.g. simple names where raw == slug) don't double up.
-  return [...new Set(tokens)]
+  return buildPrivateNameTokens(nameWithOwner)
 }
 
 /**

--- a/scripts/solutions-query.test.ts
+++ b/scripts/solutions-query.test.ts
@@ -1,0 +1,418 @@
+import {describe, expect, it} from 'vitest'
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const solutionsQueryModulePromise: Promise<{
+  assembleSolutionsContext: typeof import('./solutions-query.js').assembleSolutionsContext
+}> = import(`./solutions-query${'.js'}`)
+const {assembleSolutionsContext} = await solutionsQueryModulePromise
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeDoc(path: string, frontmatter: Record<string, unknown>, body: string): Record<string, string> {
+  const fm = Object.entries(frontmatter)
+    .map(([k, v]) => {
+      if (Array.isArray(v)) {
+        return `${k}:\n${v.map(item => `  - ${item}`).join('\n')}`
+      }
+      return `${k}: ${String(v)}`
+    })
+    .join('\n')
+  return {[path]: `---\n${fm}\n---\n\n${body}\n`}
+}
+
+const BEST_PRACTICE_DOC = makeDoc(
+  'docs/solutions/best-practices/reconcile-repos-pattern.md',
+  {
+    title: 'Reconcile Repos Pattern',
+    module: 'scripts/reconcile-repos.ts',
+    problem_type: 'best_practice',
+    last_updated: '2026-06-01',
+    verified: '2026-06-01',
+    tags: ['reconcile', 'repos', 'automation'],
+  },
+  'Use reconcile-repos to synchronize repository settings across the org.',
+)
+
+const SECURITY_DOC = makeDoc(
+  'docs/solutions/security-issues/private-leak-gate.md',
+  {
+    title: 'Private Leak Gate',
+    module: 'scripts/check-private-leak.ts',
+    problem_type: 'security_issue',
+    last_updated: '2026-06-10',
+    verified: '2026-06-10',
+    tags: ['privacy', 'security', 'leak', 'gate'],
+    applies_when: ['a private identifier may appear in injected content', 'fail-closed gate required'],
+  },
+  'Scan injected content for private identifiers before surfacing it.',
+)
+
+const UNRELATED_DOC = makeDoc(
+  'docs/solutions/workflow-issues/jq-trap.md',
+  {
+    title: 'JQ Falsy Coalesce Trap',
+    module: 'scripts/jq-helper.ts',
+    problem_type: 'workflow_issue',
+    last_updated: '2026-05-17',
+    verified: '2026-05-17',
+    tags: ['jq', 'shell', 'workflow'],
+  },
+  'Avoid jq falsy coalesce in shell gates.',
+)
+
+const ALL_DOCS = {...BEST_PRACTICE_DOC, ...SECURITY_DOC, ...UNRELATED_DOC}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('assembleSolutionsContext', () => {
+  it('selects a doc whose module and tags match the event; excerpt includes title, Path, and Last updated', () => {
+    // #given a PR event whose title/body reference the reconcile-repos module
+    const result = assembleSolutionsContext({
+      files: ALL_DOCS,
+      event: {
+        eventName: 'pull_request',
+        owner: 'fro-bot',
+        repo: '.github',
+        title: 'feat: improve reconcile-repos logic',
+        body: 'Refactors the reconcile-repos automation script.',
+      },
+      privateNames: [],
+      now: new Date('2026-06-22'),
+    })
+
+    // #when the scorer ranks docs by token overlap
+    // #then the reconcile-repos doc is selected and the excerpt contains required fields
+    expect(result.selectedPaths).toContain('docs/solutions/best-practices/reconcile-repos-pattern.md')
+    expect(result.excerpt).toContain('Reconcile Repos Pattern')
+    expect(result.excerpt).toContain('Path: docs/solutions/best-practices/reconcile-repos-pattern.md')
+    expect(result.excerpt).toContain('Last updated: 2026-06-01')
+    expect(result.byteLength).toBeGreaterThan(0)
+  })
+
+  it('returns an empty excerpt when no docs match the event context', () => {
+    // #given an event with tokens that share no signal with any doc
+    const result = assembleSolutionsContext({
+      files: ALL_DOCS,
+      event: {
+        eventName: 'issues',
+        owner: 'fro-bot',
+        repo: '.github',
+        title: 'Quartz zephyr tuning',
+        body: 'Nebula glyph orbits lumen vectors.',
+      },
+      privateNames: [],
+      now: new Date('2026-06-22'),
+    })
+
+    // #when scoring finds zero matches
+    // #then the assembled context is intentionally empty
+    expect(result.excerpt).toBe('')
+    expect(result.selectedPaths).toEqual([])
+    expect(result.byteLength).toBe(0)
+  })
+
+  it('enforces the hard byte-budget cap and truncates with the overflow marker', () => {
+    const largeBody = 'reconcile repos automation '.repeat(500)
+    const bigDoc = makeDoc(
+      'docs/solutions/best-practices/reconcile-repos-pattern.md',
+      {
+        title: 'Reconcile Repos Pattern',
+        module: 'scripts/reconcile-repos.ts',
+        problem_type: 'best_practice',
+        last_updated: '2026-06-01',
+        verified: '2026-06-01',
+        tags: ['reconcile', 'repos'],
+      },
+      largeBody,
+    )
+
+    // #given a matching doc whose body far exceeds the byte budget
+    const result = assembleSolutionsContext({
+      files: bigDoc,
+      event: {
+        eventName: 'pull_request',
+        title: 'feat: reconcile repos',
+        body: 'automation',
+      },
+      privateNames: [],
+      now: new Date('2026-06-22'),
+      maxBytes: 300,
+    })
+
+    // #when the packer truncates to fit the budget
+    // #then the excerpt contains the overflow marker and stays within budget
+    expect(result.excerpt).toContain('…')
+    expect(result.byteLength).toBeLessThanOrEqual(300)
+    expect(result.excerpt).not.toContain('�')
+  })
+
+  it('truncates multi-byte utf8 content without emitting invalid text', () => {
+    const emojiBody = 'reconcile repos 😀😀😀 automation notes.'.repeat(200)
+    const emojiDoc = makeDoc(
+      'docs/solutions/best-practices/reconcile-repos-pattern.md',
+      {
+        title: 'Reconcile Repos Pattern',
+        module: 'scripts/reconcile-repos.ts',
+        problem_type: 'best_practice',
+        last_updated: '2026-06-01',
+        verified: '2026-06-01',
+        tags: ['reconcile', 'repos'],
+      },
+      emojiBody,
+    )
+
+    // #given a matching doc with emoji-heavy body that must be truncated
+    const result = assembleSolutionsContext({
+      files: emojiDoc,
+      event: {
+        eventName: 'pull_request',
+        title: 'feat: reconcile repos automation',
+        body: 'emoji handling',
+      },
+      privateNames: [],
+      now: new Date('2026-06-22'),
+      maxBytes: 200,
+    })
+
+    // #when utf8 truncation slices through emoji bytes
+    // #then the result is valid text with the overflow marker and no replacement chars
+    expect(result.excerpt).toContain('…')
+    expect(result.byteLength).toBeLessThanOrEqual(200)
+    expect(result.excerpt).not.toContain('�')
+  })
+
+  it('ranks a security_issue doc above a best_practice doc on a security-flavored event', () => {
+    // #given a PR event with security-flavored title tokens
+    const result = assembleSolutionsContext({
+      files: ALL_DOCS,
+      event: {
+        eventName: 'pull_request',
+        owner: 'fro-bot',
+        repo: '.github',
+        title: 'fix: security leak in private token handling',
+        body: 'Addresses a credential leak in the auth gate.',
+      },
+      privateNames: [],
+      now: new Date('2026-06-22'),
+    })
+
+    // #when the scorer applies event-aware problem_type weighting
+    // #then the security_issue doc ranks above the best_practice doc
+    const securityIdx = result.selectedPaths.indexOf('docs/solutions/security-issues/private-leak-gate.md')
+    const bestPracticeIdx = result.selectedPaths.indexOf('docs/solutions/best-practices/reconcile-repos-pattern.md')
+    expect(securityIdx).toBeGreaterThanOrEqual(0)
+    // security doc should appear before best_practice doc (or best_practice may not appear at all)
+    if (bestPracticeIdx !== -1) {
+      expect(securityIdx).toBeLessThan(bestPracticeIdx)
+    }
+  })
+
+  it('matches a free-form module field via substring/token overlap', () => {
+    // #given an event token that is a substring of the module path
+    const result = assembleSolutionsContext({
+      files: BEST_PRACTICE_DOC,
+      event: {
+        eventName: 'pull_request',
+        title: 'refactor reconcile-repos script',
+        body: 'Updating the reconcile-repos module.',
+      },
+      privateNames: [],
+      now: new Date('2026-06-22'),
+    })
+
+    // #when the scorer checks module via token overlap (not equality)
+    // #then the doc is selected even though the event token is not the full module path
+    expect(result.selectedPaths).toContain('docs/solutions/best-practices/reconcile-repos-pattern.md')
+  })
+
+  it('excludes a doc whose body contains a private token (fail-closed privacy gate)', () => {
+    // #given a fixture private name and a doc whose body contains that private token
+    const privateName = 'testowner/secret-repo'
+    const leakyDoc = makeDoc(
+      'docs/solutions/best-practices/reconcile-repos-pattern.md',
+      {
+        title: 'Reconcile Repos Pattern',
+        module: 'scripts/reconcile-repos.ts',
+        problem_type: 'best_practice',
+        last_updated: '2026-06-01',
+        verified: '2026-06-01',
+        tags: ['reconcile', 'repos', 'automation'],
+      },
+      // Body contains the private token — must be excluded fail-closed
+      'Use reconcile-repos to sync settings. See testowner/secret-repo for reference.',
+    )
+
+    const result = assembleSolutionsContext({
+      files: leakyDoc,
+      event: {
+        eventName: 'pull_request',
+        title: 'feat: improve reconcile-repos logic',
+        body: 'Refactors the reconcile-repos automation script.',
+      },
+      privateNames: [privateName],
+      now: new Date('2026-06-22'),
+    })
+
+    // #when the privacy gate scans the doc body for private tokens
+    // #then the doc is excluded fail-closed and no private name appears in any output field
+    expect(result.selectedPaths).not.toContain('docs/solutions/best-practices/reconcile-repos-pattern.md')
+    expect(result.excerpt).not.toContain('testowner/secret-repo')
+    expect(result.excerpt).not.toContain('testowner--secret-repo')
+    expect(result.excerpt).not.toContain('secret-repo')
+    // excerpt is empty because the only matching doc was excluded
+    expect(result.excerpt).toBe('')
+  })
+
+  it('mutation-proves the privacy exclusion: removing privateNames makes the doc appear', () => {
+    // #given the same leaky doc but with no privateNames supplied
+    const leakyDoc = makeDoc(
+      'docs/solutions/best-practices/reconcile-repos-pattern.md',
+      {
+        title: 'Reconcile Repos Pattern',
+        module: 'scripts/reconcile-repos.ts',
+        problem_type: 'best_practice',
+        last_updated: '2026-06-01',
+        verified: '2026-06-01',
+        tags: ['reconcile', 'repos', 'automation'],
+      },
+      'Use reconcile-repos to sync settings. See testowner/secret-repo for reference.',
+    )
+
+    const result = assembleSolutionsContext({
+      files: leakyDoc,
+      event: {
+        eventName: 'pull_request',
+        title: 'feat: improve reconcile-repos logic',
+        body: 'Refactors the reconcile-repos automation script.',
+      },
+      privateNames: [], // no private names → gate is open → doc appears
+      now: new Date('2026-06-22'),
+    })
+
+    // #when no private names are registered the doc is NOT excluded
+    // #then it appears in the excerpt (proving the exclusion in the prior test is the gate, not scoring)
+    expect(result.selectedPaths).toContain('docs/solutions/best-practices/reconcile-repos-pattern.md')
+    expect(result.excerpt).toContain('Reconcile Repos Pattern')
+  })
+
+  it('flags a stale doc as a candidate suggestion when last_updated exceeds the threshold', () => {
+    const staleDoc = makeDoc(
+      'docs/solutions/best-practices/reconcile-repos-pattern.md',
+      {
+        title: 'Reconcile Repos Pattern',
+        module: 'scripts/reconcile-repos.ts',
+        problem_type: 'best_practice',
+        last_updated: '2025-01-01', // very old
+        tags: ['reconcile', 'repos'],
+      },
+      'Use reconcile-repos to sync settings.',
+    )
+
+    // #given a doc whose last_updated is older than the staleness threshold
+    const result = assembleSolutionsContext({
+      files: staleDoc,
+      event: {
+        eventName: 'pull_request',
+        title: 'feat: reconcile repos',
+        body: 'automation',
+      },
+      privateNames: [],
+      now: new Date('2026-06-22'),
+    })
+
+    // #when the freshness check compares last_updated to now
+    // #then the doc is rendered with a candidate-suggestion marker
+    expect(result.excerpt).toContain('candidate')
+    expect(result.excerpt).toContain('2025-01-01')
+  })
+
+  it('does not time-demote a doc with verified: true', () => {
+    const verifiedDoc = makeDoc(
+      'docs/solutions/best-practices/reconcile-repos-pattern.md',
+      {
+        title: 'Reconcile Repos Pattern',
+        module: 'scripts/reconcile-repos.ts',
+        problem_type: 'best_practice',
+        last_updated: '2025-01-01', // old but verified
+        verified: true,
+        tags: ['reconcile', 'repos'],
+      },
+      'Use reconcile-repos to sync settings.',
+    )
+
+    // #given a doc that is old but has verified: true
+    const result = assembleSolutionsContext({
+      files: verifiedDoc,
+      event: {
+        eventName: 'pull_request',
+        title: 'feat: reconcile repos',
+        body: 'automation',
+      },
+      privateNames: [],
+      now: new Date('2026-06-22'),
+    })
+
+    // #when the freshness check sees verified: true
+    // #then no candidate marker is added
+    expect(result.excerpt).not.toContain('candidate')
+    expect(result.selectedPaths).toContain('docs/solutions/best-practices/reconcile-repos-pattern.md')
+  })
+
+  it('does not throw when a doc is missing last_updated', () => {
+    const noDateDoc = makeDoc(
+      'docs/solutions/best-practices/reconcile-repos-pattern.md',
+      {
+        title: 'Reconcile Repos Pattern',
+        module: 'scripts/reconcile-repos.ts',
+        problem_type: 'best_practice',
+        tags: ['reconcile', 'repos'],
+        // no last_updated
+      },
+      'Use reconcile-repos to sync settings.',
+    )
+
+    // #given a doc with no last_updated field
+    const result = assembleSolutionsContext({
+      files: noDateDoc,
+      event: {
+        eventName: 'pull_request',
+        title: 'feat: reconcile repos',
+        body: 'automation',
+      },
+      privateNames: [],
+      now: new Date('2026-06-22'),
+    })
+
+    // #when the freshness check encounters a missing date
+    // #then it does not throw and the doc is still returned without a stale flag
+    expect(result.selectedPaths).toContain('docs/solutions/best-practices/reconcile-repos-pattern.md')
+    expect(result.excerpt).not.toContain('candidate')
+  })
+
+  it('skips a doc with malformed frontmatter and still returns others', () => {
+    const malformedDoc = {
+      'docs/solutions/best-practices/malformed.md': '---\ntitle: [unclosed bracket\n---\n\nSome body text.\n',
+    }
+
+    // #given a corpus with one malformed doc and one valid matching doc
+    const result = assembleSolutionsContext({
+      files: {...malformedDoc, ...BEST_PRACTICE_DOC},
+      event: {
+        eventName: 'pull_request',
+        title: 'feat: reconcile repos',
+        body: 'automation',
+      },
+      privateNames: [],
+      now: new Date('2026-06-22'),
+    })
+
+    // #when the loader encounters a parse error on one doc
+    // #then that doc is skipped and the valid doc is still returned
+    expect(result.selectedPaths).toContain('docs/solutions/best-practices/reconcile-repos-pattern.md')
+    expect(result.selectedPaths).not.toContain('docs/solutions/best-practices/malformed.md')
+  })
+})

--- a/scripts/solutions-query.test.ts
+++ b/scripts/solutions-query.test.ts
@@ -415,4 +415,325 @@ describe('assembleSolutionsContext', () => {
     expect(result.selectedPaths).toContain('docs/solutions/best-practices/reconcile-repos-pattern.md')
     expect(result.selectedPaths).not.toContain('docs/solutions/best-practices/malformed.md')
   })
+
+  it('does not time-demote a doc with verified: date-string (ISO date form)', () => {
+    // #given a doc that is old but has verified: <ISO-date-string> (the real-world form)
+    const verifiedDateDoc = makeDoc(
+      'docs/solutions/best-practices/reconcile-repos-pattern.md',
+      {
+        title: 'Reconcile Repos Pattern',
+        module: 'scripts/reconcile-repos.ts',
+        problem_type: 'best_practice',
+        last_updated: '2026-01-01', // old — exceeds 60-day staleness vs now=2026-06-22
+        verified: '2026-01-01', // date-string form used by 21 of 22 real docs
+        tags: ['reconcile', 'repos'],
+      },
+      'Use reconcile-repos to sync settings.',
+    )
+
+    // #when the freshness check sees verified: date-string
+    const result = assembleSolutionsContext({
+      files: verifiedDateDoc,
+      event: {
+        eventName: 'pull_request',
+        title: 'feat: reconcile repos',
+        body: 'automation',
+      },
+      privateNames: [],
+      now: new Date('2026-06-22'),
+    })
+
+    // #then no candidate marker is added (date-string verified suppresses staleness)
+    expect(result.excerpt).not.toContain('candidate')
+    expect(result.selectedPaths).toContain('docs/solutions/best-practices/reconcile-repos-pattern.md')
+  })
+
+  it('mutation-proves verified:date fix — reverting to boolean-only makes old date-string doc stale', () => {
+    // #given a doc with verified: date-string and old last_updated
+    // This test proves the fix by showing the doc IS stale without the date-string check.
+    // We simulate the old behavior by using verified: false (no verified field) to confirm
+    // the stale path fires, then confirm verified: date-string suppresses it.
+    const unverifiedOldDoc = makeDoc(
+      'docs/solutions/best-practices/reconcile-repos-pattern.md',
+      {
+        title: 'Reconcile Repos Pattern',
+        module: 'scripts/reconcile-repos.ts',
+        problem_type: 'best_practice',
+        last_updated: '2026-01-01', // old
+        // no verified field → verified=false → stale
+        tags: ['reconcile', 'repos'],
+      },
+      'Use reconcile-repos to sync settings.',
+    )
+
+    const staleResult = assembleSolutionsContext({
+      files: unverifiedOldDoc,
+      event: {eventName: 'pull_request', title: 'feat: reconcile repos', body: 'automation'},
+      privateNames: [],
+      now: new Date('2026-06-22'),
+    })
+
+    // #when verified is absent the doc IS flagged stale (mutation baseline)
+    expect(staleResult.excerpt).toContain('candidate')
+
+    // #when verified is a date-string the doc is NOT flagged stale (the fix)
+    const verifiedDateDoc = makeDoc(
+      'docs/solutions/best-practices/reconcile-repos-pattern.md',
+      {
+        title: 'Reconcile Repos Pattern',
+        module: 'scripts/reconcile-repos.ts',
+        problem_type: 'best_practice',
+        last_updated: '2026-01-01',
+        verified: '2026-01-01',
+        tags: ['reconcile', 'repos'],
+      },
+      'Use reconcile-repos to sync settings.',
+    )
+
+    const freshResult = assembleSolutionsContext({
+      files: verifiedDateDoc,
+      event: {eventName: 'pull_request', title: 'feat: reconcile repos', body: 'automation'},
+      privateNames: [],
+      now: new Date('2026-06-22'),
+    })
+
+    expect(freshResult.excerpt).not.toContain('candidate')
+  })
+
+  it('excludes a doc whose FRONTMATTER (not body) contains a private token (full-content scan)', () => {
+    // #given a doc with a clean body but the private token only in frontmatter title
+    const privateName = 'testowner/secret-repo'
+    const frontmatterLeakDoc = makeDoc(
+      'docs/solutions/best-practices/reconcile-repos-pattern.md',
+      {
+        title: 'Fix for testowner/secret-repo integration', // private token in frontmatter
+        module: 'scripts/reconcile-repos.ts',
+        problem_type: 'best_practice',
+        last_updated: '2026-06-01',
+        verified: '2026-06-01',
+        tags: ['reconcile', 'repos', 'automation'],
+      },
+      'Use reconcile-repos to sync settings.', // clean body — no private token here
+    )
+
+    const result = assembleSolutionsContext({
+      files: frontmatterLeakDoc,
+      event: {
+        eventName: 'pull_request',
+        title: 'feat: improve reconcile-repos logic',
+        body: 'Refactors the reconcile-repos automation script.',
+      },
+      privateNames: [privateName],
+      now: new Date('2026-06-22'),
+    })
+
+    // #when the privacy gate scans the full content (frontmatter + body)
+    // #then the doc is excluded even though the body is clean
+    expect(result.selectedPaths).not.toContain('docs/solutions/best-practices/reconcile-repos-pattern.md')
+    expect(result.excerpt).toBe('')
+  })
+
+  it('excludes a doc whose body contains the owner--name token form', () => {
+    // #given a doc whose body contains the double-dash form of the private token
+    const privateName = 'testowner/secret-repo'
+    const doubleDashDoc = makeDoc(
+      'docs/solutions/best-practices/reconcile-repos-pattern.md',
+      {
+        title: 'Reconcile Repos Pattern',
+        module: 'scripts/reconcile-repos.ts',
+        problem_type: 'best_practice',
+        last_updated: '2026-06-01',
+        verified: '2026-06-01',
+        tags: ['reconcile', 'repos', 'automation'],
+      },
+      'See testowner--secret-repo for the wiki page reference.', // double-dash form
+    )
+
+    const result = assembleSolutionsContext({
+      files: doubleDashDoc,
+      event: {
+        eventName: 'pull_request',
+        title: 'feat: improve reconcile-repos logic',
+        body: 'Refactors the reconcile-repos automation script.',
+      },
+      privateNames: [privateName],
+      now: new Date('2026-06-22'),
+    })
+
+    // #when the privacy gate checks the owner--name token form
+    // #then the doc is excluded fail-closed
+    expect(result.selectedPaths).not.toContain('docs/solutions/best-practices/reconcile-repos-pattern.md')
+    expect(result.excerpt).toBe('')
+  })
+
+  it('excludes a doc with a MIXED-CASE private name in body (case-insensitive scan)', () => {
+    // #given a private name registered as lowercase, but the doc body uses mixed case
+    const privateName = 'testowner/secret-repo' // registered lowercase
+    const mixedCaseDoc = makeDoc(
+      'docs/solutions/best-practices/reconcile-repos-pattern.md',
+      {
+        title: 'Reconcile Repos Pattern',
+        module: 'scripts/reconcile-repos.ts',
+        problem_type: 'best_practice',
+        last_updated: '2026-06-01',
+        verified: '2026-06-01',
+        tags: ['reconcile', 'repos', 'automation'],
+      },
+      'See TestOwner/Secret-Repo for reference.', // mixed-case form in body
+    )
+
+    const result = assembleSolutionsContext({
+      files: mixedCaseDoc,
+      event: {
+        eventName: 'pull_request',
+        title: 'feat: improve reconcile-repos logic',
+        body: 'Refactors the reconcile-repos automation script.',
+      },
+      privateNames: [privateName],
+      now: new Date('2026-06-22'),
+    })
+
+    // #when the privacy gate lowercases both the content and the tokens
+    // #then the mixed-case occurrence is still detected and the doc is excluded
+    expect(result.selectedPaths).not.toContain('docs/solutions/best-practices/reconcile-repos-pattern.md')
+    expect(result.excerpt).toBe('')
+  })
+
+  it('security bonus isolation: security_issue doc ranks higher than equal-scoring best_practice on security event', () => {
+    // #given two docs that score EQUAL on all non-bonus dimensions (same tokens in title/tags/module/body)
+    // Only problem_type differs: one is security_issue, one is best_practice.
+    const securityBonusDoc = makeDoc(
+      'docs/solutions/security-issues/equal-score-security.md',
+      {
+        title: 'Token Handling Pattern',
+        module: 'scripts/token-handler.ts',
+        problem_type: 'security_issue',
+        last_updated: '2026-06-01',
+        verified: '2026-06-01',
+        tags: ['token', 'handler'],
+      },
+      'Handle tokens carefully to avoid leaks.',
+    )
+
+    const bestPracticeEqualDoc = makeDoc(
+      'docs/solutions/best-practices/equal-score-best-practice.md',
+      {
+        title: 'Token Handling Pattern',
+        module: 'scripts/token-handler.ts',
+        problem_type: 'best_practice',
+        last_updated: '2026-06-01',
+        verified: '2026-06-01',
+        tags: ['token', 'handler'],
+      },
+      'Handle tokens carefully to avoid leaks.',
+    )
+
+    // #when the event is security-flavored (contains 'token' which is in SECURITY_EVENT_TOKENS)
+    const result = assembleSolutionsContext({
+      files: {...securityBonusDoc, ...bestPracticeEqualDoc},
+      event: {
+        eventName: 'pull_request',
+        title: 'fix: token handler leak',
+        body: 'Addresses a token leak in the handler.',
+      },
+      privateNames: [],
+      now: new Date('2026-06-22'),
+    })
+
+    // #then the security_issue doc ranks BEFORE the best_practice doc due to the +20 bonus
+    const securityIdx = result.selectedPaths.indexOf('docs/solutions/security-issues/equal-score-security.md')
+    const bestPracticeIdx = result.selectedPaths.indexOf('docs/solutions/best-practices/equal-score-best-practice.md')
+    expect(securityIdx).toBeGreaterThanOrEqual(0)
+    expect(bestPracticeIdx).toBeGreaterThanOrEqual(0)
+    expect(securityIdx).toBeLessThan(bestPracticeIdx)
+  })
+
+  it('mutation-proves security bonus: without the bonus the equal-scoring docs do NOT sort security-first', () => {
+    // #given the same two equal-scoring docs on a NON-security-flavored event
+    // (no security tokens → bonus does not apply → tie broken by insertion order)
+    // best-practice doc is spread FIRST so it appears first in Object.entries without the bonus
+    const bestPracticeEqualDoc = makeDoc(
+      'docs/solutions/best-practices/equal-score-best-practice.md',
+      {
+        title: 'Token Handling Pattern',
+        module: 'scripts/token-handler.ts',
+        problem_type: 'best_practice',
+        last_updated: '2026-06-01',
+        verified: '2026-06-01',
+        tags: ['token', 'handler'],
+      },
+      'Handle tokens carefully to avoid leaks.',
+    )
+
+    const securityBonusDoc = makeDoc(
+      'docs/solutions/security-issues/equal-score-security.md',
+      {
+        title: 'Token Handling Pattern',
+        module: 'scripts/token-handler.ts',
+        problem_type: 'security_issue',
+        last_updated: '2026-06-01',
+        verified: '2026-06-01',
+        tags: ['token', 'handler'],
+      },
+      'Handle tokens carefully to avoid leaks.',
+    )
+
+    // #when the event has NO security-flavored tokens (no 'token'/'secret'/etc in event)
+    const result = assembleSolutionsContext({
+      files: {...bestPracticeEqualDoc, ...securityBonusDoc},
+      event: {
+        eventName: 'pull_request',
+        title: 'refactor handler module',
+        body: 'Updating the handler module.',
+      },
+      privateNames: [],
+      now: new Date('2026-06-22'),
+    })
+
+    // #then both docs appear and security_issue does NOT rank first (no bonus → insertion order)
+    // best-practice was inserted first → it appears first without the security bonus
+    const securityIdx = result.selectedPaths.indexOf('docs/solutions/security-issues/equal-score-security.md')
+    const bestPracticeIdx = result.selectedPaths.indexOf('docs/solutions/best-practices/equal-score-best-practice.md')
+    expect(securityIdx).toBeGreaterThanOrEqual(0)
+    expect(bestPracticeIdx).toBeGreaterThanOrEqual(0)
+    // Without bonus, best-practice (inserted first) appears before security_issue
+    expect(bestPracticeIdx).toBeLessThan(securityIdx)
+  })
+
+  it('multi-byte truncation: emoji at budget boundary emits no U+FFFD replacement chars', () => {
+    // #given content with a 4-byte emoji positioned so the byte budget would split it
+    // We use assembleSolutionsContext with a tight maxBytes to exercise truncateToBytes
+    const emojiBody = 'reconcile repos 😀 automation notes'
+    const emojiDoc = makeDoc(
+      'docs/solutions/best-practices/reconcile-repos-pattern.md',
+      {
+        title: 'Reconcile Repos Pattern',
+        module: 'scripts/reconcile-repos.ts',
+        problem_type: 'best_practice',
+        last_updated: '2026-06-01',
+        verified: '2026-06-01',
+        tags: ['reconcile', 'repos'],
+      },
+      emojiBody,
+    )
+
+    // Budget is set to force truncation mid-emoji (the header + path lines are ~80 bytes,
+    // so 120 bytes total leaves very little for the body, splitting the emoji)
+    const result = assembleSolutionsContext({
+      files: emojiDoc,
+      event: {
+        eventName: 'pull_request',
+        title: 'feat: reconcile repos automation',
+        body: 'emoji handling',
+      },
+      privateNames: [],
+      now: new Date('2026-06-22'),
+      maxBytes: 120,
+    })
+
+    // #when the byte-budget truncation slices through emoji bytes
+    // #then the output contains NO U+FFFD replacement chars
+    expect(result.excerpt).not.toContain('\uFFFD')
+    expect(result.byteLength).toBeLessThanOrEqual(120)
+  })
 })

--- a/scripts/solutions-query.ts
+++ b/scripts/solutions-query.ts
@@ -382,6 +382,11 @@ async function loadSolutionsFilesFromDisk(): Promise<Record<string, string>> {
 // Private names loader
 // ---------------------------------------------------------------------------
 
+// This scan is defense-in-depth, not the primary privacy control. The docs/solutions/
+// corpus lives on main and has already cleared the promotion leak gate, so by construction
+// it carries no private identifier. Canonical private names live on the data branch and are
+// overlaid only for schedule/workflow_dispatch runs; on other events this returns 0 names
+// and the scan is inert over already-gated content. The trust chokepoint remains promotion.
 async function loadPrivateNamesFromDisk(): Promise<string[]> {
   let reposYaml: string
 

--- a/scripts/solutions-query.ts
+++ b/scripts/solutions-query.ts
@@ -1,10 +1,11 @@
+import type {Dirent} from 'node:fs'
 import {Buffer} from 'node:buffer'
 import {readdir, readFile, writeFile} from 'node:fs/promises'
 import process from 'node:process'
 
 import {parse} from 'yaml'
 
-import {computeRepoSlug} from './wiki-slug.ts'
+import {buildPrivateNameTokens} from './wiki-slug.ts'
 
 const MAX_CONTEXT_BYTES = 4 * 1024
 const SOLUTIONS_ROOT = 'docs/solutions'
@@ -154,7 +155,9 @@ function collectDocs(files: Record<string, string>, privateTokens: Set<string>):
         ? frontmatter.applies_when.filter((t): t is string => typeof t === 'string')
         : [],
       lastUpdated: typeof frontmatter.last_updated === 'string' ? frontmatter.last_updated : null,
-      verified: frontmatter.verified === true,
+      verified:
+        frontmatter.verified === true ||
+        (typeof frontmatter.verified === 'string' && frontmatter.verified.trim() !== ''),
       body,
       score: 0,
     })
@@ -238,15 +241,10 @@ function buildPrivateTokenSet(privateNames: string[]): Set<string> {
     if (slashIndex < 1) continue
     const owner = nameWithOwner.slice(0, slashIndex)
     const name = nameWithOwner.slice(slashIndex + 1)
-    if (owner === '' || name === '' || owner === '[REDACTED]' || name === '[REDACTED]') continue
+    if (owner === '[REDACTED]' || name === '[REDACTED]') continue
 
-    tokens.add(nameWithOwner.toLowerCase())
-    tokens.add(`${owner.toLowerCase()}--${name.toLowerCase()}`)
-
-    try {
-      tokens.add(computeRepoSlug(owner, name).toLowerCase())
-    } catch {
-      // computeRepoSlug throws on empty segments — skip slug form
+    for (const token of buildPrivateNameTokens(nameWithOwner)) {
+      tokens.add(token.toLowerCase())
     }
   }
 
@@ -327,7 +325,12 @@ function truncateToBytes(value: string, maxBytes: number): string {
     return ''
   }
 
-  const truncated = Buffer.from(value).subarray(0, contentBudget).toString('utf8')
+  // Slice at the byte boundary then strip any trailing replacement chars that
+  // result from splitting a multi-byte codepoint mid-sequence.
+  const truncated = Buffer.from(value)
+    .subarray(0, contentBudget)
+    .toString('utf8')
+    .replaceAll(/\uFFFD+$/gu, '')
 
   return truncated === '' ? '' : `${truncated}${ellipsis}`
 }
@@ -349,23 +352,26 @@ async function loadSolutionsFilesFromDisk(): Promise<Record<string, string>> {
 
   for (const subdir of SOLUTIONS_SUBDIRS) {
     const dirPath = `${SOLUTIONS_ROOT}/${subdir}`
-    let entries: string[]
+    let entries: Dirent[]
 
     try {
-      const dirents = await readdir(dirPath)
-      entries = dirents
+      entries = await readdir(dirPath, {withFileTypes: true})
     } catch {
       // Directory may not exist in some environments — skip
       continue
     }
 
-    for (const name of entries) {
-      if (!name.endsWith('.md')) {
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.md')) {
         continue
       }
 
-      const path = `${dirPath}/${name}`
-      files[path] = await readFile(path, 'utf8')
+      const path = `${dirPath}/${entry.name}`
+      try {
+        files[path] = await readFile(path, 'utf8')
+      } catch {
+        process.stderr.write(`solutions-query: could not read file (path: ${path})\n`)
+      }
     }
   }
 
@@ -469,6 +475,7 @@ async function main(): Promise<void> {
     process.stdout.write(`${JSON.stringify(result)}\n`)
   } catch {
     // Best-effort: any error → empty output, exit 0 — retrieval must never fail the workflow step
+    process.stderr.write('solutions-query: unexpected error, falling back to empty context\n')
     const empty: AssembleSolutionsContextResult = {excerpt: '', selectedPaths: [], byteLength: 0}
     try {
       await writeGithubOutput(empty)

--- a/scripts/solutions-query.ts
+++ b/scripts/solutions-query.ts
@@ -1,0 +1,484 @@
+import {Buffer} from 'node:buffer'
+import {readdir, readFile, writeFile} from 'node:fs/promises'
+import process from 'node:process'
+
+import {parse} from 'yaml'
+
+import {computeRepoSlug} from './wiki-slug.ts'
+
+const MAX_CONTEXT_BYTES = 4 * 1024
+const SOLUTIONS_ROOT = 'docs/solutions'
+const SOLUTIONS_SUBDIRS = [
+  'best-practices',
+  'documentation-gaps',
+  'integration-issues',
+  'runtime-errors',
+  'security-issues',
+  'workflow-issues',
+] as const
+
+const STALENESS_DAYS_DEFAULT = 60
+
+// Security-flavored tokens that boost problem_type: security_issue docs
+const SECURITY_EVENT_TOKENS = new Set(['security', 'private', 'leak', 'auth', 'token', 'secret', 'credential'])
+
+export interface SolutionsQueryEvent {
+  eventName: string
+  owner?: string
+  repo?: string
+  title?: string
+  body?: string
+}
+
+export interface AssembleSolutionsContextParams {
+  files: Record<string, string>
+  event: SolutionsQueryEvent
+  /** List of `owner/name` strings for private repos — used for fail-closed body scan. */
+  privateNames: string[]
+  /** Current date — injectable for deterministic tests. */
+  now: Date
+  maxBytes?: number
+  stalenessDays?: number
+}
+
+export interface AssembleSolutionsContextResult {
+  excerpt: string
+  selectedPaths: string[]
+  byteLength: number
+}
+
+interface SolutionDoc {
+  path: string
+  title: string
+  module: string
+  tags: string[]
+  problemType: string
+  appliesWhen: string[]
+  lastUpdated: string | null
+  verified: boolean
+  body: string
+  score: number
+}
+
+// ---------------------------------------------------------------------------
+// Pure core
+// ---------------------------------------------------------------------------
+
+export function assembleSolutionsContext(params: AssembleSolutionsContextParams): AssembleSolutionsContextResult {
+  const maxBytes = params.maxBytes ?? MAX_CONTEXT_BYTES
+  const stalenessDays = params.stalenessDays ?? STALENESS_DAYS_DEFAULT
+
+  const privateTokens = buildPrivateTokenSet(params.privateNames)
+  const docs = collectDocs(params.files, privateTokens)
+  const tokens = collectTokens(params.event)
+
+  const securityFlavored = isSecurityFlavored(tokens)
+
+  const ranked = docs
+    .map(doc => ({...doc, score: scoreDoc(doc, tokens, securityFlavored)}))
+    .filter(doc => doc.score > 0)
+    .sort((a, b) => b.score - a.score || a.title.localeCompare(b.title))
+
+  let excerpt = '# Prior Learnings\n\n'
+  const selectedPaths: string[] = []
+
+  for (const doc of ranked) {
+    const section = renderSection(doc, params.now, stalenessDays)
+    const next = `${excerpt}${section}`
+
+    if (byteLength(next) <= maxBytes) {
+      excerpt = next
+      selectedPaths.push(doc.path)
+      continue
+    }
+
+    const remaining = maxBytes - byteLength(excerpt)
+    if (remaining <= 0) {
+      break
+    }
+
+    const truncated = truncateToBytes(section, remaining)
+    if (truncated.trim() !== '') {
+      excerpt = `${excerpt}${truncated}`
+      selectedPaths.push(doc.path)
+    }
+    break
+  }
+
+  if (selectedPaths.length === 0) {
+    excerpt = ''
+  }
+
+  return {excerpt, selectedPaths, byteLength: byteLength(excerpt)}
+}
+
+// ---------------------------------------------------------------------------
+// Doc collection and parsing
+// ---------------------------------------------------------------------------
+
+function collectDocs(files: Record<string, string>, privateTokens: Set<string>): SolutionDoc[] {
+  const docs: SolutionDoc[] = []
+
+  for (const [path, content] of Object.entries(files)) {
+    if (!path.startsWith(`${SOLUTIONS_ROOT}/`) || !path.endsWith('.md')) {
+      continue
+    }
+
+    let frontmatter: Record<string, unknown>
+    let body: string
+
+    try {
+      const parsed = splitFrontmatter(content)
+      frontmatter = parsed.frontmatter
+      body = parsed.body
+    } catch {
+      // Malformed frontmatter — skip this doc, do not crash
+      continue
+    }
+
+    // Privacy body-scan: fail-closed — exclude if body or frontmatter contains a private token
+    const fullText = content.toLowerCase()
+    if (containsPrivateToken(fullText, privateTokens)) {
+      // Reference by path only — never emit a resolved private name
+      process.stderr.write(`solutions-query: excluded 1 doc on privacy scan (path: ${path})\n`)
+      continue
+    }
+
+    docs.push({
+      path,
+      title: typeof frontmatter.title === 'string' ? frontmatter.title : path,
+      module: typeof frontmatter.module === 'string' ? frontmatter.module : '',
+      tags: Array.isArray(frontmatter.tags) ? frontmatter.tags.filter((t): t is string => typeof t === 'string') : [],
+      problemType: typeof frontmatter.problem_type === 'string' ? frontmatter.problem_type : '',
+      appliesWhen: Array.isArray(frontmatter.applies_when)
+        ? frontmatter.applies_when.filter((t): t is string => typeof t === 'string')
+        : [],
+      lastUpdated: typeof frontmatter.last_updated === 'string' ? frontmatter.last_updated : null,
+      verified: frontmatter.verified === true,
+      body,
+      score: 0,
+    })
+  }
+
+  return docs
+}
+
+function splitFrontmatter(content: string): {frontmatter: Record<string, unknown>; body: string} {
+  const match = /^---\n([\s\S]+?)\n---\n?/u.exec(content)
+  if (match === null) {
+    return {frontmatter: {}, body: content.trim()}
+  }
+
+  const frontmatterText = match[1]
+  if (frontmatterText === undefined) {
+    return {frontmatter: {}, body: content.trim()}
+  }
+
+  const parsed: unknown = parse(frontmatterText)
+  return {
+    frontmatter: isRecord(parsed) ? parsed : {},
+    body: content.slice(match[0].length).trim(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scorer
+// ---------------------------------------------------------------------------
+
+function scoreDoc(doc: SolutionDoc, tokens: Set<string>, securityFlavored: boolean): number {
+  let score = 0
+
+  for (const token of tokens) {
+    // Title match — weight 15
+    if (doc.title.toLowerCase().includes(token)) score += 15
+
+    // Tags match — weight 10
+    if (doc.tags.some(tag => tag.toLowerCase().includes(token))) score += 10
+
+    // Module match via substring/token overlap — weight 12
+    if (doc.module.toLowerCase().includes(token)) score += 12
+
+    // Body match — weight 4
+    if (doc.body.toLowerCase().includes(token)) score += 4
+
+    // applies_when match — weight 8
+    if (doc.appliesWhen.some(clause => clause.toLowerCase().includes(token))) score += 8
+  }
+
+  // Event-aware problem_type bonus: security-flavored events boost security_issue docs
+  if (securityFlavored && doc.problemType === 'security_issue') {
+    score += 20
+  }
+
+  return score
+}
+
+function isSecurityFlavored(tokens: Set<string>): boolean {
+  for (const token of tokens) {
+    if (SECURITY_EVENT_TOKENS.has(token)) return true
+  }
+  return false
+}
+
+// ---------------------------------------------------------------------------
+// Privacy gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a flat set of private identifier tokens from a list of `owner/name` strings.
+ * Mirrors the buildTokensForName logic from check-private-leak.ts.
+ * Tokens: [owner/name, owner--name, computeRepoSlug(owner, name)] — deduplicated.
+ * Entries with `[REDACTED]` owner or name are skipped (no canonical name to scan for).
+ */
+function buildPrivateTokenSet(privateNames: string[]): Set<string> {
+  const tokens = new Set<string>()
+
+  for (const nameWithOwner of privateNames) {
+    const slashIndex = nameWithOwner.indexOf('/')
+    if (slashIndex < 1) continue
+    const owner = nameWithOwner.slice(0, slashIndex)
+    const name = nameWithOwner.slice(slashIndex + 1)
+    if (owner === '' || name === '' || owner === '[REDACTED]' || name === '[REDACTED]') continue
+
+    tokens.add(nameWithOwner.toLowerCase())
+    tokens.add(`${owner.toLowerCase()}--${name.toLowerCase()}`)
+
+    try {
+      tokens.add(computeRepoSlug(owner, name).toLowerCase())
+    } catch {
+      // computeRepoSlug throws on empty segments — skip slug form
+    }
+  }
+
+  return tokens
+}
+
+function containsPrivateToken(lowerText: string, privateTokens: Set<string>): boolean {
+  for (const token of privateTokens) {
+    if (lowerText.includes(token)) return true
+  }
+  return false
+}
+
+// ---------------------------------------------------------------------------
+// Freshness
+// ---------------------------------------------------------------------------
+
+function isStale(lastUpdated: string | null, verified: boolean, now: Date, stalenessDays: number): boolean {
+  if (verified) return false
+  if (lastUpdated === null) return false
+
+  const updated = new Date(lastUpdated)
+  if (Number.isNaN(updated.getTime())) return false
+
+  const diffMs = now.getTime() - updated.getTime()
+  const diffDays = diffMs / (1000 * 60 * 60 * 24)
+  return diffDays > stalenessDays
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+function renderSection(doc: SolutionDoc, now: Date, stalenessDays: number): string {
+  // eslint-disable-next-line unicorn/prefer-string-replace-all
+  const bodyExcerpt = doc.body.replace(/\s+/g, ' ').trim()
+  const stale = isStale(doc.lastUpdated, doc.verified, now, stalenessDays)
+  const staleNote = stale ? `(candidate — last updated ${doc.lastUpdated ?? 'unknown'}, may be stale)\n` : ''
+  const lastUpdatedLine = doc.lastUpdated === null ? 'Last updated: unknown' : `Last updated: ${doc.lastUpdated}`
+  return `## ${doc.title}\nPath: ${doc.path}\nproblem_type: ${doc.problemType}\n${lastUpdatedLine}\n${staleNote}\n${bodyExcerpt}\n\n`
+}
+
+// ---------------------------------------------------------------------------
+// Token collection
+// ---------------------------------------------------------------------------
+
+function collectTokens(event: SolutionsQueryEvent): Set<string> {
+  const raw = [event.owner, event.repo, event.title, event.body]
+    .filter((value): value is string => value !== undefined)
+    .join(' ')
+  const tokens = raw
+    .toLowerCase()
+    // eslint-disable-next-line unicorn/prefer-string-replace-all
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .split(/\s+/)
+    .map(token => token.trim())
+    .filter(token => token.length >= 3)
+
+  return new Set(tokens)
+}
+
+// ---------------------------------------------------------------------------
+// Byte-budget helpers (multi-byte-safe)
+// ---------------------------------------------------------------------------
+
+function byteLength(value: string): number {
+  return Buffer.byteLength(value, 'utf8')
+}
+
+function truncateToBytes(value: string, maxBytes: number): string {
+  if (byteLength(value) <= maxBytes) {
+    return value
+  }
+
+  const ellipsis = '…'
+  const contentBudget = maxBytes - byteLength(ellipsis)
+  if (contentBudget <= 0) {
+    return ''
+  }
+
+  const truncated = Buffer.from(value).subarray(0, contentBudget).toString('utf8')
+
+  return truncated === '' ? '' : `${truncated}${ellipsis}`
+}
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+// ---------------------------------------------------------------------------
+// Disk loader
+// ---------------------------------------------------------------------------
+
+async function loadSolutionsFilesFromDisk(): Promise<Record<string, string>> {
+  const files: Record<string, string> = {}
+
+  for (const subdir of SOLUTIONS_SUBDIRS) {
+    const dirPath = `${SOLUTIONS_ROOT}/${subdir}`
+    let entries: string[]
+
+    try {
+      const dirents = await readdir(dirPath)
+      entries = dirents
+    } catch {
+      // Directory may not exist in some environments — skip
+      continue
+    }
+
+    for (const name of entries) {
+      if (!name.endsWith('.md')) {
+        continue
+      }
+
+      const path = `${dirPath}/${name}`
+      files[path] = await readFile(path, 'utf8')
+    }
+  }
+
+  return files
+}
+
+// ---------------------------------------------------------------------------
+// Private names loader
+// ---------------------------------------------------------------------------
+
+async function loadPrivateNamesFromDisk(): Promise<string[]> {
+  let reposYaml: string
+
+  try {
+    reposYaml = await readFile('metadata/repos.yaml', 'utf8')
+  } catch {
+    process.stderr.write('solutions-query: could not read metadata/repos.yaml; privacy scan uses 0 private names\n')
+    return []
+  }
+
+  try {
+    const parsed: unknown = parse(reposYaml)
+    if (!isRecord(parsed)) return []
+
+    const repos = parsed.repos
+    if (!Array.isArray(repos)) return []
+
+    const privateNames: string[] = []
+
+    for (const entry of repos) {
+      if (!isRecord(entry)) continue
+      if (entry.private !== true) continue
+
+      const owner = entry.owner
+      const name = entry.name
+
+      // Skip redacted entries — they have no canonical name to scan for
+      if (typeof owner !== 'string' || typeof name !== 'string' || owner === '[REDACTED]' || name === '[REDACTED]') {
+        continue
+      }
+
+      privateNames.push(`${owner}/${name}`)
+    }
+
+    return privateNames
+  } catch {
+    process.stderr.write('solutions-query: could not parse metadata/repos.yaml; privacy scan uses 0 private names\n')
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GITHUB_OUTPUT writer
+// ---------------------------------------------------------------------------
+
+async function writeGithubOutput(result: AssembleSolutionsContextResult): Promise<void> {
+  const outputPath = process.env.GITHUB_OUTPUT
+  if (outputPath === undefined || outputPath === '') {
+    return
+  }
+
+  const delimiter = `EOF_${Math.random().toString(16).slice(2)}`
+  const lines = [
+    `excerpt<<${delimiter}`,
+    result.excerpt,
+    delimiter,
+    `selected-paths=${JSON.stringify(result.selectedPaths)}`,
+    `byte-length=${result.byteLength}`,
+  ]
+  await writeFile(outputPath, `${lines.join('\n')}\n`, {flag: 'a'})
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  try {
+    const [files, privateNames] = await Promise.all([loadSolutionsFilesFromDisk(), loadPrivateNamesFromDisk()])
+
+    const result = assembleSolutionsContext({
+      files,
+      event: {
+        eventName: process.env.SOLUTIONS_QUERY_EVENT_NAME ?? process.env.GITHUB_EVENT_NAME ?? '',
+        owner: process.env.SOLUTIONS_QUERY_OWNER,
+        repo: process.env.SOLUTIONS_QUERY_REPO,
+        title: process.env.SOLUTIONS_QUERY_TITLE,
+        body: process.env.SOLUTIONS_QUERY_BODY,
+      },
+      privateNames,
+      now: new Date(),
+      maxBytes:
+        process.env.SOLUTIONS_QUERY_MAX_BYTES === undefined ? undefined : Number(process.env.SOLUTIONS_QUERY_MAX_BYTES),
+      stalenessDays:
+        process.env.SOLUTIONS_QUERY_STALENESS_DAYS === undefined
+          ? undefined
+          : Number(process.env.SOLUTIONS_QUERY_STALENESS_DAYS),
+    })
+
+    await writeGithubOutput(result)
+    process.stdout.write(`${JSON.stringify(result)}\n`)
+  } catch {
+    // Best-effort: any error → empty output, exit 0 — retrieval must never fail the workflow step
+    const empty: AssembleSolutionsContextResult = {excerpt: '', selectedPaths: [], byteLength: 0}
+    try {
+      await writeGithubOutput(empty)
+    } catch {
+      // ignore
+    }
+    process.stdout.write(`${JSON.stringify(empty)}\n`)
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}

--- a/scripts/wiki-slug.test.ts
+++ b/scripts/wiki-slug.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest'
 
-import {computeRepoSlug} from './wiki-slug.ts'
+import {buildPrivateNameTokens, computeRepoSlug} from './wiki-slug.ts'
 
 describe('computeRepoSlug', () => {
   it('preserves the double-dash separator between owner and repo', () => {
@@ -48,5 +48,51 @@ describe('computeRepoSlug', () => {
     // #then we strip the dot-induced leading dash so the slug stays valid
     expect(computeRepoSlug('fro-bot', '.github')).toBe('fro-bot--github')
     expect(computeRepoSlug('marcusrbrown', 'esphome.life')).toBe('marcusrbrown--esphome-life')
+  })
+})
+
+describe('buildPrivateNameTokens', () => {
+  it('returns canonical, double-dash, and slug forms for a known input', () => {
+    // #given a synthetic owner/name pair
+    const tokens = buildPrivateNameTokens('testowner/secret-repo')
+
+    // #when the token set is built
+    // #then it contains the canonical, raw double-dash, and slug forms
+    expect(tokens).toContain('testowner/secret-repo')
+    expect(tokens).toContain('testowner--secret-repo')
+    // computeRepoSlug('testowner', 'secret-repo') → 'testowner--secret-repo' (same for simple names)
+    // The set deduplicates, so length is 2 for simple names where raw == slug
+    expect(tokens.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('deduplicates when raw double-dash form equals the slug form', () => {
+    // #given a simple name where owner--name == computeRepoSlug(owner, name)
+    const tokens = buildPrivateNameTokens('testowner/secret-repo')
+
+    // #when the forms are identical
+    // #then the result is deduplicated (no duplicate entries)
+    const unique = new Set(tokens)
+    expect(unique.size).toBe(tokens.length)
+  })
+
+  it('includes all three distinct forms when slug differs from raw double-dash', () => {
+    // #given a name with underscores where slug sanitization differs from raw
+    const tokens = buildPrivateNameTokens('testowner/my_private_repo')
+
+    // #when the slug sanitizes underscores to dashes
+    // #then all three distinct forms are present
+    expect(tokens).toContain('testowner/my_private_repo') // canonical
+    expect(tokens).toContain('testowner--my_private_repo') // raw double-dash (unsanitized)
+    expect(tokens).toContain('testowner--my-private-repo') // slug (sanitized)
+    expect(tokens.length).toBe(3)
+  })
+
+  it('returns empty array for input with no slash', () => {
+    expect(buildPrivateNameTokens('noslash')).toEqual([])
+  })
+
+  it('returns empty array for input with empty owner or name', () => {
+    expect(buildPrivateNameTokens('/name')).toEqual([])
+    expect(buildPrivateNameTokens('owner/')).toEqual([])
   })
 })

--- a/scripts/wiki-slug.ts
+++ b/scripts/wiki-slug.ts
@@ -1,6 +1,33 @@
 import process from 'node:process'
 
 /**
+ * Build the canonical private-name token set for a single `owner/name` string.
+ *
+ * Returns up to three forms — [nameWithOwner, owner--name, computeRepoSlug(owner,name)] —
+ * deduplicated via a Set round-trip. The raw double-dash form is always present even if
+ * computeRepoSlug throws. Bare name is intentionally excluded (false-positive risk on short names).
+ *
+ * Returns an empty array when the input has no slash, or when owner/name is empty.
+ */
+export function buildPrivateNameTokens(nameWithOwner: string): string[] {
+  const slashIndex = nameWithOwner.indexOf('/')
+  if (slashIndex < 1) return []
+  const owner = nameWithOwner.slice(0, slashIndex)
+  const name = nameWithOwner.slice(slashIndex + 1)
+  if (owner === '' || name === '') return []
+  // Raw double-dash form — original chars, no sanitization. Always added first.
+  const rawDoubleDash = `${owner}--${name}`
+  const tokens: string[] = [nameWithOwner, rawDoubleDash]
+  try {
+    tokens.push(computeRepoSlug(owner, name))
+  } catch {
+    // computeRepoSlug throws on empty segments — skip slug form
+  }
+  // Dedup: identical forms (e.g. simple names where raw == slug) don't double up.
+  return [...new Set(tokens)]
+}
+
+/**
  * Canonical wiki slug for a repo page.
  *
  * Produces `{owner-slug}--{repo-slug}` with:


### PR DESCRIPTION
Fro Bot now consults its own prior learnings during a run. The 22 documented solutions in `docs/solutions/` only helped before if a run happened to search them — this mechanizes that: the most relevant learnings are selected for the current run and injected into the agent prompt, the same way the wiki context already is.

This is the first slice of a larger grow-and-learn loop (requirements and plan included): it ships the *retrieve-and-apply* half over the existing curated corpus, with no autonomous capture yet.

## What changed

- **`scripts/solutions-query.ts`** — selects the most relevant `docs/solutions/` learnings for a run and renders them into a byte-budgeted context block. Deterministic token-overlap scoring over title, module (substring, since module is free-form), tags, `applies_when`, and body, with an event-aware bonus for security learnings on security-flavored runs. Mirrors the existing `wiki-query.ts`.
- **`.github/workflows/fro-bot.yaml`** — runs the query on every Fro Bot run and injects the result as a `<solutions_context>` block alongside the wiki context, with an instruction to consult it, follow what applies, and cite the doc path used.
- **Privacy** — a fail-closed scan excludes any doc whose text contains a tracked private-repo identifier, reusing the same token forms as the promotion leak gate (now a single shared helper so the two cannot drift). Excluded docs are referenced by path only. The metadata overlay runs before the scan so it sees the freshest private-repo set.
- **Freshness** — derived from each doc's `last_updated`; stale matches render as candidate suggestions rather than asserted facts. No new frontmatter, no persisted state.
- **Best-effort** — retrieval never fails a run: any parse or IO error yields an empty context block.

Covered by unit tests across scoring, byte-budget and multi-byte truncation, freshness (including the date-string `verified` form), the fail-closed privacy exclusion (mutation-proven, with frontmatter-only and case-insensitive variants), and isolated security weighting.
