### PR TITLE
fix(capture): correct multi-round detection and name it for what it does

### DIFF
--- a/.github/workflows/capture-learnings.yaml
+++ b/.github/workflows/capture-learnings.yaml
@@ -75,8 +75,8 @@ jobs:
       # to $RUNNER_TEMP/capture-learnings-bodies.json. Nothing else — no code edits,
       # no doc edits, no other issues, no API exploration.
       #
-      # The privacy gate and issue-create run deterministically in the propose
-      # step below (SHAPE B). The agent cannot bypass the privacy gate.
+      # The privacy gate and issue-create run deterministically in the open
+      # step below. The agent cannot bypass the privacy gate.
       #
       # The agent action requires a github-token input, so one is supplied. It is
       # the workflow's auto-provisioned GITHUB_TOKEN, scoped to `contents: read` by
@@ -99,7 +99,7 @@ jobs:
                { "candidates": [...], "telemetry": {...} }
                Each candidate in the candidates array has:
                - mergeSha: opaque merge commit SHA (the ONLY identifier you receive)
-               - reviewRounds: number of CHANGES_REQUESTED review rounds
+               - reviewRounds: number of substantive Fro Bot review rounds (approved, changes-requested, or dismissed — a dismissed approval marks a re-review forced by a new push)
                - signals: { titleTokens: string[], labels: string[] }
             2. For each candidate you judge worth proposing (reviewRounds ≥ 2 is
                already guaranteed; use signals to assess value), write a concise
@@ -135,7 +135,7 @@ jobs:
           opencode-config: ${{ secrets.OPENCODE_CONFIG }}
           prompt: ${{ env.TASK_PROMPT }}
 
-      # Deterministic open step (SHAPE B): reads the harvest digest and the
+      # Deterministic open step: reads the harvest digest and the
       # agent-authored bodies, runs the privacy gate (fail-closed against
       # metadata/repos.yaml), applies same-run dedup, and opens the issues.
       # The privacy gate runs here — not at agent discretion.
@@ -167,7 +167,7 @@ jobs:
               echo "| Merged PRs in lookback | $(jq '.telemetry.mergedPrsInLookback // 0' "$harvest") |"
               echo "| Excluded automation | $(jq '.telemetry.excludedAutomation // 0' "$harvest") |"
               echo "| Multi-round candidates | $(jq '.telemetry.multiRoundCandidates // 0' "$harvest") |"
-              echo "| After proposal dedup | $(jq '.telemetry.afterSeenDedup // 0' "$harvest") |"
+              echo "| After seen dedup | $(jq '.telemetry.afterSeenDedup // 0' "$harvest") |"
               echo "| After solutions dedup | $(jq '.telemetry.afterSolutionsDedup // 0' "$harvest") |"
               echo "| Candidates emitted | $(jq '.telemetry.emitted // 0' "$harvest") |"
             else
@@ -175,12 +175,12 @@ jobs:
             fi
 
             if [[ -s "$result" ]]; then
-              echo "| Proposals opened | $(jq '.learningsOpened // 0' "$result") |"
+              echo "| Learnings opened | $(jq '.learningsOpened // 0' "$result") |"
               echo "| Blocked on privacy | $(jq '.blockedOnPrivacy // 0' "$result") |"
               echo "| Skipped duplicate | $(jq '.skippedDuplicate // 0' "$result") |"
               echo "| Failed | $(jq '.failed // 0' "$result") |"
             else
-              echo "| Proposals opened | (propose result unavailable) |"
+              echo "| Learnings opened | (open result unavailable) |"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
         shell: bash

--- a/.github/workflows/capture-learnings.yaml
+++ b/.github/workflows/capture-learnings.yaml
@@ -1,5 +1,5 @@
 ---
-name: Capture Learning Proposals
+name: Capture Learnings
 
 on:
   schedule:
@@ -10,13 +10,13 @@ permissions:
   contents: read
 
 # Serialize runs; never cancel an in-progress run (a partial run could leave
-# the agent step mid-flight with no propose step to follow).
+# the agent step mid-flight with no open step to follow).
 concurrency:
-  group: capture-c1-proposals
+  group: capture-learnings
   cancel-in-progress: false
 
 jobs:
-  capture-c1-proposals:
+  capture-learnings:
     name: Capture learning proposals from multi-round-review PRs
     runs-on: ubuntu-latest
     # Agent step is the long pole; 30 minutes provides headroom without
@@ -54,24 +54,25 @@ jobs:
             echo "data branch not yet established; skipping metadata overlay."
           fi
 
-      # Harvest merged PRs with ≥2 CHANGES_REQUESTED reviews, dedup against
+      # Harvest merged PRs where Fro Bot's substantive reviews meet the predicate
+      # (substantiveReviewCount >= 2 AND correctionSignalCount >= 1), dedup against
       # existing learning-proposal issues and docs/solutions/, cap to
-      # MAX_PROPOSALS_PER_RUN, and write an opaque digest (merge_sha + signals —
-      # no owner/repo/number prose) directly to CAPTURE_C1_DIGEST_PATH.
+      # MAX_LEARNINGS_PER_RUN, and write an opaque digest (merge_sha + signals —
+      # no owner/repo/number prose) directly to CAPTURE_LEARNINGS_DIGEST_PATH.
       # Writing the file directly avoids the shell-injection vector that existed
       # when the digest was echoed via GITHUB_OUTPUT multiline syntax.
       - name: 🌾 Harvest candidates
         id: harvest
         env:
           GITHUB_TOKEN: ${{ steps.get-workflow-app-token.outputs.token }}
-          CAPTURE_C1_DIGEST_PATH: ${{ runner.temp }}/capture-c1-digest.json
-        run: node scripts/capture-c1-harvest.ts | tee "$RUNNER_TEMP/harvest-result.json"
+          CAPTURE_LEARNINGS_DIGEST_PATH: ${{ runner.temp }}/capture-learnings-digest.json
+        run: node scripts/capture-learnings-harvest.ts | tee "$RUNNER_TEMP/harvest-result.json"
         shell: bash
 
       # The agent's ONLY job: read the digest (merge_sha + signals, no private
       # identifiers), author a concise learning-proposal body for each candidate
       # worth proposing, and write the bodies as a JSON object keyed by merge_sha
-      # to $RUNNER_TEMP/capture-c1-bodies.json. Nothing else — no code edits,
+      # to $RUNNER_TEMP/capture-learnings-bodies.json. Nothing else — no code edits,
       # no doc edits, no other issues, no API exploration.
       #
       # The privacy gate and issue-create run deterministically in the propose
@@ -82,18 +83,19 @@ jobs:
       # this job's permissions block — it carries no `issues: write`. Issue creation
       # is prevented by that scope, not by omitting the token. The agent only reads
       # the digest file and writes the bodies file; issue creation stays exclusively
-      # in the deterministic propose step under the App token.
+      # in the deterministic open step under the App token.
       - name: 🤖 Author proposal bodies
         id: agent
         uses: fro-bot/agent@a12463fab12958ed122856db287c061b623c2834 # v0.75.0
         env:
-          CAPTURE_C1_DIGEST_PATH: ${{ runner.temp }}/capture-c1-digest.json
+          CAPTURE_LEARNINGS_DIGEST_PATH: ${{ runner.temp }}/capture-learnings-digest.json
           TASK_PROMPT: |
-            You are authoring learning-proposal bodies for the C1 capture pipeline.
+            You are authoring learning-proposal bodies. Each body distills a reusable
+            learning from a pull request that went through multiple substantive review rounds.
 
             Your ONLY job in this step:
-            1. Read the harvest digest from $CAPTURE_C1_DIGEST_PATH (or equivalently
-               $RUNNER_TEMP/capture-c1-digest.json). The digest is a JSON object:
+            1. Read the harvest digest from $CAPTURE_LEARNINGS_DIGEST_PATH (or equivalently
+               $RUNNER_TEMP/capture-learnings-digest.json). The digest is a JSON object:
                { "candidates": [...], "telemetry": {...} }
                Each candidate in the candidates array has:
                - mergeSha: opaque merge commit SHA (the ONLY identifier you receive)
@@ -108,7 +110,7 @@ jobs:
                  information and must not attempt to retrieve it)
                - Proposes what the learning would be
                - Is suitable for a human to review and author into docs/solutions/
-            3. Write the bodies as a JSON object to $RUNNER_TEMP/capture-c1-bodies.json:
+            3. Write the bodies as a JSON object to $RUNNER_TEMP/capture-learnings-bodies.json:
                { "<mergeSha>": "<body text>", ... }
                Include only candidates you judge worth proposing. Omit candidates
                you judge low-value (empty object {} is valid if none merit a proposal).
@@ -117,14 +119,14 @@ jobs:
 
             Hard boundaries:
             - Never look up PR details, owner, repo name, PR number, or author.
-            - Never create issues yourself — the propose step does that.
-            - Never write to any path other than $RUNNER_TEMP/capture-c1-bodies.json.
+            - Never create issues yourself — the open step does that.
+            - Never write to any path other than $RUNNER_TEMP/capture-learnings-bodies.json.
             - Output only the bodies file. No summary issue. No comments.
         with:
           # The action requires a github-token input. Pass the workflow's auto-provisioned
           # GITHUB_TOKEN, which is scoped to `contents: read` by this job's permissions — it
           # cannot create issues. Issue creation remains exclusively in the deterministic
-          # propose step (via the App token), so the agent still cannot bypass the privacy
+          # open step (via the App token), so the agent still cannot bypass the privacy
           # gate or open issues directly.
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auth-json: ${{ secrets.OPENCODE_AUTH_JSON }}
@@ -133,18 +135,18 @@ jobs:
           opencode-config: ${{ secrets.OPENCODE_CONFIG }}
           prompt: ${{ env.TASK_PROMPT }}
 
-      # Deterministic propose step (SHAPE B): reads the harvest digest and the
+      # Deterministic open step (SHAPE B): reads the harvest digest and the
       # agent-authored bodies, runs the privacy gate (fail-closed against
       # metadata/repos.yaml), applies same-run dedup, and opens the issues.
       # The privacy gate runs here — not at agent discretion.
       - name: 📬 Open learning-proposal issues
-        id: propose
+        id: open
         env:
           GITHUB_TOKEN: ${{ steps.get-workflow-app-token.outputs.token }}
-          CAPTURE_C1_DIGEST_PATH: ${{ runner.temp }}/capture-c1-digest.json
-          CAPTURE_C1_BODIES_PATH: ${{ runner.temp }}/capture-c1-bodies.json
-          CAPTURE_C1_RESULT_PATH: ${{ runner.temp }}/capture-c1-result.json
-        run: node scripts/capture-c1-propose.ts | tee "$RUNNER_TEMP/propose-output.json"
+          CAPTURE_LEARNINGS_DIGEST_PATH: ${{ runner.temp }}/capture-learnings-digest.json
+          CAPTURE_LEARNINGS_BODIES_PATH: ${{ runner.temp }}/capture-learnings-bodies.json
+          CAPTURE_LEARNINGS_RESULT_PATH: ${{ runner.temp }}/capture-learnings-result.json
+        run: node scripts/capture-learnings-open.ts | tee "$RUNNER_TEMP/open-output.json"
         shell: bash
 
       - if: always()
@@ -152,25 +154,28 @@ jobs:
         run: |
           set -euo pipefail
           harvest="$RUNNER_TEMP/harvest-result.json"
-          result="$RUNNER_TEMP/capture-c1-result.json"
+          result="$RUNNER_TEMP/capture-learnings-result.json"
 
           {
-            echo "## Capture Learning Proposals Summary"
+            echo "## Capture Learnings Summary"
             echo ""
             echo "| Field | Value |"
             echo "| --- | --- |"
 
             if [[ -s "$harvest" ]]; then
-              echo "| PRs examined | $(jq '.telemetry.examined // 0' "$harvest") |"
-              echo "| After proposal dedup | $(jq '.telemetry.afterProposalDedup // 0' "$harvest") |"
+              echo "| Closed PRs fetched | $(jq '.telemetry.closedPrsFetched // 0' "$harvest") |"
+              echo "| Merged PRs in lookback | $(jq '.telemetry.mergedPrsInLookback // 0' "$harvest") |"
+              echo "| Excluded automation | $(jq '.telemetry.excludedAutomation // 0' "$harvest") |"
+              echo "| Multi-round candidates | $(jq '.telemetry.multiRoundCandidates // 0' "$harvest") |"
+              echo "| After proposal dedup | $(jq '.telemetry.afterSeenDedup // 0' "$harvest") |"
               echo "| After solutions dedup | $(jq '.telemetry.afterSolutionsDedup // 0' "$harvest") |"
               echo "| Candidates emitted | $(jq '.telemetry.emitted // 0' "$harvest") |"
             else
-              echo "| PRs examined | (harvest result unavailable) |"
+              echo "| Closed PRs fetched | (harvest result unavailable) |"
             fi
 
             if [[ -s "$result" ]]; then
-              echo "| Proposals opened | $(jq '.proposalsOpened // 0' "$result") |"
+              echo "| Proposals opened | $(jq '.learningsOpened // 0' "$result") |"
               echo "| Blocked on privacy | $(jq '.blockedOnPrivacy // 0' "$result") |"
               echo "| Skipped duplicate | $(jq '.skippedDuplicate // 0' "$result") |"
               echo "| Failed | $(jq '.failed // 0' "$result") |"

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -227,15 +227,15 @@ The `Merge Data Branch` workflow runs on a schedule (weekly) and opens a `data �
 
 ## Learning-proposal capture
 
-A weekly scheduled run (`capture-learnings.yaml`, Sunday 22:30 UTC) examines this repo's merged PRs for those that required multiple rounds of changes-requested reviews — the richest mistake→correction signal — and opens a GitHub issue proposing a candidate learning for each.
+A weekly scheduled run (`capture-learnings.yaml`, Sunday 22:30 UTC) examines this repo's merged PRs for those that required multiple rounds of substantive Fro Bot reviews — the richest mistake→correction signal — and opens a GitHub issue proposing a candidate learning for each.
 
 Each proposal is labeled `learning-proposal` and carries an immutable body marker (`<!-- captured-learning:merge_sha=<sha> -->`). The marker is the reset-resilient decision log: the run rebuilds its seen-set each week by querying all `learning-proposal` issues (state: all, including closed), so a data-branch reset cannot wipe the log.
 
-**Privacy:** the harvest digest identifies candidates by merge commit SHA only — no owner, repo name, PR number, or title reaches the agent or the proposal body. The agent authors proposal bodies referencing the source by merge SHA only. Before any issue is created, the body is scanned against the private-repo token set from `metadata/repos.yaml` (fail-closed: a missing or unreadable overlay aborts the propose step with no issues posted).
+**Privacy:** the harvest digest identifies candidates by merge commit SHA only — no owner, repo name, PR number, or title reaches the agent or the proposal body. The agent authors proposal bodies referencing the source by merge SHA only. Before any issue is created, the body is scanned against the private-repo token set from `metadata/repos.yaml` (fail-closed: a missing or unreadable overlay aborts the open step with no issues posted).
 
 **Human review:** proposals are human-reviewed. There is no auto-merge or auto-promotion path. A human authors the final learning into `docs/solutions/` via `ce:compound` when a proposal is accepted.
 
-**Cadence and cost:** weekly, capped at `MAX_PROPOSALS_PER_RUN` candidates, with a bounded lookback window. The step summary reports counts only (PRs examined, candidates after dedup, proposals opened, blocked on privacy).
+**Cadence and cost:** weekly, capped at `MAX_LEARNINGS_PER_RUN` candidates, with a bounded lookback window. The step summary reports counts only (PRs examined, candidates after dedup, learnings opened, blocked on privacy).
 
 ## Metrics note
 

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -227,9 +227,9 @@ The `Merge Data Branch` workflow runs on a schedule (weekly) and opens a `data �
 
 ## Learning-proposal capture
 
-A weekly scheduled run (`capture-c1-proposals.yaml`, Sunday 22:30 UTC) examines this repo's merged PRs for those that required multiple rounds of changes-requested reviews — the richest mistake→correction signal — and opens a GitHub issue proposing a candidate learning for each.
+A weekly scheduled run (`capture-learnings.yaml`, Sunday 22:30 UTC) examines this repo's merged PRs for those that required multiple rounds of changes-requested reviews — the richest mistake→correction signal — and opens a GitHub issue proposing a candidate learning for each.
 
-Each proposal is labeled `learning-proposal` and carries an immutable body marker (`<!-- capture-c1:merge_sha=<sha> -->`). The marker is the reset-resilient decision log: the run rebuilds its seen-set each week by querying all `learning-proposal` issues (state: all, including closed), so a data-branch reset cannot wipe the log.
+Each proposal is labeled `learning-proposal` and carries an immutable body marker (`<!-- captured-learning:merge_sha=<sha> -->`). The marker is the reset-resilient decision log: the run rebuilds its seen-set each week by querying all `learning-proposal` issues (state: all, including closed), so a data-branch reset cannot wipe the log.
 
 **Privacy:** the harvest digest identifies candidates by merge commit SHA only — no owner, repo name, PR number, or title reaches the agent or the proposal body. The agent authors proposal bodies referencing the source by merge SHA only. Before any issue is created, the body is scanned against the private-repo token set from `metadata/repos.yaml` (fail-closed: a missing or unreadable overlay aborts the propose step with no issues posted).
 

--- a/scripts/capture-learnings-harvest.test.ts
+++ b/scripts/capture-learnings-harvest.test.ts
@@ -1,10 +1,10 @@
 /**
- * Tests for capture-c1-harvest.ts
+ * Tests for capture-learnings-harvest.ts
  *
  * Structure:
  * - Pure core tests: drive `buildCandidateDigest` with injected data
  * - Marker helper tests: `buildMergeShaMarker` / `parseMergeShaMarker`
- * - I/O shell tests: `harvestCandidates` and `fetchProposedMergeShas` with mocked Octokit
+ * - I/O shell tests: `harvestCandidates` and `fetchOpenedLearningShas` with mocked Octokit
  */
 
 import {describe, expect, it, vi} from 'vitest'
@@ -12,16 +12,19 @@ import {describe, expect, it, vi} from 'vitest'
 import {
   buildCandidateDigest,
   buildMergeShaMarker,
-  fetchProposedMergeShas,
+  DEPENDENCY_LABELS,
+  fetchOpenedLearningShas,
+  FRO_BOT_REVIEWER_LOGINS,
   harvestCandidates,
   LEARNING_PROPOSAL_LABEL,
   parseMergeShaMarker,
   type BuildCandidateDigestInput,
   type Candidate,
   type CandidateDigest,
+  type HarvestStageCounts,
   type OctokitClient,
   type SolutionDoc,
-} from './capture-c1-harvest.ts'
+} from './capture-learnings-harvest.ts'
 
 // ---------------------------------------------------------------------------
 // Fixture helpers
