### PR TITLE
docs: capture learnings on review-event classification and agent token wiring

### DIFF
--- a/docs/solutions/workflow-issues/classifying-github-review-events-for-iteration-signals-2026-06-22.md
+++ b/docs/solutions/workflow-issues/classifying-github-review-events-for-iteration-signals-2026-06-22.md
@@ -1,0 +1,51 @@
+---
+title: 'Classifying GitHub review events when detecting iteration signals'
+date: 2026-06-22
+last_updated: 2026-06-22
+problem_type: workflow_issue
+component: development_workflow
+module: github-actions-workflows
+severity: medium
+verified: 2026-06-22
+tags:
+  - github-api
+  - code-review
+  - detection-heuristic
+  - review-states
+  - bot-reviewer
+applies_when:
+  - A script or workflow classifies a PR's review history to detect "multi-round" or "iterated" pull requests.
+  - The reviewer whose behavior is being measured is a bot or automated reviewer with its own review-submission pattern.
+  - The heuristic counts review events (rounds, corrections, state transitions) to drive a downstream decision.
+---
+
+# Classifying GitHub review events when detecting iteration signals
+
+## Context
+
+A detector that scores PRs by "how many review rounds did this take" is only as good as its model of how the reviewer actually records reviews. The first implementation of the learning-capture harvest counted reviews in state `CHANGES_REQUESTED` and required two or more — a reasonable model for a human reviewer who explicitly requests changes each round.
+
+It found nothing. The run examined real merged PRs and emitted zero candidates.
+
+The reason was a wrong model of the reviewer. The Fro Bot reviewer (login `fro-bot`, a `User`-type bot) almost never submits `CHANGES_REQUESTED`. Its pattern is to **approve**, and when a new commit lands after approval, GitHub **auto-dismisses** that approval and the bot re-reviews — recording a `DISMISSED` event, not a `CHANGES_REQUESTED`. So the real iteration signal lived entirely in `DISMISSED` events the detector ignored, while the state it counted was one the reviewer effectively never enters.
+
+The failure was invisible in tests (which used `CHANGES_REQUESTED` fixtures that matched the code) and only surfaced when the detector ran against real review history and returned an empty cohort. Two more wrong guesses followed before the signal was grounded against actual review-state data across recent PRs.
+
+The distinction that matters: **a dismissed approval is not a fresh review round on its own merits — it is a marker that a new push invalidated a prior sign-off.** Conflating "any review event" with "a round," or assuming the human `CHANGES_REQUESTED` idiom, corrupts the count.
+
+## Guidance
+
+**Before counting review events, gather real review-state data for the specific reviewer and verify which states they actually emit.** Do not assume the human `CHANGES_REQUESTED`-per-round idiom; a bot reviewer may express the same "this changed, look again" signal as `DISMISSED`.
+
+When implementing the detector:
+
+- **Key on the reviewer identity explicitly.** Filter reviews to the reviewer login(s) you mean to measure (e.g. a `FRO_BOT_REVIEWER_LOGINS` set), not all reviewers. Counting every reviewer conflates unrelated activity into the signal.
+- **Enumerate every review state and decide its contribution deliberately.** GitHub review states are `APPROVED`, `CHANGES_REQUESTED`, `DISMISSED`, `COMMENTED`. Decide what each means for your metric rather than treating any non-empty review as a round. A useful split:
+  - *substantive rounds* = `APPROVED | CHANGES_REQUESTED | DISMISSED` (exclude `COMMENTED` — a comment is not a round).
+  - *correction signals* = `DISMISSED | CHANGES_REQUESTED` (the events that mean "this needed another pass").
+  - A predicate like `substantiveRounds >= 2 AND correctionSignals >= 1` captures genuine iteration whether the reviewer uses `CHANGES_REQUESTED` or `DISMISSED`.
+- **Do not use a proxy axis like commit count.** Commit count is a tempting "iteration" proxy but is the wrong axis: dependency-automation PRs can carry dozens of commits with no review iteration, while a genuinely iterated PR may have a handful. Exclude automation by author/label instead, and base the signal on review events.
+- **Paginate the reviews call.** `pulls.listReviews` defaults to a small page; an iterated PR can have reviews spanning pages, so an unpaginated call undercounts rounds.
+- **Pair the logic with a fixture covering the dismissed-then-reapproved sequence** specifically, plus a non-candidate fixture where the count threshold is met but the correction-signal requirement is not — that boundary is exactly where a naive "rounds >= N" predicate goes wrong.
+
+The general rule: **a heuristic that classifies its own historical signal is easy to get subtly wrong on the boundary cases, and the error stays invisible until you run it against real data.** Ground the model in observed reviewer behavior before trusting the count.

