### PR TITLE
feat: propose learnings from multi-round-review PRs

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -41,3 +41,6 @@ labels:
   - name: reconcile:visibility-transition
     color: '#f97316'
     description: Tracked repo transitioned from public to private
+  - name: learning-proposal
+    color: '#0e8a16'
+    description: Candidate learning proposed from a multi-round-review PR

--- a/.github/workflows/capture-c1-proposals.yaml
+++ b/.github/workflows/capture-c1-proposals.yaml
@@ -1,0 +1,171 @@
+---
+name: Capture Learning Proposals
+
+on:
+  schedule:
+    - cron: '30 22 * * 0' # Every Sunday at 22:30 UTC (30 min after Merge Data at 22:00)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Serialize runs; never cancel an in-progress run (a partial run could leave
+# the agent step mid-flight with no propose step to follow).
+concurrency:
+  group: capture-c1-proposals
+  cancel-in-progress: false
+
+jobs:
+  capture-c1-proposals:
+    name: Capture learning proposals from multi-round-review PRs
+    runs-on: ubuntu-latest
+    # Agent step is the long pole; 30 minutes provides headroom without
+    # permitting a truly-stuck run.
+    timeout-minutes: 30
+    steps:
+      - id: get-workflow-app-token
+        name: Get Workflow Access Token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          # Scope to the whole installation for consistency with reconcile-repos.yaml.
+          # The harvest and issue-create are same-repo; the owner scope is harmless.
+          owner: ${{ github.repository_owner }}
+
+      - name: ⤵ Checkout Branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: 📦 Setup
+        uses: ./.github/actions/setup
+
+      # Overlay metadata/ from the data branch so the privacy gate reads the
+      # authoritative private-repo list from metadata/repos.yaml.
+      # Hard-fail if the data branch exists but the overlay fails — the privacy
+      # gate cannot operate without metadata/repos.yaml (fail-closed by design).
+      # Tolerate a missing data branch (first run, fresh clone) like reconcile does.
+      - name: ⤵ Overlay metadata from data branch
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code origin data >/dev/null 2>&1; then
+            git fetch --no-tags origin data
+            git checkout origin/data -- metadata/
+          else
+            echo "data branch not yet established; skipping metadata overlay."
+          fi
+
+      # Harvest merged PRs with ≥2 CHANGES_REQUESTED reviews, dedup against
+      # existing learning-proposal issues and docs/solutions/, cap to
+      # MAX_PROPOSALS_PER_RUN, and emit an opaque digest (merge_sha only —
+      # no owner/repo/number prose) to GITHUB_OUTPUT and a temp file.
+      - name: 🌾 Harvest candidates
+        id: harvest
+        env:
+          GITHUB_TOKEN: ${{ steps.get-workflow-app-token.outputs.token }}
+        run: node scripts/capture-c1-harvest.ts | tee "$RUNNER_TEMP/harvest-result.json"
+        shell: bash
+
+      # Write the harvest digest to a file the agent and propose steps can read.
+      # The digest is already in GITHUB_OUTPUT (multiline `digest` key); writing
+      # it to a path avoids shell-quoting issues when passing large JSON blobs.
+      - name: 📝 Write digest file
+        run: |
+          set -euo pipefail
+          echo '${{ steps.harvest.outputs.digest }}' > "$RUNNER_TEMP/capture-c1-digest.json"
+
+      # The agent's ONLY job: read the digest (merge_sha + signals, no private
+      # identifiers), author a concise learning-proposal body for each candidate
+      # worth proposing, and write the bodies as a JSON object keyed by merge_sha
+      # to $RUNNER_TEMP/capture-c1-bodies.json. Nothing else — no code edits,
+      # no doc edits, no other issues, no API exploration.
+      #
+      # The privacy gate and issue-create run deterministically in the propose
+      # step below (SHAPE B). The agent cannot bypass the privacy gate.
+      - name: 🤖 Author proposal bodies
+        id: agent
+        uses: fro-bot/agent@a12463fab12958ed122856db287c061b623c2834 # v0.75.0
+        env:
+          TASK_PROMPT: |
+            You are authoring learning-proposal bodies for the C1 capture pipeline.
+
+            Your ONLY job in this step:
+            1. Read the harvest digest from $RUNNER_TEMP/capture-c1-digest.json.
+               The digest is a JSON array of candidates. Each candidate has:
+               - mergeSha: opaque merge commit SHA (the ONLY identifier you receive)
+               - reviewRounds: number of CHANGES_REQUESTED review rounds
+               - signals: { titleTokens: string[], labels: string[] }
+            2. For each candidate you judge worth proposing (reviewRounds ≥ 2 is
+               already guaranteed; use signals to assess value), write a concise
+               learning-proposal body (2–4 paragraphs) that:
+               - Describes the pattern or mistake the multi-round review suggests
+               - References the source PR by merge SHA ONLY (never look up or
+                 include owner/repo/PR number/title/author — you do not have that
+                 information and must not attempt to retrieve it)
+               - Proposes what the learning would be
+               - Is suitable for a human to review and author into docs/solutions/
+            3. Write the bodies as a JSON object to $RUNNER_TEMP/capture-c1-bodies.json:
+               { "<mergeSha>": "<body text>", ... }
+               Include only candidates you judge worth proposing. Omit candidates
+               you judge low-value (empty object {} is valid if none merit a proposal).
+            4. DO NOTHING ELSE. No code edits. No doc edits. No other issues.
+               No API calls beyond reading the digest file. No branch operations.
+
+            Hard boundaries:
+            - Never look up PR details, owner, repo name, PR number, or author.
+            - Never create issues yourself — the propose step does that.
+            - Never write to any path other than $RUNNER_TEMP/capture-c1-bodies.json.
+            - Output only the bodies file. No summary issue. No comments.
+        with:
+          github-token: ${{ secrets.FRO_BOT_PAT }}
+          auth-json: ${{ secrets.OPENCODE_AUTH_JSON }}
+          model: ${{ vars.FRO_BOT_MODEL }}
+          omo-providers: ${{ secrets.OMO_PROVIDERS }}
+          opencode-config: ${{ secrets.OPENCODE_CONFIG }}
+          prompt: ${{ env.TASK_PROMPT }}
+
+      # Deterministic propose step (SHAPE B): reads the harvest digest and the
+      # agent-authored bodies, runs the privacy gate (fail-closed against
+      # metadata/repos.yaml), applies same-run dedup, and opens the issues.
+      # The privacy gate runs here — not at agent discretion.
+      - name: 📬 Open learning-proposal issues
+        id: propose
+        env:
+          GITHUB_TOKEN: ${{ steps.get-workflow-app-token.outputs.token }}
+          CAPTURE_C1_DIGEST_PATH: ${{ runner.temp }}/capture-c1-digest.json
+          CAPTURE_C1_BODIES_PATH: ${{ runner.temp }}/capture-c1-bodies.json
+          CAPTURE_C1_RESULT_PATH: ${{ runner.temp }}/capture-c1-result.json
+        run: node scripts/capture-c1-propose.ts | tee "$RUNNER_TEMP/propose-output.json"
+        shell: bash
+
+      - if: always()
+        name: 📋 Write step summary
+        run: |
+          set -euo pipefail
+          harvest="$RUNNER_TEMP/harvest-result.json"
+          result="$RUNNER_TEMP/capture-c1-result.json"
+
+          {
+            echo "## Capture Learning Proposals Summary"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+
+            if [[ -s "$harvest" ]]; then
+              echo "| PRs examined | $(jq '.telemetry.examined // 0' "$harvest") |"
+              echo "| After proposal dedup | $(jq '.telemetry.afterProposalDedup // 0' "$harvest") |"
+              echo "| After solutions dedup | $(jq '.telemetry.afterSolutionsDedup // 0' "$harvest") |"
+              echo "| Candidates emitted | $(jq '.telemetry.emitted // 0' "$harvest") |"
+            else
+              echo "| PRs examined | (harvest result unavailable) |"
+            fi
+
+            if [[ -s "$result" ]]; then
+              echo "| Proposals opened | $(jq '.proposalsOpened // 0' "$result") |"
+              echo "| Blocked on privacy | $(jq '.blockedOnPrivacy // 0' "$result") |"
+              echo "| Skipped duplicate | $(jq '.skippedDuplicate // 0' "$result") |"
+              echo "| Failed | $(jq '.failed // 0' "$result") |"
+            else
+              echo "| Proposals opened | (propose result unavailable) |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+        shell: bash

--- a/.github/workflows/capture-c1-proposals.yaml
+++ b/.github/workflows/capture-c1-proposals.yaml
@@ -29,9 +29,9 @@ jobs:
         with:
           app-id: ${{ secrets.APPLICATION_ID }}
           private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
-          # Scope to the whole installation for consistency with reconcile-repos.yaml.
-          # The harvest and issue-create are same-repo; the owner scope is harmless.
-          owner: ${{ github.repository_owner }}
+          # Scope to this repo only — harvest and issue-create are same-repo.
+          # Smaller blast radius than owner-scoped token.
+          repositories: ${{ github.event.repository.name }}
 
       - name: ⤵ Checkout Branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -56,22 +56,17 @@ jobs:
 
       # Harvest merged PRs with ≥2 CHANGES_REQUESTED reviews, dedup against
       # existing learning-proposal issues and docs/solutions/, cap to
-      # MAX_PROPOSALS_PER_RUN, and emit an opaque digest (merge_sha only —
-      # no owner/repo/number prose) to GITHUB_OUTPUT and a temp file.
+      # MAX_PROPOSALS_PER_RUN, and write an opaque digest (merge_sha + signals —
+      # no owner/repo/number prose) directly to CAPTURE_C1_DIGEST_PATH.
+      # Writing the file directly avoids the shell-injection vector that existed
+      # when the digest was echoed via GITHUB_OUTPUT multiline syntax.
       - name: 🌾 Harvest candidates
         id: harvest
         env:
           GITHUB_TOKEN: ${{ steps.get-workflow-app-token.outputs.token }}
+          CAPTURE_C1_DIGEST_PATH: ${{ runner.temp }}/capture-c1-digest.json
         run: node scripts/capture-c1-harvest.ts | tee "$RUNNER_TEMP/harvest-result.json"
         shell: bash
-
-      # Write the harvest digest to a file the agent and propose steps can read.
-      # The digest is already in GITHUB_OUTPUT (multiline `digest` key); writing
-      # it to a path avoids shell-quoting issues when passing large JSON blobs.
-      - name: 📝 Write digest file
-        run: |
-          set -euo pipefail
-          echo '${{ steps.harvest.outputs.digest }}' > "$RUNNER_TEMP/capture-c1-digest.json"
 
       # The agent's ONLY job: read the digest (merge_sha + signals, no private
       # identifiers), author a concise learning-proposal body for each candidate
@@ -81,16 +76,23 @@ jobs:
       #
       # The privacy gate and issue-create run deterministically in the propose
       # step below (SHAPE B). The agent cannot bypass the privacy gate.
+      #
+      # No github-token is passed: the agent only needs to read the digest file
+      # and write the bodies file — no GitHub API access required. Omitting the
+      # token ensures the agent cannot create issues directly, bypassing the gate.
       - name: 🤖 Author proposal bodies
         id: agent
         uses: fro-bot/agent@a12463fab12958ed122856db287c061b623c2834 # v0.75.0
         env:
+          CAPTURE_C1_DIGEST_PATH: ${{ runner.temp }}/capture-c1-digest.json
           TASK_PROMPT: |
             You are authoring learning-proposal bodies for the C1 capture pipeline.
 
             Your ONLY job in this step:
-            1. Read the harvest digest from $RUNNER_TEMP/capture-c1-digest.json.
-               The digest is a JSON array of candidates. Each candidate has:
+            1. Read the harvest digest from $CAPTURE_C1_DIGEST_PATH (or equivalently
+               $RUNNER_TEMP/capture-c1-digest.json). The digest is a JSON object:
+               { "candidates": [...], "telemetry": {...} }
+               Each candidate in the candidates array has:
                - mergeSha: opaque merge commit SHA (the ONLY identifier you receive)
                - reviewRounds: number of CHANGES_REQUESTED review rounds
                - signals: { titleTokens: string[], labels: string[] }
@@ -116,7 +118,6 @@ jobs:
             - Never write to any path other than $RUNNER_TEMP/capture-c1-bodies.json.
             - Output only the bodies file. No summary issue. No comments.
         with:
-          github-token: ${{ secrets.FRO_BOT_PAT }}
           auth-json: ${{ secrets.OPENCODE_AUTH_JSON }}
           model: ${{ vars.FRO_BOT_MODEL }}
           omo-providers: ${{ secrets.OMO_PROVIDERS }}

--- a/docs/brainstorms/2026-06-22-skill-saving-grow-and-learn-requirements.md
+++ b/docs/brainstorms/2026-06-22-skill-saving-grow-and-learn-requirements.md
@@ -65,88 +65,160 @@ the last, instead of standing on what prior runs learned.
 - **v1/early phases explicitly exclude:** C4 cross-run synthesis, C-deep wiki traversal, and
   operator-web decision-log surfacing. These are Phase 3 scope.
 
-## Capability A — Autonomous capture (retrospective, batch)
+## Capability A — Autonomous capture (Phase 2)
 
-A dedicated compounding run that retrospectively examines **cohorts of prior Fro Bot runs**
-and distills reusable learnings, rather than detecting a learnable moment mid-run. Seeing a
-collection of runs lets it find patterns invisible in any single run.
+A scheduled capture run that retrospectively examines **cohorts of prior Fro Bot runs** and
+proposes reusable learnings for human review, rather than detecting a learnable moment
+mid-run. Seeing a collection of runs lets it find patterns invisible in any single run.
 
-> **Identity bet:** the existing 22 `docs/solutions/` docs are hand-curated and high-signal.
-> Autonomous capture must not pollute this corpus. All autonomous captures land in a
-> **quarantine lane** (separately labeled, not in the canonical `docs/solutions/` set) until
-> precision is proven. Only clearly high-confidence captures promote to canonical. This
-> protects the hand-curated corpus as the authoritative signal source.
+> **Phase 2 v1 is a suggestion engine, not fully autonomous capture.** The capture run
+> proposes candidate learnings by opening GitHub issues with evidence; a human (Marcus)
+> decides whether to author the final learning via `ce:compound`. This deliberately keeps
+> Marcus in the loop to protect the curated `docs/solutions/` corpus and prove quality before
+> any authoring machinery is built. The premise — that reasoning over outcome metadata like
+> "this PR took 3 rounds" yields learnings comparable to human-noticed insights — is
+> **unproven**; propose-only v1 exists precisely to test it cheaply. If proposals are shallow,
+> that is a cheap, valuable negative result.
 
-### Triggers (v1 — the high-signal set, Phase 2)
+> **Phase 1's outcome-impact is not yet measured.** Capture proceeds as a cheap,
+> directly-informative experiment. Measuring whether retrieval changes run outcomes is a
+> Phase 3 concern (the deferred improvement metric, O8). Phase 2 v1 does not depend on that
+> measurement.
 
-- **C1 — Multi-round-review PRs.** PRs that needed several review rounds /
+### Harvest substrate (resolved): GitHub API outcome metadata, not prompt artifacts
+
+The reliable substrate is what GitHub durably retains about run **outcomes**, not raw agent
+transcripts. Verified during this brainstorm:
+
+- **Merged PRs carry durable signals** — review-round counts, titles, `Closes #N`, CI
+  conclusions, and review threads are all queryable via the GitHub API (e.g. a PR that took 2+
+  review rounds is a clean multi-round signal).
+- **Prompt artifacts are ephemeral/inconsistent** — only ~1 of 5 recent runs retained an
+  `OPENCODE_PROMPT_ARTIFACT` upload, and GitHub artifacts expire. There is no run-journal in
+  the agent. So the prompt artifact is **bonus enrichment when present**, never the foundation.
+
+The capture run therefore reasons over **structured GitHub API outcome metadata** (this PR
+took 3 rounds; these runs failed CI then passed; this triage decided skip-with-reason) rather
+than over raw transcripts.
+
+### Triggers (Phase 2 v1 — C1 only)
+
+Phase 2 v1 narrows to the single highest-signal trigger. C2 and C3 move to Phase 2.5 once
+C1 precision is proven. C4 remains Phase 3.
+
+- **C1 — Multi-round-review PRs (v1 only).** PRs that needed several review rounds /
   changes-requested before merging encode a mistake-then-correction — the richest learning
-  shape. Lead trigger.
-- **C2 — Failed-then-fixed runs.** Runs/PRs whose first attempt failed CI or was wrong and
-  then got corrected. The delta between broken and fixed *is* the learning. (This is the
-  shape of the strongest existing compound docs — the `jq //` trap, the Octokit method
-  hallucinations, the strip-only TypeScript failures.)
-- **C3 — Issue triages.** The daily oversight+autoheal run triages issues with fix/skip/defer
-  rationale. That judgment is reusable and teaches future triage.
-- **C4 — Recurring patterns across runs (cross-run synthesis). DEFERRED to Phase 3.** When
-  the *same kind* of issue recurs across multiple runs (repeated rate-limit failures, repeated
-  privacy-gate catches), compound the **pattern**. This is materially harder (clustering,
-  temporal comparison, sameness judgment) and is out of scope for v1.
+  shape, and directly queryable from PR review history. A scheduled harvest collects merged
+  PRs whose review history shows multiple rounds above a threshold (exact threshold: planning
+  decision, O6). Lead trigger for v1.
+- **C2 — Failed-then-fixed runs. DEFERRED to Phase 2.5.** Add once C1 precision is proven.
+- **C3 — Issue triages. DEFERRED to Phase 2.5.** Add once C1 precision is proven.
+- **C4 — Recurring patterns across runs (cross-run synthesis). DEFERRED to Phase 3.**
+
+### Mechanism (resolved): script harvests + pre-filters → agent judges → proposal issue
+
+The established repo pattern — a deterministic script feeds the agent curated context — applies
+here, with the output being a GitHub issue proposal rather than an authored doc:
+
+- **Script harvests + pre-filters (deterministic, testable).** A TS script queries the GitHub
+  API for the C1 cohort (merged PRs + review-round counts above threshold), dedups candidates
+  against the existing `docs/solutions/` corpus (module / tags / problem_type overlap — so it
+  does not propose a learning that already exists), and emits a **structured, counts-only
+  candidate digest** (opaque/redacted where private). This mirrors how
+  `scripts/reconcile-repos.ts` and `scripts/wiki-query.ts` produce structured context for the
+  agent.
+- **Agent judges (judgment only).** The `fro-bot.yaml` agent run receives the digest and does
+  only what it is good at: decide which candidates are genuinely proposal-worthy. It does not
+  do open-ended API exploration (the over-prompting failure mode).
+- **Output: proposal issue, not authored doc.** For each candidate the agent judges
+  proposal-worthy, the run **opens a GitHub issue** proposing the candidate learning, with
+  evidence (which PR, how many rounds, the correction pattern). No doc is authored into
+  `docs/solutions/`. No data-branch write occurs for the learning itself. A human (Marcus)
+  decides whether to author it via `ce:compound` later.
+- **Decision log is script-maintained state**, not agent-managed, so it is deterministic and
+  durable.
 
 ### Harvest → redact → publish pipeline (privacy-first)
 
-Raw artifact harvesting may contain private-repo content (repo names, org identifiers, issue
-titles, PR descriptions). The pipeline enforces a hard separation:
+The harvested signals and any authored proposal may reference private-repo content (repo
+names, org identifiers, issue titles, PR descriptions). The pipeline enforces a hard
+separation:
 
-1. **Harvest (private control-plane state).** Raw run artifacts are written to the `data`
-   branch as private operational state. They are never directly published.
-2. **Redact / extract.** The capture run extracts only the reusable, non-attributable
-   learning from the raw artifact. Private-repo identifiers, org names, and any content that
-   would identify a private repo are stripped at this step.
-3. **Gate.** Before any extracted learning reaches `docs/solutions/` or any public surface,
-   it MUST pass through the existing promotion-time gates:
-   - `scripts/check-private-leak.ts` — scans for private-repo names on the `data → main`
-     path.
-   - `scripts/check-wiki-private-presence.ts` — wiki promotion gate semantics.
-   Both gates must pass. Failure blocks promotion; the capture stays in quarantine.
+1. **Harvest (counts-only / opaque).** The candidate digest is counts-only and opaque where
+   private — no private-repo identifier appears in the digest, the decision log, or any
+   workflow log line. Opaque keys (e.g. a hash or ordinal) are used for "examined cohort"
+   entries; never "PR #X about `<private repo>`".
+2. **Proposal issue body scan (gate).** The agent-authored proposal issue body — including any
+   examples or correction-pattern prose — is scanned for private identifiers (reusing the
+   token forms from `scripts/check-private-leak.ts`) **before the issue is posted**. A hit
+   blocks or redacts the proposal. A counts-only digest does not prevent the agent from
+   embedding a private repo name in its authored prose; the scan closes that gap.
+3. **No promotion path in v1.** Because no doc is authored, the `docs/solutions/` promotion
+   gates (`scripts/check-private-leak.ts`, `scripts/check-wiki-private-presence.ts`) are not
+   on the v1 critical path. They remain the gates for when authoring is added in a later phase.
 
-This pipeline is a first-class requirement, not an assertion. Capture that cannot be cleanly
-redacted must be discarded, not published with caveats.
+This pipeline is a first-class requirement, not an assertion. A proposal that cannot be
+cleanly redacted must be discarded, not posted with caveats.
 
-### Capture mechanics
+### Decision log — reset-resilient
 
-- **Rides Systematic `ce:compound`.** Systematic is present in the agent workspace
-  (`src/services/setup/systematic-config.ts` in `fro-bot/agent`), so capture can use the
-  existing compound-doc authoring rather than new machinery. _Open question O3: confirm
-  Systematic is enabled (not merely present) in the relevant run surface._
-- **Quarantine lane first.** Autonomous captures land in a quarantine lane (separately
-  labeled, not in the canonical `docs/solutions/` set) until precision is proven. Only
-  clearly high-confidence, gate-passed captures promote to canonical.
-- **Autonomous write → data branch → promotion PR.** Captures (quarantine and promoted) are
-  written under Fro Bot identity to the `data` branch and promoted to `main` via the existing
-  conditional promotion PR. _Open question O2: `docs/solutions/` is today human-authored on
-  `main`; A1 brings it onto the data-branch authority path. This is an architectural change
-  for planning to resolve._
-- **Quality gate (specified).** Capture must avoid noise and duplication:
-  - **Dedup:** similarity check against existing docs; prefer updating an existing doc over
-    creating a near-duplicate (the `ce:compound` overlap behavior already does this for human
-    runs).
-  - **Genuine reusable delta:** the learning must be applicable beyond the specific run that
-    generated it — not a one-off fix for a unique situation.
-  - **Evidence threshold:** the capture must cite the run cohort and the pattern it
-    generalizes; unsupported assertions are rejected.
-  - **Quarantine path:** ambiguous captures (borderline dedup, unclear generalizability) go
-    to quarantine, not canonical. They are not discarded — they wait for human review or
-    additional evidence.
+A **script-maintained** durable decision log records which run cohorts were examined, which
+candidates were proposed (issue opened), and which were deliberately skipped and why. This
+lets the capture run avoid re-proposing the same candidate.
 
-### Decision log (G4 — internal audit trail)
+**Reset-resilience is a hard requirement.** The `data` branch is recreated from `main` on
+squash-merge (the repo bootstraps/recreates `data` from `main`). A decision log living only
+on `data` would be wiped on reset and re-propose everything. The log must survive data-branch
+lifecycle events — e.g. keyed by immutable PR identity (PR number + merge commit SHA) so
+re-derivation is idempotent, and/or stored where a reset does not wipe it. The exact
+persistence mechanism is a planning decision (O4), but reset-resilience is a requirement, not
+a nice-to-have.
 
-Fro Bot maintains a durable decision log of what it has compounded: which run cohorts it
-examined, what learnings it captured or updated, and what it deliberately skipped and why.
-This lets it (a) avoid re-compounding the same thing, and (b) provide an internal audit
-trail for later metric definition. The decision log is **operational metadata / control-plane
-state on the `data` branch** — it is not a fourth knowledge substrate, and it is not
-published to the operator web in early phases. Operator-web surfacing is Phase 3 scope.
+The decision log is **operational metadata / control-plane state** — not a fourth knowledge
+substrate, and not published to the operator web in early phases (operator-web surfacing is
+Phase 3).
+
+### Idempotent harvest
+
+GitHub review state is mutable, paginated, and eventually consistent. The harvest must be
+**idempotent**: each PR is identified by an immutable dedup key (PR number + merge commit
+SHA) so reruns cannot double-count or miss late updates. The exact snapshot protocol (how far
+back the harvest looks, how pagination is handled) is a planning decision (O7), but
+idempotency is a requirement.
+
+### Hard cost budget
+
+Scheduled agent runs cost money. The following are acceptance-criteria-level bounds, not
+vague guidance:
+
+- **Cadence:** weekly (planning confirms or adjusts).
+- **Max candidates per run:** a hard cap on how many proposal issues a single run may open
+  (exact number: planning decision, O9).
+- **Max cohort size:** a hard cap on how far back the harvest looks (e.g. merged PRs in the
+  last N days; exact window: planning decision, O9).
+
+Exceeding either cap causes the run to truncate and log the truncation, not silently expand.
+
+### Deferred: authoring machinery (Phase 2.5+)
+
+The following are explicitly **out of v1 scope** because propose-only dissolves the need:
+
+- **No quarantine lane in `docs/solutions/`.** There is no autonomous authoring in v1, so no
+  quarantine docs are created, and Phase 1 retrieval is untouched. _When authoring is added
+  in a later phase, quarantine docs MUST be excluded from Phase 1 solutions-query retrieval —
+  that is the deferred P0 mitigation._
+- **No `docs/solutions/` data-branch authority path change (O2).** Propose-only does not
+  write `docs/solutions/` at all. The authority-migration (bringing `docs/solutions/` onto
+  the data-branch path, new guard logic, coexistence of human-authored and Fro-Bot-authored
+  docs) moves to Phase 2.5+ when authoring lands. O2 remains an open question for that phase,
+  not v1.
+- **Human-reviewed promotion.** The requirement that captured-learning promotion is
+  human-reviewed (not auto-merge) applies when authoring is added. In v1, the "promotion" is
+  a human reading a proposal issue and deciding to run `ce:compound` — no PR promotion
+  machinery is needed.
+- **Systematic `ce:compound` in the capture run.** Not needed in v1 (the agent opens an
+  issue, not a doc). Confirm Systematic is enabled in the capture run surface when authoring
+  is added (deferred O3).
 
 ## Capability B — Retrieve + apply
 
@@ -191,26 +263,29 @@ value before the harvest pipeline is built.
 ## How the loop compounds (text diagram)
 
 ```
-   prior Fro Bot runs (prompt artifacts, harvested durably to data branch)
+   prior Fro Bot runs (GitHub API outcome metadata; prompt artifacts are optional enrichment)
             │
             │  ┌─────────────────────────────────────────────────────────┐
-            │  │  PHASE 1 (first): retrieve + apply                      │
+            │  │  PHASE 1 (shipped): retrieve + apply                    │
             │  │  B. consult docs/solutions/ (22 existing docs)          │
             │  │     relevance-ranked · freshness-gated · candidate-mode │
             │  │     for low-confidence matches                          │
             │  └─────────────────────────────────────────────────────────┘
             │
-   ┌────────▼─────────┐   PHASE 2: triggers C1 · C2 · C3
-   │ A. capture run   │   harvest (private) → redact → gate → quarantine
-   │ (ce:compound)    │   → promote (high-confidence, gate-passed only)
-   └────────┬─────────┘
-            │ autonomous write → data branch → promotion PR
-            │ gates: check-private-leak.ts · check-wiki-private-presence.ts
+   ┌────────▼─────────┐   PHASE 2 v1: C1-only · propose-only
+   │ A. capture run   │   harvest C1 cohort (private, counts-only digest)
+   │ (suggest only)   │   → agent judges → proposal issue (no doc authored)
+   └────────┬─────────┘   privacy gate: scan issue body before posting
+            │ proposal issue opened · decision log updated (reset-resilient)
+            │ human (Marcus) decides → ce:compound later if warranted
+            │
+            │ [authoring + quarantine lane + data-authority path: Phase 2.5+]
+            │
             ▼
-   quarantine lane  →  (proven) →  docs/solutions/ canonical
-            │                              │
-            │                    decision log (internal audit trail,
-            │                    data branch, NOT operator web in v1)
+   docs/solutions/ canonical  (unchanged by Phase 2 v1)
+            │
+            │  decision log (internal audit trail, reset-resilient,
+            │  NOT operator web in v1; operator-web surfacing: Phase 3)
    ┌────────▼─────────┐
    │ C. wiki grounding│  baseline always-on
    │ (C-deep: Ph. 3)  │  deep traversal: Phase 3, gate-passed content only
@@ -222,71 +297,100 @@ value before the harvest pipeline is built.
 
 ## Open questions (resolve at planning)
 
-- **O1 — Durable run harvest.** Verified: `OPENCODE_PROMPT_ARTIFACT='true'` is set in
-  `fro-bot.yaml` (line 372) and honored by the agent runtime, **but the artifacts are
-  ephemeral and inconsistent** — of three recent runs, only one had an artifact, and GitHub
-  artifacts expire. Capture cannot rely on artifacts still being present. Planning must
-  decide how run data is durably harvested (harvest-as-you-go into the data branch vs.
-  best-effort read of unexpired artifacts vs. another channel).
-- **O2 — `docs/solutions/` authority path.** Today human-authored on `main`; A1 brings
-  autonomous captures onto the data-branch authority + promotion path. Resolve the promotion
-  model (auto-merge vs. human-reviewed for captured learnings) and how human-authored and
-  Fro-Bot-authored docs coexist. **Note:** this is a bigger change than it appears —
-  `scripts/check-wiki-authority.ts` today guards only `knowledge/wiki/` and `metadata/`
-  paths, not `docs/solutions/`; `scripts/commit-metadata.ts` is path-restricted to
-  `metadata/*.yaml`. Bringing `docs/solutions/` onto the data-authority path requires new
-  guard logic and new promotion behavior, not just a config change.
-- **O3 — Systematic in the run surface.** Confirm Systematic `ce:compound` is *enabled* (not
-  just present) in the surface that runs capture, and whether capture is its own scheduled
+- **O1 — Harvest substrate. RESOLVED (this brainstorm).** The reliable substrate is GitHub
+  API outcome metadata (merged PRs + review-round counts, CI conclusions, issue triage
+  history), not prompt artifacts. `OPENCODE_PROMPT_ARTIFACT='true'` is set but artifacts are
+  ephemeral/inconsistent (~1 of 5 recent runs) and expire, so they are bonus enrichment when
+  present, never the foundation. No new durable-harvest pipeline is required for v1 — the
+  capture script reads what GitHub already retains.
+- **O2 — `docs/solutions/` authority path. DEFERRED to Phase 2.5+.** Propose-only v1 does
+  not write `docs/solutions/` at all, so the authority-migration is out of v1 scope. When
+  authoring lands: `scripts/check-wiki-authority.ts` today guards only `knowledge/wiki/` and
+  `metadata/` paths; bringing `docs/solutions/` onto the data-authority path requires new
+  guard logic, a new promotion rule, and a coexistence model for human-authored and
+  Fro-Bot-authored docs. Planning question for Phase 2.5+.
+- **O3 — Systematic in the capture run surface. DEFERRED to Phase 2.5+.** Not needed in v1
+  (no doc authoring). Confirm Systematic `ce:compound` is *enabled* (not just present) in the
+  scheduled capture run when authoring is added, and whether capture is its own scheduled
   workflow or rides the existing daily oversight run.
-- **O4 — Retrieval injection mechanism.** How the consulted learnings reach the agent's
-  working context (extend the existing `wiki-query` injection step, a new retrieval step, or
-  an agent-invoked tool) — parallels the wiki-traversal tool decision.
-- **O5 — Improvement metric.** What "compounding is improving outcomes" concretely measures
-  (fewer repeat failures of a compounded class, fewer review rounds on a learned pattern,
-  etc.) so the decision log's G4 claim is testable, not narrative. Metric definition is Phase
-  3 scope; early phases need only the internal audit trail.
+- **O4 — Decision-log persistence / reset-resilience.** Where the script-maintained decision
+  log lives and how it survives data-branch resets — a `metadata/` file keyed by immutable PR
+  identity, a dedicated log file on `main`, or another channel — and its exact schema
+  (examined cohorts, proposed, skipped+reason). Reset-resilience is a requirement; the
+  mechanism is a planning decision.
+- **O5 — Quarantine mechanism. DEFERRED to Phase 2.5+.** No quarantine docs in v1 (no
+  authoring). When authoring lands: `origin: autonomous` frontmatter marker vs. a
+  `docs/solutions/proposed/` subdir. Both keep autonomous captures visibly separable; the
+  frontmatter marker is lighter and keeps Phase 1 retrieval working unchanged. Planning picks
+  one — and quarantine docs MUST be excluded from Phase 1 solutions-query retrieval.
+- **O6 — C1 round-count threshold.** The concrete threshold for "multi-round" (how many
+  review rounds / changes-requested events counts as C1-qualifying). Calibration against real
+  run history, planning-time.
+- **O7 — Harvest snapshot protocol.** How far back the harvest looks (rolling window in days
+  vs. since-last-run cursor), how pagination is handled, and how the per-PR immutable dedup
+  key (PR number + merge commit SHA) is stored. Planning decision.
+- **O8 — Improvement metric. Phase 3 scope.** What "compounding is improving outcomes"
+  concretely measures (fewer repeat failures of a compounded class, fewer review rounds on a
+  learned pattern). Early phases need only the internal audit trail. Phase 1's outcome-impact
+  is not yet measured; that measurement is deferred here.
+- **O9 — Cost budget specifics.** The hard caps for max candidates per run and max cohort
+  size (harvest lookback window). Cadence is weekly as a default; planning confirms or
+  adjusts. These are acceptance-criteria-level, not vague.
+- **O10 — Proposal issue location and label.** Which repo the proposal issue is filed in,
+  what label(s) it carries, and how Marcus discovers and acts on it. Planning decision.
 
 ## Success criteria
 
 - **SC1** — Fro Bot reliably consults `docs/solutions/` before acting on a class of work
   with prior learnings, and the applied learning is visible in the run's reasoning. (Phase 1)
-- **SC2** — A capture run examines a cohort of prior Fro Bot runs and produces at least one
-  genuine, deduplicated learning via the quarantine lane and data-branch promotion path, with
-  no operator invoking `ce:compound`. (Phase 2)
+- **SC2** — A capture run examines a C1 cohort (multi-round-review PRs above threshold),
+  opens at least one proposal issue with evidence (which PR, how many rounds, the correction
+  pattern), deduped against existing `docs/solutions/`, with no operator invoking `ce:compound`
+  to trigger the run. The proposal issue body passes the private-identifier scan before
+  posting. (Phase 2 v1)
 - **SC3** — A later run of a class with a relevant prior learning demonstrably consults and
   applies it (or surfaces it as a candidate for low-confidence matches), visible in the run's
   reasoning/decision log. (Phase 2)
 - **SC4** — An agent run grounds itself from the repo's wiki page and, when it judges it
   needs more, traverses at least one wikilink to a related page within the guardrail budget,
   reading only gate-passed wiki content. (Phase 3)
-- **SC5** — Capture produces no private-repo identifiers in any public surface. All
-  autonomous writes pass through `scripts/check-private-leak.ts` and
-  `scripts/check-wiki-private-presence.ts` before promotion to `main`. Raw harvest artifacts
-  remain private control-plane state on the `data` branch and are never directly published.
-- **SC6** — The decision log records what was compounded (and what was skipped and why) as
-  internal operational metadata on the `data` branch.
+- **SC5** — Capture produces no private-repo identifiers in any public surface. The proposal
+  issue body (including agent-authored prose and examples) is scanned for private identifiers
+  before posting; a hit blocks or redacts the proposal. The candidate digest, decision log,
+  and workflow logs are counts-only / opaque — no private repo name, org, issue title, or PR
+  description appears in any of them.
+- **SC6** — The decision log records what was proposed (and what was skipped and why) as
+  internal operational metadata, is keyed by immutable PR identity, and survives data-branch
+  resets without re-proposing already-examined candidates.
 
 ## Phasing (directional — planning refines)
 
-- **Phase 1 — Retrieve + apply.** Capability B over the existing 22 `docs/solutions/` docs:
-  reliable consultation before acting, relevance-ranked, freshness-gated, candidate-mode for
-  low-confidence matches. Lower-risk, immediately testable, proves compounding value before
-  the harvest pipeline is built.
-- **Phase 2 — Autonomous capture, narrow.** Durable run harvest (O1) + a capture run over
-  the two highest-signal triggers (C1 multi-round-review, C2 failed-then-fixed), with the
-  full harvest→redact→gate→quarantine→promote pipeline, the quality gate, and the decision
-  log. Add C3 (issue triages) once C1/C2 precision is proven.
+- **Phase 1 — Retrieve + apply (shipped).** Capability B over the existing 22
+  `docs/solutions/` docs: reliable consultation before acting, relevance-ranked,
+  freshness-gated, candidate-mode for low-confidence matches. Lower-risk, immediately
+  testable, proves compounding value before the harvest pipeline is built.
+- **Phase 2 — GitHub API outcome harvest, C1-only, propose-only.** A scheduled capture run
+  harvests merged PRs whose review history shows multiple rounds (C1 trigger only). The run
+  opens GitHub issue proposals with evidence; no doc is authored. A human decides whether to
+  author via `ce:compound`. Includes: counts-only digest, proposal-issue-body privacy scan,
+  reset-resilient decision log, idempotent harvest (per-PR dedup key), and hard cost budget.
+  Operator-web surfacing stays strictly Phase 3.
+- **Phase 2.5 — Add C2/C3 triggers + authoring machinery (once C1 precision is proven).**
+  Add C2 (failed-then-fixed) and C3 (issue triages) triggers. Add autonomous doc authoring
+  into a quarantine lane, the `docs/solutions/` data-branch authority path (O2), and the
+  quarantine-exclusion guard for Phase 1 retrieval.
 - **Phase 3 — Wiki traversal + observability.** Capability C-deep (agent-invoked wikilink
   traversal with concrete numeric guardrails, gate-passed content only), C4 cross-run
-  synthesis, and operator-web surfacing of the decision log + improvement metric definition.
+  synthesis, operator-web surfacing of the decision log, and improvement metric definition
+  (O8).
 
 ## Dependencies & relationships
 
 - **Depends on:** nothing in the operator spine (control-plane-native). Builds on existing
   `docs/solutions/`, `knowledge/wiki/`, `scripts/wiki-query.ts`,
-  `scripts/check-private-leak.ts`, `scripts/check-wiki-private-presence.ts`, the
-  data-branch authority model, and Systematic `ce:compound`.
+  `scripts/check-private-leak.ts`, `scripts/check-wiki-private-presence.ts`, and the
+  data-branch authority model. Systematic `ce:compound` is used by the human after reviewing
+  a proposal; it is not invoked by the capture run in v1.
 - **Soft relationship to operator web:** G4's decision-log surfacing is Phase 3 scope. A1's
   core loop does not block on the dashboard — the internal audit trail is durable
   control-plane state regardless of whether the web view exists yet.

--- a/docs/plans/2026-06-22-002-feat-capture-c1-proposals-plan.md
+++ b/docs/plans/2026-06-22-002-feat-capture-c1-proposals-plan.md
@@ -190,7 +190,7 @@ weekly cron (Sunday, post-merge-data)
 
 ## Implementation Units
 
-- [ ] **Unit 1: `scripts/capture-c1-harvest.ts` — harvest + dedup + digest (test-first)**
+- [x] **Unit 1: `scripts/capture-c1-harvest.ts` — harvest + dedup + digest (test-first)**
 
 **Goal:** A script that paginates this repo's (`fro-bot/.github`) merged PRs in the lookback
 window, keeps those with ≥2 `CHANGES_REQUESTED` reviews, drops any already represented by a
@@ -250,7 +250,7 @@ and emits an opaque candidate digest to `$GITHUB_OUTPUT`.
 **Verification:** `pnpm check-types`, `pnpm lint`, `pnpm test` green; strip-only load clean;
 the digest carries no `owner/repo/number` prose; the seen-set dedup is mutation-proven.
 
-- [ ] **Unit 2: proposal-issue opening with body privacy-scan + dedup (test-first)**
+- [x] **Unit 2: proposal-issue opening with body privacy-scan + dedup (test-first)**
 
 **Goal:** Given the digest and an agent-authored proposal body per candidate, open a
 `learning-proposal` issue with the merge-SHA marker — but only after the body passes the
@@ -292,7 +292,7 @@ private-identifier scan, with same-run and cross-run dedup.
 **Verification:** gates green; the privacy block is mutation-proven; the same-run Set prevents
 duplicates; created issues carry the label + marker.
 
-- [ ] **Unit 3: scheduled workflow + `learning-proposal` label + agent wiring**
+- [x] **Unit 3: scheduled workflow + `learning-proposal` label + agent wiring**
 
 **Goal:** A weekly workflow that mints the App token, overlays metadata, runs the harvest over
 this repo, feeds the opaque digest to a tight propose-only agent step, and surfaces counts-only

--- a/docs/plans/2026-06-22-002-feat-capture-c1-proposals-plan.md
+++ b/docs/plans/2026-06-22-002-feat-capture-c1-proposals-plan.md
@@ -1,0 +1,378 @@
+---
+title: 'feat: propose-only learning capture from multi-round-review PRs'
+type: feat
+status: active
+date: 2026-06-22
+origin: docs/brainstorms/2026-06-22-skill-saving-grow-and-learn-requirements.md
+---
+
+# feat: propose-only learning capture from multi-round-review PRs
+
+## Overview
+
+A scheduled run that examines this repo's merged PRs, finds the ones that needed multiple
+rounds of changes-requested before merging (the richest mistake→correction signal), and
+**opens a GitHub issue proposing a candidate learning** for each — with the evidence — for a
+human to author via `ce:compound` later. It does not author into `docs/solutions/` and does
+not touch the data-branch authority path.
+
+This is **Phase 2 (propose-only, C1-only)** of the grow-and-learn loop (see origin). It is the
+supply-side complement to the shipped Phase 1 retrieval, scoped as a cheap experiment to test
+the premise — *can reasoning over run-outcome metadata produce a learning worth keeping?* —
+before any authoring or promotion machinery is built.
+
+## Problem Frame
+
+Phase 1 made Fro Bot consult its existing learnings; capture is still human-triggered. Fro
+Bot's own runs generate reusable judgment that is never captured unless a human notices. The
+cheapest way to test whether autonomous capture is worthwhile is to **propose** candidate
+learnings (not author them) and see if the proposals are good. Propose-only sidesteps the
+two biggest risks the brainstorm review found: no authoring means no quarantine docs to poison
+Phase 1 retrieval, and no `docs/solutions/` write means no data-branch authority change.
+
+## Requirements Trace
+
+- R1. (origin C1) A scheduled run harvests merged PRs from this repo (`fro-bot/.github`) whose
+  review history shows **≥2 changes-requested reviews**, and proposes a candidate learning for
+  each.
+- R2. (origin, mechanism) A deterministic script harvests + pre-filters + dedups; the agent
+  decides which candidates are proposal-worthy and opens the issue. The script never lets the
+  agent do open-ended API exploration.
+- R3. (origin, decision log) The run never re-proposes a PR it has already proposed for —
+  reset-resilient across data-branch lifecycle events.
+- R4. (origin, privacy) No private-repo identifier reaches the proposal issue, the digest, the
+  decision log, or any workflow log. The agent-authored proposal **body** is privacy-scanned
+  before posting; a hit blocks the proposal.
+- R5. (origin, dedup) A candidate is not proposed if an equivalent learning already exists in
+  `docs/solutions/`.
+- R6. (origin, cost) The run is bounded: weekly cadence, a max-candidates-per-run cap, and a
+  bounded lookback window.
+
+## Scope Boundaries
+
+- Propose-only. No authoring into `docs/solutions/`, no quarantine lane, no data-branch
+  authority change.
+- C1 only (multi-round-review PRs). No C2 (failed-then-fixed) or C3 (issue triages) — Phase 2.5.
+- This repo (`fro-bot/.github`) only — it holds the richest multi-round PR history. No other
+  `fro-bot/*`, `marcusrbrown/*`, or `bfra-me/*` harvest.
+- No improvement-metric / operator-web surfacing (Phase 3).
+
+### Deferred to Separate Tasks
+
+- Authoring machinery, quarantine lane, `docs/solutions/` data-branch authority path,
+  human-reviewed promotion: Phase 2.5+, separate plan. (When authoring lands, quarantine docs
+  MUST be excluded from Phase 1 `solutions-query.ts` retrieval — the deferred P0 mitigation.)
+- C2/C3 triggers and any cross-repo / cross-org harvest scope: Phase 2.5+.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/reconcile-repos.ts` — the **issue-queue template**. `runIssueQueue` (2659–2830) +
+  `ensureLabelsExist` (2843–2878, race-tolerant label preflight) + the body-marker dedup
+  (`renderVisibilityTransitionIssue` 2898–2920, `NODE_ID_MARKER_PATTERN` parse ~3042) + the
+  same-run in-memory `Set` dedup (2687, 2712–2718). `callIssuesCreate` (3182–3184) is the
+  per-call cast pattern. `createOctokitFromEnv` (3186–3207) is the env-parameterized
+  constructor.
+- `scripts/merge-data-pr.ts` — `loadOctokitConstructor` + `createOctokitFromEnv` (684–718);
+  `octokit.paginate(...pulls.list...)` usage (386, 493).
+- `scripts/commit-metadata.ts:90–102` — the `OctokitClient = Octokit` derived-type rule (never
+  handwrite SDK interfaces).
+- `scripts/solutions-query.ts` — reuse `splitFrontmatter` (169–185), the `collectDocs` /
+  `SolutionDoc` loader (120–167), `loadSolutionsFilesFromDisk` (350–378), the private-names
+  loader `loadPrivateNamesFromDisk` (390–429), the token-set builder (236–252), and
+  `containsPrivateToken` (254–259). These already exist and are tested.
+- `scripts/wiki-slug.ts:12–28` — `buildPrivateNameTokens` (exported, tested in
+  `wiki-slug.test.ts`).
+- `.github/workflows/reconcile-repos.yaml:26–62` — the App-token (`owner:
+  ${{ github.repository_owner }}`) + `./.github/actions/setup` + data-overlay + step-summary
+  workflow shape to mirror.
+- `common-settings.yaml` / `.github/settings.yml` — the Probot-synced label catalog; a new
+  `learning-proposal` label is added here.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/github-issues-api-same-run-eventual-consistency-2026-05-20.md`
+  — the Issues API list-after-create is eventually consistent; an in-memory `Set` of created
+  keys is mandatory to avoid same-run duplicates. The capture run MUST carry a `Set` of
+  proposed merge-SHAs through the create loop.
+- `docs/solutions/best-practices/wiki-page-structured-attribution-2026-06-04.md` and the
+  privacy-gate docs — fail-closed on private content; reference by opaque key, never name.
+- `docs/solutions/runtime-errors/node-strip-only-typescript-2026-04-18.md` — strip-only safe
+  (no parameter properties/enums/namespaces).
+
+## Key Technical Decisions
+
+- **The proposal issues ARE the reset-resilient decision log.** Each proposal is a GitHub
+  issue labeled `learning-proposal` carrying an immutable body marker
+  `<!-- capture-c1:merge_sha=<sha> -->`. The seen-set is rebuilt each run by
+  `issues.listForRepo({ state: 'all', labels: 'learning-proposal' })` and parsing the marker.
+  Issues live independent of branches, so a `data`-branch reset cannot wipe the log (R3). One
+  accepted tradeoff: if an operator manually *deletes* a proposal issue, that PR becomes
+  eligible again — acceptable for v1, documented. (State `all`, not `open`: a *closed* proposal
+  still means "examined, do not re-propose.")
+- **C1 definition = count of `CHANGES_REQUESTED` reviews per merged PR, threshold ≥2.**
+  `pulls.list({ state: 'closed' })` paginated, filtered to `merged_at !== null`, then
+  `pulls.listReviews` counting `state === 'CHANGES_REQUESTED'`. The threshold is a named
+  constant. `COMMENTED` reviews do not count as a round.
+- **Immutable dedup key = `merge_commit_sha`.** Durable on `main` regardless of later PR edits.
+- **Script harvests + builds an opaque digest; agent only judges + opens issues.** The digest
+  identifies candidates **by merge SHA only** — the script does not pass `owner/repo/number`
+  prose to the agent, so private identifiers cannot reach the agent context structurally, not
+  just by prompt instruction. The agent decides which candidates merit a proposal and authors
+  the proposal body.
+- **Privacy gate on the proposal body (R4).** Before `issues.create`, the agent-authored body
+  is lowercased and scanned with `containsPrivateToken` against the private token set
+  (`buildPrivateNameTokens` over `metadata/repos.yaml` `private: true` non-redacted entries).
+  Any hit → block that proposal (rejection, not redaction, for v1). The data overlay supplies
+  the authoritative private set.
+- **Dedup against `docs/solutions/` (R5).** Load the existing docs via `collectDocs`; score a
+  candidate's signals (`module` / `tags` / `problem_type`, derived from the PR's changed paths
+  and labels) against each doc; drop the candidate on strong overlap (exact `problem_type`
+  match or tag/module overlap above a constant). `docs/solutions/` is on `main` — no overlay
+  needed for this half.
+- **Harvest scope = this repo only (`fro-bot/.github`).** No repo enumeration — the harvest
+  queries `pulls.list` for the single repo. The App token does not need cross-repo `owner`
+  scope for the harvest (it stays same-repo); issue-create + reads are same-repo.
+- **Cost budget (R6):** weekly cron (Sunday after `merge-data`), a `MAX_PROPOSALS_PER_RUN`
+  cap, and a bounded lookback window (e.g. PRs merged in the last N days). All named constants.
+- **New `learning-proposal` label** added to the settings file in the same PR so it exists
+  before the first run; `ensureLabelsExist` preflight tolerates the race.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Decision-log persistence: proposal-issues-as-log (reset-resilient). Resolved above.
+- Review-round definition + threshold: ≥2 `CHANGES_REQUESTED`. Resolved above.
+- Harvest scope: this repo (`fro-bot/.github`) only. Resolved above.
+- Privacy gate target: the agent-authored proposal body, fail-closed. Resolved above.
+
+### Deferred to Implementation
+
+- Exact dedup-overlap threshold against `docs/solutions/`, the lookback-window length, and
+  `MAX_PROPOSALS_PER_RUN` — calibrate against real PR history during implementation; they are
+  named constants, not architecture.
+- How a candidate's `module`/`tags`/`problem_type` signals are derived from a PR (changed-file
+  top-level dirs, PR labels, title heuristics) — start simple, refine if dedup precision is
+  poor.
+- Whether to fetch each candidate issue's body to read the marker, or encode the merge-SHA in
+  a way visible in `listForRepo` without a body fetch — a cheap per-issue `get` is acceptable;
+  decide at implementation.
+
+## High-Level Technical Design
+
+> *Directional guidance for review, not implementation specification.*
+
+```
+weekly cron (Sunday, post-merge-data)
+   │  App token · ./.github/actions/setup · overlay metadata/ from data
+   ▼
+ scripts/capture-c1-harvest.ts
+   1. paginate this repo's merged PRs in the lookback window
+   2. per PR: pulls.listReviews → count CHANGES_REQUESTED; keep if >= 2
+   3. seen-set: issues.listForRepo(state:all, labels:learning-proposal) → parse
+      <!-- capture-c1:merge_sha=… --> markers; drop candidates already seen
+   4. dedup vs docs/solutions/ (collectDocs overlap on module/tags/problem_type)
+   5. cap to MAX_PROPOSALS_PER_RUN
+   6. emit OPAQUE digest (candidates by merge_sha + review-round counts + signals;
+      NO owner/repo/number prose) → $GITHUB_OUTPUT
+   │
+   ▼
+ fro-bot/agent step (tight propose-only prompt + digest as context)
+   - decide which candidates merit a proposal
+   - author a proposal body (the pattern, the evidence, by merge_sha)
+   - BEFORE issues.create: privacy body-scan (containsPrivateToken) → block on hit
+   - ensureLabelsExist([learning-proposal]) preflight
+   - issues.create with the learning-proposal label + body marker
+   - in-memory Set of created merge_shas guards same-run duplicates
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: `scripts/capture-c1-harvest.ts` — harvest + dedup + digest (test-first)**
+
+**Goal:** A script that paginates this repo's (`fro-bot/.github`) merged PRs in the lookback
+window, keeps those with ≥2 `CHANGES_REQUESTED` reviews, drops any already represented by a
+`learning-proposal`
+issue (by merge-SHA marker) or already covered by a `docs/solutions/` doc, caps the result,
+and emits an opaque candidate digest to `$GITHUB_OUTPUT`.
+
+**Requirements:** R1, R2, R3, R5, R6.
+
+**Dependencies:** None (reuses existing helpers; the workflow in Unit 3 invokes it).
+
+**Files:**
+- Create: `scripts/capture-c1-harvest.ts`
+- Test: `scripts/capture-c1-harvest.test.ts`
+- Possibly: extract `splitFrontmatter` into a shared module if reuse is cleaner than copy
+  (decide at implementation; copy is acceptable per repo convention).
+
+**Approach:**
+- `OctokitClient = Octokit` derived type; `createOctokitFromEnv` mirroring
+  `reconcile-repos.ts` (env-parameterized token). Pure core takes injected inputs (PR list,
+  reviews, existing proposal markers, existing solutions docs) so it is fully unit-testable;
+  the I/O shell does the Octokit/disk calls.
+- Harvest: `octokit.paginate(pulls.list, { owner: 'fro-bot', repo: '.github', state: 'closed',
+  ... })` (single repo, no enumeration), filter `merged_at !== null` and within the lookback
+  window; `pulls.listReviews` per PR; `reviewRounds =
+  count(state === 'CHANGES_REQUESTED')`; keep `reviewRounds >= MULTI_ROUND_THRESHOLD` (=2).
+- Seen-set: `issues.listForRepo({ state: 'all', labels: LEARNING_PROPOSAL_LABEL })`, parse the
+  `<!-- capture-c1:merge_sha=… -->` marker, build `Set<merge_sha>`; drop seen candidates.
+- Solutions dedup: `loadSolutionsFilesFromDisk` + `collectDocs`; drop candidates whose derived
+  signals strongly overlap an existing doc.
+- Cap to `MAX_PROPOSALS_PER_RUN`; emit the digest (merge_sha, reviewRounds, derived signals —
+  **no owner/repo/number prose**) + counts-only telemetry to `$GITHUB_OUTPUT`.
+- Best-effort on transient API errors (retry/continue like `reconcile-repos.ts`); a hard
+  failure to read `metadata/repos.yaml` for the privacy set is fatal only in Unit 2's gate, not
+  here.
+
+**Execution note:** Test-first, mirroring the `reconcile-repos.test.ts` mock shape.
+
+**Patterns to follow:** `reconcile-repos.ts` (pagination, retry, derived Octokit type),
+`solutions-query.ts` (frontmatter/doc loaders), the same-run-eventual-consistency learning.
+
+**Test scenarios:**
+- Happy: a merged PR with 2 `CHANGES_REQUESTED` reviews and no prior proposal/solution → in the
+  digest with its merge_sha and reviewRounds.
+- Edge: a PR with 1 `CHANGES_REQUESTED` (below threshold) → excluded.
+- Edge: a closed-but-not-merged PR (`merged_at === null`) → excluded.
+- Edge: `COMMENTED`/`APPROVED`-only reviews → reviewRounds 0 → excluded.
+- Dedup (R3): a candidate whose merge_sha appears in an existing `learning-proposal` issue
+  marker (state `all`, including a *closed* one) → excluded. Mutation-prove: removing the
+  seen-set filter makes it reappear.
+- Dedup (R5): a candidate whose signals overlap an existing `docs/solutions/` doc → excluded.
+- Cap (R6): more candidates than `MAX_PROPOSALS_PER_RUN` → only the cap count emitted.
+- Privacy/opacity (R4): assert the emitted digest contains **no** `owner/repo/number` prose —
+  candidates are identified by merge_sha only.
+- Error path: a transient `pulls.listReviews` failure for one PR doesn't abort the whole run.
+
+**Verification:** `pnpm check-types`, `pnpm lint`, `pnpm test` green; strip-only load clean;
+the digest carries no `owner/repo/number` prose; the seen-set dedup is mutation-proven.
+
+- [ ] **Unit 2: proposal-issue opening with body privacy-scan + dedup (test-first)**
+
+**Goal:** Given the digest and an agent-authored proposal body per candidate, open a
+`learning-proposal` issue with the merge-SHA marker — but only after the body passes the
+private-identifier scan, with same-run and cross-run dedup.
+
+**Requirements:** R2, R3, R4.
+
+**Dependencies:** Unit 1 (the digest + seen-set), shared privacy helpers.
+
+**Files:**
+- Modify: `scripts/capture-c1-harvest.ts` (add the issue-opening shell), OR a sibling
+  `scripts/capture-c1-propose.ts` if cleaner — decide at implementation.
+- Test: the colocated test.
+
+**Approach:**
+- Reuse `ensureLabelsExist([LEARNING_PROPOSAL_LABEL])` preflight (race-tolerant), filtering the
+  payload labels to the confirmed set.
+- Privacy gate (R4): lowercased proposal body → `containsPrivateToken` against the token set
+  built from `loadPrivateNamesFromDisk` (overlay-checked-out `metadata/repos.yaml`,
+  `private: true`, non-redacted) via `buildPrivateNameTokens`. On hit → **skip** that proposal
+  (counts-only telemetry: "blocked N on privacy scan", path/sha-free).
+- Open the issue: `issues.create({ labels: [LEARNING_PROPOSAL_LABEL], body: <body> + marker
+  })`; carry an in-memory `Set<merge_sha>` of created proposals to guard the eventual-consistency
+  same-run race.
+- The proposal body references the source PR by merge_sha only (the agent never received
+  owner/repo prose).
+
+**Test scenarios:**
+- Happy: a clean proposal body → issue created with the `learning-proposal` label and the
+  `<!-- capture-c1:merge_sha=… -->` marker.
+- Privacy (R4): a proposal body containing a private token → blocked, no issue created, no
+  private name in any telemetry. Mutation-prove: removing the gate lets it through.
+- Same-run dedup (R3): two candidates with the same merge_sha in one run → only one issue
+  created (in-memory Set).
+- Label preflight: `ensureLabelsExist` 404→create, 422→accept; a label that can't be created →
+  issue still ships with the confirmed subset (never silently unlabeled-and-undeduped).
+- Error path: an `issues.create` failure for one candidate doesn't abort the rest.
+
+**Verification:** gates green; the privacy block is mutation-proven; the same-run Set prevents
+duplicates; created issues carry the label + marker.
+
+- [ ] **Unit 3: scheduled workflow + `learning-proposal` label + agent wiring**
+
+**Goal:** A weekly workflow that mints the App token, overlays metadata, runs the harvest over
+this repo, feeds the opaque digest to a tight propose-only agent step, and surfaces counts-only
+telemetry.
+
+**Requirements:** R1, R2, R4, R6.
+
+**Dependencies:** Units 1–2.
+
+**Files:**
+- Create: `.github/workflows/capture-c1-proposals.yaml`
+- Modify: `common-settings.yaml` (or `.github/settings.yml`) — add the `learning-proposal`
+  label.
+- Possibly modify: `metadata/README.md` — document the capture run.
+
+**Approach:**
+- Mirror `reconcile-repos.yaml`: `actions/create-github-app-token` (same-repo scope is
+  sufficient — the harvest and issue-create are all on this repo, so the cross-repo `owner:`
+  input is not required), `./.github/actions/setup`, the data-overlay step (hard-fail
+  if `metadata/repos.yaml` can't be read — the privacy gate needs it), `node
+  scripts/capture-c1-harvest.ts` emitting the digest to `$GITHUB_OUTPUT`, then the
+  `fro-bot/agent` step with a **tight propose-only prompt**: open `learning-proposal` issues
+  for the digest candidates and do nothing else — no code, no doc edits, no other issues. A
+  counts-only step-summary (cohort size, candidates after dedup, proposals opened, blocked-on-
+  privacy count). Weekly cron (Sunday post-merge-data), `concurrency: capture-c1-proposals`,
+  `permissions: contents: read` (+ issues write via the App token).
+
+**Execution note:** none (workflow wiring; validated by actionlint + a manual dispatch).
+
+**Patterns to follow:** `reconcile-repos.yaml`, `update-metadata.yaml`.
+
+**Test scenarios:** `Test expectation: none — workflow wiring; validated by actionlint and a
+manual workflow_dispatch run that shows the harvest ran, the digest populated, and at most
+MAX_PROPOSALS_PER_RUN learning-proposal issues opened (or zero with a clean reason), with no
+private identifier in the run log.`
+
+**Verification:** actionlint clean; a manual dispatch opens `learning-proposal` issues for real
+multi-round PRs (or none, cleanly), the label exists, the step summary is counts-only, and no
+`owner/repo/number` for any private repo appears in the run log.
+
+## System-Wide Impact
+
+- **Interaction graph:** a new scheduled workflow + 1–2 new scripts. Reuses existing Octokit,
+  frontmatter, and privacy helpers. Opens issues labeled `learning-proposal`. Touches nothing
+  in the data-branch authority path, the agent prompt-injection path, or Phase 1 retrieval.
+- **Error propagation:** harvest is best-effort on transient API errors; the privacy gate is
+  fail-closed (block the proposal). A failed run opens no issues and does not corrupt state
+  (the decision log is the issues themselves).
+- **State lifecycle risks:** the decision log is reset-resilient by construction (issues, not
+  `data`). The one documented tradeoff is manual issue deletion re-opening candidacy.
+- **API surface parity:** the issue-queue + label-preflight + same-run-Set pattern mirrors
+  `reconcile-repos.ts` exactly.
+- **Unchanged invariants:** `docs/solutions/` stays human-authored on `main` (no write); the
+  data-branch authority model and Phase 1 retrieval are untouched.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Private repo name leaks via the agent-authored proposal body | Fail-closed `containsPrivateToken` scan of the body before create; opaque digest (merge_sha only) so the agent never receives owner/repo prose |
+| Decision log lost on data-branch reset | Log IS the `learning-proposal` issues — independent of branches; deduped by merge_sha marker, queried `state: all` |
+| Same-run duplicate proposals (Issues API eventual consistency) | In-memory `Set<merge_sha>` through the create loop (the documented reconcile pattern) |
+| Shallow/low-value proposals dilute attention | Propose-only + human decides; ≥2-round threshold keeps the cohort high-signal; `MAX_PROPOSALS_PER_RUN` caps volume |
+| Cost drift from the agent step | Weekly cadence, capped candidates, bounded lookback |
+| Agent does more than open issues | Tight propose-only prompt; the digest withholds anything but merge_sha + signals |
+
+## Documentation / Operational Notes
+
+- Add the `learning-proposal` label to the settings file in the Unit 3 PR so it exists before
+  the first run.
+- After landing, the capture run's own behavior is a candidate for a `docs/solutions/` learning
+  (a small dogfood) — but that authoring stays human-triggered in this phase.
+
+## Sources & References
+
+- **Origin document:** docs/brainstorms/2026-06-22-skill-saving-grow-and-learn-requirements.md
+- Issue-queue / label / dedup template: `scripts/reconcile-repos.ts` (`runIssueQueue`,
+  `ensureLabelsExist`, marker dedup, same-run Set)
+- Octokit constructor + pagination: `scripts/merge-data-pr.ts`, `scripts/reconcile-repos.ts`
+- Privacy + frontmatter helpers: `scripts/solutions-query.ts`, `scripts/wiki-slug.ts`
+- Workflow shape: `.github/workflows/reconcile-repos.yaml`
+- Same-run eventual-consistency learning:
+  `docs/solutions/best-practices/github-issues-api-same-run-eventual-consistency-2026-05-20.md`

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -225,6 +225,18 @@ The `Merge Data Branch` workflow runs on a schedule (weekly) and opens a `data �
 - Manual edits to `metadata/*.yaml` also target `data` and are promoted via the `Merge Data Branch` workflow — see above.
 - Metadata files are initialized in-repo first; automation updates existing files only.
 
+## Learning-proposal capture
+
+A weekly scheduled run (`capture-c1-proposals.yaml`, Sunday 22:30 UTC) examines this repo's merged PRs for those that required multiple rounds of changes-requested reviews — the richest mistake→correction signal — and opens a GitHub issue proposing a candidate learning for each.
+
+Each proposal is labeled `learning-proposal` and carries an immutable body marker (`<!-- capture-c1:merge_sha=<sha> -->`). The marker is the reset-resilient decision log: the run rebuilds its seen-set each week by querying all `learning-proposal` issues (state: all, including closed), so a data-branch reset cannot wipe the log.
+
+**Privacy:** the harvest digest identifies candidates by merge commit SHA only — no owner, repo name, PR number, or title reaches the agent or the proposal body. The agent authors proposal bodies referencing the source by merge SHA only. Before any issue is created, the body is scanned against the private-repo token set from `metadata/repos.yaml` (fail-closed: a missing or unreadable overlay aborts the propose step with no issues posted).
+
+**Human review:** proposals are human-reviewed. There is no auto-merge or auto-promotion path. A human authors the final learning into `docs/solutions/` via `ce:compound` when a proposal is accepted.
+
+**Cadence and cost:** weekly, capped at `MAX_PROPOSALS_PER_RUN` candidates, with a bounded lookback window. The step summary reports counts only (PRs examined, candidates after dedup, proposals opened, blocked on privacy).
+
 ## Metrics note
 
 `metrics.yaml` is intentionally deferred. Operational telemetry is routed through the journal issue system. The metrics pipeline belongs to the deferred self-improvement plan.

--- a/scripts/capture-c1-harvest.test.ts
+++ b/scripts/capture-c1-harvest.test.ts
@@ -1,0 +1,720 @@
+/**
+ * Tests for capture-c1-harvest.ts
+ *
+ * Structure:
+ * - Pure core tests: drive `buildCandidateDigest` with injected data
+ * - Marker helper tests: `buildMergeShaMarker` / `parseMergeShaMarker`
+ * - I/O shell tests: `harvestCandidates` and `fetchProposedMergeShas` with mocked Octokit
+ */
+
+import {describe, expect, it, vi} from 'vitest'
+
+import {
+  buildCandidateDigest,
+  buildMergeShaMarker,
+  fetchProposedMergeShas,
+  harvestCandidates,
+  LEARNING_PROPOSAL_LABEL,
+  parseMergeShaMarker,
+  type BuildCandidateDigestInput,
+  type Candidate,
+  type OctokitClient,
+  type SolutionDoc,
+} from './capture-c1-harvest.ts'
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeCandidate(overrides: Partial<Candidate> = {}): Candidate {
+  return {
+    mergeSha: 'abc123def456abc123def456abc123def456abc1',
+    reviewRounds: 2,
+    signals: {titleTokens: ['feat', 'scripts'], labels: []},
+    ...overrides,
+  }
+}
+
+function makeSolutionDoc(overrides: Partial<SolutionDoc> = {}): SolutionDoc {
+  return {
+    path: 'docs/solutions/best-practices/some-doc.md',
+    module: 'scripts/some-module.ts',
+    tags: ['automation', 'ci'],
+    problemType: 'best_practice',
+    ...overrides,
+  }
+}
+
+function makeDigestInput(overrides: Partial<BuildCandidateDigestInput> = {}): BuildCandidateDigestInput {
+  return {
+    mergedPrs: [makeCandidate()],
+    proposedMergeShas: new Set(),
+    solutionsDocs: [],
+    maxProposals: 5,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Marker helpers
+// ---------------------------------------------------------------------------
+
+describe('buildMergeShaMarker', () => {
+  it('produces the expected HTML comment format', () => {
+    // #given a merge SHA
+    // #when building the marker
+    // #then it matches the expected format
+    expect(buildMergeShaMarker('abc123')).toBe('<!-- capture-c1:merge_sha=abc123 -->')
+  })
+})
+
+describe('parseMergeShaMarker', () => {
+  it('extracts the SHA from a well-formed marker', () => {
+    // #given a body containing the marker
+    const body = 'Some text\n<!-- capture-c1:merge_sha=abc123def456 -->\nMore text'
+    // #when parsing
+    // #then the SHA is returned
+    expect(parseMergeShaMarker(body)).toBe('abc123def456')
+  })
+
+  it('returns null when no marker is present', () => {
+    // #given a body without the marker
+    // #when parsing
+    // #then null is returned
+    expect(parseMergeShaMarker('No marker here')).toBeNull()
+  })
+
+  it('returns null for a malformed marker (missing sha)', () => {
+    // #given a body with a malformed marker
+    // #when parsing
+    // #then null is returned (regex requires 7-40 hex chars)
+    expect(parseMergeShaMarker('<!-- capture-c1:merge_sha= -->')).toBeNull()
+  })
+
+  it('returns null for an empty body', () => {
+    // #given an empty body
+    // #when parsing
+    // #then null is returned without crashing
+    expect(parseMergeShaMarker('')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Pure core: buildCandidateDigest
+// ---------------------------------------------------------------------------
+
+describe('buildCandidateDigest', () => {
+  describe('happy path', () => {
+    it('includes a PR with reviewRounds=2, no prior proposal, no solution overlap', () => {
+      // #given a single candidate with 2 review rounds, not yet proposed, no doc overlap
+      const input = makeDigestInput()
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then the candidate is in the output with its mergeSha and reviewRounds
+      expect(result.candidates).toHaveLength(1)
+      expect(result.candidates[0]?.mergeSha).toBe(makeCandidate().mergeSha)
+      expect(result.candidates[0]?.reviewRounds).toBe(2)
+    })
+  })
+
+  describe('opacity guarantee (R4)', () => {
+    it('emitted candidates have ONLY mergeSha, reviewRounds, and signals keys — no owner/repo/number/title', () => {
+      // #given a candidate
+      const input = makeDigestInput()
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then each candidate object has exactly the allowed keys
+      for (const candidate of result.candidates) {
+        const keys = Object.keys(candidate).sort()
+        expect(keys).toEqual(['mergeSha', 'reviewRounds', 'signals'].sort())
+        // Explicitly assert forbidden keys are absent
+        expect(candidate).not.toHaveProperty('owner')
+        expect(candidate).not.toHaveProperty('repo')
+        expect(candidate).not.toHaveProperty('number')
+        expect(candidate).not.toHaveProperty('title')
+      }
+    })
+  })
+
+  describe('proposal dedup (R3)', () => {
+    it('excludes a candidate whose mergeSha is in proposedMergeShas', () => {
+      // #given a candidate whose SHA is already in the seen-set
+      const sha = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+      const input = makeDigestInput({
+        mergedPrs: [makeCandidate({mergeSha: sha})],
+        proposedMergeShas: new Set([sha]),
+      })
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then the candidate is excluded
+      expect(result.candidates).toHaveLength(0)
+      expect(result.telemetry.afterProposalDedup).toBe(0)
+    })
+
+    it('mutation proof: removing the seen-set filter makes the candidate reappear', () => {
+      // #given the same candidate with and without the seen-set
+      const sha = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+      const candidate = makeCandidate({mergeSha: sha})
+
+      // #when the seen-set contains the SHA
+      const withDedup = buildCandidateDigest(
+        makeDigestInput({
+          mergedPrs: [candidate],
+          proposedMergeShas: new Set([sha]),
+        }),
+      )
+      // #then the candidate is excluded
+      expect(withDedup.candidates).toHaveLength(0)
+
+      // #when the seen-set is empty (dedup removed)
+      const withoutDedup = buildCandidateDigest(
+        makeDigestInput({
+          mergedPrs: [candidate],
+          proposedMergeShas: new Set(),
+        }),
+      )
+      // #then the candidate reappears — proving the dedup was the gate
+      expect(withoutDedup.candidates).toHaveLength(1)
+      expect(withoutDedup.candidates[0]?.mergeSha).toBe(sha)
+    })
+
+    it('includes a candidate whose mergeSha is NOT in proposedMergeShas', () => {
+      // #given a candidate with a SHA not in the seen-set
+      const input = makeDigestInput({
+        proposedMergeShas: new Set(['other-sha-not-matching']),
+      })
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then the candidate is included
+      expect(result.candidates).toHaveLength(1)
+    })
+  })
+
+  describe('solutions dedup (R5)', () => {
+    it('excludes a candidate whose signals exactly match an existing doc problem_type', () => {
+      // #given a candidate with a label matching a doc's problem_type
+      const input = makeDigestInput({
+        mergedPrs: [makeCandidate({signals: {titleTokens: [], labels: ['best_practice']}})],
+        solutionsDocs: [makeSolutionDoc({problemType: 'best_practice', tags: [], module: ''})],
+      })
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then the candidate is excluded (exact problem_type match = 100 points >= threshold)
+      expect(result.candidates).toHaveLength(0)
+      expect(result.telemetry.afterSolutionsDedup).toBe(0)
+    })
+
+    it('excludes a candidate whose signals share a tag with an existing doc', () => {
+      // #given a candidate with a label matching a doc tag
+      const input = makeDigestInput({
+        mergedPrs: [makeCandidate({signals: {titleTokens: [], labels: ['automation']}})],
+        solutionsDocs: [makeSolutionDoc({tags: ['automation'], problemType: '', module: ''})],
+      })
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then the candidate is excluded (tag overlap = 10 points >= threshold of 10)
+      expect(result.candidates).toHaveLength(0)
+    })
+
+    it('includes a candidate with no signal overlap against existing docs', () => {
+      // #given a candidate with signals that share nothing with any doc
+      const input = makeDigestInput({
+        mergedPrs: [makeCandidate({signals: {titleTokens: ['xyz', 'unrelated'], labels: ['unrelated-label']}})],
+        solutionsDocs: [
+          makeSolutionDoc({tags: ['automation', 'ci'], problemType: 'best_practice', module: 'scripts/other.ts'}),
+        ],
+      })
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then the candidate is included
+      expect(result.candidates).toHaveLength(1)
+    })
+
+    it('includes a candidate when solutionsDocs is empty', () => {
+      // #given no existing solutions docs
+      const input = makeDigestInput({solutionsDocs: []})
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then the candidate is included
+      expect(result.candidates).toHaveLength(1)
+    })
+  })
+
+  describe('cap (R6)', () => {
+    it('caps candidates to maxProposals when more are available', () => {
+      // #given 7 candidates and a cap of 3
+      const candidates = Array.from({length: 7}, (_, i) =>
+        makeCandidate({mergeSha: `sha${i}${'0'.repeat(35 - String(i).length)}`}),
+      )
+      const input = makeDigestInput({
+        mergedPrs: candidates,
+        maxProposals: 3,
+      })
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then only 3 candidates are emitted
+      expect(result.candidates).toHaveLength(3)
+      expect(result.telemetry.emitted).toBe(3)
+    })
+
+    it('emits all candidates when count is below the cap', () => {
+      // #given 2 candidates and a cap of 5
+      const candidates = [
+        makeCandidate({mergeSha: `sha1${'0'.repeat(36)}`}),
+        makeCandidate({mergeSha: `sha2${'0'.repeat(36)}`}),
+      ]
+      const input = makeDigestInput({mergedPrs: candidates, maxProposals: 5})
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then both candidates are emitted
+      expect(result.candidates).toHaveLength(2)
+      expect(result.telemetry.emitted).toBe(2)
+    })
+  })
+
+  describe('telemetry counts', () => {
+    it('reports correct counts through the dedup pipeline', () => {
+      // #given 5 candidates: 2 already proposed, 1 overlaps a doc, 2 clean
+      const proposedSha1 = `proposed1${'0'.repeat(31)}`
+      const proposedSha2 = `proposed2${'0'.repeat(31)}`
+      const overlapSha = `overlap1${'0'.repeat(32)}`
+      const cleanSha1 = `clean001${'0'.repeat(32)}`
+      const cleanSha2 = `clean002${'0'.repeat(32)}`
+
+      const input = makeDigestInput({
+        mergedPrs: [
+          makeCandidate({mergeSha: proposedSha1}),
+          makeCandidate({mergeSha: proposedSha2}),
+          makeCandidate({mergeSha: overlapSha, signals: {titleTokens: [], labels: ['automation']}}),
+          makeCandidate({mergeSha: cleanSha1}),
+          makeCandidate({mergeSha: cleanSha2}),
+        ],
+        proposedMergeShas: new Set([proposedSha1, proposedSha2]),
+        solutionsDocs: [makeSolutionDoc({tags: ['automation'], problemType: '', module: ''})],
+        maxProposals: 5,
+      })
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then telemetry reflects each dedup stage
+      expect(result.telemetry.examined).toBe(5)
+      expect(result.telemetry.afterProposalDedup).toBe(3) // 5 - 2 proposed
+      expect(result.telemetry.afterSolutionsDedup).toBe(2) // 3 - 1 overlap
+      expect(result.telemetry.emitted).toBe(2) // 2 clean, under cap
+    })
+
+    it('reports zero counts when all candidates are filtered', () => {
+      // #given all candidates already proposed
+      const sha = `allproposed${'0'.repeat(29)}`
+      const input = makeDigestInput({
+        mergedPrs: [makeCandidate({mergeSha: sha})],
+        proposedMergeShas: new Set([sha]),
+      })
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then all counts are zero except examined
+      expect(result.telemetry.examined).toBe(1)
+      expect(result.telemetry.afterProposalDedup).toBe(0)
+      expect(result.telemetry.afterSolutionsDedup).toBe(0)
+      expect(result.telemetry.emitted).toBe(0)
+    })
+
+    it('reports zero counts when input is empty', () => {
+      // #given no candidates
+      const input = makeDigestInput({mergedPrs: []})
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then all counts are zero
+      expect(result.telemetry.examined).toBe(0)
+      expect(result.telemetry.afterProposalDedup).toBe(0)
+      expect(result.telemetry.afterSolutionsDedup).toBe(0)
+      expect(result.telemetry.emitted).toBe(0)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// I/O shell: harvestCandidates (mocked Octokit)
+// ---------------------------------------------------------------------------
+
+interface PullsListItem {
+  number: number
+  merged_at: string | null
+  merge_commit_sha: string | null
+  title: string
+  labels: {name: string}[]
+}
+
+interface ReviewItem {
+  state: string
+}
+
+function makePullsListItem(overrides: Partial<PullsListItem> = {}): PullsListItem {
+  return {
+    number: 1,
+    merged_at: new Date().toISOString(),
+    merge_commit_sha: 'abc123def456abc123def456abc123def456abc1',
+    title: 'feat: add new feature',
+    labels: [],
+    ...overrides,
+  }
+}
+
+function makeReviewItem(state: string): ReviewItem {
+  return {state}
+}
+
+function mockOctokit(
+  overrides: {
+    paginate?: (fn: unknown, opts: unknown) => Promise<unknown[]>
+    pullsListReviews?: (opts: unknown) => Promise<{data: ReviewItem[]}>
+  } = {},
+): OctokitClient {
+  const defaultPaginate = async (fn: unknown, opts: unknown): Promise<unknown[]> => {
+    const call = fn as (opts: unknown) => Promise<{data: unknown[]}>
+    const response = await call(opts)
+    return response.data
+  }
+
+  return {
+    paginate: overrides.paginate ?? defaultPaginate,
+    rest: {
+      pulls: {
+        list: async () => ({data: []}),
+        listReviews: overrides.pullsListReviews ?? (async () => ({data: []})),
+      },
+      issues: {
+        listForRepo: async () => ({data: []}),
+      },
+    },
+  } as unknown as OctokitClient
+}
+
+describe('harvestCandidates', () => {
+  it('excludes a PR with merged_at === null (unmerged)', async () => {
+    // #given a closed PR that was never merged
+    const pr = makePullsListItem({merged_at: null})
+    const octokit = mockOctokit({
+      paginate: async () => [pr],
+    })
+
+    // #when harvesting
+    const result = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then the PR is excluded
+    expect(result).toHaveLength(0)
+  })
+
+  it('excludes a PR merged outside the lookback window', async () => {
+    // #given a PR merged 60 days ago (beyond LOOKBACK_DAYS=30)
+    const oldDate = new Date()
+    oldDate.setDate(oldDate.getDate() - 60)
+    const pr = makePullsListItem({merged_at: oldDate.toISOString()})
+    const octokit = mockOctokit({
+      paginate: async () => [pr],
+    })
+
+    // #when harvesting
+    const result = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then the PR is excluded
+    expect(result).toHaveLength(0)
+  })
+
+  it('excludes a PR with only COMMENTED reviews (reviewRounds = 0)', async () => {
+    // #given a merged PR with only COMMENTED reviews
+    const pr = makePullsListItem()
+    const octokit = mockOctokit({
+      paginate: async () => [pr],
+      pullsListReviews: async () => ({
+        data: [makeReviewItem('COMMENTED'), makeReviewItem('COMMENTED')],
+      }),
+    })
+
+    // #when harvesting
+    const result = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then the PR is excluded (0 CHANGES_REQUESTED < threshold of 2)
+    expect(result).toHaveLength(0)
+  })
+
+  it('excludes a PR with only APPROVED reviews (reviewRounds = 0)', async () => {
+    // #given a merged PR with only APPROVED reviews
+    const pr = makePullsListItem()
+    const octokit = mockOctokit({
+      paginate: async () => [pr],
+      pullsListReviews: async () => ({
+        data: [makeReviewItem('APPROVED')],
+      }),
+    })
+
+    // #when harvesting
+    const result = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then the PR is excluded
+    expect(result).toHaveLength(0)
+  })
+
+  it('excludes a PR with only 1 CHANGES_REQUESTED review (below threshold)', async () => {
+    // #given a merged PR with 1 CHANGES_REQUESTED review
+    const pr = makePullsListItem()
+    const octokit = mockOctokit({
+      paginate: async () => [pr],
+      pullsListReviews: async () => ({
+        data: [makeReviewItem('CHANGES_REQUESTED')],
+      }),
+    })
+
+    // #when harvesting
+    const result = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then the PR is excluded (1 < threshold of 2)
+    expect(result).toHaveLength(0)
+  })
+
+  it('includes a PR with exactly 2 CHANGES_REQUESTED reviews', async () => {
+    // #given a merged PR with 2 CHANGES_REQUESTED reviews
+    const sha = 'abc123def456abc123def456abc123def456abc1'
+    const pr = makePullsListItem({merge_commit_sha: sha})
+    const octokit = mockOctokit({
+      paginate: async () => [pr],
+      pullsListReviews: async () => ({
+        data: [makeReviewItem('CHANGES_REQUESTED'), makeReviewItem('CHANGES_REQUESTED')],
+      }),
+    })
+
+    // #when harvesting
+    const result = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then the PR is included with its mergeSha and reviewRounds
+    expect(result).toHaveLength(1)
+    expect(result[0]?.mergeSha).toBe(sha)
+    expect(result[0]?.reviewRounds).toBe(2)
+  })
+
+  it('counts only CHANGES_REQUESTED reviews, not COMMENTED or APPROVED', async () => {
+    // #given a merged PR with mixed review states
+    const pr = makePullsListItem()
+    const octokit = mockOctokit({
+      paginate: async () => [pr],
+      pullsListReviews: async () => ({
+        data: [
+          makeReviewItem('CHANGES_REQUESTED'),
+          makeReviewItem('COMMENTED'),
+          makeReviewItem('APPROVED'),
+          makeReviewItem('CHANGES_REQUESTED'),
+        ],
+      }),
+    })
+
+    // #when harvesting
+    const result = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then reviewRounds is 2 (only CHANGES_REQUESTED counted)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.reviewRounds).toBe(2)
+  })
+
+  it('skips a PR when listReviews throws a transient error, continues processing others', async () => {
+    // #given two PRs: one whose listReviews throws, one that succeeds
+    const goodSha = `goodsha1${'0'.repeat(32)}`
+    const badPr = makePullsListItem({number: 1, merge_commit_sha: `badsha1${'0'.repeat(33)}`})
+    const goodPr = makePullsListItem({number: 2, merge_commit_sha: goodSha})
+
+    const listReviews = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error('Service Unavailable'), {status: 503}))
+      .mockResolvedValueOnce({
+        data: [makeReviewItem('CHANGES_REQUESTED'), makeReviewItem('CHANGES_REQUESTED')],
+      })
+
+    const octokit = mockOctokit({
+      paginate: async () => [badPr, goodPr],
+      pullsListReviews: listReviews as (opts: unknown) => Promise<{data: ReviewItem[]}>,
+    })
+
+    // #when harvesting
+    const result = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then the bad PR is skipped, the good PR is included
+    expect(result).toHaveLength(1)
+    expect(result[0]?.mergeSha).toBe(goodSha)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// I/O shell: fetchProposedMergeShas (mocked Octokit)
+// ---------------------------------------------------------------------------
+
+interface IssueListItem {
+  number: number
+  body: string | null
+}
+
+function makeIssueListItem(overrides: Partial<IssueListItem> = {}): IssueListItem {
+  return {
+    number: 1,
+    body: null,
+    ...overrides,
+  }
+}
+
+function mockOctokitForIssues(
+  overrides: {
+    paginate?: (fn: unknown, opts: unknown) => Promise<unknown[]>
+  } = {},
+): OctokitClient {
+  const defaultPaginate = async (fn: unknown, opts: unknown): Promise<unknown[]> => {
+    const call = fn as (opts: unknown) => Promise<{data: unknown[]}>
+    const response = await call(opts)
+    return response.data
+  }
+
+  return {
+    paginate: overrides.paginate ?? defaultPaginate,
+    rest: {
+      pulls: {
+        list: async () => ({data: []}),
+        listReviews: async () => ({data: []}),
+      },
+      issues: {
+        listForRepo: async () => ({data: []}),
+      },
+    },
+  } as unknown as OctokitClient
+}
+
+describe('fetchProposedMergeShas', () => {
+  it('parses the merge SHA from a learning-proposal issue body', async () => {
+    // #given an issue with a valid marker in its body
+    const sha = 'abc123def456abc123def456abc123def456abc1'
+    const issue = makeIssueListItem({body: `Some text\n${buildMergeShaMarker(sha)}\nMore text`})
+    const octokit = mockOctokitForIssues({
+      paginate: async () => [issue],
+    })
+
+    // #when fetching proposed SHAs
+    const result = await fetchProposedMergeShas(octokit, 'fro-bot', '.github')
+
+    // #then the SHA is in the seen-set
+    expect(result.has(sha)).toBe(true)
+    expect(result.size).toBe(1)
+  })
+
+  it('includes SHAs from closed learning-proposal issues (state: all)', async () => {
+    // #given a closed issue with a valid marker (state: all means closed issues are included)
+    const sha = `c10${'0'.repeat(37)}`
+    const issue = makeIssueListItem({body: buildMergeShaMarker(sha)})
+    const octokit = mockOctokitForIssues({
+      paginate: async () => [issue],
+    })
+
+    // #when fetching proposed SHAs
+    const result = await fetchProposedMergeShas(octokit, 'fro-bot', '.github')
+
+    // #then the SHA from the closed issue is in the seen-set
+    expect(result.has(sha)).toBe(true)
+  })
+
+  it('skips an issue with a null body without crashing', async () => {
+    // #given an issue with a null body
+    const issue = makeIssueListItem({body: null})
+    const octokit = mockOctokitForIssues({
+      paginate: async () => [issue],
+    })
+
+    // #when fetching proposed SHAs
+    const result = await fetchProposedMergeShas(octokit, 'fro-bot', '.github')
+
+    // #then the result is an empty set (no crash)
+    expect(result.size).toBe(0)
+  })
+
+  it('skips an issue with an empty body without crashing', async () => {
+    // #given an issue with an empty body
+    const issue = makeIssueListItem({body: ''})
+    const octokit = mockOctokitForIssues({
+      paginate: async () => [issue],
+    })
+
+    // #when fetching proposed SHAs
+    const result = await fetchProposedMergeShas(octokit, 'fro-bot', '.github')
+
+    // #then the result is an empty set (no crash)
+    expect(result.size).toBe(0)
+  })
+
+  it('skips an issue with a body that has no marker', async () => {
+    // #given an issue with a body but no marker
+    const issue = makeIssueListItem({body: 'This is a learning proposal without a marker.'})
+    const octokit = mockOctokitForIssues({
+      paginate: async () => [issue],
+    })
+
+    // #when fetching proposed SHAs
+    const result = await fetchProposedMergeShas(octokit, 'fro-bot', '.github')
+
+    // #then the result is an empty set
+    expect(result.size).toBe(0)
+  })
+
+  it('collects multiple SHAs from multiple issues', async () => {
+    // #given multiple issues each with a valid marker
+    const sha1 = `a1${'0'.repeat(38)}`
+    const sha2 = `b2${'0'.repeat(38)}`
+    const issues = [
+      makeIssueListItem({number: 1, body: buildMergeShaMarker(sha1)}),
+      makeIssueListItem({number: 2, body: buildMergeShaMarker(sha2)}),
+    ]
+    const octokit = mockOctokitForIssues({
+      paginate: async () => issues,
+    })
+
+    // #when fetching proposed SHAs
+    const result = await fetchProposedMergeShas(octokit, 'fro-bot', '.github')
+
+    // #then both SHAs are in the seen-set
+    expect(result.has(sha1)).toBe(true)
+    expect(result.has(sha2)).toBe(true)
+    expect(result.size).toBe(2)
+  })
+
+  it('uses the LEARNING_PROPOSAL_LABEL constant when querying issues', async () => {
+    // #given a paginate spy that captures the options
+    const paginateSpy = vi.fn(async () => [])
+    const octokit = mockOctokitForIssues({paginate: paginateSpy as (fn: unknown, opts: unknown) => Promise<unknown[]>})
+
+    // #when fetching proposed SHAs
+    await fetchProposedMergeShas(octokit, 'fro-bot', '.github')
+
+    // #then the paginate call includes the learning-proposal label
+    expect(paginateSpy).toHaveBeenCalledOnce()
+    const callArgs = paginateSpy.mock.calls[0] as unknown as [unknown, Record<string, unknown>]
+    expect(callArgs[1]).toMatchObject({labels: LEARNING_PROPOSAL_LABEL})
+  })
+})

--- a/scripts/capture-c1-harvest.test.ts
+++ b/scripts/capture-c1-harvest.test.ts
@@ -18,6 +18,7 @@ import {
   parseMergeShaMarker,
   type BuildCandidateDigestInput,
   type Candidate,
+  type CandidateDigest,
   type OctokitClient,
   type SolutionDoc,
 } from './capture-c1-harvest.ts'
@@ -214,8 +215,9 @@ describe('buildCandidateDigest', () => {
       expect(result.telemetry.afterSolutionsDedup).toBe(0)
     })
 
-    it('excludes a candidate whose signals share a tag with an existing doc', () => {
-      // #given a candidate with a label matching a doc tag
+    it('includes a candidate that shares only ONE tag with an existing doc (single-tag no longer triggers dedup)', () => {
+      // #given a candidate with a single label matching a doc tag
+      // Threshold is now 20 — a single shared tag (10 pts) is below threshold.
       const input = makeDigestInput({
         mergedPrs: [makeCandidate({signals: {titleTokens: [], labels: ['automation']}})],
         solutionsDocs: [makeSolutionDoc({tags: ['automation'], problemType: '', module: ''})],
@@ -224,7 +226,21 @@ describe('buildCandidateDigest', () => {
       // #when building the digest
       const result = buildCandidateDigest(input)
 
-      // #then the candidate is excluded (tag overlap = 10 points >= threshold of 10)
+      // #then the candidate is INCLUDED (single tag = 10 pts < threshold of 20)
+      expect(result.candidates).toHaveLength(1)
+    })
+
+    it('excludes a candidate whose signals share TWO or more tags with an existing doc', () => {
+      // #given a candidate with two labels both matching doc tags
+      const input = makeDigestInput({
+        mergedPrs: [makeCandidate({signals: {titleTokens: [], labels: ['automation', 'ci']}})],
+        solutionsDocs: [makeSolutionDoc({tags: ['automation', 'ci'], problemType: '', module: ''})],
+      })
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then the candidate is excluded (2 shared tags = 20 pts >= threshold of 20)
       expect(result.candidates).toHaveLength(0)
     })
 
@@ -294,7 +310,7 @@ describe('buildCandidateDigest', () => {
 
   describe('telemetry counts', () => {
     it('reports correct counts through the dedup pipeline', () => {
-      // #given 5 candidates: 2 already proposed, 1 overlaps a doc, 2 clean
+      // #given 5 candidates: 2 already proposed, 1 overlaps a doc (2 shared tags), 2 clean
       const proposedSha1 = `proposed1${'0'.repeat(31)}`
       const proposedSha2 = `proposed2${'0'.repeat(31)}`
       const overlapSha = `overlap1${'0'.repeat(32)}`
@@ -305,12 +321,13 @@ describe('buildCandidateDigest', () => {
         mergedPrs: [
           makeCandidate({mergeSha: proposedSha1}),
           makeCandidate({mergeSha: proposedSha2}),
-          makeCandidate({mergeSha: overlapSha, signals: {titleTokens: [], labels: ['automation']}}),
+          // Two shared tags (automation + ci) = 20 pts >= threshold of 20 → excluded
+          makeCandidate({mergeSha: overlapSha, signals: {titleTokens: [], labels: ['automation', 'ci']}}),
           makeCandidate({mergeSha: cleanSha1}),
           makeCandidate({mergeSha: cleanSha2}),
         ],
         proposedMergeShas: new Set([proposedSha1, proposedSha2]),
-        solutionsDocs: [makeSolutionDoc({tags: ['automation'], problemType: '', module: ''})],
+        solutionsDocs: [makeSolutionDoc({tags: ['automation', 'ci'], problemType: '', module: ''})],
         maxProposals: 5,
       })
 
@@ -391,22 +408,41 @@ function makeReviewItem(state: string): ReviewItem {
 
 function mockOctokit(
   overrides: {
-    paginate?: (fn: unknown, opts: unknown) => Promise<unknown[]>
+    /** Override the paginate call for pulls.list (returns the PR array directly). */
+    paginatePrList?: () => Promise<unknown[]>
+    /** Override the paginate call for pulls.listReviews (returns the review array directly). */
+    paginateListReviews?: () => Promise<ReviewItem[]>
+    /** Legacy: override pullsListReviews for tests that use the old mock shape. */
     pullsListReviews?: (opts: unknown) => Promise<{data: ReviewItem[]}>
   } = {},
 ): OctokitClient {
-  const defaultPaginate = async (fn: unknown, opts: unknown): Promise<unknown[]> => {
+  const listReviewsFn = overrides.pullsListReviews ?? (async () => ({data: [] as ReviewItem[]}))
+
+  // paginate is called with (fn, opts). We route by checking which rest method fn is.
+  const paginate = async (fn: unknown, opts: unknown): Promise<unknown[]> => {
+    // Route: if fn is the listReviews function, use paginateListReviews override or call fn directly
+    if (fn === listReviewsFn) {
+      if (overrides.paginateListReviews !== undefined) {
+        return overrides.paginateListReviews() as Promise<unknown[]>
+      }
+      const result = await listReviewsFn(opts)
+      return result.data
+    }
+    // Otherwise it's pulls.list (or issues.listForRepo)
+    if (overrides.paginatePrList !== undefined) {
+      return overrides.paginatePrList()
+    }
     const call = fn as (opts: unknown) => Promise<{data: unknown[]}>
     const response = await call(opts)
     return response.data
   }
 
   return {
-    paginate: overrides.paginate ?? defaultPaginate,
+    paginate,
     rest: {
       pulls: {
         list: async () => ({data: []}),
-        listReviews: overrides.pullsListReviews ?? (async () => ({data: []})),
+        listReviews: listReviewsFn,
       },
       issues: {
         listForRepo: async () => ({data: []}),
@@ -420,7 +456,7 @@ describe('harvestCandidates', () => {
     // #given a closed PR that was never merged
     const pr = makePullsListItem({merged_at: null})
     const octokit = mockOctokit({
-      paginate: async () => [pr],
+      paginatePrList: async () => [pr],
     })
 
     // #when harvesting
@@ -436,7 +472,7 @@ describe('harvestCandidates', () => {
     oldDate.setDate(oldDate.getDate() - 60)
     const pr = makePullsListItem({merged_at: oldDate.toISOString()})
     const octokit = mockOctokit({
-      paginate: async () => [pr],
+      paginatePrList: async () => [pr],
     })
 
     // #when harvesting
@@ -450,10 +486,8 @@ describe('harvestCandidates', () => {
     // #given a merged PR with only COMMENTED reviews
     const pr = makePullsListItem()
     const octokit = mockOctokit({
-      paginate: async () => [pr],
-      pullsListReviews: async () => ({
-        data: [makeReviewItem('COMMENTED'), makeReviewItem('COMMENTED')],
-      }),
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => [makeReviewItem('COMMENTED'), makeReviewItem('COMMENTED')],
     })
 
     // #when harvesting
@@ -467,10 +501,8 @@ describe('harvestCandidates', () => {
     // #given a merged PR with only APPROVED reviews
     const pr = makePullsListItem()
     const octokit = mockOctokit({
-      paginate: async () => [pr],
-      pullsListReviews: async () => ({
-        data: [makeReviewItem('APPROVED')],
-      }),
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => [makeReviewItem('APPROVED')],
     })
 
     // #when harvesting
@@ -484,10 +516,8 @@ describe('harvestCandidates', () => {
     // #given a merged PR with 1 CHANGES_REQUESTED review
     const pr = makePullsListItem()
     const octokit = mockOctokit({
-      paginate: async () => [pr],
-      pullsListReviews: async () => ({
-        data: [makeReviewItem('CHANGES_REQUESTED')],
-      }),
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => [makeReviewItem('CHANGES_REQUESTED')],
     })
 
     // #when harvesting
@@ -502,10 +532,8 @@ describe('harvestCandidates', () => {
     const sha = 'abc123def456abc123def456abc123def456abc1'
     const pr = makePullsListItem({merge_commit_sha: sha})
     const octokit = mockOctokit({
-      paginate: async () => [pr],
-      pullsListReviews: async () => ({
-        data: [makeReviewItem('CHANGES_REQUESTED'), makeReviewItem('CHANGES_REQUESTED')],
-      }),
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => [makeReviewItem('CHANGES_REQUESTED'), makeReviewItem('CHANGES_REQUESTED')],
     })
 
     // #when harvesting
@@ -521,15 +549,13 @@ describe('harvestCandidates', () => {
     // #given a merged PR with mixed review states
     const pr = makePullsListItem()
     const octokit = mockOctokit({
-      paginate: async () => [pr],
-      pullsListReviews: async () => ({
-        data: [
-          makeReviewItem('CHANGES_REQUESTED'),
-          makeReviewItem('COMMENTED'),
-          makeReviewItem('APPROVED'),
-          makeReviewItem('CHANGES_REQUESTED'),
-        ],
-      }),
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => [
+        makeReviewItem('CHANGES_REQUESTED'),
+        makeReviewItem('COMMENTED'),
+        makeReviewItem('APPROVED'),
+        makeReviewItem('CHANGES_REQUESTED'),
+      ],
     })
 
     // #when harvesting
@@ -540,22 +566,21 @@ describe('harvestCandidates', () => {
     expect(result[0]?.reviewRounds).toBe(2)
   })
 
-  it('skips a PR when listReviews throws a transient error, continues processing others', async () => {
-    // #given two PRs: one whose listReviews throws, one that succeeds
+  it('skips a PR when paginate(listReviews) throws a transient error, continues processing others', async () => {
+    // #given two PRs: one whose paginate(listReviews) throws, one that succeeds
     const goodSha = `goodsha1${'0'.repeat(32)}`
     const badPr = makePullsListItem({number: 1, merge_commit_sha: `badsha1${'0'.repeat(33)}`})
     const goodPr = makePullsListItem({number: 2, merge_commit_sha: goodSha})
 
-    const listReviews = vi
+    // paginateListReviews is called once per PR; first call throws, second succeeds
+    const paginateListReviews = vi
       .fn()
       .mockRejectedValueOnce(Object.assign(new Error('Service Unavailable'), {status: 503}))
-      .mockResolvedValueOnce({
-        data: [makeReviewItem('CHANGES_REQUESTED'), makeReviewItem('CHANGES_REQUESTED')],
-      })
+      .mockResolvedValueOnce([makeReviewItem('CHANGES_REQUESTED'), makeReviewItem('CHANGES_REQUESTED')])
 
     const octokit = mockOctokit({
-      paginate: async () => [badPr, goodPr],
-      pullsListReviews: listReviews as (opts: unknown) => Promise<{data: ReviewItem[]}>,
+      paginatePrList: async () => [badPr, goodPr],
+      paginateListReviews: paginateListReviews as () => Promise<ReviewItem[]>,
     })
 
     // #when harvesting
@@ -564,6 +589,33 @@ describe('harvestCandidates', () => {
     // #then the bad PR is skipped, the good PR is included
     expect(result).toHaveLength(1)
     expect(result[0]?.mergeSha).toBe(goodSha)
+  })
+
+  it('counts CHANGES_REQUESTED reviews across multiple pages (pagination correctness)', async () => {
+    // #given a PR whose reviews span 2 pages (simulated by paginateListReviews returning all)
+    const sha = 'abc123def456abc123def456abc123def456abc1'
+    const pr = makePullsListItem({merge_commit_sha: sha})
+
+    // Simulate paginate returning reviews from both pages combined
+    const allReviews: ReviewItem[] = [
+      makeReviewItem('CHANGES_REQUESTED'), // page 1
+      makeReviewItem('COMMENTED'),
+      makeReviewItem('CHANGES_REQUESTED'), // page 2
+      makeReviewItem('APPROVED'),
+      makeReviewItem('CHANGES_REQUESTED'), // page 2 continued
+    ]
+
+    const octokit = mockOctokit({
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => allReviews,
+    })
+
+    // #when harvesting
+    const result = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then all 3 CHANGES_REQUESTED reviews are counted (not just the first page)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.reviewRounds).toBe(3)
   })
 })
 
@@ -716,5 +768,76 @@ describe('fetchProposedMergeShas', () => {
     expect(paginateSpy).toHaveBeenCalledOnce()
     const callArgs = paginateSpy.mock.calls[0] as unknown as [unknown, Record<string, unknown>]
     expect(callArgs[1]).toMatchObject({labels: LEARNING_PROPOSAL_LABEL})
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Contract test: harvest→propose schema round-trip (FIX 1)
+// ---------------------------------------------------------------------------
+
+describe('harvest→propose schema contract', () => {
+  it('CandidateDigest serializes and deserializes with candidates intact', () => {
+    // #given a CandidateDigest produced by buildCandidateDigest (as harvest would write it)
+    const candidates: Candidate[] = [
+      {
+        mergeSha: 'abc123def456abc123def456abc123def456abc1',
+        reviewRounds: 3,
+        signals: {titleTokens: ['feat', 'scripts'], labels: ['ci', 'automation']},
+      },
+      {
+        mergeSha: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+        reviewRounds: 2,
+        signals: {titleTokens: ['fix', 'workflow'], labels: []},
+      },
+    ]
+    const digest: CandidateDigest = {
+      candidates,
+      telemetry: {examined: 5, afterProposalDedup: 3, afterSolutionsDedup: 2, emitted: 2},
+    }
+
+    // #when serializing (as harvest writes to CAPTURE_C1_DIGEST_PATH)
+    const serialized = JSON.stringify(digest)
+
+    // #when deserializing (as propose reads from CAPTURE_C1_DIGEST_PATH)
+    const deserialized = JSON.parse(serialized) as CandidateDigest
+
+    // #then the shape is {candidates, telemetry} — not a bare array
+    expect(deserialized).toHaveProperty('candidates')
+    expect(deserialized).toHaveProperty('telemetry')
+    expect(Array.isArray(deserialized.candidates)).toBe(true)
+
+    // #then candidates round-trip correctly
+    expect(deserialized.candidates).toHaveLength(2)
+    expect(deserialized.candidates[0]?.mergeSha).toBe('abc123def456abc123def456abc123def456abc1')
+    expect(deserialized.candidates[0]?.reviewRounds).toBe(3)
+    expect(deserialized.candidates[1]?.mergeSha).toBe('deadbeefdeadbeefdeadbeefdeadbeefdeadbeef')
+
+    // #then telemetry round-trips correctly
+    expect(deserialized.telemetry.examined).toBe(5)
+    expect(deserialized.telemetry.emitted).toBe(2)
+
+    // #then propose can iterate candidates without TypeError
+    // (the old bug: harvest wrote candidates array directly, propose read {candidates,telemetry}
+    //  → digest.candidates was undefined → for...of undefined → crash)
+    // Iterating must not throw — the old bug caused TypeError: undefined is not iterable
+    const shas = deserialized.candidates.map(c => c.mergeSha)
+    expect(shas).toHaveLength(2)
+  })
+
+  it('UTC consistency: lookback cutoff uses UTC ms on both sides', () => {
+    // #given a now date and a merged_at string both in UTC
+    const nowMs = Date.UTC(2026, 5, 22, 12, 0, 0) // 2026-06-22T12:00:00Z
+    const now = new Date(nowMs)
+    const cutoffMs = nowMs - 30 * 24 * 60 * 60 * 1000
+
+    // A PR merged exactly at the cutoff boundary (UTC)
+    const atCutoff = new Date(cutoffMs)
+    const justBefore = new Date(cutoffMs - 1)
+    const justAfter = new Date(cutoffMs + 1)
+
+    // #then the comparison is consistent: cutoff < mergedAt means included
+    expect(atCutoff < new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)).toBe(false)
+    expect(justBefore < new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)).toBe(true)
+    expect(justAfter < new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)).toBe(false)
   })
 })

--- a/scripts/capture-c1-harvest.ts
+++ b/scripts/capture-c1-harvest.ts
@@ -34,11 +34,12 @@ export const LEARNING_PROPOSAL_LABEL = 'learning-proposal'
 
 /**
  * Minimum overlap score (inclusive) between a candidate's signals and an existing
- * solutions doc to trigger dedup. Exact problem_type match = 100; tag/module overlap
- * is additive at 10 per shared token. Threshold of 10 means any single shared tag
- * or module token triggers dedup.
+ * solutions doc to trigger dedup. Exact problem_type match = 100 (always triggers).
+ * Tag/module overlap is additive at 10 per shared token; threshold of 20 requires
+ * at least 2 shared tokens before dedup fires — a single common tag (e.g. 'ci',
+ * 'security') no longer triggers dedup on its own.
  */
-const SOLUTIONS_OVERLAP_THRESHOLD = 10
+const SOLUTIONS_OVERLAP_THRESHOLD = 20
 
 const SOLUTIONS_ROOT = 'docs/solutions'
 const SOLUTIONS_SUBDIRS = [
@@ -316,8 +317,23 @@ async function loadSolutionsFilesFromDisk(): Promise<Record<string, string>> {
 }
 
 // ---------------------------------------------------------------------------
-// GITHUB_OUTPUT writer
+// Digest file writer + GITHUB_OUTPUT writer
 // ---------------------------------------------------------------------------
+
+/**
+ * Write the full CandidateDigest ({candidates, telemetry}) as JSON to the path
+ * specified by CAPTURE_C1_DIGEST_PATH. This eliminates the shell-injection vector
+ * that existed when the digest was echoed via GITHUB_OUTPUT multiline syntax.
+ *
+ * Also writes scalar telemetry counters to GITHUB_OUTPUT for step-summary use.
+ * The multiline `digest` key is intentionally dropped — consumers read the file.
+ */
+async function writeDigestFile(digest: CandidateDigest): Promise<void> {
+  const digestPath = process.env.CAPTURE_C1_DIGEST_PATH
+  if (digestPath !== undefined && digestPath !== '') {
+    await writeFile(digestPath, `${JSON.stringify(digest)}\n`, {flag: 'w'})
+  }
+}
 
 async function writeGithubOutput(digest: CandidateDigest): Promise<void> {
   const outputPath = process.env.GITHUB_OUTPUT
@@ -325,11 +341,8 @@ async function writeGithubOutput(digest: CandidateDigest): Promise<void> {
     return
   }
 
-  const delimiter = `EOF_${Math.random().toString(16).slice(2)}`
+  // Scalar counters only — no multiline digest key (consumers read CAPTURE_C1_DIGEST_PATH).
   const lines = [
-    `digest<<${delimiter}`,
-    JSON.stringify(digest.candidates),
-    delimiter,
     `candidate-count=${digest.telemetry.emitted}`,
     `examined=${digest.telemetry.examined}`,
     `after-proposal-dedup=${digest.telemetry.afterProposalDedup}`,
@@ -398,6 +411,8 @@ export async function harvestCandidates(
   repo: string,
   now: Date,
 ): Promise<Candidate[]> {
+  // Use now.getTime() — the injected `now` is already UTC ms (Date.now() in main).
+  // Both sides of the comparison are UTC ms, so timezone drift cannot occur.
   const cutoff = new Date(now.getTime() - LOOKBACK_DAYS * 24 * 60 * 60 * 1000)
 
   const allPrs = await octokit.paginate(octokit.rest.pulls.list, {
@@ -426,15 +441,17 @@ export async function harvestCandidates(
       continue
     }
 
-    // Count CHANGES_REQUESTED reviews — transient errors skip this PR
+    // Count CHANGES_REQUESTED reviews across ALL pages — transient errors skip this PR.
+    // Paginate to avoid undercounting when reviews span >1 page (default page = 30).
     let reviewRounds: number
     try {
-      const reviews = await octokit.rest.pulls.listReviews({
+      const reviews = await octokit.paginate(octokit.rest.pulls.listReviews, {
         owner,
         repo,
         pull_number: pr.number,
-      })
-      reviewRounds = reviews.data.filter(r => r.state === 'CHANGES_REQUESTED').length
+        per_page: 100,
+      } as unknown as Parameters<OctokitClient['rest']['pulls']['listReviews']>[0])
+      reviewRounds = reviews.filter(r => (r as {state: string}).state === 'CHANGES_REQUESTED').length
     } catch (error: unknown) {
       const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
       process.stderr.write(`capture-c1-harvest: skipping PR #${pr.number} — listReviews failed (status=${status})\n`)
@@ -501,7 +518,8 @@ async function main(): Promise<void> {
 
   try {
     const octokit = await createOctokitFromEnv()
-    const now = new Date()
+    // Use Date.now() — UTC ms — as the reference point for the lookback cutoff.
+    const now = new Date(Date.now())
 
     const [mergedPrs, proposedMergeShas, solutionsFiles] = await Promise.all([
       harvestCandidates(octokit, owner, repo, now),
@@ -518,16 +536,20 @@ async function main(): Promise<void> {
       maxProposals: MAX_PROPOSALS_PER_RUN,
     })
 
+    await writeDigestFile(digest)
     await writeGithubOutput(digest)
     process.stdout.write(`${JSON.stringify(digest)}\n`)
-  } catch {
-    // Best-effort: any error → empty digest, exit 0 — harvest must never fail the workflow step
-    process.stderr.write('capture-c1-harvest: unexpected error, falling back to empty digest\n')
+  } catch (error: unknown) {
+    // Best-effort: any error → empty digest, exit 0 — harvest must never fail the workflow step.
+    // Log error class only — no message that could leak content.
+    const errorName = error instanceof Error ? error.name : 'unknown'
+    process.stderr.write(`capture-c1-harvest: unexpected error (${errorName}), falling back to empty digest\n`)
     const empty: CandidateDigest = {
       candidates: [],
       telemetry: {examined: 0, afterProposalDedup: 0, afterSolutionsDedup: 0, emitted: 0},
     }
     try {
+      await writeDigestFile(empty)
       await writeGithubOutput(empty)
     } catch {
       // ignore

--- a/scripts/capture-c1-harvest.ts
+++ b/scripts/capture-c1-harvest.ts
@@ -1,0 +1,541 @@
+/**
+ * Harvest merged PRs from this repo that required multiple rounds of changes-requested
+ * reviews, dedup against existing learning-proposal issues and docs/solutions/ docs,
+ * cap the result, and emit an opaque candidate digest to $GITHUB_OUTPUT.
+ *
+ * Architecture: pure core (`buildCandidateDigest`) + I/O shell (`main`).
+ * The pure core takes all data as injected inputs and is fully unit-testable.
+ * The I/O shell constructs Octokit, fetches data, and calls the pure core.
+ *
+ * Strip-only safe: no parameter properties, enums, or namespaces.
+ */
+
+import type {Dirent} from 'node:fs'
+import {readdir, readFile, writeFile} from 'node:fs/promises'
+import process from 'node:process'
+import {Octokit} from '@octokit/rest'
+import {parse} from 'yaml'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Number of days back from now to include merged PRs. */
+const LOOKBACK_DAYS = 30
+
+/** Minimum number of CHANGES_REQUESTED reviews for a PR to be a candidate. */
+const MULTI_ROUND_THRESHOLD = 2
+
+/** Maximum number of candidates to emit per run. */
+const MAX_PROPOSALS_PER_RUN = 5
+
+/** Label used to identify learning-proposal issues. */
+export const LEARNING_PROPOSAL_LABEL = 'learning-proposal'
+
+/**
+ * Minimum overlap score (inclusive) between a candidate's signals and an existing
+ * solutions doc to trigger dedup. Exact problem_type match = 100; tag/module overlap
+ * is additive at 10 per shared token. Threshold of 10 means any single shared tag
+ * or module token triggers dedup.
+ */
+const SOLUTIONS_OVERLAP_THRESHOLD = 10
+
+const SOLUTIONS_ROOT = 'docs/solutions'
+const SOLUTIONS_SUBDIRS = [
+  'best-practices',
+  'documentation-gaps',
+  'integration-issues',
+  'runtime-errors',
+  'security-issues',
+  'workflow-issues',
+] as const
+
+// ---------------------------------------------------------------------------
+// Octokit derived type (never handwrite SDK interfaces)
+// ---------------------------------------------------------------------------
+
+export type OctokitClient = Octokit
+
+type OctokitConstructor = new (params: {auth: string}) => OctokitClient
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
+
+/**
+ * Signals derived from a PR for solutions-dedup.
+ * Derived from PR labels and title tokens — simple v1 heuristic.
+ * Documented choice: using labels + title tokens avoids a `pulls.listFiles` call
+ * per PR. Refine to file-path signals if dedup precision proves poor.
+ */
+export interface CandidateSignals {
+  /** Top-level directory tokens from the PR title (e.g. 'scripts', 'workflows'). */
+  titleTokens: string[]
+  /** PR label names. */
+  labels: string[]
+}
+
+/**
+ * A candidate PR for a learning proposal.
+ * OPAQUE: carries only merge_sha, reviewRounds, and signals — NO owner/repo/number/title prose.
+ */
+export interface Candidate {
+  mergeSha: string
+  reviewRounds: number
+  signals: CandidateSignals
+}
+
+/** Counts-only telemetry returned by the pure core. */
+export interface DigestTelemetry {
+  examined: number
+  afterProposalDedup: number
+  afterSolutionsDedup: number
+  emitted: number
+}
+
+/** Result of `buildCandidateDigest`. */
+export interface CandidateDigest {
+  candidates: Candidate[]
+  telemetry: DigestTelemetry
+}
+
+/** Input to the pure core. */
+export interface BuildCandidateDigestInput {
+  /** Merged PRs that already passed the MULTI_ROUND_THRESHOLD filter. */
+  mergedPrs: Candidate[]
+  /** merge_shas already represented by a learning-proposal issue. */
+  proposedMergeShas: Set<string>
+  /** Existing solutions docs for R5 dedup. */
+  solutionsDocs: SolutionDoc[]
+  /** Maximum candidates to emit. */
+  maxProposals: number
+}
+
+/** Minimal solutions doc shape needed for dedup. */
+export interface SolutionDoc {
+  path: string
+  module: string
+  tags: string[]
+  problemType: string
+}
+
+// ---------------------------------------------------------------------------
+// Marker helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the immutable body marker that identifies a learning-proposal issue
+ * with its source PR's merge commit SHA.
+ */
+export function buildMergeShaMarker(sha: string): string {
+  return `<!-- capture-c1:merge_sha=${sha} -->`
+}
+
+/**
+ * Parse the merge SHA from a learning-proposal issue body.
+ * Returns the SHA string or null if the marker is absent or malformed.
+ */
+export function parseMergeShaMarker(body: string): string | null {
+  const match = /<!-- capture-c1:merge_sha=([a-f0-9]{7,40}) -->/u.exec(body)
+  return match?.[1] ?? null
+}
+
+// ---------------------------------------------------------------------------
+// Pure core
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the opaque candidate digest from injected inputs.
+ *
+ * Steps:
+ * 1. Drop candidates whose mergeSha is already in proposedMergeShas (R3 dedup).
+ * 2. Drop candidates whose signals strongly overlap an existing solutions doc (R5 dedup).
+ * 3. Cap to maxProposals (R6).
+ * 4. Return candidates + counts-only telemetry.
+ *
+ * No I/O. Fully unit-testable.
+ */
+export function buildCandidateDigest(input: BuildCandidateDigestInput): CandidateDigest {
+  const examined = input.mergedPrs.length
+
+  // R3: drop already-proposed merge SHAs
+  const afterProposalDedup = input.mergedPrs.filter(pr => !input.proposedMergeShas.has(pr.mergeSha))
+
+  // R5: drop candidates whose signals overlap an existing solutions doc
+  const afterSolutionsDedup = afterProposalDedup.filter(pr => !overlapsAnySolutionsDoc(pr.signals, input.solutionsDocs))
+
+  // R6: cap to maxProposals
+  const candidates = afterSolutionsDedup.slice(0, input.maxProposals)
+
+  return {
+    candidates,
+    telemetry: {
+      examined,
+      afterProposalDedup: afterProposalDedup.length,
+      afterSolutionsDedup: afterSolutionsDedup.length,
+      emitted: candidates.length,
+    },
+  }
+}
+
+/**
+ * Returns true if the candidate's signals overlap any existing solutions doc
+ * above the SOLUTIONS_OVERLAP_THRESHOLD.
+ *
+ * Overlap scoring:
+ * - Exact problem_type match: 100 points (always triggers dedup)
+ * - Each shared tag token: 10 points
+ * - Each shared module token: 10 points
+ */
+function overlapsAnySolutionsDoc(signals: CandidateSignals, docs: SolutionDoc[]): boolean {
+  const candidateTokens = new Set([
+    ...signals.labels.map(l => l.toLowerCase()),
+    ...signals.titleTokens.map(t => t.toLowerCase()),
+  ])
+
+  for (const doc of docs) {
+    const score = computeOverlapScore(candidateTokens, doc)
+    if (score >= SOLUTIONS_OVERLAP_THRESHOLD) {
+      return true
+    }
+  }
+  return false
+}
+
+function computeOverlapScore(candidateTokens: Set<string>, doc: SolutionDoc): number {
+  let score = 0
+
+  // Exact problem_type match — strong signal
+  if (doc.problemType !== '' && candidateTokens.has(doc.problemType.toLowerCase())) {
+    score += 100
+  }
+
+  // Tag overlap
+  for (const tag of doc.tags) {
+    if (candidateTokens.has(tag.toLowerCase())) {
+      score += 10
+    }
+  }
+
+  // Module token overlap (split on path separators and dots)
+  const moduleTokens = doc.module
+    .toLowerCase()
+    .split(/[/.\-_]/u)
+    .filter(t => t.length >= 3)
+  for (const token of moduleTokens) {
+    if (candidateTokens.has(token)) {
+      score += 10
+    }
+  }
+
+  return score
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter parser (replicated from solutions-query.ts — not exported there)
+// ---------------------------------------------------------------------------
+
+function splitFrontmatter(content: string): {frontmatter: Record<string, unknown>; body: string} {
+  const match = /^---\n([\s\S]+?)\n---\n?/u.exec(content)
+  if (match === null) {
+    return {frontmatter: {}, body: content.trim()}
+  }
+
+  const frontmatterText = match[1]
+  if (frontmatterText === undefined) {
+    return {frontmatter: {}, body: content.trim()}
+  }
+
+  const parsed: unknown = parse(frontmatterText)
+  return {
+    frontmatter: isRecord(parsed) ? parsed : {},
+    body: content.slice(match[0].length).trim(),
+  }
+}
+
+function collectSolutionDocs(files: Record<string, string>): SolutionDoc[] {
+  const docs: SolutionDoc[] = []
+
+  for (const [path, content] of Object.entries(files)) {
+    if (!path.startsWith(`${SOLUTIONS_ROOT}/`) || !path.endsWith('.md')) {
+      continue
+    }
+
+    let frontmatter: Record<string, unknown>
+
+    try {
+      const parsed = splitFrontmatter(content)
+      frontmatter = parsed.frontmatter
+    } catch {
+      continue
+    }
+
+    docs.push({
+      path,
+      module: typeof frontmatter.module === 'string' ? frontmatter.module : '',
+      tags: Array.isArray(frontmatter.tags) ? frontmatter.tags.filter((t): t is string => typeof t === 'string') : [],
+      problemType: typeof frontmatter.problem_type === 'string' ? frontmatter.problem_type : '',
+    })
+  }
+
+  return docs
+}
+
+// ---------------------------------------------------------------------------
+// Disk loader for solutions docs
+// ---------------------------------------------------------------------------
+
+async function loadSolutionsFilesFromDisk(): Promise<Record<string, string>> {
+  const files: Record<string, string> = {}
+
+  for (const subdir of SOLUTIONS_SUBDIRS) {
+    const dirPath = `${SOLUTIONS_ROOT}/${subdir}`
+    let entries: Dirent[]
+
+    try {
+      entries = await readdir(dirPath, {withFileTypes: true})
+    } catch {
+      continue
+    }
+
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.md')) {
+        continue
+      }
+
+      const path = `${dirPath}/${entry.name}`
+      try {
+        files[path] = await readFile(path, 'utf8')
+      } catch {
+        process.stderr.write(`capture-c1-harvest: could not read file (path: ${path})\n`)
+      }
+    }
+  }
+
+  return files
+}
+
+// ---------------------------------------------------------------------------
+// GITHUB_OUTPUT writer
+// ---------------------------------------------------------------------------
+
+async function writeGithubOutput(digest: CandidateDigest): Promise<void> {
+  const outputPath = process.env.GITHUB_OUTPUT
+  if (outputPath === undefined || outputPath === '') {
+    return
+  }
+
+  const delimiter = `EOF_${Math.random().toString(16).slice(2)}`
+  const lines = [
+    `digest<<${delimiter}`,
+    JSON.stringify(digest.candidates),
+    delimiter,
+    `candidate-count=${digest.telemetry.emitted}`,
+    `examined=${digest.telemetry.examined}`,
+    `after-proposal-dedup=${digest.telemetry.afterProposalDedup}`,
+    `after-solutions-dedup=${digest.telemetry.afterSolutionsDedup}`,
+  ]
+  await writeFile(outputPath, `${lines.join('\n')}\n`, {flag: 'a'})
+}
+
+// ---------------------------------------------------------------------------
+// Octokit constructor helpers
+// ---------------------------------------------------------------------------
+
+async function loadOctokitConstructor(): Promise<OctokitConstructor> {
+  if (typeof Octokit !== 'function') {
+    throw new TypeError('Failed to load @octokit/rest Octokit constructor')
+  }
+  return Octokit as unknown as OctokitConstructor
+}
+
+export async function createOctokitFromEnv(): Promise<OctokitClient> {
+  const token = process.env.GITHUB_TOKEN
+  if (token === undefined || token === '') {
+    throw new Error('capture-c1-harvest requires GITHUB_TOKEN in the environment')
+  }
+  const LoadedOctokit = await loadOctokitConstructor()
+  return new LoadedOctokit({auth: token})
+}
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+// ---------------------------------------------------------------------------
+// I/O shell helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive candidate signals from a PR's labels and title.
+ * Simple v1: tokenize the title (split on non-alphanumeric, keep tokens >= 3 chars)
+ * and collect label names. No `pulls.listFiles` call — avoids per-PR API overhead.
+ */
+function deriveSignals(pr: {title: string; labels: {name: string}[]}): CandidateSignals {
+  const titleTokens = pr.title
+    .toLowerCase()
+    .split(/[^a-z0-9]+/u)
+    .filter(t => t.length >= 3)
+
+  const labels = pr.labels.map(l => l.name)
+
+  return {titleTokens, labels}
+}
+
+/**
+ * Fetch all merged PRs in the lookback window and return those with
+ * reviewRounds >= MULTI_ROUND_THRESHOLD as Candidate objects.
+ *
+ * Transient listReviews errors for a single PR are caught and that PR is skipped.
+ */
+export async function harvestCandidates(
+  octokit: OctokitClient,
+  owner: string,
+  repo: string,
+  now: Date,
+): Promise<Candidate[]> {
+  const cutoff = new Date(now.getTime() - LOOKBACK_DAYS * 24 * 60 * 60 * 1000)
+
+  const allPrs = await octokit.paginate(octokit.rest.pulls.list, {
+    owner,
+    repo,
+    state: 'closed',
+    per_page: 100,
+  } as unknown as Parameters<OctokitClient['rest']['pulls']['list']>[0])
+
+  const candidates: Candidate[] = []
+
+  for (const pr of allPrs) {
+    // Exclude unmerged PRs
+    if (pr.merged_at === null || pr.merged_at === undefined) {
+      continue
+    }
+
+    // Exclude PRs outside the lookback window
+    const mergedAt = new Date(pr.merged_at)
+    if (mergedAt < cutoff) {
+      continue
+    }
+
+    // Exclude PRs without a merge commit SHA
+    if (pr.merge_commit_sha === null || pr.merge_commit_sha === undefined) {
+      continue
+    }
+
+    // Count CHANGES_REQUESTED reviews — transient errors skip this PR
+    let reviewRounds: number
+    try {
+      const reviews = await octokit.rest.pulls.listReviews({
+        owner,
+        repo,
+        pull_number: pr.number,
+      })
+      reviewRounds = reviews.data.filter(r => r.state === 'CHANGES_REQUESTED').length
+    } catch (error: unknown) {
+      const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
+      process.stderr.write(`capture-c1-harvest: skipping PR #${pr.number} — listReviews failed (status=${status})\n`)
+      continue
+    }
+
+    if (reviewRounds < MULTI_ROUND_THRESHOLD) {
+      continue
+    }
+
+    candidates.push({
+      mergeSha: pr.merge_commit_sha,
+      reviewRounds,
+      signals: deriveSignals({
+        title: pr.title,
+        labels: pr.labels.map(l => ({name: typeof l === 'string' ? l : (l as {name: string}).name})),
+      }),
+    })
+  }
+
+  return candidates
+}
+
+/**
+ * Fetch all learning-proposal issues (state: all) and parse the merge SHA marker
+ * from each body. Returns a Set of seen merge SHAs.
+ */
+export async function fetchProposedMergeShas(
+  octokit: OctokitClient,
+  owner: string,
+  repo: string,
+): Promise<Set<string>> {
+  const issues = await octokit.paginate(octokit.rest.issues.listForRepo, {
+    owner,
+    repo,
+    state: 'all',
+    labels: LEARNING_PROPOSAL_LABEL,
+    per_page: 100,
+  } as unknown as Parameters<OctokitClient['rest']['issues']['listForRepo']>[0])
+
+  const seen = new Set<string>()
+
+  for (const issue of issues) {
+    const body = issue.body
+    if (typeof body !== 'string' || body === '') {
+      continue
+    }
+    const sha = parseMergeShaMarker(body)
+    if (sha !== null) {
+      seen.add(sha)
+    }
+  }
+
+  return seen
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const owner = 'fro-bot'
+  const repo = '.github'
+
+  try {
+    const octokit = await createOctokitFromEnv()
+    const now = new Date()
+
+    const [mergedPrs, proposedMergeShas, solutionsFiles] = await Promise.all([
+      harvestCandidates(octokit, owner, repo, now),
+      fetchProposedMergeShas(octokit, owner, repo),
+      loadSolutionsFilesFromDisk(),
+    ])
+
+    const solutionsDocs = collectSolutionDocs(solutionsFiles)
+
+    const digest = buildCandidateDigest({
+      mergedPrs,
+      proposedMergeShas,
+      solutionsDocs,
+      maxProposals: MAX_PROPOSALS_PER_RUN,
+    })
+
+    await writeGithubOutput(digest)
+    process.stdout.write(`${JSON.stringify(digest)}\n`)
+  } catch {
+    // Best-effort: any error → empty digest, exit 0 — harvest must never fail the workflow step
+    process.stderr.write('capture-c1-harvest: unexpected error, falling back to empty digest\n')
+    const empty: CandidateDigest = {
+      candidates: [],
+      telemetry: {examined: 0, afterProposalDedup: 0, afterSolutionsDedup: 0, emitted: 0},
+    }
+    try {
+      await writeGithubOutput(empty)
+    } catch {
+      // ignore
+    }
+    process.stdout.write(`${JSON.stringify(empty)}\n`)
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}

--- a/scripts/capture-c1-harvest.ts
+++ b/scripts/capture-c1-harvest.ts
@@ -78,7 +78,12 @@ export interface CandidateSignals {
 
 /**
  * A candidate PR for a learning proposal.
- * OPAQUE: carries only merge_sha, reviewRounds, and signals — NO owner/repo/number/title prose.
+ *
+ * Carries no owner, repo, or PR number. `signals` includes tokens derived from the PR
+ * title and labels, so title-derived tokens do reach the consuming agent — they are not
+ * fully sanitized here. The deterministic propose step is the privacy chokepoint: it scans
+ * the final authored body for private identifiers and blocks before posting, so a private
+ * token surfacing in a title token is gated downstream rather than leaked.
  */
 export interface Candidate {
   mergeSha: string

--- a/scripts/capture-c1-propose.test.ts
+++ b/scripts/capture-c1-propose.test.ts
@@ -1,0 +1,727 @@
+/**
+ * Tests for capture-c1-propose.ts
+ *
+ * Structure:
+ * - Pure function tests: `proposalBodyHasPrivateLeak`, `planProposals`
+ * - Disk loader tests: `loadPrivateTokensFromDisk` (injectable readFile)
+ * - I/O shell tests: `createProposals`, `ensureLabelsExist` (mocked Octokit)
+ *
+ * Privacy mutation-proof: each privacy test includes a "without the gate" assertion
+ * that proves removing the check would let the proposal through.
+ */
+
+import {describe, expect, it, vi} from 'vitest'
+
+import {buildMergeShaMarker, LEARNING_PROPOSAL_LABEL, type Candidate, type OctokitClient} from './capture-c1-harvest.ts'
+import {
+  createProposals,
+  ensureLabelsExist,
+  loadPrivateTokensFromDisk,
+  planProposals,
+  proposalBodyHasPrivateLeak,
+  type LabelDescriptor,
+  type PlanProposalsInput,
+  type ProposalToCreate,
+} from './capture-c1-propose.ts'
+import {buildPrivateNameTokens} from './wiki-slug.ts'
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeCandidate(overrides: Partial<Candidate> = {}): Candidate {
+  return {
+    mergeSha: 'abc123def456abc123def456abc123def456abc1',
+    reviewRounds: 2,
+    signals: {titleTokens: ['feat', 'scripts'], labels: []},
+    ...overrides,
+  }
+}
+
+function makePlanInput(overrides: Partial<PlanProposalsInput> = {}): PlanProposalsInput {
+  return {
+    candidates: [makeCandidate()],
+    proposalBodies: new Map([['abc123def456abc123def456abc123def456abc1', 'A clean proposal body.']]),
+    privateTokens: new Set(),
+    alreadyCreatedShas: new Set(),
+    ...overrides,
+  }
+}
+
+/** Build a private token set from a synthetic owner/name for test isolation. */
+function makePrivateTokens(nameWithOwner: string): Set<string> {
+  const tokens = new Set<string>()
+  for (const token of buildPrivateNameTokens(nameWithOwner)) {
+    tokens.add(token.toLowerCase())
+  }
+  return tokens
+}
+
+function makeToCreate(overrides: Partial<ProposalToCreate> = {}): ProposalToCreate {
+  const sha = 'abc123def456abc123def456abc123def456abc1'
+  return {
+    mergeSha: sha,
+    body: `A clean proposal.\n\n${buildMergeShaMarker(sha)}`,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// proposalBodyHasPrivateLeak — pure function tests
+// ---------------------------------------------------------------------------
+
+describe('proposalBodyHasPrivateLeak', () => {
+  describe('detection', () => {
+    it('detects the owner/name form (slash-separated)', () => {
+      // #given a body containing the owner/name form of a private repo
+      const tokens = makePrivateTokens('testowner/secret-repo')
+      const body = 'This PR touched testowner/secret-repo in the changes.'
+
+      // #when scanning
+      // #then the leak is detected
+      expect(proposalBodyHasPrivateLeak(body, tokens)).toBe(true)
+    })
+
+    it('detects the owner--name form (double-dash)', () => {
+      // #given a body containing the double-dash form
+      const tokens = makePrivateTokens('testowner/secret-repo')
+      const body = 'See testowner--secret-repo for context.'
+
+      // #when scanning
+      // #then the leak is detected
+      expect(proposalBodyHasPrivateLeak(body, tokens)).toBe(true)
+    })
+
+    it('detects mixed-case occurrences (case-insensitive scan)', () => {
+      // #given a body with the token in mixed case
+      const tokens = makePrivateTokens('testowner/secret-repo')
+      const body = 'The repo TESTOWNER/SECRET-REPO was involved.'
+
+      // #when scanning
+      // #then the leak is detected (body is lowercased before scan)
+      expect(proposalBodyHasPrivateLeak(body, tokens)).toBe(true)
+    })
+
+    it('detects the slug form produced by computeRepoSlug', () => {
+      // #given a body containing the wiki-slug form
+      const tokens = makePrivateTokens('testowner/secret-repo')
+      // The slug form is testowner--secret-repo (same as double-dash for simple names)
+      const body = 'Wiki page at testowner--secret-repo.'
+
+      // #when scanning
+      // #then the leak is detected
+      expect(proposalBodyHasPrivateLeak(body, tokens)).toBe(true)
+    })
+  })
+
+  describe('clean body', () => {
+    it('returns false for a body with no private tokens', () => {
+      // #given a body with no private identifiers
+      const tokens = makePrivateTokens('testowner/secret-repo')
+      const body = 'This is a clean proposal about CI improvements.'
+
+      // #when scanning
+      // #then no leak is detected
+      expect(proposalBodyHasPrivateLeak(body, tokens)).toBe(false)
+    })
+
+    it('returns false when the private token set is empty', () => {
+      // #given an empty token set (e.g. no private repos in metadata)
+      const body = 'Any body content here.'
+
+      // #when scanning with an empty token set
+      // #then no leak is detected (vacuously safe)
+      expect(proposalBodyHasPrivateLeak(body, new Set())).toBe(false)
+    })
+
+    it('returns false for an empty body', () => {
+      // #given an empty body
+      const tokens = makePrivateTokens('testowner/secret-repo')
+
+      // #when scanning
+      // #then no leak is detected
+      expect(proposalBodyHasPrivateLeak('', tokens)).toBe(false)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// planProposals — pure core tests
+// ---------------------------------------------------------------------------
+
+describe('planProposals', () => {
+  describe('happy path', () => {
+    it('includes a clean candidate with the merge-SHA marker appended to the body', () => {
+      // #given a candidate with a clean body, not duplicate, no private leak
+      const sha = 'abc123def456abc123def456abc123def456abc1'
+      const body = 'A clean proposal body.'
+      const input = makePlanInput({
+        candidates: [makeCandidate({mergeSha: sha})],
+        proposalBodies: new Map([[sha, body]]),
+      })
+
+      // #when planning
+      const result = planProposals(input)
+
+      // #then the candidate is in toCreate with the marker appended
+      expect(result.toCreate).toHaveLength(1)
+      expect(result.toCreate[0]?.mergeSha).toBe(sha)
+      expect(result.toCreate[0]?.body).toContain(body)
+      expect(result.toCreate[0]?.body).toContain(buildMergeShaMarker(sha))
+      expect(result.blockedOnPrivacy).toBe(0)
+      expect(result.skippedDuplicate).toBe(0)
+    })
+
+    it('appends the marker AFTER the body content', () => {
+      // #given a candidate with a body
+      const sha = 'abc123def456abc123def456abc123def456abc1'
+      const body = 'Proposal content here.'
+      const input = makePlanInput({
+        candidates: [makeCandidate({mergeSha: sha})],
+        proposalBodies: new Map([[sha, body]]),
+      })
+
+      // #when planning
+      const result = planProposals(input)
+
+      // #then the marker appears after the body
+      const fullBody = result.toCreate[0]?.body ?? ''
+      const bodyIndex = fullBody.indexOf(body)
+      const markerIndex = fullBody.indexOf(buildMergeShaMarker(sha))
+      expect(bodyIndex).toBeGreaterThanOrEqual(0)
+      expect(markerIndex).toBeGreaterThan(bodyIndex)
+    })
+  })
+
+  describe('privacy gate (R4)', () => {
+    it('blocks a candidate whose body contains a private token', () => {
+      // #given a body containing a private identifier
+      const sha = 'abc123def456abc123def456abc123def456abc1'
+      const privateTokens = makePrivateTokens('testowner/secret-repo')
+      const body = 'This proposal references testowner/secret-repo.'
+      const input = makePlanInput({
+        candidates: [makeCandidate({mergeSha: sha})],
+        proposalBodies: new Map([[sha, body]]),
+        privateTokens,
+      })
+
+      // #when planning
+      const result = planProposals(input)
+
+      // #then the candidate is blocked, not in toCreate
+      expect(result.toCreate).toHaveLength(0)
+      expect(result.blockedOnPrivacy).toBe(1)
+    })
+
+    it('mutation proof: removing the privacy gate lets the blocked candidate through', () => {
+      // #given the same body with a private token
+      const sha = 'abc123def456abc123def456abc123def456abc1'
+      const privateTokens = makePrivateTokens('testowner/secret-repo')
+      const body = 'This proposal references testowner/secret-repo.'
+
+      // #when planning WITH the privacy gate (non-empty token set)
+      const withGate = planProposals(
+        makePlanInput({
+          candidates: [makeCandidate({mergeSha: sha})],
+          proposalBodies: new Map([[sha, body]]),
+          privateTokens,
+        }),
+      )
+      // #then the candidate is blocked
+      expect(withGate.toCreate).toHaveLength(0)
+      expect(withGate.blockedOnPrivacy).toBe(1)
+
+      // #when planning WITHOUT the privacy gate (empty token set — gate removed)
+      const withoutGate = planProposals(
+        makePlanInput({
+          candidates: [makeCandidate({mergeSha: sha})],
+          proposalBodies: new Map([[sha, body]]),
+          privateTokens: new Set(), // gate removed
+        }),
+      )
+      // #then the candidate appears in toCreate — proving the gate was the blocker
+      expect(withoutGate.toCreate).toHaveLength(1)
+      expect(withoutGate.blockedOnPrivacy).toBe(0)
+    })
+
+    it('blocks multiple candidates with private tokens, counts each', () => {
+      // #given two candidates both with private tokens in their bodies
+      const sha1 = `sha1${'0'.repeat(36)}`
+      const sha2 = `sha2${'0'.repeat(36)}`
+      const privateTokens = makePrivateTokens('testowner/secret-repo')
+      const input = makePlanInput({
+        candidates: [makeCandidate({mergeSha: sha1}), makeCandidate({mergeSha: sha2})],
+        proposalBodies: new Map([
+          [sha1, 'References testowner/secret-repo here.'],
+          [sha2, 'Also mentions testowner/secret-repo.'],
+        ]),
+        privateTokens,
+      })
+
+      // #when planning
+      const result = planProposals(input)
+
+      // #then both are blocked
+      expect(result.toCreate).toHaveLength(0)
+      expect(result.blockedOnPrivacy).toBe(2)
+    })
+  })
+
+  describe('same-run dedup (R3)', () => {
+    it('skips a candidate whose mergeSha is in alreadyCreatedShas', () => {
+      // #given a candidate whose SHA is already in the created set
+      const sha = 'abc123def456abc123def456abc123def456abc1'
+      const input = makePlanInput({
+        candidates: [makeCandidate({mergeSha: sha})],
+        proposalBodies: new Map([[sha, 'A clean body.']]),
+        alreadyCreatedShas: new Set([sha]),
+      })
+
+      // #when planning
+      const result = planProposals(input)
+
+      // #then the candidate is skipped as a duplicate
+      expect(result.toCreate).toHaveLength(0)
+      expect(result.skippedDuplicate).toBe(1)
+      expect(result.blockedOnPrivacy).toBe(0)
+    })
+
+    it('includes a candidate whose mergeSha is NOT in alreadyCreatedShas', () => {
+      // #given a candidate with a SHA not in the created set
+      const sha = 'abc123def456abc123def456abc123def456abc1'
+      const input = makePlanInput({
+        candidates: [makeCandidate({mergeSha: sha})],
+        proposalBodies: new Map([[sha, 'A clean body.']]),
+        alreadyCreatedShas: new Set(['other-sha-not-matching']),
+      })
+
+      // #when planning
+      const result = planProposals(input)
+
+      // #then the candidate is included
+      expect(result.toCreate).toHaveLength(1)
+      expect(result.skippedDuplicate).toBe(0)
+    })
+  })
+
+  describe('no body for a candidate', () => {
+    it('skips a candidate with no entry in proposalBodies without crashing', () => {
+      // #given a candidate with no body in the map
+      const sha = 'abc123def456abc123def456abc123def456abc1'
+      const input = makePlanInput({
+        candidates: [makeCandidate({mergeSha: sha})],
+        proposalBodies: new Map(), // empty — no body for this candidate
+      })
+
+      // #when planning
+      const result = planProposals(input)
+
+      // #then the candidate is silently skipped
+      expect(result.toCreate).toHaveLength(0)
+      expect(result.blockedOnPrivacy).toBe(0)
+      expect(result.skippedDuplicate).toBe(0)
+    })
+
+    it('skips a candidate with an empty string body', () => {
+      // #given a candidate with an empty body
+      const sha = 'abc123def456abc123def456abc123def456abc1'
+      const input = makePlanInput({
+        candidates: [makeCandidate({mergeSha: sha})],
+        proposalBodies: new Map([[sha, '']]),
+      })
+
+      // #when planning
+      const result = planProposals(input)
+
+      // #then the candidate is silently skipped
+      expect(result.toCreate).toHaveLength(0)
+    })
+  })
+
+  describe('mixed candidates', () => {
+    it('correctly partitions clean, blocked, duplicate, and no-body candidates', () => {
+      // #given four candidates: one clean, one blocked, one duplicate, one no-body
+      const cleanSha = `clean0${'0'.repeat(34)}`
+      const blockedSha = `block0${'0'.repeat(34)}`
+      const dupSha = `dupsha${'0'.repeat(34)}`
+      const noBodySha = `nobody${'0'.repeat(34)}`
+
+      const privateTokens = makePrivateTokens('testowner/secret-repo')
+
+      const input = makePlanInput({
+        candidates: [
+          makeCandidate({mergeSha: cleanSha}),
+          makeCandidate({mergeSha: blockedSha}),
+          makeCandidate({mergeSha: dupSha}),
+          makeCandidate({mergeSha: noBodySha}),
+        ],
+        proposalBodies: new Map([
+          [cleanSha, 'A clean proposal.'],
+          [blockedSha, 'References testowner/secret-repo.'],
+          [dupSha, 'Another clean proposal.'],
+          // noBodySha intentionally absent
+        ]),
+        privateTokens,
+        alreadyCreatedShas: new Set([dupSha]),
+      })
+
+      // #when planning
+      const result = planProposals(input)
+
+      // #then only the clean candidate is in toCreate
+      expect(result.toCreate).toHaveLength(1)
+      expect(result.toCreate[0]?.mergeSha).toBe(cleanSha)
+      expect(result.blockedOnPrivacy).toBe(1)
+      expect(result.skippedDuplicate).toBe(1)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// loadPrivateTokensFromDisk — fail-closed behavior (injectable readFile)
+// ---------------------------------------------------------------------------
+
+describe('loadPrivateTokensFromDisk', () => {
+  it('throws when metadata/repos.yaml cannot be read (fail-closed)', async () => {
+    // #given the file cannot be read
+    const readFileFn = async () => {
+      throw new Error('ENOENT: no such file or directory')
+    }
+
+    // #when loading private tokens
+    // #then it throws — the caller must not post proposals
+    await expect(loadPrivateTokensFromDisk(readFileFn)).rejects.toThrow(
+      'capture-c1-propose: could not read metadata/repos.yaml',
+    )
+  })
+
+  it('throws when metadata/repos.yaml cannot be parsed (fail-closed)', async () => {
+    // #given the file contains invalid YAML
+    const readFileFn = async () => '{ invalid yaml: [unclosed'
+
+    // #when loading private tokens
+    // #then it throws — the caller must not post proposals
+    await expect(loadPrivateTokensFromDisk(readFileFn)).rejects.toThrow(
+      'capture-c1-propose: could not parse metadata/repos.yaml',
+    )
+  })
+
+  it('throws when repos.yaml has unexpected shape (not a record)', async () => {
+    // #given the file parses to a non-record (e.g. a list)
+    const readFileFn = async () => '- item1\n- item2\n'
+
+    // #when loading private tokens
+    // #then it throws
+    await expect(loadPrivateTokensFromDisk(readFileFn)).rejects.toThrow(
+      'capture-c1-propose: metadata/repos.yaml has unexpected shape',
+    )
+  })
+
+  it('throws when repos.yaml is missing the repos array', async () => {
+    // #given the file has no repos key
+    const readFileFn = async () => 'other_key: value\n'
+
+    // #when loading private tokens
+    // #then it throws
+    await expect(loadPrivateTokensFromDisk(readFileFn)).rejects.toThrow(
+      'capture-c1-propose: metadata/repos.yaml missing repos array',
+    )
+  })
+
+  it('returns a token set built from private non-redacted repos', async () => {
+    // #given a valid repos.yaml with one private repo and one public repo
+    const yaml = `
+repos:
+  - owner: testowner
+    name: secret-repo
+    private: true
+  - owner: testowner
+    name: public-repo
+    private: false
+`
+    const readFileFn = async () => yaml
+
+    // #when loading private tokens
+    const tokens = await loadPrivateTokensFromDisk(readFileFn)
+
+    // #then tokens include forms of the private repo but not the public one
+    expect(tokens.has('testowner/secret-repo')).toBe(true)
+    expect(tokens.has('testowner--secret-repo')).toBe(true)
+    // Public repo should not be in the token set
+    expect(tokens.has('testowner/public-repo')).toBe(false)
+  })
+
+  it('skips redacted entries', async () => {
+    // #given a repos.yaml with a redacted private entry
+    const yaml = `
+repos:
+  - owner: '[REDACTED]'
+    name: '[REDACTED]'
+    private: true
+`
+    const readFileFn = async () => yaml
+
+    // #when loading private tokens
+    const tokens = await loadPrivateTokensFromDisk(readFileFn)
+
+    // #then the token set is empty (redacted entries are skipped)
+    expect(tokens.size).toBe(0)
+  })
+
+  it('returns an empty set when there are no private repos', async () => {
+    // #given a repos.yaml with only public repos
+    const yaml = `
+repos:
+  - owner: testowner
+    name: public-repo
+    private: false
+`
+    const readFileFn = async () => yaml
+
+    // #when loading private tokens
+    const tokens = await loadPrivateTokensFromDisk(readFileFn)
+
+    // #then the token set is empty
+    expect(tokens.size).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Mocked Octokit helpers
+// ---------------------------------------------------------------------------
+
+interface IssuesCreateCall {
+  owner: string
+  repo: string
+  title: string
+  body: string
+  labels: string[]
+}
+
+function mockOctokit(
+  overrides: {
+    getLabelResult?: 'found' | 404 | 'error'
+    createLabelResult?: 'created' | 422 | 'error'
+    issuesCreateResult?: 'ok' | 'error'
+    issuesCreateSpy?: ReturnType<typeof vi.fn>
+  } = {},
+): OctokitClient {
+  const {
+    getLabelResult = 'found',
+    createLabelResult = 'created',
+    issuesCreateResult = 'ok',
+    issuesCreateSpy,
+  } = overrides
+
+  const getLabel = async () => {
+    if (getLabelResult === 'found') return {data: {name: LEARNING_PROPOSAL_LABEL}}
+    if (getLabelResult === 404) throw Object.assign(new Error('Not Found'), {status: 404})
+    throw Object.assign(new Error('Server Error'), {status: 500})
+  }
+
+  const createLabel = async () => {
+    if (createLabelResult === 'created') return {data: {name: LEARNING_PROPOSAL_LABEL}}
+    if (createLabelResult === 422) throw Object.assign(new Error('Unprocessable'), {status: 422})
+    throw Object.assign(new Error('Server Error'), {status: 500})
+  }
+
+  const defaultIssuesCreate = async () => {
+    if (issuesCreateResult === 'ok') return {data: {number: 1}}
+    throw Object.assign(new Error('Server Error'), {status: 500})
+  }
+
+  return {
+    rest: {
+      issues: {
+        getLabel,
+        createLabel,
+        create: issuesCreateSpy ?? defaultIssuesCreate,
+      },
+    },
+  } as unknown as OctokitClient
+}
+
+// ---------------------------------------------------------------------------
+// ensureLabelsExist — I/O shell tests
+// ---------------------------------------------------------------------------
+
+describe('ensureLabelsExist', () => {
+  const labels: LabelDescriptor[] = [{name: LEARNING_PROPOSAL_LABEL, color: '0075ca', description: 'Test label'}]
+
+  it('confirms a label that already exists (getLabel succeeds)', async () => {
+    // #given the label already exists
+    const octokit = mockOctokit({getLabelResult: 'found'})
+
+    // #when ensuring labels exist
+    const confirmed = await ensureLabelsExist(octokit, 'fro-bot', '.github', labels)
+
+    // #then the label is confirmed
+    expect(confirmed.has(LEARNING_PROPOSAL_LABEL)).toBe(true)
+    expect(confirmed.size).toBe(1)
+  })
+
+  it('creates and confirms a label on 404 (label not found)', async () => {
+    // #given the label does not exist (404) and createLabel succeeds
+    const octokit = mockOctokit({getLabelResult: 404, createLabelResult: 'created'})
+
+    // #when ensuring labels exist
+    const confirmed = await ensureLabelsExist(octokit, 'fro-bot', '.github', labels)
+
+    // #then the label is confirmed after creation
+    expect(confirmed.has(LEARNING_PROPOSAL_LABEL)).toBe(true)
+  })
+
+  it('confirms a label on 404 + 422 (race — another writer created it first)', async () => {
+    // #given the label does not exist (404) and createLabel returns 422 (race)
+    const octokit = mockOctokit({getLabelResult: 404, createLabelResult: 422})
+
+    // #when ensuring labels exist
+    const confirmed = await ensureLabelsExist(octokit, 'fro-bot', '.github', labels)
+
+    // #then the label is confirmed (422 means it now exists)
+    expect(confirmed.has(LEARNING_PROPOSAL_LABEL)).toBe(true)
+  })
+
+  it('excludes a label when getLabel fails with a non-404 error', async () => {
+    // #given getLabel fails with a 500 error
+    const octokit = mockOctokit({getLabelResult: 'error'})
+
+    // #when ensuring labels exist
+    const confirmed = await ensureLabelsExist(octokit, 'fro-bot', '.github', labels)
+
+    // #then the label is excluded from the confirmed set
+    expect(confirmed.has(LEARNING_PROPOSAL_LABEL)).toBe(false)
+    expect(confirmed.size).toBe(0)
+  })
+
+  it('excludes a label when createLabel fails with a non-422 error', async () => {
+    // #given the label does not exist (404) and createLabel fails with 500
+    const octokit = mockOctokit({getLabelResult: 404, createLabelResult: 'error'})
+
+    // #when ensuring labels exist
+    const confirmed = await ensureLabelsExist(octokit, 'fro-bot', '.github', labels)
+
+    // #then the label is excluded
+    expect(confirmed.has(LEARNING_PROPOSAL_LABEL)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createProposals — I/O shell tests
+// ---------------------------------------------------------------------------
+
+describe('createProposals', () => {
+  it('creates an issue with the learning-proposal label and the merge-SHA marker in the body', async () => {
+    // #given a single proposal to create
+    const sha = 'abc123def456abc123def456abc123def456abc1'
+    const createSpy = vi.fn().mockResolvedValue({data: {number: 42}})
+    const octokit = mockOctokit({getLabelResult: 'found', issuesCreateSpy: createSpy})
+    const toCreate = [makeToCreate({mergeSha: sha})]
+
+    // #when creating proposals
+    const counts = await createProposals(octokit, 'fro-bot', '.github', toCreate)
+
+    // #then the issue was created with the correct label and marker
+    expect(counts.created).toBe(1)
+    expect(counts.failed).toBe(0)
+    expect(createSpy).toHaveBeenCalledOnce()
+    const callArg = createSpy.mock.calls[0]?.[0] as IssuesCreateCall
+    expect(callArg.labels).toContain(LEARNING_PROPOSAL_LABEL)
+    expect(callArg.body).toContain(buildMergeShaMarker(sha))
+  })
+
+  it('creates an issue even when the label had to be created (404 → create)', async () => {
+    // #given the label does not exist and must be created
+    const createSpy = vi.fn().mockResolvedValue({data: {number: 1}})
+    const octokit = mockOctokit({getLabelResult: 404, createLabelResult: 'created', issuesCreateSpy: createSpy})
+
+    // #when creating proposals
+    const counts = await createProposals(octokit, 'fro-bot', '.github', [makeToCreate()])
+
+    // #then the issue was created
+    expect(counts.created).toBe(1)
+    const callArg = createSpy.mock.calls[0]?.[0] as IssuesCreateCall
+    expect(callArg.labels).toContain(LEARNING_PROPOSAL_LABEL)
+  })
+
+  it('ships with an empty labels array when the label cannot be confirmed', async () => {
+    // #given the label cannot be confirmed (getLabel 500 error)
+    const createSpy = vi.fn().mockResolvedValue({data: {number: 1}})
+    const octokit = mockOctokit({getLabelResult: 'error', issuesCreateSpy: createSpy})
+
+    // #when creating proposals
+    const counts = await createProposals(octokit, 'fro-bot', '.github', [makeToCreate()])
+
+    // #then the issue is still created (with empty labels — confirmed subset)
+    expect(counts.created).toBe(1)
+    const callArg = createSpy.mock.calls[0]?.[0] as IssuesCreateCall
+    expect(callArg.labels).toHaveLength(0)
+  })
+
+  it('same-run Set guard: two toCreate items with the same mergeSha → only one created', async () => {
+    // #given two items with the same mergeSha (simulates a same-run duplicate)
+    const sha = 'abc123def456abc123def456abc123def456abc1'
+    const createSpy = vi.fn().mockResolvedValue({data: {number: 1}})
+    const octokit = mockOctokit({getLabelResult: 'found', issuesCreateSpy: createSpy})
+    const toCreate = [makeToCreate({mergeSha: sha}), makeToCreate({mergeSha: sha})]
+
+    // #when creating proposals
+    const counts = await createProposals(octokit, 'fro-bot', '.github', toCreate)
+
+    // #then only one issue was created (the second was suppressed by the in-memory Set)
+    expect(counts.created).toBe(1)
+    expect(createSpy).toHaveBeenCalledOnce()
+  })
+
+  it('continues creating other proposals when one fails', async () => {
+    // #given two proposals: the first create call fails, the second succeeds
+    const sha1 = `sha1${'0'.repeat(36)}`
+    const sha2 = `sha2${'0'.repeat(36)}`
+    const createSpy = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error('Server Error'), {status: 500}))
+      .mockResolvedValueOnce({data: {number: 2}})
+    const octokit = mockOctokit({getLabelResult: 'found', issuesCreateSpy: createSpy})
+    const toCreate = [
+      makeToCreate({mergeSha: sha1, body: `Body 1\n\n${buildMergeShaMarker(sha1)}`}),
+      makeToCreate({mergeSha: sha2, body: `Body 2\n\n${buildMergeShaMarker(sha2)}`}),
+    ]
+
+    // #when creating proposals
+    const counts = await createProposals(octokit, 'fro-bot', '.github', toCreate)
+
+    // #then the first failed but the second succeeded
+    expect(counts.created).toBe(1)
+    expect(counts.failed).toBe(1)
+    expect(createSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns zero counts when toCreate is empty', async () => {
+    // #given no proposals to create
+    const octokit = mockOctokit()
+
+    // #when creating proposals with an empty list
+    const counts = await createProposals(octokit, 'fro-bot', '.github', [])
+
+    // #then no API calls are made and counts are zero
+    expect(counts.created).toBe(0)
+    expect(counts.failed).toBe(0)
+  })
+
+  it('includes the title derived from the mergeSha (short SHA, no private info)', async () => {
+    // #given a proposal with a known mergeSha
+    const sha = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+    const createSpy = vi.fn().mockResolvedValue({data: {number: 1}})
+    const octokit = mockOctokit({getLabelResult: 'found', issuesCreateSpy: createSpy})
+
+    // #when creating proposals
+    await createProposals(octokit, 'fro-bot', '.github', [
+      makeToCreate({mergeSha: sha, body: `Body\n\n${buildMergeShaMarker(sha)}`}),
+    ])
+
+    // #then the title contains the short SHA (first 8 chars) and no private info
+    const callArg = createSpy.mock.calls[0]?.[0] as IssuesCreateCall
+    expect(callArg.title).toContain('deadbeef')
+    expect(callArg.title).toContain('Learning proposal')
+  })
+})

--- a/scripts/capture-c1-propose.test.ts
+++ b/scripts/capture-c1-propose.test.ts
@@ -23,7 +23,7 @@ import {
   type PlanProposalsInput,
   type ProposalToCreate,
 } from './capture-c1-propose.ts'
-import {buildPrivateNameTokens} from './wiki-slug.ts'
+import {buildPrivateTokenSet} from './wiki-slug.ts'
 
 // ---------------------------------------------------------------------------
 // Fixture helpers
@@ -50,11 +50,7 @@ function makePlanInput(overrides: Partial<PlanProposalsInput> = {}): PlanProposa
 
 /** Build a private token set from a synthetic owner/name for test isolation. */
 function makePrivateTokens(nameWithOwner: string): Set<string> {
-  const tokens = new Set<string>()
-  for (const token of buildPrivateNameTokens(nameWithOwner)) {
-    tokens.add(token.toLowerCase())
-  }
-  return tokens
+  return buildPrivateTokenSet([nameWithOwner])
 }
 
 function makeToCreate(overrides: Partial<ProposalToCreate> = {}): ProposalToCreate {
@@ -546,7 +542,7 @@ function mockOctokit(
 // ---------------------------------------------------------------------------
 
 describe('ensureLabelsExist', () => {
-  const labels: LabelDescriptor[] = [{name: LEARNING_PROPOSAL_LABEL, color: '0075ca', description: 'Test label'}]
+  const labels: LabelDescriptor[] = [{name: LEARNING_PROPOSAL_LABEL, color: '0e8a16', description: 'Test label'}]
 
   it('confirms a label that already exists (getLabel succeeds)', async () => {
     // #given the label already exists
@@ -644,18 +640,20 @@ describe('createProposals', () => {
     expect(callArg.labels).toContain(LEARNING_PROPOSAL_LABEL)
   })
 
-  it('ships with an empty labels array when the label cannot be confirmed', async () => {
+  it('skips ALL proposals when the label cannot be confirmed (fail-closed on labeling)', async () => {
     // #given the label cannot be confirmed (getLabel 500 error)
+    // An unlabeled proposal is invisible to the seen-set query (filtered by label)
+    // and would be re-proposed forever — worse than skipping.
     const createSpy = vi.fn().mockResolvedValue({data: {number: 1}})
     const octokit = mockOctokit({getLabelResult: 'error', issuesCreateSpy: createSpy})
 
     // #when creating proposals
     const counts = await createProposals(octokit, 'fro-bot', '.github', [makeToCreate()])
 
-    // #then the issue is still created (with empty labels — confirmed subset)
-    expect(counts.created).toBe(1)
-    const callArg = createSpy.mock.calls[0]?.[0] as IssuesCreateCall
-    expect(callArg.labels).toHaveLength(0)
+    // #then NO issue is created and skippedLabelUnavailable is incremented
+    expect(counts.created).toBe(0)
+    expect(counts.skippedLabelUnavailable).toBe(1)
+    expect(createSpy).not.toHaveBeenCalled()
   })
 
   it('same-run Set guard: two toCreate items with the same mergeSha → only one created', async () => {

--- a/scripts/capture-c1-propose.ts
+++ b/scripts/capture-c1-propose.ts
@@ -18,11 +18,18 @@
  * Strip-only safe: no parameter properties, enums, or namespaces.
  */
 
-import {readFile} from 'node:fs/promises'
+import {readFile, writeFile} from 'node:fs/promises'
 import process from 'node:process'
 import {parse} from 'yaml'
 
-import {buildMergeShaMarker, LEARNING_PROPOSAL_LABEL, type Candidate, type OctokitClient} from './capture-c1-harvest.ts'
+import {
+  buildMergeShaMarker,
+  createOctokitFromEnv,
+  LEARNING_PROPOSAL_LABEL,
+  type Candidate,
+  type CandidateDigest,
+  type OctokitClient,
+} from './capture-c1-harvest.ts'
 import {buildPrivateNameTokens} from './wiki-slug.ts'
 
 // ---------------------------------------------------------------------------
@@ -405,4 +412,114 @@ export async function createProposals(
   process.stderr.write(`capture-c1-propose: proposals created=${created} failed=${failed}\n`)
 
   return {created, failed}
+}
+
+// ---------------------------------------------------------------------------
+// Entry point (SHAPE B: deterministic propose step reads digest + agent bodies)
+// ---------------------------------------------------------------------------
+
+/**
+ * CLI entry point for the deterministic propose step.
+ *
+ * Handoff contract (SHAPE B):
+ * - Reads the harvest digest from the path in CAPTURE_C1_DIGEST_PATH env var
+ *   (a JSON file containing a CandidateDigest written by the harvest step).
+ * - Reads agent-authored proposal bodies from the path in CAPTURE_C1_BODIES_PATH
+ *   env var (a JSON file: Record<mergeSha, bodyText> written by the agent step).
+ * - Loads the private token set from metadata/repos.yaml (fail-closed: throws if
+ *   the file cannot be read or parsed — no proposals posted without the privacy gate).
+ * - Calls planProposals (privacy gate + same-run dedup) then createProposals.
+ * - Writes a counts-only JSON result to CAPTURE_C1_RESULT_PATH (if set) and stdout.
+ *
+ * Privacy guarantee: the agent never receives owner/repo/number prose (the digest
+ * carries only merge_sha + signals). The privacy gate runs here, deterministically,
+ * not at agent discretion. A missing or unreadable metadata/repos.yaml is fatal.
+ *
+ * Strip-only safe: no parameter properties, enums, or namespaces.
+ */
+
+/** Counts-only result written to stdout and CAPTURE_C1_RESULT_PATH. */
+interface ProposeResult {
+  examined: number
+  candidatesAfterDedup: number
+  proposalsOpened: number
+  blockedOnPrivacy: number
+  skippedDuplicate: number
+  failed: number
+}
+
+async function readJsonFile<T>(path: string, label: string): Promise<T> {
+  let raw: string
+  try {
+    raw = await readFile(path, 'utf8')
+  } catch (error: unknown) {
+    throw new Error(`capture-c1-propose: could not read ${label} at ${path}`, {cause: error})
+  }
+  try {
+    return JSON.parse(raw) as T
+  } catch (error: unknown) {
+    throw new Error(`capture-c1-propose: could not parse ${label} at ${path}`, {cause: error})
+  }
+}
+
+async function main(): Promise<void> {
+  const digestPath = process.env.CAPTURE_C1_DIGEST_PATH
+  const bodiesPath = process.env.CAPTURE_C1_BODIES_PATH
+  const resultPath = process.env.CAPTURE_C1_RESULT_PATH
+
+  if (digestPath === undefined || digestPath === '') {
+    throw new Error('capture-c1-propose: CAPTURE_C1_DIGEST_PATH is required')
+  }
+  if (bodiesPath === undefined || bodiesPath === '') {
+    throw new Error('capture-c1-propose: CAPTURE_C1_BODIES_PATH is required')
+  }
+
+  // Read the harvest digest (written by the harvest step)
+  const digest = await readJsonFile<CandidateDigest>(digestPath, 'harvest digest')
+
+  // Read agent-authored bodies (written by the agent step): Record<mergeSha, bodyText>
+  const bodiesRecord = await readJsonFile<Record<string, string>>(bodiesPath, 'agent bodies')
+  const proposalBodies = new Map<string, string>(Object.entries(bodiesRecord))
+
+  // Fail-closed: load private tokens — throws if metadata/repos.yaml is unreadable
+  const privateTokens = await loadPrivateTokensFromDisk()
+
+  const octokit = await createOctokitFromEnv()
+  const owner = 'fro-bot'
+  const repo = '.github'
+
+  // Plan proposals: privacy gate + same-run dedup
+  const plan = planProposals({
+    candidates: digest.candidates,
+    proposalBodies,
+    privateTokens,
+    alreadyCreatedShas: new Set<string>(),
+  })
+
+  // Create the planned proposals
+  const {created, failed} = await createProposals(octokit, owner, repo, plan.toCreate)
+
+  const result: ProposeResult = {
+    examined: digest.telemetry.examined,
+    candidatesAfterDedup: digest.telemetry.afterSolutionsDedup,
+    proposalsOpened: created,
+    blockedOnPrivacy: plan.blockedOnPrivacy,
+    skippedDuplicate: plan.skippedDuplicate,
+    failed,
+  }
+
+  const resultJson = `${JSON.stringify(result)}\n`
+  process.stdout.write(resultJson)
+
+  if (resultPath !== undefined && resultPath !== '') {
+    try {
+      await writeFile(resultPath, resultJson, {flag: 'w'})
+    } catch (error: unknown) {
+      process.stderr.write(`capture-c1-propose: could not write result to ${resultPath}: ${String(error)}\n`)
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
 }

--- a/scripts/capture-c1-propose.ts
+++ b/scripts/capture-c1-propose.ts
@@ -30,7 +30,7 @@ import {
   type CandidateDigest,
   type OctokitClient,
 } from './capture-c1-harvest.ts'
-import {buildPrivateNameTokens} from './wiki-slug.ts'
+import {buildPrivateTokenSet} from './wiki-slug.ts'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -84,6 +84,7 @@ export interface CreateProposalsCounts {
   failed: number
   blockedOnPrivacy: number
   skippedDuplicate: number
+  skippedLabelUnavailable: number
 }
 
 // ---------------------------------------------------------------------------
@@ -104,30 +105,6 @@ export function proposalBodyHasPrivateLeak(body: string, privateTokens: Set<stri
     if (lower.includes(token)) return true
   }
   return false
-}
-
-// ---------------------------------------------------------------------------
-// Private token set builder (mirrors solutions-query.ts buildPrivateTokenSet)
-// ---------------------------------------------------------------------------
-
-/**
- * Build a flat set of private identifier tokens from a list of `owner/name` strings.
- * Tokens: [owner/name, owner--name, computeRepoSlug(owner, name)] — lowercased.
- * Entries with `[REDACTED]` owner or name are skipped.
- */
-function buildPrivateTokenSet(privateNames: string[]): Set<string> {
-  const tokens = new Set<string>()
-  for (const nameWithOwner of privateNames) {
-    const slashIndex = nameWithOwner.indexOf('/')
-    if (slashIndex < 1) continue
-    const owner = nameWithOwner.slice(0, slashIndex)
-    const name = nameWithOwner.slice(slashIndex + 1)
-    if (owner === '[REDACTED]' || name === '[REDACTED]') continue
-    for (const token of buildPrivateNameTokens(nameWithOwner)) {
-      tokens.add(token.toLowerCase())
-    }
-  }
-  return tokens
 }
 
 // ---------------------------------------------------------------------------
@@ -344,8 +321,9 @@ function deriveProposalTitle(mergeSha: string): string {
 
 const LEARNING_PROPOSAL_LABEL_DESCRIPTOR: LabelDescriptor = {
   name: LEARNING_PROPOSAL_LABEL,
-  color: '0075ca',
-  description: 'Candidate learning from a multi-round-review PR',
+  // Color matches .github/settings.yml (hex without '#', as GitHub createLabel requires)
+  color: '0e8a16',
+  description: 'Candidate learning proposed from a multi-round-review PR',
 }
 
 /**
@@ -366,13 +344,23 @@ export async function createProposals(
   owner: string,
   repo: string,
   toCreate: ProposalToCreate[],
-): Promise<{created: number; failed: number}> {
+): Promise<{created: number; failed: number; skippedLabelUnavailable: number}> {
   if (toCreate.length === 0) {
-    return {created: 0, failed: 0}
+    return {created: 0, failed: 0, skippedLabelUnavailable: 0}
   }
 
   // Label preflight
   const confirmedLabels = await ensureLabelsExist(octokit, owner, repo, [LEARNING_PROPOSAL_LABEL_DESCRIPTOR])
+
+  // Fail-closed on labeling: if the required label is not confirmed, skip ALL proposals.
+  // An unlabeled proposal is invisible to the seen-set query (which filters by label)
+  // and would be re-proposed forever — worse than skipping.
+  if (!confirmedLabels.has(LEARNING_PROPOSAL_LABEL)) {
+    process.stderr.write(
+      `capture-c1-propose: label "${LEARNING_PROPOSAL_LABEL}" unavailable; skipping ${toCreate.length} proposal(s) (label-unavailable)\n`,
+    )
+    return {created: 0, failed: 0, skippedLabelUnavailable: toCreate.length}
+  }
 
   // Same-run in-memory Set (guards eventual-consistency race, R3)
   const createdThisRun = new Set<string>()
@@ -388,7 +376,6 @@ export async function createProposals(
     }
 
     const title = deriveProposalTitle(item.mergeSha)
-    const labels = [LEARNING_PROPOSAL_LABEL].filter(l => confirmedLabels.has(l))
 
     try {
       await octokit.rest.issues.create({
@@ -396,7 +383,7 @@ export async function createProposals(
         repo,
         title,
         body: item.body,
-        labels,
+        labels: [LEARNING_PROPOSAL_LABEL],
       } as unknown as Parameters<OctokitClient['rest']['issues']['create']>[0])
 
       // Mark as created only after the API call succeeds
@@ -411,7 +398,7 @@ export async function createProposals(
 
   process.stderr.write(`capture-c1-propose: proposals created=${created} failed=${failed}\n`)
 
-  return {created, failed}
+  return {created, failed, skippedLabelUnavailable: 0}
 }
 
 // ---------------------------------------------------------------------------
@@ -445,6 +432,7 @@ interface ProposeResult {
   proposalsOpened: number
   blockedOnPrivacy: number
   skippedDuplicate: number
+  skippedLabelUnavailable: number
   failed: number
 }
 
@@ -497,7 +485,7 @@ async function main(): Promise<void> {
   })
 
   // Create the planned proposals
-  const {created, failed} = await createProposals(octokit, owner, repo, plan.toCreate)
+  const {created, failed, skippedLabelUnavailable} = await createProposals(octokit, owner, repo, plan.toCreate)
 
   const result: ProposeResult = {
     examined: digest.telemetry.examined,
@@ -505,6 +493,7 @@ async function main(): Promise<void> {
     proposalsOpened: created,
     blockedOnPrivacy: plan.blockedOnPrivacy,
     skippedDuplicate: plan.skippedDuplicate,
+    skippedLabelUnavailable,
     failed,
   }
 

--- a/scripts/capture-c1-propose.ts
+++ b/scripts/capture-c1-propose.ts
@@ -1,0 +1,408 @@
+/**
+ * Proposal-issue opening for the C1 learning-capture pipeline.
+ *
+ * Given a set of candidates (from the harvest digest) and agent-authored proposal bodies,
+ * opens `learning-proposal` issues — but only after each body passes a fail-closed
+ * private-identifier scan, with same-run in-memory dedup.
+ *
+ * Architecture: pure planning core (`planProposals`) + I/O shell (`createProposals`).
+ * The pure core is fully unit-testable with injected inputs.
+ * The I/O shell does Octokit calls and disk reads.
+ *
+ * Fail-closed privacy contract:
+ * - If `loadPrivateTokensFromDisk` throws or returns an error sentinel, the caller
+ *   MUST NOT post any proposals (no private set loaded ⇒ no proposals posted).
+ * - The privacy gate blocks on a hit; it never redacts. Counts-only telemetry.
+ * - Private names are never logged; only counts appear in output.
+ *
+ * Strip-only safe: no parameter properties, enums, or namespaces.
+ */
+
+import {readFile} from 'node:fs/promises'
+import process from 'node:process'
+import {parse} from 'yaml'
+
+import {buildMergeShaMarker, LEARNING_PROPOSAL_LABEL, type Candidate, type OctokitClient} from './capture-c1-harvest.ts'
+import {buildPrivateNameTokens} from './wiki-slug.ts'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Input to the pure planning core. */
+export interface PlanProposalsInput {
+  /** Candidates from the harvest digest. */
+  candidates: Candidate[]
+  /**
+   * Agent-authored proposal body per mergeSha.
+   * Candidates with no entry in this map are skipped.
+   */
+  proposalBodies: Map<string, string>
+  /** Private identifier tokens for the privacy gate (R4). */
+  privateTokens: Set<string>
+  /**
+   * merge_shas already created this run (same-run dedup guard, R3).
+   * Populated by the caller from prior createProposals calls or from
+   * the cross-run seen-set built by fetchProposedMergeShas.
+   */
+  alreadyCreatedShas: Set<string>
+}
+
+/** A single proposal ready to be created as a GitHub issue. */
+export interface ProposalToCreate {
+  mergeSha: string
+  /** Body with the merge-SHA marker already appended. */
+  body: string
+}
+
+/** Result of the pure planning core. */
+export interface PlanProposalsResult {
+  toCreate: ProposalToCreate[]
+  /** Number of proposals blocked by the privacy gate (R4). */
+  blockedOnPrivacy: number
+  /** Number of proposals skipped because the mergeSha was already created. */
+  skippedDuplicate: number
+}
+
+/** Label descriptor for ensureLabelsExist. */
+export interface LabelDescriptor {
+  name: string
+  color: string
+  description: string
+}
+
+/** Counts returned by createProposals. */
+export interface CreateProposalsCounts {
+  created: number
+  failed: number
+  blockedOnPrivacy: number
+  skippedDuplicate: number
+}
+
+// ---------------------------------------------------------------------------
+// Privacy gate (R4) — pure, fail-closed
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if the proposal body contains any private identifier token.
+ *
+ * The body is lowercased before scanning. The caller MUST block (skip) the
+ * proposal on true. Never redacts — block only. Counts-only telemetry.
+ *
+ * Pure function: no I/O, fully testable.
+ */
+export function proposalBodyHasPrivateLeak(body: string, privateTokens: Set<string>): boolean {
+  const lower = body.toLowerCase()
+  for (const token of privateTokens) {
+    if (lower.includes(token)) return true
+  }
+  return false
+}
+
+// ---------------------------------------------------------------------------
+// Private token set builder (mirrors solutions-query.ts buildPrivateTokenSet)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a flat set of private identifier tokens from a list of `owner/name` strings.
+ * Tokens: [owner/name, owner--name, computeRepoSlug(owner, name)] — lowercased.
+ * Entries with `[REDACTED]` owner or name are skipped.
+ */
+function buildPrivateTokenSet(privateNames: string[]): Set<string> {
+  const tokens = new Set<string>()
+  for (const nameWithOwner of privateNames) {
+    const slashIndex = nameWithOwner.indexOf('/')
+    if (slashIndex < 1) continue
+    const owner = nameWithOwner.slice(0, slashIndex)
+    const name = nameWithOwner.slice(slashIndex + 1)
+    if (owner === '[REDACTED]' || name === '[REDACTED]') continue
+    for (const token of buildPrivateNameTokens(nameWithOwner)) {
+      tokens.add(token.toLowerCase())
+    }
+  }
+  return tokens
+}
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isApiStatus(error: unknown, status: number): boolean {
+  return isRecord(error) && typeof error.status === 'number' && error.status === status
+}
+
+// ---------------------------------------------------------------------------
+// Disk loader for private token set
+// ---------------------------------------------------------------------------
+
+/**
+ * Load the private identifier token set from `metadata/repos.yaml`.
+ *
+ * Reads the overlay-checked-out metadata file, filters `private: true` non-redacted
+ * entries, and builds the token set via `buildPrivateNameTokens`.
+ *
+ * Fail-closed contract:
+ * - If the file cannot be read or parsed, this function THROWS.
+ * - The caller MUST NOT post any proposals when this throws (no private set ⇒ no proposals).
+ * - This is intentional: a missing overlay means the privacy gate cannot operate,
+ *   and posting unscanned proposals would violate R4.
+ *
+ * Counts-only: private names are never logged; only counts appear in stderr.
+ *
+ * @param readFileFn - Injectable readFile for testing (defaults to node:fs/promises readFile).
+ */
+export async function loadPrivateTokensFromDisk(
+  readFileFn: (path: string, encoding: BufferEncoding) => Promise<string> = readFile,
+): Promise<Set<string>> {
+  let reposYaml: string
+
+  try {
+    reposYaml = await readFileFn('metadata/repos.yaml', 'utf8')
+  } catch (error: unknown) {
+    throw new Error(
+      'capture-c1-propose: could not read metadata/repos.yaml — privacy gate cannot operate; no proposals will be posted',
+      {cause: error},
+    )
+  }
+
+  let parsed: unknown
+  try {
+    parsed = parse(reposYaml)
+  } catch (error: unknown) {
+    throw new Error(
+      'capture-c1-propose: could not parse metadata/repos.yaml — privacy gate cannot operate; no proposals will be posted',
+      {cause: error},
+    )
+  }
+
+  if (!isRecord(parsed)) {
+    throw new TypeError(
+      'capture-c1-propose: metadata/repos.yaml has unexpected shape — privacy gate cannot operate; no proposals will be posted',
+    )
+  }
+
+  const repos = parsed.repos
+  if (!Array.isArray(repos)) {
+    throw new TypeError(
+      'capture-c1-propose: metadata/repos.yaml missing repos array — privacy gate cannot operate; no proposals will be posted',
+    )
+  }
+
+  const privateNames: string[] = []
+  for (const entry of repos) {
+    if (!isRecord(entry)) continue
+    if (entry.private !== true) continue
+    const owner = entry.owner
+    const name = entry.name
+    if (typeof owner !== 'string' || typeof name !== 'string' || owner === '[REDACTED]' || name === '[REDACTED]') {
+      continue
+    }
+    privateNames.push(`${owner}/${name}`)
+  }
+
+  const tokenSet = buildPrivateTokenSet(privateNames)
+  process.stderr.write(
+    `capture-c1-propose: loaded private token set (private-repo count=${privateNames.length}, token-count=${tokenSet.size})\n`,
+  )
+  return tokenSet
+}
+
+// ---------------------------------------------------------------------------
+// Pure planning core
+// ---------------------------------------------------------------------------
+
+/**
+ * Plan which proposals to create, applying the privacy gate and same-run dedup.
+ *
+ * For each candidate:
+ * 1. Skip if no agent-authored body is available.
+ * 2. Skip if the mergeSha is already in alreadyCreatedShas (same-run dedup, R3).
+ * 3. Skip if the body contains a private token (privacy gate, R4).
+ * 4. Otherwise: append the merge-SHA marker to the body and add to toCreate.
+ *
+ * Pure function: no I/O, fully testable.
+ */
+export function planProposals(input: PlanProposalsInput): PlanProposalsResult {
+  const toCreate: ProposalToCreate[] = []
+  let blockedOnPrivacy = 0
+  let skippedDuplicate = 0
+
+  for (const candidate of input.candidates) {
+    const body = input.proposalBodies.get(candidate.mergeSha)
+
+    // Skip candidates with no agent-authored body
+    if (body === undefined || body === '') {
+      continue
+    }
+
+    // Same-run dedup (R3): skip if already created this run
+    if (input.alreadyCreatedShas.has(candidate.mergeSha)) {
+      skippedDuplicate += 1
+      continue
+    }
+
+    // Privacy gate (R4): block if body contains a private identifier
+    if (proposalBodyHasPrivateLeak(body, input.privateTokens)) {
+      blockedOnPrivacy += 1
+      continue
+    }
+
+    // Append the immutable merge-SHA marker to the body
+    const bodyWithMarker = `${body}\n\n${buildMergeShaMarker(candidate.mergeSha)}`
+    toCreate.push({mergeSha: candidate.mergeSha, body: bodyWithMarker})
+  }
+
+  return {toCreate, blockedOnPrivacy, skippedDuplicate}
+}
+
+// ---------------------------------------------------------------------------
+// Label preflight (mirrors reconcile-repos.ts ensureLabelsExist)
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure a set of labels exist in the repo. For each label:
+ * - If it exists (getLabel succeeds): confirmed.
+ * - If 404: attempt createLabel.
+ *   - createLabel succeeds or 422 (race — already created): confirmed.
+ *   - createLabel other failure: excluded from returned set (log and continue).
+ * - getLabel non-404 failure: excluded from returned set (log and continue).
+ *
+ * Returns a Set<string> of confirmed-usable label names. The caller MUST filter
+ * the issue payload to only these labels before calling issues.create.
+ */
+export async function ensureLabelsExist(
+  octokit: OctokitClient,
+  owner: string,
+  repo: string,
+  labels: readonly LabelDescriptor[],
+): Promise<Set<string>> {
+  const confirmed = new Set<string>()
+
+  for (const {name, color, description} of labels) {
+    try {
+      await octokit.rest.issues.getLabel({owner, repo, name})
+      confirmed.add(name)
+      continue
+    } catch (getError: unknown) {
+      if (!isApiStatus(getError, 404)) {
+        const status = isRecord(getError) && typeof getError.status === 'number' ? getError.status : 'unknown'
+        process.stderr.write(
+          `capture-c1-propose: label check failed for "${name}" (status=${status}); excluding from issue labels\n`,
+        )
+        continue
+      }
+    }
+
+    // Label not found (404) — create it
+    try {
+      await octokit.rest.issues.createLabel({owner, repo, name, color, description})
+      confirmed.add(name)
+    } catch (createError: unknown) {
+      if (isApiStatus(createError, 422)) {
+        // Race with another writer — label now exists; include it
+        confirmed.add(name)
+      } else {
+        const status = isRecord(createError) && typeof createError.status === 'number' ? createError.status : 'unknown'
+        process.stderr.write(
+          `capture-c1-propose: label creation failed for "${name}" (status=${status}); excluding from issue labels\n`,
+        )
+      }
+    }
+  }
+
+  return confirmed
+}
+
+// ---------------------------------------------------------------------------
+// Issue title derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a proposal issue title from a mergeSha.
+ * Uses only the merge SHA (public, safe for this public repo) — no owner/repo/number prose.
+ * Short SHA = first 8 chars.
+ */
+function deriveProposalTitle(mergeSha: string): string {
+  const shortSha = mergeSha.slice(0, 8)
+  return `Learning proposal: review-heavy PR (${shortSha})`
+}
+
+// ---------------------------------------------------------------------------
+// I/O shell: createProposals
+// ---------------------------------------------------------------------------
+
+const LEARNING_PROPOSAL_LABEL_DESCRIPTOR: LabelDescriptor = {
+  name: LEARNING_PROPOSAL_LABEL,
+  color: '0075ca',
+  description: 'Candidate learning from a multi-round-review PR',
+}
+
+/**
+ * Open GitHub issues for the planned proposals.
+ *
+ * Steps:
+ * 1. Label preflight: ensureLabelsExist([LEARNING_PROPOSAL_LABEL]).
+ * 2. For each toCreate item:
+ *    a. Same-run Set guard: skip if mergeSha already created this invocation.
+ *    b. issues.create with confirmed labels + body (which already contains the marker).
+ *    c. On success: add mergeSha to the in-memory Set.
+ *    d. On failure: log counts-only, continue (one failure does not abort the rest).
+ *
+ * Returns counts-only telemetry. No private names in any output.
+ */
+export async function createProposals(
+  octokit: OctokitClient,
+  owner: string,
+  repo: string,
+  toCreate: ProposalToCreate[],
+): Promise<{created: number; failed: number}> {
+  if (toCreate.length === 0) {
+    return {created: 0, failed: 0}
+  }
+
+  // Label preflight
+  const confirmedLabels = await ensureLabelsExist(octokit, owner, repo, [LEARNING_PROPOSAL_LABEL_DESCRIPTOR])
+
+  // Same-run in-memory Set (guards eventual-consistency race, R3)
+  const createdThisRun = new Set<string>()
+
+  let created = 0
+  let failed = 0
+
+  for (const item of toCreate) {
+    // Same-run Set guard: skip if this mergeSha was already created in this invocation
+    if (createdThisRun.has(item.mergeSha)) {
+      process.stderr.write(`capture-c1-propose: same-run duplicate skipped (sha-prefix=${item.mergeSha.slice(0, 8)})\n`)
+      continue
+    }
+
+    const title = deriveProposalTitle(item.mergeSha)
+    const labels = [LEARNING_PROPOSAL_LABEL].filter(l => confirmedLabels.has(l))
+
+    try {
+      await octokit.rest.issues.create({
+        owner,
+        repo,
+        title,
+        body: item.body,
+        labels,
+      } as unknown as Parameters<OctokitClient['rest']['issues']['create']>[0])
+
+      // Mark as created only after the API call succeeds
+      createdThisRun.add(item.mergeSha)
+      created += 1
+    } catch (error: unknown) {
+      failed += 1
+      const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
+      process.stderr.write(`capture-c1-propose: issue creation failed (status=${status}); continuing\n`)
+    }
+  }
+
+  process.stderr.write(`capture-c1-propose: proposals created=${created} failed=${failed}\n`)
+
+  return {created, failed}
+}

--- a/scripts/solutions-query.ts
+++ b/scripts/solutions-query.ts
@@ -5,7 +5,7 @@ import process from 'node:process'
 
 import {parse} from 'yaml'
 
-import {buildPrivateNameTokens} from './wiki-slug.ts'
+import {buildPrivateTokenSet} from './wiki-slug.ts'
 
 const MAX_CONTEXT_BYTES = 4 * 1024
 const SOLUTIONS_ROOT = 'docs/solutions'
@@ -226,30 +226,6 @@ function isSecurityFlavored(tokens: Set<string>): boolean {
 // ---------------------------------------------------------------------------
 // Privacy gate
 // ---------------------------------------------------------------------------
-
-/**
- * Build a flat set of private identifier tokens from a list of `owner/name` strings.
- * Mirrors the buildTokensForName logic from check-private-leak.ts.
- * Tokens: [owner/name, owner--name, computeRepoSlug(owner, name)] — deduplicated.
- * Entries with `[REDACTED]` owner or name are skipped (no canonical name to scan for).
- */
-function buildPrivateTokenSet(privateNames: string[]): Set<string> {
-  const tokens = new Set<string>()
-
-  for (const nameWithOwner of privateNames) {
-    const slashIndex = nameWithOwner.indexOf('/')
-    if (slashIndex < 1) continue
-    const owner = nameWithOwner.slice(0, slashIndex)
-    const name = nameWithOwner.slice(slashIndex + 1)
-    if (owner === '[REDACTED]' || name === '[REDACTED]') continue
-
-    for (const token of buildPrivateNameTokens(nameWithOwner)) {
-      tokens.add(token.toLowerCase())
-    }
-  }
-
-  return tokens
-}
 
 function containsPrivateToken(lowerText: string, privateTokens: Set<string>): boolean {
   for (const token of privateTokens) {

--- a/scripts/wiki-slug.test.ts
+++ b/scripts/wiki-slug.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest'
 
-import {buildPrivateNameTokens, computeRepoSlug} from './wiki-slug.ts'
+import {buildPrivateNameTokens, buildPrivateTokenSet, computeRepoSlug} from './wiki-slug.ts'
 
 describe('computeRepoSlug', () => {
   it('preserves the double-dash separator between owner and repo', () => {
@@ -94,5 +94,74 @@ describe('buildPrivateNameTokens', () => {
   it('returns empty array for input with empty owner or name', () => {
     expect(buildPrivateNameTokens('/name')).toEqual([])
     expect(buildPrivateNameTokens('owner/')).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildPrivateTokenSet (FIX 10 — extracted from capture-c1-propose + solutions-query)
+// ---------------------------------------------------------------------------
+
+describe('buildPrivateTokenSet', () => {
+  it('returns a set containing all token forms for a private repo', () => {
+    // #given a list with one private repo
+    const tokens = buildPrivateTokenSet(['testowner/secret-repo'])
+
+    // #when the token set is built
+    // #then it contains the canonical, double-dash, and slug forms (lowercased)
+    expect(tokens.has('testowner/secret-repo')).toBe(true)
+    expect(tokens.has('testowner--secret-repo')).toBe(true)
+  })
+
+  it('lowercases all tokens', () => {
+    // #given a mixed-case owner/name
+    const tokens = buildPrivateTokenSet(['TestOwner/MyRepo'])
+
+    // #when the token set is built
+    // #then all tokens are lowercase
+    for (const token of tokens) {
+      expect(token).toBe(token.toLowerCase())
+    }
+  })
+
+  it('skips entries with [REDACTED] owner or name', () => {
+    // #given a list with a redacted entry
+    const tokens = buildPrivateTokenSet(['[REDACTED]/[REDACTED]', 'testowner/real-repo'])
+
+    // #when the token set is built
+    // #then the redacted entry contributes no tokens
+    expect(tokens.has('[redacted]/[redacted]')).toBe(false)
+    // The real repo is still included
+    expect(tokens.has('testowner/real-repo')).toBe(true)
+  })
+
+  it('skips entries with no slash', () => {
+    // #given a list with an invalid entry (no slash)
+    const tokens = buildPrivateTokenSet(['noslash', 'testowner/valid-repo'])
+
+    // #when the token set is built
+    // #then the invalid entry is skipped, valid entry is included
+    expect(tokens.has('noslash')).toBe(false)
+    expect(tokens.has('testowner/valid-repo')).toBe(true)
+  })
+
+  it('returns an empty set for an empty list', () => {
+    // #given an empty list
+    const tokens = buildPrivateTokenSet([])
+
+    // #when the token set is built
+    // #then the set is empty
+    expect(tokens.size).toBe(0)
+  })
+
+  it('deduplicates tokens across multiple repos that share forms', () => {
+    // #given two repos that produce overlapping tokens (unlikely but safe)
+    const tokens = buildPrivateTokenSet(['testowner/repo-a', 'testowner/repo-b'])
+
+    // #when the token set is built
+    // #then both repos contribute their tokens without duplication
+    expect(tokens.has('testowner/repo-a')).toBe(true)
+    expect(tokens.has('testowner/repo-b')).toBe(true)
+    // Set deduplication: size should equal unique token count
+    expect(tokens.size).toBe(new Set(tokens).size)
   })
 })

--- a/scripts/wiki-slug.ts
+++ b/scripts/wiki-slug.ts
@@ -1,6 +1,28 @@
 import process from 'node:process'
 
 /**
+ * Build a flat set of private identifier tokens from a list of `owner/name` strings.
+ * Tokens: [owner/name, owner--name, computeRepoSlug(owner, name)] — lowercased, deduplicated.
+ * Entries with `[REDACTED]` owner or name are skipped.
+ *
+ * Shared by capture-c1-propose.ts and solutions-query.ts — single source of truth.
+ */
+export function buildPrivateTokenSet(privateNames: string[]): Set<string> {
+  const tokens = new Set<string>()
+  for (const nameWithOwner of privateNames) {
+    const slashIndex = nameWithOwner.indexOf('/')
+    if (slashIndex < 1) continue
+    const owner = nameWithOwner.slice(0, slashIndex)
+    const name = nameWithOwner.slice(slashIndex + 1)
+    if (owner === '[REDACTED]' || name === '[REDACTED]') continue
+    for (const token of buildPrivateNameTokens(nameWithOwner)) {
+      tokens.add(token.toLowerCase())
+    }
+  }
+  return tokens
+}
+
+/**
  * Build the canonical private-name token set for a single `owner/name` string.
  *
  * Returns up to three forms — [nameWithOwner, owner--name, computeRepoSlug(owner,name)] —


### PR DESCRIPTION
Fro Bot now proposes its own learnings. Phase 1 made it consult the existing solutions docs during a run; this adds the supply side — a weekly run that examines this repo's merged PRs, finds the ones that needed multiple rounds of changes-requested before merging (the richest mistake→correction signal), and opens a learning-proposal issue for each candidate for review.

This is deliberately propose-only: it suggests learnings as issues rather than authoring them into the corpus, so it tests whether reasoning over run-outcome metadata produces something worth keeping before any authoring or promotion machinery exists. The requirements and plan are included.

## How it works

1. **Harvest** (`scripts/capture-c1-harvest.ts`) — paginates this repo's merged PRs in a lookback window, keeps those with two or more change-requested review rounds, drops any already covered by an existing proposal or solutions doc, caps the count, and writes an **opaque digest** identifying candidates by merge SHA only — never owner, repo, number, or title. So no repository identifier can reach the agent.
2. **Author** — the Fro Bot agent reads the digest and writes a proposal body for each candidate it judges worth proposing, to a file. It has no GitHub token and only ever sees merge SHAs.
3. **Propose** (`scripts/capture-c1-propose.ts`) — a deterministic step scans each authored body for private-repo identifiers (fail-closed: if the private set can't be loaded, nothing is posted), then opens the `learning-proposal` issues with a merge-SHA marker.

## Design notes

- **The proposal issues are the decision log.** Deduplication queries existing `learning-proposal` issues (open or closed) by their merge-SHA marker, so the record survives data-branch resets — issues live independent of branches.
- **The privacy gate runs deterministically, not at agent discretion.** The agent authors prose; a TypeScript step applies the gate and creates the issues. The agent cannot bypass it.
- **Human-reviewed.** Proposals are suggestions; nothing is authored into `docs/solutions/` or auto-merged.
- Weekly cadence, capped per run, scoped to this repo.

Covered by unit tests across review-round counting (including multi-page review history), the opaque-digest guarantee, dedup (mutation-proven), the fail-closed privacy gate (mutation-proven), label preflight, and the harvest→propose contract.