@@ -46,12 +49,22 @@ function makeSolutionDoc(overrides: Partial<SolutionDoc> = {}): SolutionDoc {
   }
 }
 
+function makeZeroStageCounts(): HarvestStageCounts {
+  return {
+    closedPrsFetched: 0,
+    mergedPrsInLookback: 0,
+    excludedAutomation: 0,
+    multiRoundCandidates: 0,
+  }
+}
+
 function makeDigestInput(overrides: Partial<BuildCandidateDigestInput> = {}): BuildCandidateDigestInput {
   return {
     mergedPrs: [makeCandidate()],
-    proposedMergeShas: new Set(),
+    stageCounts: makeZeroStageCounts(),
+    openedLearningShas: new Set(),
     solutionsDocs: [],
-    maxProposals: 5,
+    maxLearnings: 5,
     ...overrides,
   }
 }
@@ -65,14 +78,14 @@ describe('buildMergeShaMarker', () => {
     // #given a merge SHA
     // #when building the marker
     // #then it matches the expected format
-    expect(buildMergeShaMarker('abc123')).toBe('<!-- capture-c1:merge_sha=abc123 -->')
+    expect(buildMergeShaMarker('abc123')).toBe('<!-- captured-learning:merge_sha=abc123 -->')
   })
 })
 
 describe('parseMergeShaMarker', () => {
   it('extracts the SHA from a well-formed marker', () => {
     // #given a body containing the marker
-    const body = 'Some text\n<!-- capture-c1:merge_sha=abc123def456 -->\nMore text'
+    const body = 'Some text\n<!-- captured-learning:merge_sha=abc123def456 -->\nMore text'
     // #when parsing
     // #then the SHA is returned
     expect(parseMergeShaMarker(body)).toBe('abc123def456')
@@ -89,7 +102,7 @@ describe('parseMergeShaMarker', () => {
     // #given a body with a malformed marker
     // #when parsing
     // #then null is returned (regex requires 7-40 hex chars)
-    expect(parseMergeShaMarker('<!-- capture-c1:merge_sha= -->')).toBeNull()
+    expect(parseMergeShaMarker('<!-- captured-learning:merge_sha= -->')).toBeNull()
   })
 
   it('returns null for an empty body', () => {
@@ -142,12 +155,12 @@ describe('buildCandidateDigest', () => {
   })
 
   describe('proposal dedup (R3)', () => {
-    it('excludes a candidate whose mergeSha is in proposedMergeShas', () => {
+    it('excludes a candidate whose mergeSha is in openedLearningShas', () => {
       // #given a candidate whose SHA is already in the seen-set
       const sha = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
       const input = makeDigestInput({
         mergedPrs: [makeCandidate({mergeSha: sha})],
-        proposedMergeShas: new Set([sha]),
+        openedLearningShas: new Set([sha]),
       })
 
       // #when building the digest
@@ -155,7 +168,7 @@ describe('buildCandidateDigest', () => {
 
       // #then the candidate is excluded
       expect(result.candidates).toHaveLength(0)
-      expect(result.telemetry.afterProposalDedup).toBe(0)
+      expect(result.telemetry.afterSeenDedup).toBe(0)
     })
 
     it('mutation proof: removing the seen-set filter makes the candidate reappear', () => {
@@ -167,7 +180,7 @@ describe('buildCandidateDigest', () => {
       const withDedup = buildCandidateDigest(
         makeDigestInput({
           mergedPrs: [candidate],
-          proposedMergeShas: new Set([sha]),
+          openedLearningShas: new Set([sha]),
         }),
       )
       // #then the candidate is excluded
@@ -177,7 +190,7 @@ describe('buildCandidateDigest', () => {
       const withoutDedup = buildCandidateDigest(
         makeDigestInput({
           mergedPrs: [candidate],
-          proposedMergeShas: new Set(),
+          openedLearningShas: new Set(),
         }),
       )
       // #then the candidate reappears — proving the dedup was the gate
@@ -185,10 +198,10 @@ describe('buildCandidateDigest', () => {
       expect(withoutDedup.candidates[0]?.mergeSha).toBe(sha)
     })
 
-    it('includes a candidate whose mergeSha is NOT in proposedMergeShas', () => {
+    it('includes a candidate whose mergeSha is NOT in openedLearningShas', () => {
       // #given a candidate with a SHA not in the seen-set
       const input = makeDigestInput({
-        proposedMergeShas: new Set(['other-sha-not-matching']),
+        openedLearningShas: new Set(['other-sha-not-matching']),
       })
 
       // #when building the digest
@@ -273,14 +286,14 @@ describe('buildCandidateDigest', () => {
   })
 
   describe('cap (R6)', () => {
-    it('caps candidates to maxProposals when more are available', () => {
+    it('caps candidates to maxLearnings when more are available', () => {
       // #given 7 candidates and a cap of 3
       const candidates = Array.from({length: 7}, (_, i) =>
         makeCandidate({mergeSha: `sha${i}${'0'.repeat(35 - String(i).length)}`}),
       )
       const input = makeDigestInput({
         mergedPrs: candidates,
-        maxProposals: 3,
+        maxLearnings: 3,
       })
 
       // #when building the digest
@@ -297,7 +310,7 @@ describe('buildCandidateDigest', () => {
         makeCandidate({mergeSha: `sha1${'0'.repeat(36)}`}),
         makeCandidate({mergeSha: `sha2${'0'.repeat(36)}`}),
       ]
-      const input = makeDigestInput({mergedPrs: candidates, maxProposals: 5})
+      const input = makeDigestInput({mergedPrs: candidates, maxLearnings: 5})
 
       // #when building the digest
       const result = buildCandidateDigest(input)
@@ -311,32 +324,44 @@ describe('buildCandidateDigest', () => {
   describe('telemetry counts', () => {
     it('reports correct counts through the dedup pipeline', () => {
       // #given 5 candidates: 2 already proposed, 1 overlaps a doc (2 shared tags), 2 clean
-      const proposedSha1 = `proposed1${'0'.repeat(31)}`
-      const proposedSha2 = `proposed2${'0'.repeat(31)}`
+      const seenSha1 = `proposed1${'0'.repeat(31)}`
+      const seenSha2 = `proposed2${'0'.repeat(31)}`
       const overlapSha = `overlap1${'0'.repeat(32)}`
       const cleanSha1 = `clean001${'0'.repeat(32)}`
       const cleanSha2 = `clean002${'0'.repeat(32)}`
 
+      const stageCounts: HarvestStageCounts = {
+        closedPrsFetched: 20,
+        mergedPrsInLookback: 10,
+        excludedAutomation: 2,
+        multiRoundCandidates: 5,
+      }
+
       const input = makeDigestInput({
         mergedPrs: [
-          makeCandidate({mergeSha: proposedSha1}),
-          makeCandidate({mergeSha: proposedSha2}),
+          makeCandidate({mergeSha: seenSha1}),
+          makeCandidate({mergeSha: seenSha2}),
           // Two shared tags (automation + ci) = 20 pts >= threshold of 20 → excluded
           makeCandidate({mergeSha: overlapSha, signals: {titleTokens: [], labels: ['automation', 'ci']}}),
           makeCandidate({mergeSha: cleanSha1}),
           makeCandidate({mergeSha: cleanSha2}),
         ],
-        proposedMergeShas: new Set([proposedSha1, proposedSha2]),
+        stageCounts,
+        openedLearningShas: new Set([seenSha1, seenSha2]),
         solutionsDocs: [makeSolutionDoc({tags: ['automation', 'ci'], problemType: '', module: ''})],
-        maxProposals: 5,
+        maxLearnings: 5,
       })
 
       // #when building the digest
       const result = buildCandidateDigest(input)
 
-      // #then telemetry reflects each dedup stage
-      expect(result.telemetry.examined).toBe(5)
-      expect(result.telemetry.afterProposalDedup).toBe(3) // 5 - 2 proposed
+      // #then harvest-stage telemetry is threaded through
+      expect(result.telemetry.closedPrsFetched).toBe(20)
+      expect(result.telemetry.mergedPrsInLookback).toBe(10)
+      expect(result.telemetry.excludedAutomation).toBe(2)
+      expect(result.telemetry.multiRoundCandidates).toBe(5)
+      // #then dedup-stage telemetry reflects each stage
+      expect(result.telemetry.afterSeenDedup).toBe(3) // 5 - 2 proposed
       expect(result.telemetry.afterSolutionsDedup).toBe(2) // 3 - 1 overlap
       expect(result.telemetry.emitted).toBe(2) // 2 clean, under cap
     })
@@ -346,15 +371,14 @@ describe('buildCandidateDigest', () => {
       const sha = `allproposed${'0'.repeat(29)}`
       const input = makeDigestInput({
         mergedPrs: [makeCandidate({mergeSha: sha})],
-        proposedMergeShas: new Set([sha]),
+        openedLearningShas: new Set([sha]),
       })
 
       // #when building the digest
       const result = buildCandidateDigest(input)
 
-      // #then all counts are zero except examined
-      expect(result.telemetry.examined).toBe(1)
-      expect(result.telemetry.afterProposalDedup).toBe(0)
+      // #then dedup counts are zero
+      expect(result.telemetry.afterSeenDedup).toBe(0)
       expect(result.telemetry.afterSolutionsDedup).toBe(0)
       expect(result.telemetry.emitted).toBe(0)
     })
@@ -367,8 +391,7 @@ describe('buildCandidateDigest', () => {
       const result = buildCandidateDigest(input)
 
       // #then all counts are zero
-      expect(result.telemetry.examined).toBe(0)
-      expect(result.telemetry.afterProposalDedup).toBe(0)
+      expect(result.telemetry.afterSeenDedup).toBe(0)
       expect(result.telemetry.afterSolutionsDedup).toBe(0)
       expect(result.telemetry.emitted).toBe(0)
     })
@@ -385,10 +408,12 @@ interface PullsListItem {
   merge_commit_sha: string | null
   title: string
   labels: {name: string}[]
+  user: {login: string} | null
 }
 
 interface ReviewItem {
   state: string
+  user: {login: string} | null
 }
 
 function makePullsListItem(overrides: Partial<PullsListItem> = {}): PullsListItem {
@@ -398,12 +423,13 @@ function makePullsListItem(overrides: Partial<PullsListItem> = {}): PullsListIte
     merge_commit_sha: 'abc123def456abc123def456abc123def456abc1',
     title: 'feat: add new feature',
     labels: [],
+    user: {login: 'some-human'},
     ...overrides,
   }
 }
 
-function makeReviewItem(state: string): ReviewItem {
-  return {state}
+function makeReviewItem(state: string, login = 'fro-bot'): ReviewItem {
+  return {state, user: {login}}
 }
 
 function mockOctokit(
@@ -452,6 +478,10 @@ function mockOctokit(
 }
 
 describe('harvestCandidates', () => {
+  // -------------------------------------------------------------------------
+  // Basic exclusion (merged_at / lookback / merge_commit_sha)
+  // -------------------------------------------------------------------------
+
   it('excludes a PR with merged_at === null (unmerged)', async () => {
     // #given a closed PR that was never merged
     const pr = makePullsListItem({merged_at: null})
@@ -460,10 +490,10 @@ describe('harvestCandidates', () => {
     })
 
     // #when harvesting
-    const result = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
 
     // #then the PR is excluded
-    expect(result).toHaveLength(0)
+    expect(candidates).toHaveLength(0)
   })
 
   it('excludes a PR merged outside the lookback window', async () => {
@@ -476,29 +506,167 @@ describe('harvestCandidates', () => {
     })
 
     // #when harvesting
-    const result = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
 
     // #then the PR is excluded
-    expect(result).toHaveLength(0)
+    expect(candidates).toHaveLength(0)
   })
 
-  it('excludes a PR with only COMMENTED reviews (reviewRounds = 0)', async () => {
-    // #given a merged PR with only COMMENTED reviews
-    const pr = makePullsListItem()
+  // -------------------------------------------------------------------------
+  // Dependency-automation exclusion
+  // -------------------------------------------------------------------------
+
+  it('excludes a PR authored by renovate[bot]', async () => {
+    // #given a merged PR authored by renovate[bot] with qualifying fro-bot reviews
+    const pr = makePullsListItem({user: {login: 'renovate[bot]'}})
     const octokit = mockOctokit({
       paginatePrList: async () => [pr],
-      paginateListReviews: async () => [makeReviewItem('COMMENTED'), makeReviewItem('COMMENTED')],
+      paginateListReviews: async () => [makeReviewItem('APPROVED'), makeReviewItem('DISMISSED')],
     })
 
     // #when harvesting
-    const result = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+    const {candidates, stageCounts} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
 
-    // #then the PR is excluded (0 CHANGES_REQUESTED < threshold of 2)
-    expect(result).toHaveLength(0)
+    // #then the PR is excluded by author, not counted as a candidate
+    expect(candidates).toHaveLength(0)
+    expect(stageCounts.excludedAutomation).toBe(1)
   })
 
-  it('excludes a PR with only APPROVED reviews (reviewRounds = 0)', async () => {
-    // #given a merged PR with only APPROVED reviews
+  it('excludes a PR authored by dependabot[bot]', async () => {
+    // #given a merged PR authored by dependabot[bot]
+    const pr = makePullsListItem({user: {login: 'dependabot[bot]'}})
+    const octokit = mockOctokit({
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => [makeReviewItem('APPROVED'), makeReviewItem('DISMISSED')],
+    })
+
+    // #when harvesting
+    const {candidates, stageCounts} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then the PR is excluded by author
+    expect(candidates).toHaveLength(0)
+    expect(stageCounts.excludedAutomation).toBe(1)
+  })
+
+  it('excludes a PR carrying a "dependencies" label', async () => {
+    // #given a merged PR with a 'dependencies' label and qualifying fro-bot reviews
+    const pr = makePullsListItem({labels: [{name: 'dependencies'}]})
+    const octokit = mockOctokit({
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => [makeReviewItem('APPROVED'), makeReviewItem('DISMISSED')],
+    })
+
+    // #when harvesting
+    const {candidates, stageCounts} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then the PR is excluded by label
+    expect(candidates).toHaveLength(0)
+    expect(stageCounts.excludedAutomation).toBe(1)
+  })
+
+  it('excludes a PR carrying a "renovate" label', async () => {
+    // #given a merged PR with a 'renovate' label
+    const pr = makePullsListItem({labels: [{name: 'renovate'}]})
+    const octokit = mockOctokit({
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => [makeReviewItem('APPROVED'), makeReviewItem('DISMISSED')],
+    })
+
+    // #when harvesting
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then the PR is excluded by label
+    expect(candidates).toHaveLength(0)
+  })
+
+  it('DEPENDENCY_LABELS set contains the expected labels', () => {
+    // #given the exported constant
+    // #then it contains the three expected labels
+    expect(DEPENDENCY_LABELS.has('dependencies')).toBe(true)
+    expect(DEPENDENCY_LABELS.has('renovate')).toBe(true)
+    expect(DEPENDENCY_LABELS.has('dependencies:github-actions')).toBe(true)
+  })
+
+  // -------------------------------------------------------------------------
+  // New predicate: fro-bot login keying + substantive/correction counts
+  // -------------------------------------------------------------------------
+
+  it('APPROVED 1 + DISMISSED 1 → CANDIDATE (substantive=2, correction=1) — #3540/#3543 shape', async () => {
+    // #given a merged PR where fro-bot submitted APPROVED then DISMISSED
+    // DISMISSED = prior APPROVED auto-dismissed by a new push = real correction round
+    const sha = 'abc123def456abc123def456abc123def456abc1'
+    const pr = makePullsListItem({merge_commit_sha: sha})
+    const octokit = mockOctokit({
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => [makeReviewItem('APPROVED'), makeReviewItem('DISMISSED')],
+    })
+
+    // #when harvesting
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then the PR is a candidate with reviewRounds = 2 (substantive count)
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0]?.mergeSha).toBe(sha)
+    expect(candidates[0]?.reviewRounds).toBe(2)
+  })
+
+  it('CHANGES_REQUESTED 1 + APPROVED 1 → CANDIDATE (substantive=2, correction=1) — #3530/#3517 shape', async () => {
+    // #given a merged PR where fro-bot submitted CHANGES_REQUESTED then APPROVED
+    const sha = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+    const pr = makePullsListItem({merge_commit_sha: sha})
+    const octokit = mockOctokit({
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => [makeReviewItem('CHANGES_REQUESTED'), makeReviewItem('APPROVED')],
+    })
+
+    // #when harvesting
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then the PR is a candidate (CR still counts as correction signal)
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0]?.reviewRounds).toBe(2)
+  })
+
+  it('APPROVED 2 + DISMISSED 1 → CANDIDATE (substantive=3, correction=1) — #3526 shape', async () => {
+    // #given a merged PR with 3 substantive fro-bot reviews, 1 correction
+    const sha = `sha3526${'0'.repeat(34)}`
+    const pr = makePullsListItem({merge_commit_sha: sha})
+    const octokit = mockOctokit({
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => [
+        makeReviewItem('APPROVED'),
+        makeReviewItem('DISMISSED'),
+        makeReviewItem('APPROVED'),
+      ],
+    })
+
+    // #when harvesting
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then the PR is a candidate with reviewRounds = 3
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0]?.reviewRounds).toBe(3)
+  })
+
+  it('DISMISSED 2 → CANDIDATE (substantive=2, correction=2) — #3514 shape', async () => {
+    // #given a merged PR where fro-bot submitted 2 DISMISSED reviews
+    const sha = `sha3514${'0'.repeat(34)}`
+    const pr = makePullsListItem({merge_commit_sha: sha})
+    const octokit = mockOctokit({
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => [makeReviewItem('DISMISSED'), makeReviewItem('DISMISSED')],
+    })
+
+    // #when harvesting
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then the PR is a candidate
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0]?.reviewRounds).toBe(2)
+  })
+
+  it('APPROVED 1 only → NOT candidate (substantive=1 < MIN_SUBSTANTIVE_REVIEW_ROUNDS) — #3539 shape', async () => {
+    // #given a merged PR with only 1 fro-bot APPROVED review (clean single-round approval)
     const pr = makePullsListItem()
     const octokit = mockOctokit({
       paginatePrList: async () => [pr],
@@ -506,64 +674,100 @@ describe('harvestCandidates', () => {
     })
 
     // #when harvesting
-    const result = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
 
-    // #then the PR is excluded
-    expect(result).toHaveLength(0)
+    // #then the PR is NOT a candidate (below MIN_SUBSTANTIVE_REVIEW_ROUNDS)
+    expect(candidates).toHaveLength(0)
   })
 
-  it('excludes a PR with only 1 CHANGES_REQUESTED review (below threshold)', async () => {
-    // #given a merged PR with 1 CHANGES_REQUESTED review
+  it('APPROVED 2, no correction → NOT candidate (substantive=2 but correction=0) — key edge case', async () => {
+    // #given a merged PR with 2 fro-bot APPROVED reviews but zero correction signals
+    // This proves correction >= MIN_CORRECTION_SIGNALS is required, not just rounds >= 2.
     const pr = makePullsListItem()
     const octokit = mockOctokit({
       paginatePrList: async () => [pr],
-      paginateListReviews: async () => [makeReviewItem('CHANGES_REQUESTED')],
+      paginateListReviews: async () => [makeReviewItem('APPROVED'), makeReviewItem('APPROVED')],
     })
 
     // #when harvesting
-    const result = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
 
-    // #then the PR is excluded (1 < threshold of 2)
-    expect(result).toHaveLength(0)
+    // #then the PR is NOT a candidate (no correction signal)
+    expect(candidates).toHaveLength(0)
   })
 
-  it('includes a PR with exactly 2 CHANGES_REQUESTED reviews', async () => {
-    // #given a merged PR with 2 CHANGES_REQUESTED reviews
-    const sha = 'abc123def456abc123def456abc123def456abc1'
-    const pr = makePullsListItem({merge_commit_sha: sha})
-    const octokit = mockOctokit({
-      paginatePrList: async () => [pr],
-      paginateListReviews: async () => [makeReviewItem('CHANGES_REQUESTED'), makeReviewItem('CHANGES_REQUESTED')],
-    })
-
-    // #when harvesting
-    const result = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
-
-    // #then the PR is included with its mergeSha and reviewRounds
-    expect(result).toHaveLength(1)
-    expect(result[0]?.mergeSha).toBe(sha)
-    expect(result[0]?.reviewRounds).toBe(2)
-  })
-
-  it('counts only CHANGES_REQUESTED reviews, not COMMENTED or APPROVED', async () => {
-    // #given a merged PR with mixed review states
+  it('reviews by a non-fro-bot login are NOT counted — login keying proof', async () => {
+    // #given a merged PR where 'someone-else' submitted APPROVED + DISMISSED
+    // (qualifying if login filter were absent, but fro-bot has no reviews)
     const pr = makePullsListItem()
     const octokit = mockOctokit({
       paginatePrList: async () => [pr],
       paginateListReviews: async () => [
-        makeReviewItem('CHANGES_REQUESTED'),
-        makeReviewItem('COMMENTED'),
-        makeReviewItem('APPROVED'),
-        makeReviewItem('CHANGES_REQUESTED'),
+        makeReviewItem('APPROVED', 'someone-else'),
+        makeReviewItem('DISMISSED', 'someone-else'),
       ],
     })
 
     // #when harvesting
-    const result = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
 
-    // #then reviewRounds is 2 (only CHANGES_REQUESTED counted)
-    expect(result).toHaveLength(1)
-    expect(result[0]?.reviewRounds).toBe(2)
+    // #then the PR is NOT a candidate (non-fro-bot reviews are ignored)
+    expect(candidates).toHaveLength(0)
+  })
+
+  it('mutation proof: removing login filter makes non-fro-bot multi-review PR a candidate', async () => {
+    // #given a PR with 'someone-else' APPROVED + DISMISSED (would qualify without login filter)
+    // This test proves the login filter is the gate — if you remove it, the PR wrongly qualifies.
+    // We verify by checking FRO_BOT_REVIEWER_LOGINS does NOT contain 'someone-else'.
+    expect(FRO_BOT_REVIEWER_LOGINS.has('someone-else')).toBe(false)
+    expect(FRO_BOT_REVIEWER_LOGINS.has('fro-bot')).toBe(true)
+
+    // #when the same reviews are attributed to fro-bot instead
+    const sha = `mutationproof${'0'.repeat(28)}`
+    const pr = makePullsListItem({merge_commit_sha: sha})
+    const octokit = mockOctokit({
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => [makeReviewItem('APPROVED', 'fro-bot'), makeReviewItem('DISMISSED', 'fro-bot')],
+    })
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then with fro-bot login the PR IS a candidate — proving login keying is the gate
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0]?.mergeSha).toBe(sha)
+  })
+
+  it('COMMENTED reviews do not count toward substantive (2 COMMENTED → not candidate)', async () => {
+    // #given a merged PR where fro-bot submitted 2 COMMENTED reviews only
+    const pr = makePullsListItem()
+    const octokit = mockOctokit({
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => [makeReviewItem('COMMENTED'), makeReviewItem('COMMENTED')],
+    })
+
+    // #when harvesting
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then the PR is NOT a candidate (COMMENTED excluded from substantive count)
+    expect(candidates).toHaveLength(0)
+  })
+
+  it('COMMENTED reviews mixed with 1 APPROVED → not candidate (substantive=1)', async () => {
+    // #given fro-bot submitted 2 COMMENTED + 1 APPROVED
+    const pr = makePullsListItem()
+    const octokit = mockOctokit({
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => [
+        makeReviewItem('COMMENTED'),
+        makeReviewItem('COMMENTED'),
+        makeReviewItem('APPROVED'),
+      ],
+    })
+
+    // #when harvesting
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then the PR is NOT a candidate (only 1 substantive review)
+    expect(candidates).toHaveLength(0)
   })
 
   it('skips a PR when paginate(listReviews) throws a transient error, continues processing others', async () => {
@@ -576,7 +780,7 @@ describe('harvestCandidates', () => {
     const paginateListReviews = vi
       .fn()
       .mockRejectedValueOnce(Object.assign(new Error('Service Unavailable'), {status: 503}))
-      .mockResolvedValueOnce([makeReviewItem('CHANGES_REQUESTED'), makeReviewItem('CHANGES_REQUESTED')])
+      .mockResolvedValueOnce([makeReviewItem('APPROVED'), makeReviewItem('DISMISSED')])
 
     const octokit = mockOctokit({
       paginatePrList: async () => [badPr, goodPr],
@@ -584,25 +788,26 @@ describe('harvestCandidates', () => {
     })
 
     // #when harvesting
-    const result = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
 
     // #then the bad PR is skipped, the good PR is included
-    expect(result).toHaveLength(1)
-    expect(result[0]?.mergeSha).toBe(goodSha)
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0]?.mergeSha).toBe(goodSha)
   })
 
-  it('counts CHANGES_REQUESTED reviews across multiple pages (pagination correctness)', async () => {
+  it('counts substantive reviews across multiple pages (pagination correctness)', async () => {
     // #given a PR whose reviews span 2 pages (simulated by paginateListReviews returning all)
     const sha = 'abc123def456abc123def456abc123def456abc1'
     const pr = makePullsListItem({merge_commit_sha: sha})
 
-    // Simulate paginate returning reviews from both pages combined
+    // Simulate paginate returning reviews from both pages combined:
+    // fro-bot: APPROVED, DISMISSED, APPROVED (3 substantive, 1 correction)
+    // COMMENTED is excluded from substantive count
     const allReviews: ReviewItem[] = [
-      makeReviewItem('CHANGES_REQUESTED'), // page 1
-      makeReviewItem('COMMENTED'),
-      makeReviewItem('CHANGES_REQUESTED'), // page 2
-      makeReviewItem('APPROVED'),
-      makeReviewItem('CHANGES_REQUESTED'), // page 2 continued
+      makeReviewItem('APPROVED'), // page 1
+      makeReviewItem('COMMENTED'), // excluded
+      makeReviewItem('DISMISSED'), // page 2 — correction signal
+      makeReviewItem('APPROVED'), // page 2 continued
     ]
 
     const octokit = mockOctokit({
@@ -611,16 +816,80 @@ describe('harvestCandidates', () => {
     })
 
     // #when harvesting
-    const result = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
 
-    // #then all 3 CHANGES_REQUESTED reviews are counted (not just the first page)
-    expect(result).toHaveLength(1)
-    expect(result[0]?.reviewRounds).toBe(3)
+    // #then all 3 substantive reviews are counted (not just the first page)
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0]?.reviewRounds).toBe(3)
+  })
+
+  // -------------------------------------------------------------------------
+  // Telemetry: explicit stage counts
+  // -------------------------------------------------------------------------
+
+  it('telemetry: reports correct stage counts through a multi-PR scenario', async () => {
+    // #given 6 closed PRs:
+    //   - 1 unmerged (excluded before mergedPrsInLookback)
+    //   - 1 merged outside lookback (excluded before mergedPrsInLookback)
+    //   - 1 merged in lookback, renovate[bot] author (excludedAutomation)
+    //   - 1 merged in lookback, no fro-bot substantive review (not a candidate)
+    //   - 1 merged in lookback, APPROVED only (not a candidate)
+    //   - 2 merged in lookback, qualifying fro-bot reviews (candidates)
+    const oldDate = new Date()
+    oldDate.setDate(oldDate.getDate() - 60)
+
+    const unmergedPr = makePullsListItem({number: 1, merged_at: null})
+    const oldPr = makePullsListItem({number: 2, merged_at: oldDate.toISOString()})
+    const renovatePr = makePullsListItem({number: 3, user: {login: 'renovate[bot]'}})
+    const noReviewPr = makePullsListItem({number: 4, merge_commit_sha: `norev${'0'.repeat(35)}`})
+    const approvedOnlyPr = makePullsListItem({number: 5, merge_commit_sha: `appr1${'0'.repeat(35)}`})
+    const candidate1Pr = makePullsListItem({number: 6, merge_commit_sha: `cand1${'0'.repeat(35)}`})
+    const candidate2Pr = makePullsListItem({number: 7, merge_commit_sha: `cand2${'0'.repeat(35)}`})
+
+    const reviewsByPr: Record<number, ReviewItem[]> = {
+      3: [makeReviewItem('APPROVED'), makeReviewItem('DISMISSED')], // renovate — excluded before reviews
+      4: [], // no reviews
+      5: [makeReviewItem('APPROVED')], // only 1 substantive
+      6: [makeReviewItem('APPROVED'), makeReviewItem('DISMISSED')], // candidate
+      7: [makeReviewItem('CHANGES_REQUESTED'), makeReviewItem('APPROVED')], // candidate
+    }
+
+    let reviewCallCount = 0
+    const paginateListReviews = vi.fn(async () => {
+      // PRs are processed in order: renovate is excluded before reviews are fetched.
+      // Remaining: noReviewPr(4), approvedOnlyPr(5), candidate1Pr(6), candidate2Pr(7)
+      const prNumbers = [4, 5, 6, 7]
+      const prNum = prNumbers[reviewCallCount++]
+      return reviewsByPr[prNum ?? 4] ?? []
+    })
+
+    const octokit = mockOctokit({
+      paginatePrList: async () => [
+        unmergedPr,
+        oldPr,
+        renovatePr,
+        noReviewPr,
+        approvedOnlyPr,
+        candidate1Pr,
+        candidate2Pr,
+      ],
+      paginateListReviews: paginateListReviews as () => Promise<ReviewItem[]>,
+    })
+
+    // #when harvesting
+    const {candidates, stageCounts} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then stage counts are explicit and correct
+    expect(stageCounts.closedPrsFetched).toBe(7)
+    expect(stageCounts.mergedPrsInLookback).toBe(5) // excludes unmerged + old
+    expect(stageCounts.excludedAutomation).toBe(1) // renovate[bot]
+    expect(stageCounts.multiRoundCandidates).toBe(2) // cand1 + cand2
+    expect(candidates).toHaveLength(2)
   })
 })
 
 // ---------------------------------------------------------------------------
-// I/O shell: fetchProposedMergeShas (mocked Octokit)
+// I/O shell: fetchOpenedLearningShas (mocked Octokit)
 // ---------------------------------------------------------------------------
 
 interface IssueListItem {
@@ -661,7 +930,7 @@ function mockOctokitForIssues(
   } as unknown as OctokitClient
 }
 
-describe('fetchProposedMergeShas', () => {
+describe('fetchOpenedLearningShas', () => {
   it('parses the merge SHA from a learning-proposal issue body', async () => {
     // #given an issue with a valid marker in its body
     const sha = 'abc123def456abc123def456abc123def456abc1'
@@ -671,7 +940,7 @@ describe('fetchProposedMergeShas', () => {
     })
 
     // #when fetching proposed SHAs
-    const result = await fetchProposedMergeShas(octokit, 'fro-bot', '.github')
+    const result = await fetchOpenedLearningShas(octokit, 'fro-bot', '.github')
 
     // #then the SHA is in the seen-set
     expect(result.has(sha)).toBe(true)
@@ -687,7 +956,7 @@ describe('fetchProposedMergeShas', () => {
     })
 
     // #when fetching proposed SHAs
-    const result = await fetchProposedMergeShas(octokit, 'fro-bot', '.github')
+    const result = await fetchOpenedLearningShas(octokit, 'fro-bot', '.github')
 
     // #then the SHA from the closed issue is in the seen-set
     expect(result.has(sha)).toBe(true)
@@ -701,7 +970,7 @@ describe('fetchProposedMergeShas', () => {
     })
 
     // #when fetching proposed SHAs
-    const result = await fetchProposedMergeShas(octokit, 'fro-bot', '.github')
+    const result = await fetchOpenedLearningShas(octokit, 'fro-bot', '.github')
 
     // #then the result is an empty set (no crash)
     expect(result.size).toBe(0)
@@ -715,7 +984,7 @@ describe('fetchProposedMergeShas', () => {
     })
 
     // #when fetching proposed SHAs
-    const result = await fetchProposedMergeShas(octokit, 'fro-bot', '.github')
+    const result = await fetchOpenedLearningShas(octokit, 'fro-bot', '.github')
 
     // #then the result is an empty set (no crash)
     expect(result.size).toBe(0)
@@ -729,7 +998,7 @@ describe('fetchProposedMergeShas', () => {
     })
 
     // #when fetching proposed SHAs
-    const result = await fetchProposedMergeShas(octokit, 'fro-bot', '.github')
+    const result = await fetchOpenedLearningShas(octokit, 'fro-bot', '.github')
 
     // #then the result is an empty set
     expect(result.size).toBe(0)
@@ -748,7 +1017,7 @@ describe('fetchProposedMergeShas', () => {
     })
 
     // #when fetching proposed SHAs
-    const result = await fetchProposedMergeShas(octokit, 'fro-bot', '.github')
+    const result = await fetchOpenedLearningShas(octokit, 'fro-bot', '.github')
 
     // #then both SHAs are in the seen-set
     expect(result.has(sha1)).toBe(true)
@@ -762,7 +1031,7 @@ describe('fetchProposedMergeShas', () => {
     const octokit = mockOctokitForIssues({paginate: paginateSpy as (fn: unknown, opts: unknown) => Promise<unknown[]>})
 
     // #when fetching proposed SHAs
-    await fetchProposedMergeShas(octokit, 'fro-bot', '.github')
+    await fetchOpenedLearningShas(octokit, 'fro-bot', '.github')
 
     // #then the paginate call includes the learning-proposal label
     expect(paginateSpy).toHaveBeenCalledOnce()
@@ -772,7 +1041,7 @@ describe('fetchProposedMergeShas', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Contract test: harvest→propose schema round-trip (FIX 1)
+// Contract test: harvest→propose schema round-trip
 // ---------------------------------------------------------------------------
 
 describe('harvest→propose schema contract', () => {
@@ -792,13 +1061,21 @@ describe('harvest→propose schema contract', () => {
     ]
     const digest: CandidateDigest = {
       candidates,
-      telemetry: {examined: 5, afterProposalDedup: 3, afterSolutionsDedup: 2, emitted: 2},
+      telemetry: {
+        closedPrsFetched: 20,
+        mergedPrsInLookback: 10,
+        excludedAutomation: 1,
+        multiRoundCandidates: 5,
+        afterSeenDedup: 3,
+        afterSolutionsDedup: 2,
+        emitted: 2,
+      },
     }
 
-    // #when serializing (as harvest writes to CAPTURE_C1_DIGEST_PATH)
+    // #when serializing (as harvest writes to CAPTURE_LEARNINGS_DIGEST_PATH)
     const serialized = JSON.stringify(digest)
 
-    // #when deserializing (as propose reads from CAPTURE_C1_DIGEST_PATH)
+    // #when deserializing (as propose reads from CAPTURE_LEARNINGS_DIGEST_PATH)
     const deserialized = JSON.parse(serialized) as CandidateDigest
 
     // #then the shape is {candidates, telemetry} — not a bare array
@@ -813,13 +1090,13 @@ describe('harvest→propose schema contract', () => {
     expect(deserialized.candidates[1]?.mergeSha).toBe('deadbeefdeadbeefdeadbeefdeadbeefdeadbeef')
 
     // #then telemetry round-trips correctly
-    expect(deserialized.telemetry.examined).toBe(5)
+    expect(deserialized.telemetry.closedPrsFetched).toBe(20)
+    expect(deserialized.telemetry.mergedPrsInLookback).toBe(10)
+    expect(deserialized.telemetry.excludedAutomation).toBe(1)
+    expect(deserialized.telemetry.multiRoundCandidates).toBe(5)
     expect(deserialized.telemetry.emitted).toBe(2)
 
     // #then propose can iterate candidates without TypeError
-    // (the old bug: harvest wrote candidates array directly, propose read {candidates,telemetry}
-    //  → digest.candidates was undefined → for...of undefined → crash)
-    // Iterating must not throw — the old bug caused TypeError: undefined is not iterable
     const shas = deserialized.candidates.map(c => c.mergeSha)
     expect(shas).toHaveLength(2)
   })

--- a/scripts/capture-learnings-harvest.test.ts
+++ b/scripts/capture-learnings-harvest.test.ts
@@ -80,6 +80,20 @@ describe('buildMergeShaMarker', () => {
     // #then it matches the expected format
     expect(buildMergeShaMarker('abc123')).toBe('<!-- captured-learning:merge_sha=abc123 -->')
   })
+
+  it('marker round-trip: buildMergeShaMarker output is parsed back by parseMergeShaMarker', () => {
+    // #given a full-length merge SHA
+    const sha = 'abc123def456abc123def456abc123def456abc1'
+
+    // #when building the marker and parsing it back
+    const marker = buildMergeShaMarker(sha)
+    const parsed = parseMergeShaMarker(marker)
+
+    // #then the SHA round-trips correctly
+    expect(parsed).toBe(sha)
+    // #then the marker string starts with the expected prefix
+    expect(marker.startsWith('<!-- captured-learning:')).toBe(true)
+  })
 })
 
 describe('parseMergeShaMarker', () => {
@@ -133,7 +147,7 @@ describe('buildCandidateDigest', () => {
     })
   })
 
-  describe('opacity guarantee (R4)', () => {
+  describe('opacity guarantee', () => {
     it('emitted candidates have ONLY mergeSha, reviewRounds, and signals keys — no owner/repo/number/title', () => {
       // #given a candidate
       const input = makeDigestInput()
@@ -154,7 +168,7 @@ describe('buildCandidateDigest', () => {
     })
   })
 
-  describe('proposal dedup (R3)', () => {
+  describe('seen-set dedup', () => {
     it('excludes a candidate whose mergeSha is in openedLearningShas', () => {
       // #given a candidate whose SHA is already in the seen-set
       const sha = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
@@ -212,7 +226,7 @@ describe('buildCandidateDigest', () => {
     })
   })
 
-  describe('solutions dedup (R5)', () => {
+  describe('solutions dedup', () => {
     it('excludes a candidate whose signals exactly match an existing doc problem_type', () => {
       // #given a candidate with a label matching a doc's problem_type
       const input = makeDigestInput({
@@ -285,7 +299,7 @@ describe('buildCandidateDigest', () => {
     })
   })
 
-  describe('cap (R6)', () => {
+  describe('cap', () => {
     it('caps candidates to maxLearnings when more are available', () => {
       // #given 7 candidates and a cap of 3
       const candidates = Array.from({length: 7}, (_, i) =>
@@ -573,9 +587,42 @@ describe('harvestCandidates', () => {
     })
 
     // #when harvesting
-    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+    const {candidates, stageCounts} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
 
     // #then the PR is excluded by label
+    expect(candidates).toHaveLength(0)
+    expect(stageCounts.excludedAutomation).toBe(1)
+  })
+
+  it('excludes a PR carrying a "dependencies:github-actions" label', async () => {
+    // #given a merged PR with a 'dependencies:github-actions' label and qualifying fro-bot reviews
+    const pr = makePullsListItem({labels: [{name: 'dependencies:github-actions'}]})
+    const octokit = mockOctokit({
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => [makeReviewItem('APPROVED'), makeReviewItem('DISMISSED')],
+    })
+
+    // #when harvesting
+    const {candidates, stageCounts} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then the PR is excluded by label, counted as automation
+    expect(candidates).toHaveLength(0)
+    expect(stageCounts.excludedAutomation).toBe(1)
+  })
+
+  it('excludes a PR with merge_commit_sha === null even when merged_at is valid', async () => {
+    // #given a merged PR with a valid merged_at but null merge_commit_sha
+    // (can happen when a merge commit is not recorded, e.g. squash-merge edge cases)
+    const pr = makePullsListItem({merge_commit_sha: null})
+    const octokit = mockOctokit({
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => [makeReviewItem('APPROVED'), makeReviewItem('DISMISSED')],
+    })
+
+    // #when harvesting
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then the PR is excluded (no merge SHA to use as the candidate identifier)
     expect(candidates).toHaveLength(0)
   })
 
@@ -1044,7 +1091,7 @@ describe('fetchOpenedLearningShas', () => {
 // Contract test: harvest→propose schema round-trip
 // ---------------------------------------------------------------------------
 
-describe('harvest→propose schema contract', () => {
+describe('harvest→open schema contract', () => {
   it('CandidateDigest serializes and deserializes with candidates intact', () => {
     // #given a CandidateDigest produced by buildCandidateDigest (as harvest would write it)
     const candidates: Candidate[] = [
@@ -1075,7 +1122,7 @@ describe('harvest→propose schema contract', () => {
     // #when serializing (as harvest writes to CAPTURE_LEARNINGS_DIGEST_PATH)
     const serialized = JSON.stringify(digest)
 
-    // #when deserializing (as propose reads from CAPTURE_LEARNINGS_DIGEST_PATH)
+    // #when deserializing (as the open step reads from CAPTURE_LEARNINGS_DIGEST_PATH)
     const deserialized = JSON.parse(serialized) as CandidateDigest
 
     // #then the shape is {candidates, telemetry} — not a bare array
@@ -1096,7 +1143,7 @@ describe('harvest→propose schema contract', () => {
     expect(deserialized.telemetry.multiRoundCandidates).toBe(5)
     expect(deserialized.telemetry.emitted).toBe(2)
 
-    // #then propose can iterate candidates without TypeError
+    // #then the open step can iterate candidates without TypeError
     const shas = deserialized.candidates.map(c => c.mergeSha)
     expect(shas).toHaveLength(2)
   })

--- a/scripts/capture-learnings-harvest.ts
+++ b/scripts/capture-learnings-harvest.ts
@@ -1,9 +1,9 @@
 /**
- * Harvest merged PRs from this repo that required multiple rounds of changes-requested
- * reviews, dedup against existing learning-proposal issues and docs/solutions/ docs,
+ * Harvest merged PRs from this repo that required multiple rounds of Fro Bot review,
+ * dedup against existing learning-proposal issues and docs/solutions/ docs,
  * cap the result, and emit an opaque candidate digest to $GITHUB_OUTPUT.
  *
- * Architecture: pure core (`buildCandidateDigest`) + I/O shell (`main`).
+ * Architecture: pure core (`buildCandidateDigest`) + I/O shell (`harvestCandidates` / `main`).
  * The pure core takes all data as injected inputs and is fully unit-testable.
  * The I/O shell constructs Octokit, fetches data, and calls the pure core.
  *
@@ -23,14 +23,35 @@ import {parse} from 'yaml'
 /** Number of days back from now to include merged PRs. */
 const LOOKBACK_DAYS = 30
 
-/** Minimum number of CHANGES_REQUESTED reviews for a PR to be a candidate. */
-const MULTI_ROUND_THRESHOLD = 2
+/**
+ * Minimum number of Fro Bot substantive reviews (APPROVED | CHANGES_REQUESTED | DISMISSED)
+ * for a PR to be a candidate. Requires at least 2 rounds of substantive engagement.
+ */
+const MIN_SUBSTANTIVE_REVIEW_ROUNDS = 2
+
+/**
+ * Minimum number of correction signals (DISMISSED | CHANGES_REQUESTED) from Fro Bot
+ * for a PR to be a candidate. At least one correction round must have occurred.
+ */
+const MIN_CORRECTION_SIGNALS = 1
 
 /** Maximum number of candidates to emit per run. */
-const MAX_PROPOSALS_PER_RUN = 5
+const MAX_LEARNINGS_PER_RUN = 5
 
 /** Label used to identify learning-proposal issues. */
 export const LEARNING_PROPOSAL_LABEL = 'learning-proposal'
+
+/**
+ * Fro Bot reviewer logins to key review counting on.
+ * A Set so it is easy to extend if the login ever changes.
+ */
+export const FRO_BOT_REVIEWER_LOGINS = new Set(['fro-bot'])
+
+/**
+ * PR label names that identify dependency-automation PRs.
+ * PRs carrying any of these labels are excluded before review counting.
+ */
+export const DEPENDENCY_LABELS = new Set(['dependencies', 'renovate', 'dependencies:github-actions'])
 
 /**
  * Minimum overlap score (inclusive) between a candidate's signals and an existing
@@ -87,14 +108,33 @@ export interface CandidateSignals {
  */
 export interface Candidate {
   mergeSha: string
+  /**
+   * Number of Fro Bot substantive review rounds (APPROVED | CHANGES_REQUESTED | DISMISSED).
+   * Named `reviewRounds` to preserve the contract with the agent prompt in
+   * capture-learnings.yaml, which references this field by name.
+   */
   reviewRounds: number
   signals: CandidateSignals
 }
 
-/** Counts-only telemetry returned by the pure core. */
+/**
+ * Harvest-stage counts threaded from `harvestCandidates` into the final telemetry.
+ * Kept separate from the pure core so `buildCandidateDigest` remains I/O-free.
+ */
+export interface HarvestStageCounts {
+  closedPrsFetched: number
+  mergedPrsInLookback: number
+  excludedAutomation: number
+  multiRoundCandidates: number
+}
+
+/** Counts-only telemetry returned by the pure core + harvest stage. */
 export interface DigestTelemetry {
-  examined: number
-  afterProposalDedup: number
+  closedPrsFetched: number
+  mergedPrsInLookback: number
+  excludedAutomation: number
+  multiRoundCandidates: number
+  afterSeenDedup: number
   afterSolutionsDedup: number
   emitted: number
 }
@@ -107,14 +147,16 @@ export interface CandidateDigest {
 
 /** Input to the pure core. */
 export interface BuildCandidateDigestInput {
-  /** Merged PRs that already passed the MULTI_ROUND_THRESHOLD filter. */
+  /** Merged PRs that already passed the review-predicate filter. */
   mergedPrs: Candidate[]
+  /** Harvest-stage counts to thread into the final telemetry. */
+  stageCounts: HarvestStageCounts
   /** merge_shas already represented by a learning-proposal issue. */
-  proposedMergeShas: Set<string>
+  openedLearningShas: Set<string>
   /** Existing solutions docs for R5 dedup. */
   solutionsDocs: SolutionDoc[]
   /** Maximum candidates to emit. */
-  maxProposals: number
+  maxLearnings: number
 }
 
 /** Minimal solutions doc shape needed for dedup. */
@@ -134,7 +176,7 @@ export interface SolutionDoc {
  * with its source PR's merge commit SHA.
  */
 export function buildMergeShaMarker(sha: string): string {
-  return `<!-- capture-c1:merge_sha=${sha} -->`
+  return `<!-- captured-learning:merge_sha=${sha} -->`
 }
 
 /**
@@ -142,7 +184,7 @@ export function buildMergeShaMarker(sha: string): string {
  * Returns the SHA string or null if the marker is absent or malformed.
  */
 export function parseMergeShaMarker(body: string): string | null {
-  const match = /<!-- capture-c1:merge_sha=([a-f0-9]{7,40}) -->/u.exec(body)
+  const match = /<!-- captured-learning:merge_sha=([a-f0-9]{7,40}) -->/u.exec(body)
   return match?.[1] ?? null
 }
 
@@ -154,30 +196,28 @@ export function parseMergeShaMarker(body: string): string | null {
  * Build the opaque candidate digest from injected inputs.
  *
  * Steps:
- * 1. Drop candidates whose mergeSha is already in proposedMergeShas (R3 dedup).
+ * 1. Drop candidates whose mergeSha is already in openedLearningShas (R3 dedup).
  * 2. Drop candidates whose signals strongly overlap an existing solutions doc (R5 dedup).
- * 3. Cap to maxProposals (R6).
- * 4. Return candidates + counts-only telemetry.
+ * 3. Cap to maxLearnings (R6).
+ * 4. Return candidates + counts-only telemetry (harvest stage counts + dedup stage counts).
  *
  * No I/O. Fully unit-testable.
  */
 export function buildCandidateDigest(input: BuildCandidateDigestInput): CandidateDigest {
-  const examined = input.mergedPrs.length
-
   // R3: drop already-proposed merge SHAs
-  const afterProposalDedup = input.mergedPrs.filter(pr => !input.proposedMergeShas.has(pr.mergeSha))
+  const afterSeenDedup = input.mergedPrs.filter(pr => !input.openedLearningShas.has(pr.mergeSha))
 
   // R5: drop candidates whose signals overlap an existing solutions doc
-  const afterSolutionsDedup = afterProposalDedup.filter(pr => !overlapsAnySolutionsDoc(pr.signals, input.solutionsDocs))
+  const afterSolutionsDedup = afterSeenDedup.filter(pr => !overlapsAnySolutionsDoc(pr.signals, input.solutionsDocs))
 
-  // R6: cap to maxProposals
-  const candidates = afterSolutionsDedup.slice(0, input.maxProposals)
+  // R6: cap to maxLearnings
+  const candidates = afterSolutionsDedup.slice(0, input.maxLearnings)
 
   return {
     candidates,
     telemetry: {
-      examined,
-      afterProposalDedup: afterProposalDedup.length,
+      ...input.stageCounts,
+      afterSeenDedup: afterSeenDedup.length,
       afterSolutionsDedup: afterSolutionsDedup.length,
       emitted: candidates.length,
     },
@@ -313,7 +353,7 @@ async function loadSolutionsFilesFromDisk(): Promise<Record<string, string>> {
       try {
         files[path] = await readFile(path, 'utf8')
       } catch {
-        process.stderr.write(`capture-c1-harvest: could not read file (path: ${path})\n`)
+        process.stderr.write(`capture-learnings-harvest: could not read file (path: ${path})\n`)
       }
     }
   }
@@ -327,14 +367,14 @@ async function loadSolutionsFilesFromDisk(): Promise<Record<string, string>> {
 
 /**
  * Write the full CandidateDigest ({candidates, telemetry}) as JSON to the path
- * specified by CAPTURE_C1_DIGEST_PATH. This eliminates the shell-injection vector
+ * specified by CAPTURE_LEARNINGS_DIGEST_PATH. This eliminates the shell-injection vector
  * that existed when the digest was echoed via GITHUB_OUTPUT multiline syntax.
  *
  * Also writes scalar telemetry counters to GITHUB_OUTPUT for step-summary use.
  * The multiline `digest` key is intentionally dropped — consumers read the file.
  */
 async function writeDigestFile(digest: CandidateDigest): Promise<void> {
-  const digestPath = process.env.CAPTURE_C1_DIGEST_PATH
+  const digestPath = process.env.CAPTURE_LEARNINGS_DIGEST_PATH
   if (digestPath !== undefined && digestPath !== '') {
     await writeFile(digestPath, `${JSON.stringify(digest)}\n`, {flag: 'w'})
   }
@@ -346,11 +386,14 @@ async function writeGithubOutput(digest: CandidateDigest): Promise<void> {
     return
   }
 
-  // Scalar counters only — no multiline digest key (consumers read CAPTURE_C1_DIGEST_PATH).
+  // Scalar counters only — no multiline digest key (consumers read CAPTURE_LEARNINGS_DIGEST_PATH).
   const lines = [
     `candidate-count=${digest.telemetry.emitted}`,
-    `examined=${digest.telemetry.examined}`,
-    `after-proposal-dedup=${digest.telemetry.afterProposalDedup}`,
+    `closed-prs-fetched=${digest.telemetry.closedPrsFetched}`,
+    `merged-prs-in-lookback=${digest.telemetry.mergedPrsInLookback}`,
+    `excluded-automation=${digest.telemetry.excludedAutomation}`,
+    `multi-round-candidates=${digest.telemetry.multiRoundCandidates}`,
+    `after-seen-dedup=${digest.telemetry.afterSeenDedup}`,
     `after-solutions-dedup=${digest.telemetry.afterSolutionsDedup}`,
   ]
   await writeFile(outputPath, `${lines.join('\n')}\n`, {flag: 'a'})
@@ -370,7 +413,7 @@ async function loadOctokitConstructor(): Promise<OctokitConstructor> {
 export async function createOctokitFromEnv(): Promise<OctokitClient> {
   const token = process.env.GITHUB_TOKEN
   if (token === undefined || token === '') {
-    throw new Error('capture-c1-harvest requires GITHUB_TOKEN in the environment')
+    throw new Error('capture-learnings-harvest requires GITHUB_TOKEN in the environment')
   }
   const LoadedOctokit = await loadOctokitConstructor()
   return new LoadedOctokit({auth: token})
@@ -404,18 +447,33 @@ function deriveSignals(pr: {title: string; labels: {name: string}[]}): Candidate
   return {titleTokens, labels}
 }
 
+/** Result of `harvestCandidates` — candidates plus explicit harvest-stage counts. */
+export interface HarvestResult {
+  candidates: Candidate[]
+  stageCounts: HarvestStageCounts
+}
+
 /**
- * Fetch all merged PRs in the lookback window and return those with
- * reviewRounds >= MULTI_ROUND_THRESHOLD as Candidate objects.
+ * Fetch all merged PRs in the lookback window and return those where Fro Bot's
+ * substantive reviews meet the predicate:
+ *   substantiveReviewCount >= MIN_SUBSTANTIVE_REVIEW_ROUNDS
+ *   AND correctionSignalCount >= MIN_CORRECTION_SIGNALS
+ *
+ * Substantive reviews: APPROVED | CHANGES_REQUESTED | DISMISSED (COMMENTED excluded).
+ * Correction signals: DISMISSED | CHANGES_REQUESTED.
+ *
+ * Only reviews by logins in FRO_BOT_REVIEWER_LOGINS are counted.
+ * Dependency-automation PRs (by author login or label) are excluded before counting.
  *
  * Transient listReviews errors for a single PR are caught and that PR is skipped.
+ * Returns candidates alongside explicit harvest-stage counts for honest telemetry.
  */
 export async function harvestCandidates(
   octokit: OctokitClient,
   owner: string,
   repo: string,
   now: Date,
-): Promise<Candidate[]> {
+): Promise<HarvestResult> {
   // Use now.getTime() — the injected `now` is already UTC ms (Date.now() in main).
   // Both sides of the comparison are UTC ms, so timezone drift cannot occur.
   const cutoff = new Date(now.getTime() - LOOKBACK_DAYS * 24 * 60 * 60 * 1000)
@@ -427,7 +485,11 @@ export async function harvestCandidates(
     per_page: 100,
   } as unknown as Parameters<OctokitClient['rest']['pulls']['list']>[0])
 
+  const closedPrsFetched = allPrs.length
+
   const candidates: Candidate[] = []
+  let mergedPrsInLookback = 0
+  let excludedAutomation = 0
 
   for (const pr of allPrs) {
     // Exclude unmerged PRs
@@ -446,9 +508,26 @@ export async function harvestCandidates(
       continue
     }
 
-    // Count CHANGES_REQUESTED reviews across ALL pages — transient errors skip this PR.
+    mergedPrsInLookback++
+
+    // Exclude dependency-automation PRs by author login
+    const authorLogin = (pr.user as {login?: string} | null)?.login ?? ''
+    if (authorLogin === 'renovate[bot]' || authorLogin === 'dependabot[bot]') {
+      excludedAutomation++
+      continue
+    }
+
+    // Exclude dependency-automation PRs by label
+    const prLabels = pr.labels.map(l => (typeof l === 'string' ? l : (l as {name: string}).name))
+    if (prLabels.some(name => DEPENDENCY_LABELS.has(name))) {
+      excludedAutomation++
+      continue
+    }
+
+    // Fetch Fro Bot's reviews and apply the predicate.
     // Paginate to avoid undercounting when reviews span >1 page (default page = 30).
-    let reviewRounds: number
+    let substantiveReviewCount: number
+    let correctionSignalCount: number
     try {
       const reviews = await octokit.paginate(octokit.rest.pulls.listReviews, {
         owner,
@@ -456,35 +535,62 @@ export async function harvestCandidates(
         pull_number: pr.number,
         per_page: 100,
       } as unknown as Parameters<OctokitClient['rest']['pulls']['listReviews']>[0])
-      reviewRounds = reviews.filter(r => (r as {state: string}).state === 'CHANGES_REQUESTED').length
+
+      // Key all counting on Fro Bot reviewer logins only.
+      const froBotReviews = reviews.filter(r => {
+        const login = (r as {user?: {login?: string}}).user?.login ?? ''
+        return FRO_BOT_REVIEWER_LOGINS.has(login)
+      })
+
+      // Substantive: APPROVED | CHANGES_REQUESTED | DISMISSED (COMMENTED excluded).
+      substantiveReviewCount = froBotReviews.filter(r => {
+        const state = (r as {state: string}).state
+        return state === 'APPROVED' || state === 'CHANGES_REQUESTED' || state === 'DISMISSED'
+      }).length
+
+      // Correction signals: DISMISSED | CHANGES_REQUESTED.
+      correctionSignalCount = froBotReviews.filter(r => {
+        const state = (r as {state: string}).state
+        return state === 'DISMISSED' || state === 'CHANGES_REQUESTED'
+      }).length
     } catch (error: unknown) {
       const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
-      process.stderr.write(`capture-c1-harvest: skipping PR #${pr.number} — listReviews failed (status=${status})\n`)
+      process.stderr.write(
+        `capture-learnings-harvest: skipping PR #${pr.number} — listReviews failed (status=${status})\n`,
+      )
       continue
     }
 
-    if (reviewRounds < MULTI_ROUND_THRESHOLD) {
+    if (substantiveReviewCount < MIN_SUBSTANTIVE_REVIEW_ROUNDS || correctionSignalCount < MIN_CORRECTION_SIGNALS) {
       continue
     }
 
     candidates.push({
       mergeSha: pr.merge_commit_sha,
-      reviewRounds,
+      reviewRounds: substantiveReviewCount,
       signals: deriveSignals({
         title: pr.title,
-        labels: pr.labels.map(l => ({name: typeof l === 'string' ? l : (l as {name: string}).name})),
+        labels: prLabels.map(name => ({name})),
       }),
     })
   }
 
-  return candidates
+  return {
+    candidates,
+    stageCounts: {
+      closedPrsFetched,
+      mergedPrsInLookback,
+      excludedAutomation,
+      multiRoundCandidates: candidates.length,
+    },
+  }
 }
 
 /**
  * Fetch all learning-proposal issues (state: all) and parse the merge SHA marker
  * from each body. Returns a Set of seen merge SHAs.
  */
-export async function fetchProposedMergeShas(
+export async function fetchOpenedLearningShas(
   octokit: OctokitClient,
   owner: string,
   repo: string,
@@ -526,9 +632,9 @@ async function main(): Promise<void> {
     // Use Date.now() — UTC ms — as the reference point for the lookback cutoff.
     const now = new Date(Date.now())
 
-    const [mergedPrs, proposedMergeShas, solutionsFiles] = await Promise.all([
+    const [{candidates: mergedPrs, stageCounts}, openedLearningShas, solutionsFiles] = await Promise.all([
       harvestCandidates(octokit, owner, repo, now),
-      fetchProposedMergeShas(octokit, owner, repo),
+      fetchOpenedLearningShas(octokit, owner, repo),
       loadSolutionsFilesFromDisk(),
     ])
 
@@ -536,9 +642,10 @@ async function main(): Promise<void> {
 
     const digest = buildCandidateDigest({
       mergedPrs,
-      proposedMergeShas,
+      stageCounts,
+      openedLearningShas,
       solutionsDocs,
-      maxProposals: MAX_PROPOSALS_PER_RUN,
+      maxLearnings: MAX_LEARNINGS_PER_RUN,
     })
 
     await writeDigestFile(digest)
@@ -548,10 +655,18 @@ async function main(): Promise<void> {
     // Best-effort: any error → empty digest, exit 0 — harvest must never fail the workflow step.
     // Log error class only — no message that could leak content.
     const errorName = error instanceof Error ? error.name : 'unknown'
-    process.stderr.write(`capture-c1-harvest: unexpected error (${errorName}), falling back to empty digest\n`)
+    process.stderr.write(`capture-learnings-harvest: unexpected error (${errorName}), falling back to empty digest\n`)
     const empty: CandidateDigest = {
       candidates: [],
-      telemetry: {examined: 0, afterProposalDedup: 0, afterSolutionsDedup: 0, emitted: 0},
+      telemetry: {
+        closedPrsFetched: 0,
+        mergedPrsInLookback: 0,
+        excludedAutomation: 0,
+        multiRoundCandidates: 0,
+        afterSeenDedup: 0,
+        afterSolutionsDedup: 0,
+        emitted: 0,
+      },
     }
     try {
       await writeDigestFile(empty)

--- a/scripts/capture-learnings-harvest.ts
+++ b/scripts/capture-learnings-harvest.ts
@@ -102,7 +102,7 @@ export interface CandidateSignals {
  *
  * Carries no owner, repo, or PR number. `signals` includes tokens derived from the PR
  * title and labels, so title-derived tokens do reach the consuming agent — they are not
- * fully sanitized here. The deterministic propose step is the privacy chokepoint: it scans
+ * fully sanitized here. The deterministic open step is the privacy chokepoint: it scans
  * the final authored body for private identifiers and blocks before posting, so a private
  * token surfacing in a title token is gated downstream rather than leaked.
  */
@@ -153,7 +153,7 @@ export interface BuildCandidateDigestInput {
   stageCounts: HarvestStageCounts
   /** merge_shas already represented by a learning-proposal issue. */
   openedLearningShas: Set<string>
-  /** Existing solutions docs for R5 dedup. */
+  /** Existing solutions docs for solutions dedup. */
   solutionsDocs: SolutionDoc[]
   /** Maximum candidates to emit. */
   maxLearnings: number
@@ -196,21 +196,21 @@ export function parseMergeShaMarker(body: string): string | null {
  * Build the opaque candidate digest from injected inputs.
  *
  * Steps:
- * 1. Drop candidates whose mergeSha is already in openedLearningShas (R3 dedup).
- * 2. Drop candidates whose signals strongly overlap an existing solutions doc (R5 dedup).
- * 3. Cap to maxLearnings (R6).
+ * 1. Drop candidates whose mergeSha is already in openedLearningShas (seen-set dedup).
+ * 2. Drop candidates whose signals strongly overlap an existing solutions doc (solutions dedup).
+ * 3. Cap to maxLearnings.
  * 4. Return candidates + counts-only telemetry (harvest stage counts + dedup stage counts).
  *
  * No I/O. Fully unit-testable.
  */
 export function buildCandidateDigest(input: BuildCandidateDigestInput): CandidateDigest {
-  // R3: drop already-proposed merge SHAs
+  // drop already-proposed merge SHAs
   const afterSeenDedup = input.mergedPrs.filter(pr => !input.openedLearningShas.has(pr.mergeSha))
 
-  // R5: drop candidates whose signals overlap an existing solutions doc
+  // drop candidates whose signals overlap an existing solutions doc
   const afterSolutionsDedup = afterSeenDedup.filter(pr => !overlapsAnySolutionsDoc(pr.signals, input.solutionsDocs))
 
-  // R6: cap to maxLearnings
+  // cap to maxLearnings
   const candidates = afterSolutionsDedup.slice(0, input.maxLearnings)
 
   return {
@@ -369,34 +369,12 @@ async function loadSolutionsFilesFromDisk(): Promise<Record<string, string>> {
  * Write the full CandidateDigest ({candidates, telemetry}) as JSON to the path
  * specified by CAPTURE_LEARNINGS_DIGEST_PATH. This eliminates the shell-injection vector
  * that existed when the digest was echoed via GITHUB_OUTPUT multiline syntax.
- *
- * Also writes scalar telemetry counters to GITHUB_OUTPUT for step-summary use.
- * The multiline `digest` key is intentionally dropped — consumers read the file.
  */
 async function writeDigestFile(digest: CandidateDigest): Promise<void> {
   const digestPath = process.env.CAPTURE_LEARNINGS_DIGEST_PATH
   if (digestPath !== undefined && digestPath !== '') {
     await writeFile(digestPath, `${JSON.stringify(digest)}\n`, {flag: 'w'})
   }
-}
-
-async function writeGithubOutput(digest: CandidateDigest): Promise<void> {
-  const outputPath = process.env.GITHUB_OUTPUT
-  if (outputPath === undefined || outputPath === '') {
-    return
-  }
-
-  // Scalar counters only — no multiline digest key (consumers read CAPTURE_LEARNINGS_DIGEST_PATH).
-  const lines = [
-    `candidate-count=${digest.telemetry.emitted}`,
-    `closed-prs-fetched=${digest.telemetry.closedPrsFetched}`,
-    `merged-prs-in-lookback=${digest.telemetry.mergedPrsInLookback}`,
-    `excluded-automation=${digest.telemetry.excludedAutomation}`,
-    `multi-round-candidates=${digest.telemetry.multiRoundCandidates}`,
-    `after-seen-dedup=${digest.telemetry.afterSeenDedup}`,
-    `after-solutions-dedup=${digest.telemetry.afterSolutionsDedup}`,
-  ]
-  await writeFile(outputPath, `${lines.join('\n')}\n`, {flag: 'a'})
 }
 
 // ---------------------------------------------------------------------------
@@ -407,7 +385,7 @@ async function loadOctokitConstructor(): Promise<OctokitConstructor> {
   if (typeof Octokit !== 'function') {
     throw new TypeError('Failed to load @octokit/rest Octokit constructor')
   }
-  return Octokit as unknown as OctokitConstructor
+  return Octokit as OctokitConstructor
 }
 
 export async function createOctokitFromEnv(): Promise<OctokitClient> {
@@ -511,14 +489,14 @@ export async function harvestCandidates(
     mergedPrsInLookback++
 
     // Exclude dependency-automation PRs by author login
-    const authorLogin = (pr.user as {login?: string} | null)?.login ?? ''
+    const authorLogin = pr.user?.login ?? ''
     if (authorLogin === 'renovate[bot]' || authorLogin === 'dependabot[bot]') {
       excludedAutomation++
       continue
     }
 
     // Exclude dependency-automation PRs by label
-    const prLabels = pr.labels.map(l => (typeof l === 'string' ? l : (l as {name: string}).name))
+    const prLabels = pr.labels.map(l => (typeof l === 'string' ? l : l.name))
     if (prLabels.some(name => DEPENDENCY_LABELS.has(name))) {
       excludedAutomation++
       continue
@@ -538,20 +516,18 @@ export async function harvestCandidates(
 
       // Key all counting on Fro Bot reviewer logins only.
       const froBotReviews = reviews.filter(r => {
-        const login = (r as {user?: {login?: string}}).user?.login ?? ''
+        const login = r.user?.login ?? ''
         return FRO_BOT_REVIEWER_LOGINS.has(login)
       })
 
       // Substantive: APPROVED | CHANGES_REQUESTED | DISMISSED (COMMENTED excluded).
       substantiveReviewCount = froBotReviews.filter(r => {
-        const state = (r as {state: string}).state
-        return state === 'APPROVED' || state === 'CHANGES_REQUESTED' || state === 'DISMISSED'
+        return r.state === 'APPROVED' || r.state === 'CHANGES_REQUESTED' || r.state === 'DISMISSED'
       }).length
 
       // Correction signals: DISMISSED | CHANGES_REQUESTED.
       correctionSignalCount = froBotReviews.filter(r => {
-        const state = (r as {state: string}).state
-        return state === 'DISMISSED' || state === 'CHANGES_REQUESTED'
+        return r.state === 'DISMISSED' || r.state === 'CHANGES_REQUESTED'
       }).length
     } catch (error: unknown) {
       const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
@@ -649,7 +625,6 @@ async function main(): Promise<void> {
     })
 
     await writeDigestFile(digest)
-    await writeGithubOutput(digest)
     process.stdout.write(`${JSON.stringify(digest)}\n`)
   } catch (error: unknown) {
     // Best-effort: any error → empty digest, exit 0 — harvest must never fail the workflow step.
@@ -670,7 +645,6 @@ async function main(): Promise<void> {
     }
     try {
       await writeDigestFile(empty)
-      await writeGithubOutput(empty)
     } catch {
       // ignore
     }

--- a/scripts/capture-learnings-open.test.ts
+++ b/scripts/capture-learnings-open.test.ts
@@ -1,28 +1,33 @@
 /**
- * Tests for capture-c1-propose.ts
+ * Tests for capture-learnings-open.ts
  *
  * Structure:
- * - Pure function tests: `proposalBodyHasPrivateLeak`, `planProposals`
+ * - Pure function tests: `learningBodyHasPrivateLeak`, `planLearnings`
  * - Disk loader tests: `loadPrivateTokensFromDisk` (injectable readFile)
- * - I/O shell tests: `createProposals`, `ensureLabelsExist` (mocked Octokit)
+ * - I/O shell tests: `openLearningIssues`, `ensureLabelsExist` (mocked Octokit)
  *
  * Privacy mutation-proof: each privacy test includes a "without the gate" assertion
- * that proves removing the check would let the proposal through.
+ * that proves removing the check would let the learning through.
  */
 
 import {describe, expect, it, vi} from 'vitest'
 
-import {buildMergeShaMarker, LEARNING_PROPOSAL_LABEL, type Candidate, type OctokitClient} from './capture-c1-harvest.ts'
 import {
-  createProposals,
+  buildMergeShaMarker,
+  LEARNING_PROPOSAL_LABEL,
+  type Candidate,
+  type OctokitClient,
+} from './capture-learnings-harvest.ts'
+import {
   ensureLabelsExist,
+  learningBodyHasPrivateLeak,
   loadPrivateTokensFromDisk,
-  planProposals,
-  proposalBodyHasPrivateLeak,
+  openLearningIssues,
+  planLearnings,
   type LabelDescriptor,
-  type PlanProposalsInput,
-  type ProposalToCreate,
-} from './capture-c1-propose.ts'
+  type LearningToOpen,
+  type PlanLearningsInput,
+} from './capture-learnings-open.ts'
 import {buildPrivateTokenSet} from './wiki-slug.ts'
 
 // ---------------------------------------------------------------------------
@@ -38,10 +43,10 @@ function makeCandidate(overrides: Partial<Candidate> = {}): Candidate {
   }
 }
 
-function makePlanInput(overrides: Partial<PlanProposalsInput> = {}): PlanProposalsInput {
+function makePlanInput(overrides: Partial<PlanLearningsInput> = {}): PlanLearningsInput {
   return {
     candidates: [makeCandidate()],
-    proposalBodies: new Map([['abc123def456abc123def456abc123def456abc1', 'A clean proposal body.']]),
+    learningBodies: new Map([['abc123def456abc123def456abc123def456abc1', 'A clean learning body.']]),
     privateTokens: new Set(),
     alreadyCreatedShas: new Set(),
     ...overrides,
@@ -53,20 +58,20 @@ function makePrivateTokens(nameWithOwner: string): Set<string> {
   return buildPrivateTokenSet([nameWithOwner])
 }
 
-function makeToCreate(overrides: Partial<ProposalToCreate> = {}): ProposalToCreate {
+function makeToCreate(overrides: Partial<LearningToOpen> = {}): LearningToOpen {
   const sha = 'abc123def456abc123def456abc123def456abc1'
   return {
     mergeSha: sha,
-    body: `A clean proposal.\n\n${buildMergeShaMarker(sha)}`,
+    body: `A clean learning.\n\n${buildMergeShaMarker(sha)}`,
     ...overrides,
   }
 }
 
 // ---------------------------------------------------------------------------
-// proposalBodyHasPrivateLeak — pure function tests
+// learningBodyHasPrivateLeak — pure function tests
 // ---------------------------------------------------------------------------
 
-describe('proposalBodyHasPrivateLeak', () => {
+describe('learningBodyHasPrivateLeak', () => {
   describe('detection', () => {
     it('detects the owner/name form (slash-separated)', () => {
       // #given a body containing the owner/name form of a private repo
@@ -75,7 +80,7 @@ describe('proposalBodyHasPrivateLeak', () => {
 
       // #when scanning
       // #then the leak is detected
-      expect(proposalBodyHasPrivateLeak(body, tokens)).toBe(true)
+      expect(learningBodyHasPrivateLeak(body, tokens)).toBe(true)
     })
 
     it('detects the owner--name form (double-dash)', () => {
@@ -85,7 +90,7 @@ describe('proposalBodyHasPrivateLeak', () => {
 
       // #when scanning
       // #then the leak is detected
-      expect(proposalBodyHasPrivateLeak(body, tokens)).toBe(true)
+      expect(learningBodyHasPrivateLeak(body, tokens)).toBe(true)
     })
 
     it('detects mixed-case occurrences (case-insensitive scan)', () => {
@@ -95,7 +100,7 @@ describe('proposalBodyHasPrivateLeak', () => {
 
       // #when scanning
       // #then the leak is detected (body is lowercased before scan)
-      expect(proposalBodyHasPrivateLeak(body, tokens)).toBe(true)
+      expect(learningBodyHasPrivateLeak(body, tokens)).toBe(true)
     })
 
     it('detects the slug form produced by computeRepoSlug', () => {
@@ -106,7 +111,7 @@ describe('proposalBodyHasPrivateLeak', () => {
 
       // #when scanning
       // #then the leak is detected
-      expect(proposalBodyHasPrivateLeak(body, tokens)).toBe(true)
+      expect(learningBodyHasPrivateLeak(body, tokens)).toBe(true)
     })
   })
 
@@ -114,11 +119,11 @@ describe('proposalBodyHasPrivateLeak', () => {
     it('returns false for a body with no private tokens', () => {
       // #given a body with no private identifiers
       const tokens = makePrivateTokens('testowner/secret-repo')
-      const body = 'This is a clean proposal about CI improvements.'
+      const body = 'This is a clean learning about CI improvements.'
 
       // #when scanning
       // #then no leak is detected
-      expect(proposalBodyHasPrivateLeak(body, tokens)).toBe(false)
+      expect(learningBodyHasPrivateLeak(body, tokens)).toBe(false)
     })
 
     it('returns false when the private token set is empty', () => {
@@ -127,7 +132,7 @@ describe('proposalBodyHasPrivateLeak', () => {
 
       // #when scanning with an empty token set
       // #then no leak is detected (vacuously safe)
-      expect(proposalBodyHasPrivateLeak(body, new Set())).toBe(false)
+      expect(learningBodyHasPrivateLeak(body, new Set())).toBe(false)
     })
 
     it('returns false for an empty body', () => {
@@ -136,28 +141,28 @@ describe('proposalBodyHasPrivateLeak', () => {
 
       // #when scanning
       // #then no leak is detected
-      expect(proposalBodyHasPrivateLeak('', tokens)).toBe(false)
+      expect(learningBodyHasPrivateLeak('', tokens)).toBe(false)
     })
   })
 })
 
 // ---------------------------------------------------------------------------
-// planProposals — pure core tests
+// planLearnings — pure core tests
 // ---------------------------------------------------------------------------
 
-describe('planProposals', () => {
+describe('planLearnings', () => {
   describe('happy path', () => {
     it('includes a clean candidate with the merge-SHA marker appended to the body', () => {
       // #given a candidate with a clean body, not duplicate, no private leak
       const sha = 'abc123def456abc123def456abc123def456abc1'
-      const body = 'A clean proposal body.'
+      const body = 'A clean learning body.'
       const input = makePlanInput({
         candidates: [makeCandidate({mergeSha: sha})],
-        proposalBodies: new Map([[sha, body]]),
+        learningBodies: new Map([[sha, body]]),
       })
 
       // #when planning
-      const result = planProposals(input)
+      const result = planLearnings(input)
 
       // #then the candidate is in toCreate with the marker appended
       expect(result.toCreate).toHaveLength(1)
@@ -171,14 +176,14 @@ describe('planProposals', () => {
     it('appends the marker AFTER the body content', () => {
       // #given a candidate with a body
       const sha = 'abc123def456abc123def456abc123def456abc1'
-      const body = 'Proposal content here.'
+      const body = 'Learning content here.'
       const input = makePlanInput({
         candidates: [makeCandidate({mergeSha: sha})],
-        proposalBodies: new Map([[sha, body]]),
+        learningBodies: new Map([[sha, body]]),
       })
 
       // #when planning
-      const result = planProposals(input)
+      const result = planLearnings(input)
 
       // #then the marker appears after the body
       const fullBody = result.toCreate[0]?.body ?? ''
@@ -194,15 +199,15 @@ describe('planProposals', () => {
       // #given a body containing a private identifier
       const sha = 'abc123def456abc123def456abc123def456abc1'
       const privateTokens = makePrivateTokens('testowner/secret-repo')
-      const body = 'This proposal references testowner/secret-repo.'
+      const body = 'This learning references testowner/secret-repo.'
       const input = makePlanInput({
         candidates: [makeCandidate({mergeSha: sha})],
-        proposalBodies: new Map([[sha, body]]),
+        learningBodies: new Map([[sha, body]]),
         privateTokens,
       })
 
       // #when planning
-      const result = planProposals(input)
+      const result = planLearnings(input)
 
       // #then the candidate is blocked, not in toCreate
       expect(result.toCreate).toHaveLength(0)
@@ -213,13 +218,13 @@ describe('planProposals', () => {
       // #given the same body with a private token
       const sha = 'abc123def456abc123def456abc123def456abc1'
       const privateTokens = makePrivateTokens('testowner/secret-repo')
-      const body = 'This proposal references testowner/secret-repo.'
+      const body = 'This learning references testowner/secret-repo.'
 
       // #when planning WITH the privacy gate (non-empty token set)
-      const withGate = planProposals(
+      const withGate = planLearnings(
         makePlanInput({
           candidates: [makeCandidate({mergeSha: sha})],
-          proposalBodies: new Map([[sha, body]]),
+          learningBodies: new Map([[sha, body]]),
           privateTokens,
         }),
       )
@@ -228,10 +233,10 @@ describe('planProposals', () => {
       expect(withGate.blockedOnPrivacy).toBe(1)
 
       // #when planning WITHOUT the privacy gate (empty token set — gate removed)
-      const withoutGate = planProposals(
+      const withoutGate = planLearnings(
         makePlanInput({
           candidates: [makeCandidate({mergeSha: sha})],
-          proposalBodies: new Map([[sha, body]]),
+          learningBodies: new Map([[sha, body]]),
           privateTokens: new Set(), // gate removed
         }),
       )
@@ -247,7 +252,7 @@ describe('planProposals', () => {
       const privateTokens = makePrivateTokens('testowner/secret-repo')
       const input = makePlanInput({
         candidates: [makeCandidate({mergeSha: sha1}), makeCandidate({mergeSha: sha2})],
-        proposalBodies: new Map([
+        learningBodies: new Map([
           [sha1, 'References testowner/secret-repo here.'],
           [sha2, 'Also mentions testowner/secret-repo.'],
         ]),
@@ -255,7 +260,7 @@ describe('planProposals', () => {
       })
 
       // #when planning
-      const result = planProposals(input)
+      const result = planLearnings(input)
 
       // #then both are blocked
       expect(result.toCreate).toHaveLength(0)
@@ -269,12 +274,12 @@ describe('planProposals', () => {
       const sha = 'abc123def456abc123def456abc123def456abc1'
       const input = makePlanInput({
         candidates: [makeCandidate({mergeSha: sha})],
-        proposalBodies: new Map([[sha, 'A clean body.']]),
+        learningBodies: new Map([[sha, 'A clean body.']]),
         alreadyCreatedShas: new Set([sha]),
       })
 
       // #when planning
-      const result = planProposals(input)
+      const result = planLearnings(input)
 
       // #then the candidate is skipped as a duplicate
       expect(result.toCreate).toHaveLength(0)
@@ -287,12 +292,12 @@ describe('planProposals', () => {
       const sha = 'abc123def456abc123def456abc123def456abc1'
       const input = makePlanInput({
         candidates: [makeCandidate({mergeSha: sha})],
-        proposalBodies: new Map([[sha, 'A clean body.']]),
+        learningBodies: new Map([[sha, 'A clean body.']]),
         alreadyCreatedShas: new Set(['other-sha-not-matching']),
       })
 
       // #when planning
-      const result = planProposals(input)
+      const result = planLearnings(input)
 
       // #then the candidate is included
       expect(result.toCreate).toHaveLength(1)
@@ -301,16 +306,16 @@ describe('planProposals', () => {
   })
 
   describe('no body for a candidate', () => {
-    it('skips a candidate with no entry in proposalBodies without crashing', () => {
+    it('skips a candidate with no entry in learningBodies without crashing', () => {
       // #given a candidate with no body in the map
       const sha = 'abc123def456abc123def456abc123def456abc1'
       const input = makePlanInput({
         candidates: [makeCandidate({mergeSha: sha})],
-        proposalBodies: new Map(), // empty — no body for this candidate
+        learningBodies: new Map(), // empty — no body for this candidate
       })
 
       // #when planning
-      const result = planProposals(input)
+      const result = planLearnings(input)
 
       // #then the candidate is silently skipped
       expect(result.toCreate).toHaveLength(0)
@@ -323,11 +328,11 @@ describe('planProposals', () => {
       const sha = 'abc123def456abc123def456abc123def456abc1'
       const input = makePlanInput({
         candidates: [makeCandidate({mergeSha: sha})],
-        proposalBodies: new Map([[sha, '']]),
+        learningBodies: new Map([[sha, '']]),
       })
 
       // #when planning
-      const result = planProposals(input)
+      const result = planLearnings(input)
 
       // #then the candidate is silently skipped
       expect(result.toCreate).toHaveLength(0)
@@ -351,10 +356,10 @@ describe('planProposals', () => {
           makeCandidate({mergeSha: dupSha}),
           makeCandidate({mergeSha: noBodySha}),
         ],
-        proposalBodies: new Map([
-          [cleanSha, 'A clean proposal.'],
+        learningBodies: new Map([
+          [cleanSha, 'A clean learning.'],
           [blockedSha, 'References testowner/secret-repo.'],
-          [dupSha, 'Another clean proposal.'],
+          [dupSha, 'Another clean learning.'],
           // noBodySha intentionally absent
         ]),
         privateTokens,
@@ -362,7 +367,7 @@ describe('planProposals', () => {
       })
 
       // #when planning
-      const result = planProposals(input)
+      const result = planLearnings(input)
 
       // #then only the clean candidate is in toCreate
       expect(result.toCreate).toHaveLength(1)
@@ -387,7 +392,7 @@ describe('loadPrivateTokensFromDisk', () => {
     // #when loading private tokens
     // #then it throws — the caller must not post proposals
     await expect(loadPrivateTokensFromDisk(readFileFn)).rejects.toThrow(
-      'capture-c1-propose: could not read metadata/repos.yaml',
+      'capture-learnings-open: could not read metadata/repos.yaml',
     )
   })
 
@@ -398,7 +403,7 @@ describe('loadPrivateTokensFromDisk', () => {
     // #when loading private tokens
     // #then it throws — the caller must not post proposals
     await expect(loadPrivateTokensFromDisk(readFileFn)).rejects.toThrow(
-      'capture-c1-propose: could not parse metadata/repos.yaml',
+      'capture-learnings-open: could not parse metadata/repos.yaml',
     )
   })
 
@@ -409,7 +414,7 @@ describe('loadPrivateTokensFromDisk', () => {
     // #when loading private tokens
     // #then it throws
     await expect(loadPrivateTokensFromDisk(readFileFn)).rejects.toThrow(
-      'capture-c1-propose: metadata/repos.yaml has unexpected shape',
+      'capture-learnings-open: metadata/repos.yaml has unexpected shape',
     )
   })
 
@@ -420,7 +425,7 @@ describe('loadPrivateTokensFromDisk', () => {
     // #when loading private tokens
     // #then it throws
     await expect(loadPrivateTokensFromDisk(readFileFn)).rejects.toThrow(
-      'capture-c1-propose: metadata/repos.yaml missing repos array',
+      'capture-learnings-open: metadata/repos.yaml missing repos array',
     )
   })
 
@@ -603,19 +608,19 @@ describe('ensureLabelsExist', () => {
 })
 
 // ---------------------------------------------------------------------------
-// createProposals — I/O shell tests
+// openLearningIssues — I/O shell tests
 // ---------------------------------------------------------------------------
 
-describe('createProposals', () => {
+describe('openLearningIssues', () => {
   it('creates an issue with the learning-proposal label and the merge-SHA marker in the body', async () => {
-    // #given a single proposal to create
+    // #given a single learning to create
     const sha = 'abc123def456abc123def456abc123def456abc1'
     const createSpy = vi.fn().mockResolvedValue({data: {number: 42}})
     const octokit = mockOctokit({getLabelResult: 'found', issuesCreateSpy: createSpy})
     const toCreate = [makeToCreate({mergeSha: sha})]
 
-    // #when creating proposals
-    const counts = await createProposals(octokit, 'fro-bot', '.github', toCreate)
+    // #when opening learning issues
+    const counts = await openLearningIssues(octokit, 'fro-bot', '.github', toCreate)
 
     // #then the issue was created with the correct label and marker
     expect(counts.created).toBe(1)
@@ -631,8 +636,8 @@ describe('createProposals', () => {
     const createSpy = vi.fn().mockResolvedValue({data: {number: 1}})
     const octokit = mockOctokit({getLabelResult: 404, createLabelResult: 'created', issuesCreateSpy: createSpy})
 
-    // #when creating proposals
-    const counts = await createProposals(octokit, 'fro-bot', '.github', [makeToCreate()])
+    // #when opening learning issues
+    const counts = await openLearningIssues(octokit, 'fro-bot', '.github', [makeToCreate()])
 
     // #then the issue was created
     expect(counts.created).toBe(1)
@@ -640,15 +645,15 @@ describe('createProposals', () => {
     expect(callArg.labels).toContain(LEARNING_PROPOSAL_LABEL)
   })
 
-  it('skips ALL proposals when the label cannot be confirmed (fail-closed on labeling)', async () => {
+  it('skips ALL learnings when the label cannot be confirmed (fail-closed on labeling)', async () => {
     // #given the label cannot be confirmed (getLabel 500 error)
-    // An unlabeled proposal is invisible to the seen-set query (filtered by label)
+    // An unlabeled learning is invisible to the seen-set query (filtered by label)
     // and would be re-proposed forever — worse than skipping.
     const createSpy = vi.fn().mockResolvedValue({data: {number: 1}})
     const octokit = mockOctokit({getLabelResult: 'error', issuesCreateSpy: createSpy})
 
-    // #when creating proposals
-    const counts = await createProposals(octokit, 'fro-bot', '.github', [makeToCreate()])
+    // #when opening learning issues
+    const counts = await openLearningIssues(octokit, 'fro-bot', '.github', [makeToCreate()])
 
     // #then NO issue is created and skippedLabelUnavailable is incremented
     expect(counts.created).toBe(0)
@@ -663,16 +668,16 @@ describe('createProposals', () => {
     const octokit = mockOctokit({getLabelResult: 'found', issuesCreateSpy: createSpy})
     const toCreate = [makeToCreate({mergeSha: sha}), makeToCreate({mergeSha: sha})]
 
-    // #when creating proposals
-    const counts = await createProposals(octokit, 'fro-bot', '.github', toCreate)
+    // #when opening learning issues
+    const counts = await openLearningIssues(octokit, 'fro-bot', '.github', toCreate)
 
     // #then only one issue was created (the second was suppressed by the in-memory Set)
     expect(counts.created).toBe(1)
     expect(createSpy).toHaveBeenCalledOnce()
   })
 
-  it('continues creating other proposals when one fails', async () => {
-    // #given two proposals: the first create call fails, the second succeeds
+  it('continues creating other learnings when one fails', async () => {
+    // #given two learnings: the first create call fails, the second succeeds
     const sha1 = `sha1${'0'.repeat(36)}`
     const sha2 = `sha2${'0'.repeat(36)}`
     const createSpy = vi
@@ -685,8 +690,8 @@ describe('createProposals', () => {
       makeToCreate({mergeSha: sha2, body: `Body 2\n\n${buildMergeShaMarker(sha2)}`}),
     ]
 
-    // #when creating proposals
-    const counts = await createProposals(octokit, 'fro-bot', '.github', toCreate)
+    // #when opening learning issues
+    const counts = await openLearningIssues(octokit, 'fro-bot', '.github', toCreate)
 
     // #then the first failed but the second succeeded
     expect(counts.created).toBe(1)
@@ -695,11 +700,11 @@ describe('createProposals', () => {
   })
 
   it('returns zero counts when toCreate is empty', async () => {
-    // #given no proposals to create
+    // #given no learnings to create
     const octokit = mockOctokit()
 
-    // #when creating proposals with an empty list
-    const counts = await createProposals(octokit, 'fro-bot', '.github', [])
+    // #when opening learning issues with an empty list
+    const counts = await openLearningIssues(octokit, 'fro-bot', '.github', [])
 
     // #then no API calls are made and counts are zero
     expect(counts.created).toBe(0)
@@ -707,13 +712,13 @@ describe('createProposals', () => {
   })
 
   it('includes the title derived from the mergeSha (short SHA, no private info)', async () => {
-    // #given a proposal with a known mergeSha
+    // #given a learning with a known mergeSha
     const sha = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
     const createSpy = vi.fn().mockResolvedValue({data: {number: 1}})
     const octokit = mockOctokit({getLabelResult: 'found', issuesCreateSpy: createSpy})
 
-    // #when creating proposals
-    await createProposals(octokit, 'fro-bot', '.github', [
+    // #when opening learning issues
+    await openLearningIssues(octokit, 'fro-bot', '.github', [
       makeToCreate({mergeSha: sha, body: `Body\n\n${buildMergeShaMarker(sha)}`}),
     ])
 

--- a/scripts/capture-learnings-open.test.ts
+++ b/scripts/capture-learnings-open.test.ts
@@ -194,7 +194,7 @@ describe('planLearnings', () => {
     })
   })
 
-  describe('privacy gate (R4)', () => {
+  describe('privacy gate', () => {
     it('blocks a candidate whose body contains a private token', () => {
       // #given a body containing a private identifier
       const sha = 'abc123def456abc123def456abc123def456abc1'
@@ -268,7 +268,7 @@ describe('planLearnings', () => {
     })
   })
 
-  describe('same-run dedup (R3)', () => {
+  describe('same-run dedup', () => {
     it('skips a candidate whose mergeSha is in alreadyCreatedShas', () => {
       // #given a candidate whose SHA is already in the created set
       const sha = 'abc123def456abc123def456abc123def456abc1'
@@ -392,7 +392,7 @@ describe('loadPrivateTokensFromDisk', () => {
     // #when loading private tokens
     // #then it throws — the caller must not post proposals
     await expect(loadPrivateTokensFromDisk(readFileFn)).rejects.toThrow(
-      'capture-learnings-open: could not read metadata/repos.yaml',
+      'capture-learnings-open: could not read metadata/repos.yaml — privacy gate cannot operate; no learnings will be posted',
     )
   })
 
@@ -403,7 +403,7 @@ describe('loadPrivateTokensFromDisk', () => {
     // #when loading private tokens
     // #then it throws — the caller must not post proposals
     await expect(loadPrivateTokensFromDisk(readFileFn)).rejects.toThrow(
-      'capture-learnings-open: could not parse metadata/repos.yaml',
+      'capture-learnings-open: could not parse metadata/repos.yaml — privacy gate cannot operate; no learnings will be posted',
     )
   })
 

--- a/scripts/capture-learnings-open.ts
+++ b/scripts/capture-learnings-open.ts
@@ -45,10 +45,10 @@ export interface PlanLearningsInput {
    * Candidates with no entry in this map are skipped.
    */
   learningBodies: Map<string, string>
-  /** Private identifier tokens for the privacy gate (R4). */
+  /** Private identifier tokens for the privacy gate. */
   privateTokens: Set<string>
   /**
-   * merge_shas already created this run (same-run dedup guard, R3).
+   * merge_shas already created this run (same-run dedup guard).
    * Populated by the caller from prior openLearningIssues calls or from
    * the cross-run seen-set built by fetchOpenedLearningShas.
    */
@@ -65,7 +65,7 @@ export interface LearningToOpen {
 /** Result of the pure planning core. */
 export interface PlanLearningsResult {
   toCreate: LearningToOpen[]
-  /** Number of learnings blocked by the privacy gate (R4). */
+  /** Number of learnings blocked by the privacy gate. */
   blockedOnPrivacy: number
   /** Number of learnings skipped because the mergeSha was already created. */
   skippedDuplicate: number
@@ -88,7 +88,7 @@ export interface OpenLearningsCounts {
 }
 
 // ---------------------------------------------------------------------------
-// Privacy gate (R4) — pure, fail-closed
+// Privacy gate — pure, fail-closed
 // ---------------------------------------------------------------------------
 
 /**
@@ -133,7 +133,7 @@ function isApiStatus(error: unknown, status: number): boolean {
  * - If the file cannot be read or parsed, this function THROWS.
  * - The caller MUST NOT post any proposals when this throws (no private set ⇒ no proposals).
  * - This is intentional: a missing overlay means the privacy gate cannot operate,
- *   and posting unscanned proposals would violate R4.
+ *   and posting unscanned proposals would violate the privacy-gate contract.
  *
  * Counts-only: private names are never logged; only counts appear in stderr.
  *
@@ -148,7 +148,7 @@ export async function loadPrivateTokensFromDisk(
     reposYaml = await readFileFn('metadata/repos.yaml', 'utf8')
   } catch (error: unknown) {
     throw new Error(
-      'capture-learnings-open: could not read metadata/repos.yaml — privacy gate cannot operate; no proposals will be posted',
+      'capture-learnings-open: could not read metadata/repos.yaml — privacy gate cannot operate; no learnings will be posted',
       {cause: error},
     )
   }
@@ -158,21 +158,21 @@ export async function loadPrivateTokensFromDisk(
     parsed = parse(reposYaml)
   } catch (error: unknown) {
     throw new Error(
-      'capture-learnings-open: could not parse metadata/repos.yaml — privacy gate cannot operate; no proposals will be posted',
+      'capture-learnings-open: could not parse metadata/repos.yaml — privacy gate cannot operate; no learnings will be posted',
       {cause: error},
     )
   }
 
   if (!isRecord(parsed)) {
     throw new TypeError(
-      'capture-learnings-open: metadata/repos.yaml has unexpected shape — privacy gate cannot operate; no proposals will be posted',
+      'capture-learnings-open: metadata/repos.yaml has unexpected shape — privacy gate cannot operate; no learnings will be posted',
     )
   }
 
   const repos = parsed.repos
   if (!Array.isArray(repos)) {
     throw new TypeError(
-      'capture-learnings-open: metadata/repos.yaml missing repos array — privacy gate cannot operate; no proposals will be posted',
+      'capture-learnings-open: metadata/repos.yaml missing repos array — privacy gate cannot operate; no learnings will be posted',
     )
   }
 
@@ -204,8 +204,8 @@ export async function loadPrivateTokensFromDisk(
  *
  * For each candidate:
  * 1. Skip if no agent-authored body is available.
- * 2. Skip if the mergeSha is already in alreadyCreatedShas (same-run dedup, R3).
- * 3. Skip if the body contains a private token (privacy gate, R4).
+ * 2. Skip if the mergeSha is already in alreadyCreatedShas (same-run dedup).
+ * 3. Skip if the body contains a private token (privacy gate).
  * 4. Otherwise: append the merge-SHA marker to the body and add to toCreate.
  *
  * Pure function: no I/O, fully testable.
@@ -223,13 +223,13 @@ export function planLearnings(input: PlanLearningsInput): PlanLearningsResult {
       continue
     }
 
-    // Same-run dedup (R3): skip if already created this run
+    // Same-run dedup: skip if already created this run
     if (input.alreadyCreatedShas.has(candidate.mergeSha)) {
       skippedDuplicate += 1
       continue
     }
 
-    // Privacy gate (R4): block if body contains a private identifier
+    // Privacy gate: block if body contains a private identifier
     if (learningBodyHasPrivateLeak(body, input.privateTokens)) {
       blockedOnPrivacy += 1
       continue
@@ -362,7 +362,7 @@ export async function openLearningIssues(
     return {created: 0, failed: 0, skippedLabelUnavailable: toCreate.length}
   }
 
-  // Same-run in-memory Set (guards eventual-consistency race, R3)
+  // Same-run in-memory Set (guards eventual-consistency race)
   const createdThisRun = new Set<string>()
 
   let created = 0
@@ -404,13 +404,13 @@ export async function openLearningIssues(
 }
 
 // ---------------------------------------------------------------------------
-// Entry point (SHAPE B: deterministic open step reads digest + agent bodies)
+// Entry point (deterministic open step reads digest + agent bodies)
 // ---------------------------------------------------------------------------
 
 /**
  * CLI entry point for the deterministic open step.
  *
- * Handoff contract (SHAPE B):
+ * Handoff contract:
  * - Reads the harvest digest from the path in CAPTURE_LEARNINGS_DIGEST_PATH env var
  *   (a JSON file containing a CandidateDigest written by the harvest step).
  * - Reads agent-authored proposal bodies from the path in CAPTURE_LEARNINGS_BODIES_PATH
@@ -423,6 +423,7 @@ export async function openLearningIssues(
  * Privacy guarantee: the agent never receives owner/repo/number prose (the digest
  * carries only merge_sha + signals). The privacy gate runs here, deterministically,
  * not at agent discretion. A missing or unreadable metadata/repos.yaml is fatal.
+ *
  *
  * Strip-only safe: no parameter properties, enums, or namespaces.
  */

--- a/scripts/capture-learnings-open.ts
+++ b/scripts/capture-learnings-open.ts
@@ -492,7 +492,9 @@ async function main(): Promise<void> {
 
   const result: OpenResult = {
     examined: digest.telemetry.multiRoundCandidates,
-    candidatesAfterDedup: digest.telemetry.afterSolutionsDedup,
+    // The count actually fed into planning — digest.candidates is already capped to
+    // MAX_LEARNINGS_PER_RUN, so this reflects what was processed, not the pre-cap total.
+    candidatesAfterDedup: digest.candidates.length,
     learningsOpened: created,
     blockedOnPrivacy: plan.blockedOnPrivacy,
     skippedDuplicate: plan.skippedDuplicate,

--- a/scripts/capture-learnings-open.ts
+++ b/scripts/capture-learnings-open.ts
@@ -1,11 +1,11 @@
 /**
- * Proposal-issue opening for the C1 learning-capture pipeline.
+ * Opens learning-proposal issues from harvested candidate pull requests.
  *
  * Given a set of candidates (from the harvest digest) and agent-authored proposal bodies,
  * opens `learning-proposal` issues — but only after each body passes a fail-closed
  * private-identifier scan, with same-run in-memory dedup.
  *
- * Architecture: pure planning core (`planProposals`) + I/O shell (`createProposals`).
+ * Architecture: pure planning core (`planLearnings`) + I/O shell (`openLearningIssues`).
  * The pure core is fully unit-testable with injected inputs.
  * The I/O shell does Octokit calls and disk reads.
  *
@@ -29,7 +29,7 @@ import {
   type Candidate,
   type CandidateDigest,
   type OctokitClient,
-} from './capture-c1-harvest.ts'
+} from './capture-learnings-harvest.ts'
 import {buildPrivateTokenSet} from './wiki-slug.ts'
 
 // ---------------------------------------------------------------------------
@@ -37,37 +37,37 @@ import {buildPrivateTokenSet} from './wiki-slug.ts'
 // ---------------------------------------------------------------------------
 
 /** Input to the pure planning core. */
-export interface PlanProposalsInput {
+export interface PlanLearningsInput {
   /** Candidates from the harvest digest. */
   candidates: Candidate[]
   /**
    * Agent-authored proposal body per mergeSha.
    * Candidates with no entry in this map are skipped.
    */
-  proposalBodies: Map<string, string>
+  learningBodies: Map<string, string>
   /** Private identifier tokens for the privacy gate (R4). */
   privateTokens: Set<string>
   /**
    * merge_shas already created this run (same-run dedup guard, R3).
-   * Populated by the caller from prior createProposals calls or from
-   * the cross-run seen-set built by fetchProposedMergeShas.
+   * Populated by the caller from prior openLearningIssues calls or from
+   * the cross-run seen-set built by fetchOpenedLearningShas.
    */
   alreadyCreatedShas: Set<string>
 }
 
-/** A single proposal ready to be created as a GitHub issue. */
-export interface ProposalToCreate {
+/** A single learning ready to be created as a GitHub issue. */
+export interface LearningToOpen {
   mergeSha: string
   /** Body with the merge-SHA marker already appended. */
   body: string
 }
 
 /** Result of the pure planning core. */
-export interface PlanProposalsResult {
-  toCreate: ProposalToCreate[]
-  /** Number of proposals blocked by the privacy gate (R4). */
+export interface PlanLearningsResult {
+  toCreate: LearningToOpen[]
+  /** Number of learnings blocked by the privacy gate (R4). */
   blockedOnPrivacy: number
-  /** Number of proposals skipped because the mergeSha was already created. */
+  /** Number of learnings skipped because the mergeSha was already created. */
   skippedDuplicate: number
 }
 
@@ -78,8 +78,8 @@ export interface LabelDescriptor {
   description: string
 }
 
-/** Counts returned by createProposals. */
-export interface CreateProposalsCounts {
+/** Counts returned by openLearningIssues. */
+export interface OpenLearningsCounts {
   created: number
   failed: number
   blockedOnPrivacy: number
@@ -92,14 +92,14 @@ export interface CreateProposalsCounts {
 // ---------------------------------------------------------------------------
 
 /**
- * Returns true if the proposal body contains any private identifier token.
+ * Returns true if the learning body contains any private identifier token.
  *
  * The body is lowercased before scanning. The caller MUST block (skip) the
- * proposal on true. Never redacts — block only. Counts-only telemetry.
+ * learning on true. Never redacts — block only. Counts-only telemetry.
  *
  * Pure function: no I/O, fully testable.
  */
-export function proposalBodyHasPrivateLeak(body: string, privateTokens: Set<string>): boolean {
+export function learningBodyHasPrivateLeak(body: string, privateTokens: Set<string>): boolean {
   const lower = body.toLowerCase()
   for (const token of privateTokens) {
     if (lower.includes(token)) return true
@@ -148,7 +148,7 @@ export async function loadPrivateTokensFromDisk(
     reposYaml = await readFileFn('metadata/repos.yaml', 'utf8')
   } catch (error: unknown) {
     throw new Error(
-      'capture-c1-propose: could not read metadata/repos.yaml — privacy gate cannot operate; no proposals will be posted',
+      'capture-learnings-open: could not read metadata/repos.yaml — privacy gate cannot operate; no proposals will be posted',
       {cause: error},
     )
   }
@@ -158,21 +158,21 @@ export async function loadPrivateTokensFromDisk(
     parsed = parse(reposYaml)
   } catch (error: unknown) {
     throw new Error(
-      'capture-c1-propose: could not parse metadata/repos.yaml — privacy gate cannot operate; no proposals will be posted',
+      'capture-learnings-open: could not parse metadata/repos.yaml — privacy gate cannot operate; no proposals will be posted',
       {cause: error},
     )
   }
 
   if (!isRecord(parsed)) {
     throw new TypeError(
-      'capture-c1-propose: metadata/repos.yaml has unexpected shape — privacy gate cannot operate; no proposals will be posted',
+      'capture-learnings-open: metadata/repos.yaml has unexpected shape — privacy gate cannot operate; no proposals will be posted',
     )
   }
 
   const repos = parsed.repos
   if (!Array.isArray(repos)) {
     throw new TypeError(
-      'capture-c1-propose: metadata/repos.yaml missing repos array — privacy gate cannot operate; no proposals will be posted',
+      'capture-learnings-open: metadata/repos.yaml missing repos array — privacy gate cannot operate; no proposals will be posted',
     )
   }
 
@@ -190,7 +190,7 @@ export async function loadPrivateTokensFromDisk(
 
   const tokenSet = buildPrivateTokenSet(privateNames)
   process.stderr.write(
-    `capture-c1-propose: loaded private token set (private-repo count=${privateNames.length}, token-count=${tokenSet.size})\n`,
+    `capture-learnings-open: loaded private token set (private-repo count=${privateNames.length}, token-count=${tokenSet.size})\n`,
   )
   return tokenSet
 }
@@ -200,7 +200,7 @@ export async function loadPrivateTokensFromDisk(
 // ---------------------------------------------------------------------------
 
 /**
- * Plan which proposals to create, applying the privacy gate and same-run dedup.
+ * Plan which learnings to create, applying the privacy gate and same-run dedup.
  *
  * For each candidate:
  * 1. Skip if no agent-authored body is available.
@@ -210,13 +210,13 @@ export async function loadPrivateTokensFromDisk(
  *
  * Pure function: no I/O, fully testable.
  */
-export function planProposals(input: PlanProposalsInput): PlanProposalsResult {
-  const toCreate: ProposalToCreate[] = []
+export function planLearnings(input: PlanLearningsInput): PlanLearningsResult {
+  const toCreate: LearningToOpen[] = []
   let blockedOnPrivacy = 0
   let skippedDuplicate = 0
 
   for (const candidate of input.candidates) {
-    const body = input.proposalBodies.get(candidate.mergeSha)
+    const body = input.learningBodies.get(candidate.mergeSha)
 
     // Skip candidates with no agent-authored body
     if (body === undefined || body === '') {
@@ -230,7 +230,7 @@ export function planProposals(input: PlanProposalsInput): PlanProposalsResult {
     }
 
     // Privacy gate (R4): block if body contains a private identifier
-    if (proposalBodyHasPrivateLeak(body, input.privateTokens)) {
+    if (learningBodyHasPrivateLeak(body, input.privateTokens)) {
       blockedOnPrivacy += 1
       continue
     }
@@ -275,7 +275,7 @@ export async function ensureLabelsExist(
       if (!isApiStatus(getError, 404)) {
         const status = isRecord(getError) && typeof getError.status === 'number' ? getError.status : 'unknown'
         process.stderr.write(
-          `capture-c1-propose: label check failed for "${name}" (status=${status}); excluding from issue labels\n`,
+          `capture-learnings-open: label check failed for "${name}" (status=${status}); excluding from issue labels\n`,
         )
         continue
       }
@@ -292,7 +292,7 @@ export async function ensureLabelsExist(
       } else {
         const status = isRecord(createError) && typeof createError.status === 'number' ? createError.status : 'unknown'
         process.stderr.write(
-          `capture-c1-propose: label creation failed for "${name}" (status=${status}); excluding from issue labels\n`,
+          `capture-learnings-open: label creation failed for "${name}" (status=${status}); excluding from issue labels\n`,
         )
       }
     }
@@ -306,17 +306,17 @@ export async function ensureLabelsExist(
 // ---------------------------------------------------------------------------
 
 /**
- * Derive a proposal issue title from a mergeSha.
+ * Derive a learning issue title from a mergeSha.
  * Uses only the merge SHA (public, safe for this public repo) — no owner/repo/number prose.
  * Short SHA = first 8 chars.
  */
-function deriveProposalTitle(mergeSha: string): string {
+function deriveLearningTitle(mergeSha: string): string {
   const shortSha = mergeSha.slice(0, 8)
   return `Learning proposal: review-heavy PR (${shortSha})`
 }
 
 // ---------------------------------------------------------------------------
-// I/O shell: createProposals
+// I/O shell: openLearningIssues
 // ---------------------------------------------------------------------------
 
 const LEARNING_PROPOSAL_LABEL_DESCRIPTOR: LabelDescriptor = {
@@ -327,7 +327,7 @@ const LEARNING_PROPOSAL_LABEL_DESCRIPTOR: LabelDescriptor = {
 }
 
 /**
- * Open GitHub issues for the planned proposals.
+ * Open GitHub issues for the planned learnings.
  *
  * Steps:
  * 1. Label preflight: ensureLabelsExist([LEARNING_PROPOSAL_LABEL]).
@@ -339,11 +339,11 @@ const LEARNING_PROPOSAL_LABEL_DESCRIPTOR: LabelDescriptor = {
  *
  * Returns counts-only telemetry. No private names in any output.
  */
-export async function createProposals(
+export async function openLearningIssues(
   octokit: OctokitClient,
   owner: string,
   repo: string,
-  toCreate: ProposalToCreate[],
+  toCreate: LearningToOpen[],
 ): Promise<{created: number; failed: number; skippedLabelUnavailable: number}> {
   if (toCreate.length === 0) {
     return {created: 0, failed: 0, skippedLabelUnavailable: 0}
@@ -352,12 +352,12 @@ export async function createProposals(
   // Label preflight
   const confirmedLabels = await ensureLabelsExist(octokit, owner, repo, [LEARNING_PROPOSAL_LABEL_DESCRIPTOR])
 
-  // Fail-closed on labeling: if the required label is not confirmed, skip ALL proposals.
-  // An unlabeled proposal is invisible to the seen-set query (which filters by label)
+  // Fail-closed on labeling: if the required label is not confirmed, skip ALL learnings.
+  // An unlabeled learning is invisible to the seen-set query (which filters by label)
   // and would be re-proposed forever — worse than skipping.
   if (!confirmedLabels.has(LEARNING_PROPOSAL_LABEL)) {
     process.stderr.write(
-      `capture-c1-propose: label "${LEARNING_PROPOSAL_LABEL}" unavailable; skipping ${toCreate.length} proposal(s) (label-unavailable)\n`,
+      `capture-learnings-open: label "${LEARNING_PROPOSAL_LABEL}" unavailable; skipping ${toCreate.length} learning(s) (label-unavailable)\n`,
     )
     return {created: 0, failed: 0, skippedLabelUnavailable: toCreate.length}
   }
@@ -371,11 +371,13 @@ export async function createProposals(
   for (const item of toCreate) {
     // Same-run Set guard: skip if this mergeSha was already created in this invocation
     if (createdThisRun.has(item.mergeSha)) {
-      process.stderr.write(`capture-c1-propose: same-run duplicate skipped (sha-prefix=${item.mergeSha.slice(0, 8)})\n`)
+      process.stderr.write(
+        `capture-learnings-open: same-run duplicate skipped (sha-prefix=${item.mergeSha.slice(0, 8)})\n`,
+      )
       continue
     }
 
-    const title = deriveProposalTitle(item.mergeSha)
+    const title = deriveLearningTitle(item.mergeSha)
 
     try {
       await octokit.rest.issues.create({
@@ -392,31 +394,31 @@ export async function createProposals(
     } catch (error: unknown) {
       failed += 1
       const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
-      process.stderr.write(`capture-c1-propose: issue creation failed (status=${status}); continuing\n`)
+      process.stderr.write(`capture-learnings-open: issue creation failed (status=${status}); continuing\n`)
     }
   }
 
-  process.stderr.write(`capture-c1-propose: proposals created=${created} failed=${failed}\n`)
+  process.stderr.write(`capture-learnings-open: learnings created=${created} failed=${failed}\n`)
 
   return {created, failed, skippedLabelUnavailable: 0}
 }
 
 // ---------------------------------------------------------------------------
-// Entry point (SHAPE B: deterministic propose step reads digest + agent bodies)
+// Entry point (SHAPE B: deterministic open step reads digest + agent bodies)
 // ---------------------------------------------------------------------------
 
 /**
- * CLI entry point for the deterministic propose step.
+ * CLI entry point for the deterministic open step.
  *
  * Handoff contract (SHAPE B):
- * - Reads the harvest digest from the path in CAPTURE_C1_DIGEST_PATH env var
+ * - Reads the harvest digest from the path in CAPTURE_LEARNINGS_DIGEST_PATH env var
  *   (a JSON file containing a CandidateDigest written by the harvest step).
- * - Reads agent-authored proposal bodies from the path in CAPTURE_C1_BODIES_PATH
+ * - Reads agent-authored proposal bodies from the path in CAPTURE_LEARNINGS_BODIES_PATH
  *   env var (a JSON file: Record<mergeSha, bodyText> written by the agent step).
  * - Loads the private token set from metadata/repos.yaml (fail-closed: throws if
  *   the file cannot be read or parsed — no proposals posted without the privacy gate).
- * - Calls planProposals (privacy gate + same-run dedup) then createProposals.
- * - Writes a counts-only JSON result to CAPTURE_C1_RESULT_PATH (if set) and stdout.
+ * - Calls planLearnings (privacy gate + same-run dedup) then openLearningIssues.
+ * - Writes a counts-only JSON result to CAPTURE_LEARNINGS_RESULT_PATH (if set) and stdout.
  *
  * Privacy guarantee: the agent never receives owner/repo/number prose (the digest
  * carries only merge_sha + signals). The privacy gate runs here, deterministically,
@@ -425,11 +427,11 @@ export async function createProposals(
  * Strip-only safe: no parameter properties, enums, or namespaces.
  */
 
-/** Counts-only result written to stdout and CAPTURE_C1_RESULT_PATH. */
-interface ProposeResult {
+/** Counts-only result written to stdout and CAPTURE_LEARNINGS_RESULT_PATH. */
+interface OpenResult {
   examined: number
   candidatesAfterDedup: number
-  proposalsOpened: number
+  learningsOpened: number
   blockedOnPrivacy: number
   skippedDuplicate: number
   skippedLabelUnavailable: number
@@ -441,25 +443,25 @@ async function readJsonFile<T>(path: string, label: string): Promise<T> {
   try {
     raw = await readFile(path, 'utf8')
   } catch (error: unknown) {
-    throw new Error(`capture-c1-propose: could not read ${label} at ${path}`, {cause: error})
+    throw new Error(`capture-learnings-open: could not read ${label} at ${path}`, {cause: error})
   }
   try {
     return JSON.parse(raw) as T
   } catch (error: unknown) {
-    throw new Error(`capture-c1-propose: could not parse ${label} at ${path}`, {cause: error})
+    throw new Error(`capture-learnings-open: could not parse ${label} at ${path}`, {cause: error})
   }
 }
 
 async function main(): Promise<void> {
-  const digestPath = process.env.CAPTURE_C1_DIGEST_PATH
-  const bodiesPath = process.env.CAPTURE_C1_BODIES_PATH
-  const resultPath = process.env.CAPTURE_C1_RESULT_PATH
+  const digestPath = process.env.CAPTURE_LEARNINGS_DIGEST_PATH
+  const bodiesPath = process.env.CAPTURE_LEARNINGS_BODIES_PATH
+  const resultPath = process.env.CAPTURE_LEARNINGS_RESULT_PATH
 
   if (digestPath === undefined || digestPath === '') {
-    throw new Error('capture-c1-propose: CAPTURE_C1_DIGEST_PATH is required')
+    throw new Error('capture-learnings-open: CAPTURE_LEARNINGS_DIGEST_PATH is required')
   }
   if (bodiesPath === undefined || bodiesPath === '') {
-    throw new Error('capture-c1-propose: CAPTURE_C1_BODIES_PATH is required')
+    throw new Error('capture-learnings-open: CAPTURE_LEARNINGS_BODIES_PATH is required')
   }
 
   // Read the harvest digest (written by the harvest step)
@@ -467,7 +469,7 @@ async function main(): Promise<void> {
 
   // Read agent-authored bodies (written by the agent step): Record<mergeSha, bodyText>
   const bodiesRecord = await readJsonFile<Record<string, string>>(bodiesPath, 'agent bodies')
-  const proposalBodies = new Map<string, string>(Object.entries(bodiesRecord))
+  const learningBodies = new Map<string, string>(Object.entries(bodiesRecord))
 
   // Fail-closed: load private tokens — throws if metadata/repos.yaml is unreadable
   const privateTokens = await loadPrivateTokensFromDisk()
@@ -476,21 +478,21 @@ async function main(): Promise<void> {
   const owner = 'fro-bot'
   const repo = '.github'
 
-  // Plan proposals: privacy gate + same-run dedup
-  const plan = planProposals({
+  // Plan learnings: privacy gate + same-run dedup
+  const plan = planLearnings({
     candidates: digest.candidates,
-    proposalBodies,
+    learningBodies,
     privateTokens,
     alreadyCreatedShas: new Set<string>(),
   })
 
-  // Create the planned proposals
-  const {created, failed, skippedLabelUnavailable} = await createProposals(octokit, owner, repo, plan.toCreate)
+  // Open the planned learning issues
+  const {created, failed, skippedLabelUnavailable} = await openLearningIssues(octokit, owner, repo, plan.toCreate)
 
-  const result: ProposeResult = {
-    examined: digest.telemetry.examined,
+  const result: OpenResult = {
+    examined: digest.telemetry.multiRoundCandidates,
     candidatesAfterDedup: digest.telemetry.afterSolutionsDedup,
-    proposalsOpened: created,
+    learningsOpened: created,
     blockedOnPrivacy: plan.blockedOnPrivacy,
     skippedDuplicate: plan.skippedDuplicate,
     skippedLabelUnavailable,
@@ -504,7 +506,7 @@ async function main(): Promise<void> {
     try {
       await writeFile(resultPath, resultJson, {flag: 'w'})
     } catch (error: unknown) {
-      process.stderr.write(`capture-c1-propose: could not write result to ${resultPath}: ${String(error)}\n`)
+      process.stderr.write(`capture-learnings-open: could not write result to ${resultPath}: ${String(error)}\n`)
     }
   }
 }

--- a/scripts/wiki-slug.test.ts
+++ b/scripts/wiki-slug.test.ts
@@ -98,7 +98,7 @@ describe('buildPrivateNameTokens', () => {
 })
 
 // ---------------------------------------------------------------------------
-// buildPrivateTokenSet (FIX 10 — extracted from capture-c1-propose + solutions-query)
+// buildPrivateTokenSet — shared by the learning-proposal privacy gate and solutions-query
 // ---------------------------------------------------------------------------
 
 describe('buildPrivateTokenSet', () => {

--- a/scripts/wiki-slug.ts
+++ b/scripts/wiki-slug.ts
@@ -5,7 +5,7 @@ import process from 'node:process'
  * Tokens: [owner/name, owner--name, computeRepoSlug(owner, name)] — lowercased, deduplicated.
  * Entries with `[REDACTED]` owner or name are skipped.
  *
- * Shared by capture-c1-propose.ts and solutions-query.ts — single source of truth.
+ * Shared by capture-learnings-open.ts and solutions-query.ts — single source of truth.
  */
 export function buildPrivateTokenSet(privateNames: string[]): Set<string> {
   const tokens = new Set<string>()


### PR DESCRIPTION
The Capture Learnings run was finding zero candidates because its detection signal was wrong, and its names carried internal trigger taxonomy. This corrects both.

## Detection

The harvest counted `CHANGES_REQUESTED` reviews — which the Fro Bot reviewer almost never submits (it approves, or has an approval auto-dismissed when a new commit lands). So the run examined real PRs and matched nothing.

The signal now keys on the Fro Bot reviewer identity and requires **two or more substantive reviews** (approved, changes-requested, or dismissed) **with at least one correction signal** (dismissed or changes-requested) — where a dismissed approval marks a re-review forced by a new push. Dependency-automation PRs are excluded by author and label; commit count is not used as a signal (it would catch Renovate churn). Per-stage counts replace the previous ambiguous total.

Calibrated against this repo's recent merged PRs, it flags the genuinely iterated ones and excludes clean approvals and dependency churn.

## Naming

Scripts, workflow, and identifiers now describe what the run does — capture learnings from reviewed pull requests — rather than an internal trigger label. "Proposal" remains only on the `learning-proposal` GitHub label and the prose explaining a human reviews each captured learning. The dedup marker changed accordingly; there are no existing learning-proposal issues, so nothing needs migrating.

## Verification

Types, lint, actionlint, strip-only load all clean; full suite green. The detection predicate, login keying, automation exclusion, telemetry, and marker round-trip are covered by tests, including a mutation-proof that removing the reviewer-identity filter changes the result.