--- a/docs/solutions/workflow-issues/required-github-token-for-agent-steps-2026-06-22.md
+++ b/docs/solutions/workflow-issues/required-github-token-for-agent-steps-2026-06-22.md
@@ -1,0 +1,51 @@
+---
+title: 'Agent and automation steps need their GitHub token wired explicitly'
+date: 2026-06-22
+last_updated: 2026-06-22
+problem_type: workflow_issue
+component: development_workflow
+module: github-actions-workflows
+severity: medium
+verified: 2026-06-22
+tags:
+  - github-actions
+  - github-token
+  - agent-step
+  - credentials
+  - least-privilege
+applies_when:
+  - A workflow invokes a third-party action or agent step that performs GitHub API operations.
+  - The step declares a required token input, or relies on a token to authenticate.
+  - A privacy or security review removed a token from a step and now the step fails at startup.
+---
+
+# Agent and automation steps need their GitHub token wired explicitly
+
+## Context
+
+The learning-capture workflow's agent step failed on its first run at bootstrap with:
+
+```
+Invalid inputs: Input required and not supplied: github-token
+```
+
+The harvest step before it succeeded; only the agent step failed. The cause was a token-wiring gap created by a well-intentioned security fix: the agent step had been stripped of its `github-token` to prevent the agent from creating issues directly (issue creation was meant to happen only in a later deterministic step). But the agent action declares `github-token` as a **required** input, so removing it entirely breaks the step before any of its logic runs.
+
+The symptom is easy to misread. "Input required and not supplied" surfaces from inside the action, so it can look like a logic or configuration bug in the agent rather than a missing-credential bug in the workflow. The first instinct was to investigate the agent's behavior; the actual fix was one line of token wiring.
+
+The right resolution was **not** to hand back a broad token. The agent does need *a* token to satisfy the required input, but it must not be able to perform the writes the deterministic step owns. The fix passed the workflow's auto-provisioned `GITHUB_TOKEN`, scoped by the job's `permissions:` block to `contents: read` only. That satisfies the required input while denying the agent any issue-creation reach — issue creation stays in the deterministic step under a separate App token. The security goal (the agent cannot bypass the downstream gate) is preserved by the **token scope**, not by token absence.
+
+## Guidance
+
+**Treat token wiring into agent/automation steps as a first-class concern, separate from token scope.**
+
+- **A required `github-token` input must be supplied** even when you want to restrict what the step can do. Removing it breaks the step at startup, not at the point of a privileged operation.
+- **Restrict capability by scope, not by omission.** To deny a step write access, pass the auto-provisioned `GITHUB_TOKEN` and constrain the job's `permissions:` (e.g. `contents: read`, no `issues: write`). The step authenticates but cannot perform writes outside its scope.
+- **Keep privileged operations in a separate step with its own credential.** If one step must read and another must write, give the write step its own token (e.g. a GitHub App installation token) and keep the read-only step on the constrained `GITHUB_TOKEN`. The trust boundary is then enforced by which step holds which token.
+- **When a step claims a token is missing, start debugging at the credential wiring, not the step's logic.** The failure signature ("input required and not supplied", or auth/permission errors surfacing from inside a nested tool invocation) points at the token plumbing first. The default workflow token is not always wired through to nested tool steps, and a required input will not inherit implicitly.
+- **Keep the comments honest about the mechanism.** If a step omits a token "so it can't write," and a later change adds the token back under a read-only scope, update the comment — the invariant moved from *token absence* to *token scope*, and a stale comment documents a false security guarantee for the next reviewer.
+
+## Related
+
+- [Survey workflow-side privacy gate](../security-issues/survey-workflow-side-privacy-gate-2026-05-16.md) — the same separate-step-with-its-own-credential pattern, where a privacy gate runs under a distinct token so the boundary is enforced by which step holds which credential.
+- [Privacy-gate promotion leak prevention](../best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md) — a related case of a gate that must live inside the trust boundary it protects, using a scoped default token rather than a broad PAT for the read it needs.


### PR DESCRIPTION
Two reusable learnings, authored into `docs/solutions/`. Each is the authored output of a learning-proposal the capture run opened.

## Review event classification for iteration detection

When a workflow detects multi-round-review PRs, it must model how the reviewer actually records reviews. A bot reviewer expresses "this changed, look again" as a *dismissed approval* (auto-dismissed on a new push), not a changes-requested review — so a detector keyed on `CHANGES_REQUESTED` finds nothing. The guidance: key on reviewer identity, enumerate every review state deliberately, count substantive rounds plus correction signals, paginate the reviews call, and don't use commit count as an iteration proxy.

## Agent automation steps need explicit GitHub token wiring

An agent/automation step that declares a required `github-token` must be supplied one even when you want to limit what it can do. Restrict capability by token *scope* (a read-only `GITHUB_TOKEN`), not by omitting the token, and keep privileged writes in a separate step under their own credential. Cross-referenced to the related privacy-gate docs.

Both follow the existing `docs/solutions/` frontmatter convention so they're retrievable by the learning-consultation step.

Closes #3548
Closes #3549
