### PR TITLE
feat(capture): enrich the digest with privacy-gated review prose

### DIFF
--- a/.github/workflows/capture-learnings.yaml
+++ b/.github/workflows/capture-learnings.yaml
@@ -100,11 +100,16 @@ jobs:
                Each candidate in the candidates array has:
                - mergeSha: opaque merge commit SHA (the ONLY identifier you receive)
                - reviewRounds: number of substantive Fro Bot review rounds (approved, changes-requested, or dismissed — a dismissed approval marks a re-review forced by a new push)
-               - signals: { titleTokens: string[], labels: string[] }
+               - reviewExcerpts: string[] — the actual review prose from the rounds (review bodies and line-level review comments), ranked with the correction feedback first. This is your PRIMARY signal: it is what the reviewer actually said about what was wrong and how it was fixed. It has been privacy-scanned; use it as given. May be empty for some candidates.
+               - signals: { titleTokens: string[], labels: string[] } — secondary context only
             2. For each candidate you judge worth proposing (reviewRounds ≥ 2 is
-               already guaranteed; use signals to assess value), write a concise
-               learning-proposal body (2–4 paragraphs) that:
-               - Describes the pattern or mistake the multi-round review suggests
+               already guaranteed), write a concise learning-proposal body (2–4
+               paragraphs) that:
+               - Distills the reusable learning from reviewExcerpts — what the
+                 review rounds actually said was wrong and how it was corrected.
+                 Ground the learning in that prose, not in the title tokens. When
+                 reviewExcerpts is empty, fall back to signals but keep the body
+                 modest and clearly general rather than inventing specifics.
                - References the source PR by merge SHA ONLY (never look up or
                  include owner/repo/PR number/title/author — you do not have that
                  information and must not attempt to retrieve it)

--- a/.github/workflows/capture-learnings.yaml
+++ b/.github/workflows/capture-learnings.yaml
@@ -175,6 +175,7 @@ jobs:
               echo "| After seen dedup | $(jq '.telemetry.afterSeenDedup // 0' "$harvest") |"
               echo "| After solutions dedup | $(jq '.telemetry.afterSolutionsDedup // 0' "$harvest") |"
               echo "| Candidates emitted | $(jq '.telemetry.emitted // 0' "$harvest") |"
+              echo "| Enrichment blocked by privacy | $(jq '.telemetry.enrichmentBlocked // 0' "$harvest") |"
             else
               echo "| Closed PRs fetched | (harvest result unavailable) |"
             fi

--- a/docs/plans/2026-06-22-003-feat-enrich-capture-digest-plan.md
+++ b/docs/plans/2026-06-22-003-feat-enrich-capture-digest-plan.md
@@ -1,0 +1,314 @@
+---
+title: 'feat: enrich the learning-capture digest with review-thread content'
+type: feat
+status: active
+date: 2026-06-22
+origin: docs/brainstorms/2026-06-22-skill-saving-grow-and-learn-requirements.md
+---
+
+# feat: enrich the learning-capture digest with review-thread content
+
+# Overview
+
+The learning-capture run gives the agent only a merge SHA, a review-round count, and tokens
+derived from the PR title. The first production run confirmed the consequence: descriptive
+titles produced plausible learnings, terse ones produced generic platitudes. The agent has no
+other signal to distill from.
+
+This adds the corrective signal the harvest already has cheap access to — the **review prose**
+(review bodies + line-level review-thread comments) — to the candidate digest, so the agent
+distills the learning from what the reviewer actually said. Because review prose carries
+private-repo cross-references (`owner/repo#123`, `@mentions`, private names), the fail-closed
+privacy gate moves **upstream to harvest time**: enriched content is scanned before it enters
+the digest and reaches the agent's reasoning context, not only on the authored body afterward.
+
+This is the **Phase 2.5 digest-enrichment** step (see origin) — the quality lever identified
+by shipping Phase 2, sequenced ahead of broadening triggers or adding authoring.
+
+# Problem Frame
+
+The agent's proposal quality is structurally capped by a title-only digest. `harvestCandidates`
+emits each candidate as `{mergeSha, reviewRounds, signals}` where `signals` is `{titleTokens,
+labels}` from `deriveSignals` — the review *rounds* are counted but their *bodies are discarded*
+(`listReviews` is paginated only for the count). The agent prompt then hands the model only
+title tokens and labels as substance. The fix is to retain and privacy-gate the review prose
+the harvest already fetches, plus the line-level thread comments where the sharpest corrections
+live. (Tracked as issue #3552.)
+
+# Requirements Trace
+
+- R1. (origin Phase 2.5) The candidate digest carries review-prose excerpts (review bodies +
+  line-level review-thread comments) so the agent distills from what the rounds said, not the
+  title.
+- R2. (origin SC5 / #3552) A fail-closed privacy scan runs on the enriched content **at harvest
+  time, before it enters the digest** — review prose containing a private-repo identifier is
+  dropped, never passed to the agent. The existing authored-body scan in the open step stays as
+  defense-in-depth.
+- R3. (#3552 budget) Enriched content is bounded per candidate, ranked by correction signal
+  (changes-requested / thread-reply prose preferred over approval boilerplate) so truncation
+  does not clip the correction sentence.
+- R4. (opacity) Enrichment introduces no owner/repo/PR-number into the digest beyond what the
+  privacy scan permits; candidates remain keyed by merge SHA.
+
+# Scope Boundaries
+
+- Enrichment with review bodies + line-level review-thread comments only. No diff/file summary
+  (`pulls.listFiles` gives filenames, not reasoning — the weaker lever).
+- No change to the detection predicate, the dedup logic, the cost cap, or the open step's
+  issue-creation flow.
+- No authoring, no quarantine lane, no new triggers (those remain later Phase 2.5+ items).
+
+## Deferred to Separate Tasks
+
+- Diff/file-summary enrichment, if review prose proves insufficient: future.
+- C2/C3 triggers and autonomous authoring: later Phase 2.5+, separate plans.
+
+# Context & Research
+
+## Relevant Code and Patterns
+
+- `scripts/capture-learnings-harvest.ts`
+  - `harvestCandidates` — paginates `pulls.listReviews` per surviving candidate **for the
+    count only**; the `reviews` array already carries `r.body`, currently discarded. This is
+    where review bodies are retained and `pulls.listReviewComments` is added.
+  - `deriveSignals` — title/label tokenizer; enrichment is a *new* field alongside `signals`,
+    not a replacement (titleTokens/labels stay for scoring).
+  - `Candidate` interface — gains an enrichment field (e.g. `reviewExcerpts`).
+  - `buildCandidateDigest` (pure core) — receives the private token set so the upstream scan is
+    unit-testable; threads enrichment + the drop count into telemetry.
+  - `main()` — must `loadPrivateTokens...` before building the digest (harvest does **not** load
+    `metadata/repos.yaml` today; the workflow overlays it once per job at
+    `capture-learnings.yaml:47-55`, so the file is present, but harvest must read it).
+- `scripts/capture-learnings-open.ts`
+  - `learningBodyHasPrivateLeak` + `loadPrivateTokensFromDisk` — the pure, fail-closed gate
+    functions to **extract to a shared module** (Fork 2). The open step keeps using them via the
+    shared module (authored-body scan, unchanged).
+- `scripts/wiki-slug.ts` — `buildPrivateNameTokens`, already the shared token-set source the gate
+  builds on (precedent: extracted there specifically to stop gate drift).
+- `.github/workflows/capture-learnings.yaml`
+  - `Harvest candidates` step — needs the App token (already has `GITHUB_TOKEN`) and the metadata
+    overlay already present; the agent prompt (lines ~100-103) must be updated to distill from
+    the new excerpts field, not titleTokens.
+
+## Institutional Learnings
+
+- `docs/solutions/best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md` and the
+  survey-privacy-gate docs — a gate must live *inside* the trust boundary it protects, and scan
+  content not just identifiers. The upstream-at-harvest placement (R2) is exactly this lesson:
+  the boundary is "before the agent sees it," so the gate belongs at harvest, not only at
+  authoring.
+- `docs/solutions/workflow-issues/required-github-token-for-agent-steps-2026-06-22.md` — the
+  harvest step's token wiring; no scope change needed (read-only review access).
+- Node 24 strip-only safety; the pure-core / I/O-shell split already in both scripts makes the
+  new scan and enrichment straightforward to test.
+
+# Key Technical Decisions
+
+- **Enrich with review bodies + line-level thread comments (Fork 1).** Reuse `r.body` from the
+  already-fetched `listReviews` (zero new calls for bodies) + one paginated
+  `pulls.listReviewComments` per surviving candidate (bounded: candidates capped at
+  `MAX_LEARNINGS_PER_RUN = 5`). Skip diff summary.
+- **Extract the privacy gate to a shared module (Fork 2).** Move `learningBodyHasPrivateLeak` +
+  `loadPrivateTokensFromDisk` into `scripts/capture-learnings-privacy.ts`, imported by both
+  harvest (new upstream scan) and open (existing authored-body scan). Single source of truth;
+  the two gates cannot drift. Mirrors the `buildPrivateNameTokens` extraction precedent.
+- **Privacy gate runs upstream, fail-closed, drop-not-redact (R2).** In harvest `main()`, load
+  the private token set (fail-closed: if `metadata/repos.yaml` is unreadable, emit no enriched
+  content — never unscanned prose). Scan each candidate's enriched content; on a hit, **drop the
+  enriched content for that candidate** (the candidate may still proceed with title-only signal,
+  OR be dropped entirely — see Open Questions). Consistent with the open step's block-don't-redact
+  contract.
+- **Rank by correction signal when truncating (R3).** Bound enriched content per candidate
+  (e.g. a per-candidate char cap). When trimming, prefer `CHANGES_REQUESTED` review bodies and
+  thread-reply prose over `APPROVED` boilerplate — rank by correction signal, not chronology, so
+  the correction sentence is not clipped.
+- **Enrichment is a new `Candidate` field, not a replacement.** `signals` (titleTokens/labels)
+  stays for scoring/dedup; `reviewExcerpts` is additive. The agent prompt is updated to distill
+  from `reviewExcerpts` primarily.
+- **Amend plan/req R4 framing.** The privacy requirement now covers enriched digest content, not
+  only the authored body (the origin doc's Phase 2.5 reshaping already states this; the plan
+  records it as R2).
+
+# Open Questions
+
+## Resolved During Planning
+
+- Enrichment scope: review bodies + line-level thread comments (no diff summary). Resolved.
+- Gate sharing: extract to `scripts/capture-learnings-privacy.ts`. Resolved.
+- Gate placement: upstream at harvest, fail-closed, before the digest. Resolved (the #3552
+  load-bearing finding).
+
+## Deferred to Implementation
+
+- **On a private-token hit, drop the enriched content only, or drop the whole candidate?**
+  Dropping enriched-content-only lets the candidate proceed title-only (degraded but not lost);
+  dropping the candidate is stricter. Lean: drop enriched content, keep the candidate with a
+  counts-only "enrichment-blocked" signal — but decide against the privacy contract during
+  implementation. (A candidate whose *only* signal was private prose is low-value anyway.)
+- Exact per-candidate char budget and the correction-signal ranking weights — calibrate against
+  real review threads during implementation.
+- Whether `reviewExcerpts` is a single truncated string or a small array — implementation choice;
+  array gives the agent clearer structure.
+
+# Implementation Units
+
+- [ ] **Unit 1: Extract the privacy gate to a shared module**
+
+**Goal:** Move the fail-closed gate functions into a shared module both harvest and open import,
+so there is one source of truth for the contract.
+
+**Requirements:** R2 (enables the shared upstream scan).
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `scripts/capture-learnings-privacy.ts`
+- Modify: `scripts/capture-learnings-open.ts` (import from the shared module instead of defining)
+- Test: `scripts/capture-learnings-privacy.test.ts` (move/extend the existing gate tests)
+
+**Approach:**
+- Move `learningBodyHasPrivateLeak` + `loadPrivateTokensFromDisk` (and the token-set builder they
+  use) into `capture-learnings-privacy.ts`, preserving the fail-closed throw contract and the
+  counts-only logging exactly.
+- `capture-learnings-open.ts` imports them; its behavior is unchanged (verify the open tests
+  still pass against the moved functions).
+
+**Patterns to follow:** the `buildPrivateNameTokens` extraction in `scripts/wiki-slug.ts`; the
+existing `loadPrivateTokensFromDisk` injectable-`readFile` test seam.
+
+**Test scenarios:**
+- Happy: `learningBodyHasPrivateLeak` flags a body containing each private token variant
+  (owner/name, owner--name, slug); clean body → false.
+- Fail-closed: `loadPrivateTokensFromDisk` throws on unreadable / unparseable / wrong-shape /
+  missing-`repos` metadata (the four existing branches), with no private name in the message.
+- Redacted entries (`[REDACTED]`) contribute no token; `private !== true` entries excluded.
+- Integration: `capture-learnings-open.ts` still blocks a private-laden authored body after the
+  move (no behavior change).
+
+**Verification:** gates green; open-step tests pass unchanged against the shared module; strip-only
+load clean.
+
+- [ ] **Unit 2: Harvest enrichment + upstream fail-closed privacy scan (test-first)**
+
+**Goal:** Retain review-body prose, fetch line-level thread comments per candidate, privacy-scan
+the enriched content fail-closed before it enters the digest, and bound it ranked by correction
+signal.
+
+**Requirements:** R1, R2, R3, R4.
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `scripts/capture-learnings-harvest.ts`
+- Test: `scripts/capture-learnings-harvest.test.ts`
+
+**Approach:**
+- In `harvestCandidates`, retain `r.body` from the already-fetched reviews; add a paginated
+  `pulls.listReviewComments` call per surviving candidate (after the predicate filter, so it runs
+  only for the ≤ cap candidates).
+- Add `reviewExcerpts` to `Candidate`. Build the excerpt by ranking review/thread prose by
+  correction signal (changes-requested / reply prose first), then truncating to a per-candidate
+  char budget (named constant). Exclude approval boilerplate first when over budget.
+- Pure core: `buildCandidateDigest` receives the private token set and the per-candidate enriched
+  prose; it scans each fail-closed and drops enriched content (or the candidate — see deferred Q)
+  on a hit, threading an `enrichmentBlocked` count into telemetry. Keep the core pure (inject the
+  token set + prose; no I/O).
+- `main()`: load the private token set via the shared module **before** building the digest
+  (fail-closed: throw → emit empty/title-only digest, never unscanned prose). The metadata overlay
+  is already present in the job.
+
+**Execution note:** Test-first — the upstream scan is security-critical; write the
+private-hit-drops-enrichment test (and its mutation proof) before the implementation.
+
+**Patterns to follow:** the existing `harvestCandidates` pagination + retry-continue; the
+pure-core/I/O-shell split; the `loadPrivateTokensFromDisk` fail-closed contract from Unit 1.
+
+**Test scenarios:**
+- Happy: a candidate with review bodies + thread comments → `reviewExcerpts` populated, ranked
+  with correction prose first.
+- Privacy (R2), load-bearing: a candidate whose review prose contains a private token → enriched
+  content dropped fail-closed; assert the private token does NOT appear in the digest or any
+  output. **Mutation-prove**: removing the scan lets the private prose into the digest → test fails.
+- Fail-closed: unreadable `metadata/repos.yaml` → no enriched content emitted (title-only or empty),
+  never unscanned prose; no crash.
+- Budget (R3): over-budget enriched content is truncated; correction-signal prose is retained over
+  approval boilerplate; assert the correction sentence survives a representative trim.
+- Thread comments: `pulls.listReviewComments` paginated; a candidate with multi-page comments
+  includes later pages.
+- Opacity (R4): `reviewExcerpts` after the scan contains no tracked private identifier; candidate
+  still keyed by merge SHA.
+- Telemetry: `enrichmentBlocked` (or equivalent) count is correct in a mixed scenario.
+- Error path: a transient `listReviewComments` failure for one candidate degrades that candidate to
+  title-only, does not abort the run.
+
+**Verification:** gates green (~1212+ baseline plus new tests); strip-only load clean; the privacy
+mutation-proof bites; no private identifier in any digest/output for the private-prose fixture.
+
+- [ ] **Unit 3: Update the agent prompt to distill from review excerpts**
+
+**Goal:** Point the agent at `reviewExcerpts` as the primary substance, so it distills from review
+prose rather than title tokens.
+
+**Requirements:** R1.
+
+**Dependencies:** Unit 2.
+
+**Files:**
+- Modify: `.github/workflows/capture-learnings.yaml`
+
+**Approach:**
+- Update the `Author proposal bodies` step prompt: the digest candidates now carry
+  `reviewExcerpts` (privacy-scanned review/thread prose); instruct the agent to base the learning
+  on what the review rounds actually said, using `reviewExcerpts` as the primary signal and
+  title/labels only as secondary context. Keep all existing hard boundaries (merge-SHA-only
+  references, write only the bodies file, no other actions). Keep the `reviewRounds` description
+  accurate (substantive rounds).
+
+**Test expectation:** none — workflow prompt wiring; validated by actionlint and a manual dispatch
+that shows `reviewExcerpts` populated in the digest and the agent citing review-derived substance.
+
+**Verification:** actionlint clean; a manual `workflow_dispatch` shows the digest carries
+privacy-scanned `reviewExcerpts`, the agent authors bodies grounded in review prose, and no private
+identifier appears in the run log.
+
+# System-Wide Impact
+
+- **Interaction graph:** harvest gains one paginated API call per candidate (≤ 5) and an upstream
+  privacy scan; the digest gains an enrichment field; the agent prompt changes its primary signal.
+  The open step is unchanged except importing the gate from the shared module.
+- **Error propagation:** the upstream scan is fail-closed (no token set ⇒ no enriched content); a
+  per-candidate enrichment-fetch error degrades to title-only, never aborts. The open step's
+  authored-body scan remains as defense-in-depth.
+- **State lifecycle risks:** none new — no persisted state; the decision log (proposal issues)
+  is untouched.
+- **API surface parity:** the harvest-time gate and the open-step gate now share one module, so
+  they cannot drift — the explicit goal of the extraction.
+- **Unchanged invariants:** opacity (merge-SHA keying), the detection predicate, the dedup marker,
+  the cost cap, and the data-branch authority model.
+
+# Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Review prose leaks a private identifier into the agent's context | Fail-closed upstream scan at harvest (R2) before the digest; mutation-proven; drop-not-redact |
+| Truncation clips the correction sentence (generic-platitude failure in a new costume) | Rank by correction signal not chronology (R3); test that the correction sentence survives a trim |
+| Gate drift between harvest and open | Single shared module (Unit 1) imported by both |
+| Per-candidate `listReviewComments` cost | Bounded by `MAX_LEARNINGS_PER_RUN = 5`; runs only after the predicate filter |
+| Harvest can't read `metadata/repos.yaml` | Fail-closed: emit title-only/empty, never unscanned prose |
+
+# Documentation / Operational Notes
+
+- After landing, the upstream-privacy-gate-at-harvest pattern is a candidate `docs/solutions/`
+  learning (a gate moved to sit inside the trust boundary it protects) — author via `ce:compound`
+  if it proves reusable.
+- Close #3552 when this ships.
+
+# Sources & References
+
+- **Origin document:** docs/brainstorms/2026-06-22-skill-saving-grow-and-learn-requirements.md
+- **Seed:** issue #3552 (Fro Bot triage — the grounded technical analysis this plan implements)
+- Code: `scripts/capture-learnings-harvest.ts` (`harvestCandidates`, `deriveSignals`, `Candidate`,
+  `buildCandidateDigest`), `scripts/capture-learnings-open.ts` (`learningBodyHasPrivateLeak`,
+  `loadPrivateTokensFromDisk`), `scripts/wiki-slug.ts` (`buildPrivateNameTokens`),
+  `.github/workflows/capture-learnings.yaml`
+- Prior plan: docs/plans/2026-06-22-002-feat-capture-c1-proposals-plan.md

--- a/docs/plans/2026-06-22-003-feat-enrich-capture-digest-plan.md
+++ b/docs/plans/2026-06-22-003-feat-enrich-capture-digest-plan.md
@@ -152,7 +152,7 @@ live. (Tracked as issue #3552.)
 
 # Implementation Units
 
-- [ ] **Unit 1: Extract the privacy gate to a shared module**
+- [x] **Unit 1: Extract the privacy gate to a shared module**
 
 **Goal:** Move the fail-closed gate functions into a shared module both harvest and open import,
 so there is one source of truth for the contract.
@@ -188,7 +188,7 @@ existing `loadPrivateTokensFromDisk` injectable-`readFile` test seam.
 **Verification:** gates green; open-step tests pass unchanged against the shared module; strip-only
 load clean.
 
-- [ ] **Unit 2: Harvest enrichment + upstream fail-closed privacy scan (test-first)**
+- [x] **Unit 2: Harvest enrichment + upstream fail-closed privacy scan (test-first)**
 
 **Goal:** Retain review-body prose, fetch line-level thread comments per candidate, privacy-scan
 the enriched content fail-closed before it enters the digest, and bound it ranked by correction
@@ -244,7 +244,7 @@ pure-core/I/O-shell split; the `loadPrivateTokensFromDisk` fail-closed contract 
 **Verification:** gates green (~1212+ baseline plus new tests); strip-only load clean; the privacy
 mutation-proof bites; no private identifier in any digest/output for the private-prose fixture.
 
-- [ ] **Unit 3: Update the agent prompt to distill from review excerpts**
+- [x] **Unit 3: Update the agent prompt to distill from review excerpts**
 
 **Goal:** Point the agent at `reviewExcerpts` as the primary substance, so it distills from review
 prose rather than title tokens.

--- a/scripts/capture-learnings-harvest.test.ts
+++ b/scripts/capture-learnings-harvest.test.ts
@@ -17,6 +17,7 @@ import {
   FRO_BOT_REVIEWER_LOGINS,
   harvestCandidates,
   LEARNING_PROPOSAL_LABEL,
+  MAX_EXCERPT_CHARS_PER_CANDIDATE,
   parseMergeShaMarker,
   type BuildCandidateDigestInput,
   type Candidate,
@@ -25,6 +26,7 @@ import {
   type OctokitClient,
   type SolutionDoc,
 } from './capture-learnings-harvest.ts'
+import {buildPrivateTokenSet} from './wiki-slug.ts'
 
 // ---------------------------------------------------------------------------
 // Fixture helpers
@@ -35,6 +37,7 @@ function makeCandidate(overrides: Partial<Candidate> = {}): Candidate {
     mergeSha: 'abc123def456abc123def456abc123def456abc1',
     reviewRounds: 2,
     signals: {titleTokens: ['feat', 'scripts'], labels: []},
+    reviewExcerpts: [],
     ...overrides,
   }
 }
@@ -65,6 +68,7 @@ function makeDigestInput(overrides: Partial<BuildCandidateDigestInput> = {}): Bu
     openedLearningShas: new Set(),
     solutionsDocs: [],
     maxLearnings: 5,
+    privateTokens: new Set(),
     ...overrides,
   }
 }
@@ -148,7 +152,7 @@ describe('buildCandidateDigest', () => {
   })
 
   describe('opacity guarantee', () => {
-    it('emitted candidates have ONLY mergeSha, reviewRounds, and signals keys — no owner/repo/number/title', () => {
+    it('emitted candidates have ONLY mergeSha, reviewRounds, signals, and reviewExcerpts keys — no owner/repo/number/title', () => {
       // #given a candidate
       const input = makeDigestInput()
 
@@ -158,7 +162,7 @@ describe('buildCandidateDigest', () => {
       // #then each candidate object has exactly the allowed keys
       for (const candidate of result.candidates) {
         const keys = Object.keys(candidate).sort()
-        expect(keys).toEqual(['mergeSha', 'reviewRounds', 'signals'].sort())
+        expect(keys).toEqual(['mergeSha', 'reviewExcerpts', 'reviewRounds', 'signals'].sort())
         // Explicitly assert forbidden keys are absent
         expect(candidate).not.toHaveProperty('owner')
         expect(candidate).not.toHaveProperty('repo')
@@ -378,6 +382,8 @@ describe('buildCandidateDigest', () => {
       expect(result.telemetry.afterSeenDedup).toBe(3) // 5 - 2 proposed
       expect(result.telemetry.afterSolutionsDedup).toBe(2) // 3 - 1 overlap
       expect(result.telemetry.emitted).toBe(2) // 2 clean, under cap
+      // #then enrichmentBlocked is zero (no private tokens, no enriched content)
+      expect(result.telemetry.enrichmentBlocked).toBe(0)
     })
 
     it('reports zero counts when all candidates are filtered', () => {
@@ -428,6 +434,11 @@ interface PullsListItem {
 interface ReviewItem {
   state: string
   user: {login: string} | null
+  body?: string
+}
+
+interface ReviewCommentItem {
+  body: string
 }
 
 function makePullsListItem(overrides: Partial<PullsListItem> = {}): PullsListItem {
@@ -442,8 +453,12 @@ function makePullsListItem(overrides: Partial<PullsListItem> = {}): PullsListIte
   }
 }
 
-function makeReviewItem(state: string, login = 'fro-bot'): ReviewItem {
-  return {state, user: {login}}
+function makeReviewItem(state: string, login = 'fro-bot', body = ''): ReviewItem {
+  return {state, user: {login}, body}
+}
+
+function makeReviewCommentItem(body: string): ReviewCommentItem {
+  return {body}
 }
 
 function mockOctokit(
@@ -452,11 +467,14 @@ function mockOctokit(
     paginatePrList?: () => Promise<unknown[]>
     /** Override the paginate call for pulls.listReviews (returns the review array directly). */
     paginateListReviews?: () => Promise<ReviewItem[]>
+    /** Override the paginate call for pulls.listReviewComments (returns the comment array directly). */
+    paginateListReviewComments?: () => Promise<ReviewCommentItem[]>
     /** Legacy: override pullsListReviews for tests that use the old mock shape. */
     pullsListReviews?: (opts: unknown) => Promise<{data: ReviewItem[]}>
   } = {},
 ): OctokitClient {
   const listReviewsFn = overrides.pullsListReviews ?? (async () => ({data: [] as ReviewItem[]}))
+  const listReviewCommentsFn = async () => ({data: [] as ReviewCommentItem[]})
 
   // paginate is called with (fn, opts). We route by checking which rest method fn is.
   const paginate = async (fn: unknown, opts: unknown): Promise<unknown[]> => {
@@ -467,6 +485,13 @@ function mockOctokit(
       }
       const result = await listReviewsFn(opts)
       return result.data
+    }
+    // Route: if fn is the listReviewComments function
+    if (fn === listReviewCommentsFn) {
+      if (overrides.paginateListReviewComments !== undefined) {
+        return overrides.paginateListReviewComments() as Promise<unknown[]>
+      }
+      return []
     }
     // Otherwise it's pulls.list (or issues.listForRepo)
     if (overrides.paginatePrList !== undefined) {
@@ -483,6 +508,7 @@ function mockOctokit(
       pulls: {
         list: async () => ({data: []}),
         listReviews: listReviewsFn,
+        listReviewComments: listReviewCommentsFn,
       },
       issues: {
         listForRepo: async () => ({data: []}),
@@ -1099,11 +1125,13 @@ describe('harvest→open schema contract', () => {
         mergeSha: 'abc123def456abc123def456abc123def456abc1',
         reviewRounds: 3,
         signals: {titleTokens: ['feat', 'scripts'], labels: ['ci', 'automation']},
+        reviewExcerpts: ['The correction prose here.'],
       },
       {
         mergeSha: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
         reviewRounds: 2,
         signals: {titleTokens: ['fix', 'workflow'], labels: []},
+        reviewExcerpts: [],
       },
     ]
     const digest: CandidateDigest = {
@@ -1116,6 +1144,7 @@ describe('harvest→open schema contract', () => {
         afterSeenDedup: 3,
         afterSolutionsDedup: 2,
         emitted: 2,
+        enrichmentBlocked: 0,
       },
     }
 
@@ -1163,5 +1192,446 @@ describe('harvest→open schema contract', () => {
     expect(atCutoff < new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)).toBe(false)
     expect(justBefore < new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)).toBe(true)
     expect(justAfter < new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Pure core: enrichment + upstream privacy scan
+// ---------------------------------------------------------------------------
+
+describe('buildCandidateDigest — enrichment and upstream privacy scan', () => {
+  describe('happy path: reviewExcerpts populated and ranked', () => {
+    it('candidate with review excerpts passes them through when no private tokens match', () => {
+      // #given a candidate with review excerpts (correction prose + approval boilerplate)
+      const candidate = makeCandidate({
+        reviewExcerpts: ['Please fix the null check here.', 'LGTM, approved!'],
+      })
+      const input = makeDigestInput({
+        mergedPrs: [candidate],
+        privateTokens: new Set(),
+      })
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then the candidate is emitted with its reviewExcerpts intact
+      expect(result.candidates).toHaveLength(1)
+      expect(result.candidates[0]?.reviewExcerpts).toEqual(['Please fix the null check here.', 'LGTM, approved!'])
+      expect(result.telemetry.enrichmentBlocked).toBe(0)
+    })
+
+    it('candidate with empty reviewExcerpts emits with empty array', () => {
+      // #given a candidate with no review excerpts (title-only)
+      const candidate = makeCandidate({reviewExcerpts: []})
+      const input = makeDigestInput({mergedPrs: [candidate], privateTokens: new Set()})
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then the candidate is emitted with empty reviewExcerpts
+      expect(result.candidates[0]?.reviewExcerpts).toEqual([])
+      expect(result.telemetry.enrichmentBlocked).toBe(0)
+    })
+  })
+
+  describe('upstream privacy scan — load-bearing security', () => {
+    it('drops reviewExcerpts when prose contains a private token, keeps the candidate (title-only)', () => {
+      // #given a private token set built from a synthetic private repo
+      const privateTokens = buildPrivateTokenSet(['testowner/secret-repo'])
+
+      // #given a candidate whose review prose contains the private repo reference
+      const candidate = makeCandidate({
+        mergeSha: 'privateshaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1',
+        reviewExcerpts: ['See testowner/secret-repo#42 for context.', 'LGTM'],
+      })
+      const input = makeDigestInput({
+        mergedPrs: [candidate],
+        privateTokens,
+      })
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then the candidate is KEPT (not dropped)
+      expect(result.candidates).toHaveLength(1)
+      // #then reviewExcerpts are DROPPED (empty — enrichment blocked)
+      expect(result.candidates[0]?.reviewExcerpts).toEqual([])
+      // #then enrichmentBlocked is incremented
+      expect(result.telemetry.enrichmentBlocked).toBe(1)
+      // #then the private token does NOT appear anywhere in the serialized digest
+      const serialized = JSON.stringify(result)
+      expect(serialized).not.toContain('testowner/secret-repo')
+      expect(serialized).not.toContain('testowner--secret-repo')
+    })
+
+    it('mutation proof: removing the scan lets private prose into reviewExcerpts', () => {
+      // #given a private token set and a candidate with private prose
+      const privateTokens = buildPrivateTokenSet(['testowner/secret-repo'])
+      const privateExcerpts = ['See testowner/secret-repo#42 for context.']
+
+      // #when the scan IS applied (normal path)
+      const withScan = buildCandidateDigest(
+        makeDigestInput({
+          mergedPrs: [makeCandidate({reviewExcerpts: privateExcerpts})],
+          privateTokens,
+        }),
+      )
+      // #then private prose is NOT in the output
+      expect(JSON.stringify(withScan)).not.toContain('testowner/secret-repo')
+
+      // #when the scan is bypassed (empty token set — simulating removal of the gate)
+      const withoutScan = buildCandidateDigest(
+        makeDigestInput({
+          mergedPrs: [makeCandidate({reviewExcerpts: privateExcerpts})],
+          privateTokens: new Set(), // gate removed
+        }),
+      )
+      // #then private prose DOES appear — proving the scan was the gate
+      expect(JSON.stringify(withoutScan)).toContain('testowner/secret-repo')
+    })
+
+    it('clean candidate passes through with reviewExcerpts intact when private tokens are loaded', () => {
+      // #given a private token set and a candidate with clean prose
+      const privateTokens = buildPrivateTokenSet(['testowner/secret-repo'])
+      const candidate = makeCandidate({
+        reviewExcerpts: ['Please add a null check here.', 'LGTM'],
+      })
+      const input = makeDigestInput({mergedPrs: [candidate], privateTokens})
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then the candidate is emitted with its reviewExcerpts intact
+      expect(result.candidates[0]?.reviewExcerpts).toEqual(['Please add a null check here.', 'LGTM'])
+      expect(result.telemetry.enrichmentBlocked).toBe(0)
+    })
+
+    it('mixed scenario: one blocked, one clean — enrichmentBlocked=1', () => {
+      // #given two candidates: one with private prose, one clean
+      const privateTokens = buildPrivateTokenSet(['testowner/secret-repo'])
+      const blockedCandidate = makeCandidate({
+        mergeSha: 'blocked1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1',
+        reviewExcerpts: ['See testowner/secret-repo#1 for details.'],
+      })
+      const cleanCandidate = makeCandidate({
+        mergeSha: 'clean001aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1',
+        reviewExcerpts: ['Fix the null check in the handler.'],
+      })
+      const input = makeDigestInput({
+        mergedPrs: [blockedCandidate, cleanCandidate],
+        privateTokens,
+      })
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then both candidates are emitted
+      expect(result.candidates).toHaveLength(2)
+      // #then the blocked candidate has empty reviewExcerpts
+      const blocked = result.candidates.find(c => c.mergeSha === blockedCandidate.mergeSha)
+      expect(blocked?.reviewExcerpts).toEqual([])
+      // #then the clean candidate retains its reviewExcerpts
+      const clean = result.candidates.find(c => c.mergeSha === cleanCandidate.mergeSha)
+      expect(clean?.reviewExcerpts).toEqual(['Fix the null check in the handler.'])
+      // #then enrichmentBlocked is 1
+      expect(result.telemetry.enrichmentBlocked).toBe(1)
+      // #then the private token does not appear in the serialized digest
+      expect(JSON.stringify(result)).not.toContain('testowner/secret-repo')
+    })
+
+    it('opacity: reviewExcerpts after scan contains no tracked private token', () => {
+      // #given a private token set with multiple token forms
+      const privateTokens = buildPrivateTokenSet(['testowner/secret-repo'])
+      // #given a candidate with prose containing each token form
+      const candidate = makeCandidate({
+        reviewExcerpts: [
+          'testowner/secret-repo is referenced here',
+          'testowner--secret-repo slug form',
+          'testowner--secret-repo another form',
+        ],
+      })
+      const input = makeDigestInput({mergedPrs: [candidate], privateTokens})
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then no private token form appears in the output
+      const serialized = JSON.stringify(result)
+      for (const token of privateTokens) {
+        expect(serialized).not.toContain(token)
+      }
+    })
+  })
+
+  describe('fail-closed: empty/missing token set behavior', () => {
+    it('candidate with enriched prose and empty privateTokens passes through (no tokens to match)', () => {
+      // #given an empty private token set (e.g. no private repos in metadata)
+      const candidate = makeCandidate({
+        reviewExcerpts: ['Some review prose here.'],
+      })
+      const input = makeDigestInput({mergedPrs: [candidate], privateTokens: new Set()})
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then the candidate passes through (empty token set = nothing to block)
+      expect(result.candidates[0]?.reviewExcerpts).toEqual(['Some review prose here.'])
+      expect(result.telemetry.enrichmentBlocked).toBe(0)
+    })
+  })
+
+  describe('enrichmentBlocked telemetry', () => {
+    it('enrichmentBlocked is 0 when no candidates have private prose', () => {
+      // #given candidates with clean prose and a loaded private token set
+      const privateTokens = buildPrivateTokenSet(['testowner/secret-repo'])
+      const input = makeDigestInput({
+        mergedPrs: [
+          makeCandidate({mergeSha: `clean1${'0'.repeat(34)}`, reviewExcerpts: ['Fix the handler.']}),
+          makeCandidate({mergeSha: `clean2${'0'.repeat(34)}`, reviewExcerpts: ['Add null check.']}),
+        ],
+        privateTokens,
+      })
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then enrichmentBlocked is 0
+      expect(result.telemetry.enrichmentBlocked).toBe(0)
+    })
+
+    it('enrichmentBlocked counts all candidates with private prose hits', () => {
+      // #given two candidates both with private prose
+      const privateTokens = buildPrivateTokenSet(['testowner/secret-repo'])
+      const input = makeDigestInput({
+        mergedPrs: [
+          makeCandidate({
+            mergeSha: `priv1${'0'.repeat(35)}`,
+            reviewExcerpts: ['See testowner/secret-repo#1'],
+          }),
+          makeCandidate({
+            mergeSha: `priv2${'0'.repeat(35)}`,
+            reviewExcerpts: ['Also testowner/secret-repo#2'],
+          }),
+        ],
+        privateTokens,
+      })
+
+      // #when building the digest
+      const result = buildCandidateDigest(input)
+
+      // #then enrichmentBlocked is 2
+      expect(result.telemetry.enrichmentBlocked).toBe(2)
+      // #then both candidates are still emitted (title-only)
+      expect(result.candidates).toHaveLength(2)
+      for (const c of result.candidates) {
+        expect(c.reviewExcerpts).toEqual([])
+      }
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// I/O shell: harvestCandidates — enrichment fetch
+// ---------------------------------------------------------------------------
+
+describe('harvestCandidates — enrichment fetch', () => {
+  it('happy path: candidate with review bodies and thread comments → reviewExcerpts populated', async () => {
+    // #given a qualifying PR with fro-bot reviews carrying bodies and thread comments
+    const sha = 'enriched1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1'
+    const pr = makePullsListItem({merge_commit_sha: sha})
+
+    // Reviews: CHANGES_REQUESTED (correction) + APPROVED (boilerplate)
+    const reviews: ReviewItem[] = [
+      makeReviewItem('CHANGES_REQUESTED', 'fro-bot', 'Please fix the null check in the handler.'),
+      makeReviewItem('APPROVED', 'fro-bot', 'LGTM, looks good now.'),
+    ]
+    // Thread comments: line-level correction prose
+    const reviewComments: ReviewCommentItem[] = [makeReviewCommentItem('This line needs a guard clause.')]
+
+    const paginateListReviews = vi.fn(async () => reviews)
+    const paginateListReviewComments = vi.fn(async () => reviewComments)
+
+    const octokit = mockOctokit({
+      paginatePrList: async () => [pr],
+      paginateListReviews: paginateListReviews as () => Promise<ReviewItem[]>,
+      paginateListReviewComments: paginateListReviewComments as () => Promise<ReviewCommentItem[]>,
+    })
+
+    // #when harvesting
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then the candidate has reviewExcerpts populated
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0]?.reviewExcerpts).toBeDefined()
+    expect(candidates[0]?.reviewExcerpts.length).toBeGreaterThan(0)
+    // #then correction prose appears in the excerpts
+    const excerptText = candidates[0]?.reviewExcerpts.join(' ') ?? ''
+    expect(excerptText).toContain('null check')
+  })
+
+  it('correction-signal prose ranked first: CHANGES_REQUESTED body before APPROVED body', async () => {
+    // #given a PR with APPROVED review first, then CHANGES_REQUESTED (chronological order reversed from rank)
+    const sha = 'ranktest1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    const pr = makePullsListItem({merge_commit_sha: sha})
+
+    // Chronological order: APPROVED first, CHANGES_REQUESTED second
+    const reviews: ReviewItem[] = [
+      makeReviewItem('APPROVED', 'fro-bot', 'Looks good to me.'),
+      makeReviewItem('CHANGES_REQUESTED', 'fro-bot', 'Please fix the null check — this is the correction.'),
+    ]
+
+    const octokit = mockOctokit({
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => reviews,
+      paginateListReviewComments: async () => [],
+    })
+
+    // #when harvesting
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then the CHANGES_REQUESTED body appears before the APPROVED body in reviewExcerpts
+    expect(candidates[0]?.reviewExcerpts).toBeDefined()
+    const excerpts = candidates[0]?.reviewExcerpts ?? []
+    expect(excerpts.length).toBeGreaterThan(0)
+    // The correction sentence must appear before the approval boilerplate
+    const correctionIdx = excerpts.findIndex(e => e.includes('null check'))
+    const approvalIdx = excerpts.findIndex(e => e.includes('Looks good'))
+    expect(correctionIdx).not.toBe(-1)
+    // If both are present, correction must come first
+    if (approvalIdx !== -1) {
+      expect(correctionIdx).toBeLessThan(approvalIdx)
+    }
+  })
+
+  it('budget: over-budget prose is truncated to MAX_EXCERPT_CHARS_PER_CANDIDATE', async () => {
+    // #given a PR with a CHANGES_REQUESTED body (correction) and a very long APPROVED body (boilerplate)
+    const sha = 'budgettest1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    const pr = makePullsListItem({merge_commit_sha: sha})
+
+    const correctionBody = 'Fix the null check here — this is the critical correction sentence.'
+    // Boilerplate that would overflow the budget on its own
+    const boilerplateBody = 'A'.repeat(MAX_EXCERPT_CHARS_PER_CANDIDATE + 500)
+
+    const reviews: ReviewItem[] = [
+      makeReviewItem('APPROVED', 'fro-bot', boilerplateBody),
+      makeReviewItem('CHANGES_REQUESTED', 'fro-bot', correctionBody),
+    ]
+
+    const octokit = mockOctokit({
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => reviews,
+      paginateListReviewComments: async () => [],
+    })
+
+    // #when harvesting
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then the total excerpt length is within budget
+    const excerpts = candidates[0]?.reviewExcerpts ?? []
+    const totalChars = excerpts.join('').length
+    expect(totalChars).toBeLessThanOrEqual(MAX_EXCERPT_CHARS_PER_CANDIDATE)
+    // #then the correction sentence survives (ranked first, not clipped)
+    const excerptText = excerpts.join(' ')
+    expect(excerptText).toContain('null check')
+  })
+
+  it('thread comments pagination: multi-page comments are all included', async () => {
+    // #given a PR with qualifying reviews and review comments spanning multiple pages
+    const sha = 'multipage1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    const pr = makePullsListItem({merge_commit_sha: sha})
+
+    const reviews: ReviewItem[] = [
+      makeReviewItem('CHANGES_REQUESTED', 'fro-bot', 'See inline comments.'),
+      makeReviewItem('APPROVED', 'fro-bot', 'LGTM'),
+    ]
+    // Simulate paginate returning all pages combined (as octokit.paginate does)
+    const allComments: ReviewCommentItem[] = [
+      makeReviewCommentItem('Page 1 comment: fix the guard.'),
+      makeReviewCommentItem('Page 2 comment: also check the edge case.'),
+    ]
+
+    const octokit = mockOctokit({
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => reviews,
+      paginateListReviewComments: async () => allComments,
+    })
+
+    // #when harvesting
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then both pages of comments are included in reviewExcerpts
+    const excerptText = candidates[0]?.reviewExcerpts.join(' ') ?? ''
+    expect(excerptText).toContain('Page 1 comment')
+    expect(excerptText).toContain('Page 2 comment')
+  })
+
+  it('error path: transient listReviewComments failure → candidate title-only, run not aborted', async () => {
+    // #given two PRs: one whose listReviewComments throws, one that succeeds
+    const sha1 = 'errorpath1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    const sha2 = 'errorpath2aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    const pr1 = makePullsListItem({number: 1, merge_commit_sha: sha1})
+    const pr2 = makePullsListItem({number: 2, merge_commit_sha: sha2})
+
+    const reviews: ReviewItem[] = [
+      makeReviewItem('CHANGES_REQUESTED', 'fro-bot', 'Fix this.'),
+      makeReviewItem('APPROVED', 'fro-bot', 'LGTM'),
+    ]
+
+    let commentCallCount = 0
+    const paginateListReviewComments = vi.fn(async () => {
+      commentCallCount++
+      if (commentCallCount === 1) {
+        throw Object.assign(new Error('Service Unavailable'), {status: 503})
+      }
+      return [makeReviewCommentItem('Good comment from PR 2.')]
+    })
+
+    const octokit = mockOctokit({
+      paginatePrList: async () => [pr1, pr2],
+      paginateListReviews: async () => reviews,
+      paginateListReviewComments: paginateListReviewComments as () => Promise<ReviewCommentItem[]>,
+    })
+
+    // #when harvesting
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then both candidates are returned (run not aborted)
+    expect(candidates).toHaveLength(2)
+    // #then the first candidate (error) has review body excerpts but no thread comments
+    const c1 = candidates.find(c => c.mergeSha === sha1)
+    expect(c1).toBeDefined()
+    // It may have review body excerpts (from listReviews which succeeded), but no thread comments
+    // The key assertion: the run was not aborted
+    // #then the second candidate has its thread comment
+    const c2 = candidates.find(c => c.mergeSha === sha2)
+    expect(c2).toBeDefined()
+    const c2Text = c2?.reviewExcerpts.join(' ') ?? ''
+    expect(c2Text).toContain('Good comment from PR 2')
+  })
+
+  it('empty review bodies are excluded from reviewExcerpts', async () => {
+    // #given a PR with reviews that have empty/whitespace bodies
+    const sha = 'emptybody1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    const pr = makePullsListItem({merge_commit_sha: sha})
+
+    const reviews: ReviewItem[] = [
+      makeReviewItem('CHANGES_REQUESTED', 'fro-bot', ''), // empty body — skip
+      makeReviewItem('APPROVED', 'fro-bot', '   '), // whitespace only — skip
+      makeReviewItem('DISMISSED', 'fro-bot', 'This was dismissed because of the null check issue.'),
+    ]
+
+    const octokit = mockOctokit({
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => reviews,
+      paginateListReviewComments: async () => [],
+    })
+
+    // #when harvesting
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then only the non-empty body is in reviewExcerpts
+    const excerpts = candidates[0]?.reviewExcerpts ?? []
+    expect(excerpts).toHaveLength(1)
+    expect(excerpts[0]).toContain('null check issue')
   })
 })

--- a/scripts/capture-learnings-harvest.test.ts
+++ b/scripts/capture-learnings-harvest.test.ts
@@ -10,6 +10,7 @@
 import {describe, expect, it, vi} from 'vitest'
 
 import {
+  applyEnrichmentScanAvailability,
   buildCandidateDigest,
   buildMergeShaMarker,
   DEPENDENCY_LABELS,
@@ -1431,6 +1432,71 @@ describe('buildCandidateDigest — enrichment and upstream privacy scan', () => 
 })
 
 // ---------------------------------------------------------------------------
+// Pure helper: applyEnrichmentScanAvailability — fail-closed composition
+// ---------------------------------------------------------------------------
+
+describe('applyEnrichmentScanAvailability', () => {
+  it('scanAvailable=true → candidates returned unchanged', () => {
+    // #given candidates with reviewExcerpts
+    const candidates: Candidate[] = [
+      makeCandidate({mergeSha: `sha1${'0'.repeat(35)}`, reviewExcerpts: ['Fix the null check.']}),
+      makeCandidate({mergeSha: `sha2${'0'.repeat(35)}`, reviewExcerpts: ['Another correction.']}),
+    ]
+
+    // #when scan is available
+    const result = applyEnrichmentScanAvailability(candidates, true)
+
+    // #then candidates are returned unchanged (same references)
+    expect(result).toBe(candidates)
+    expect(result[0]?.reviewExcerpts).toEqual(['Fix the null check.'])
+    expect(result[1]?.reviewExcerpts).toEqual(['Another correction.'])
+  })
+
+  it('scanAvailable=false → all reviewExcerpts cleared (fail-closed)', () => {
+    // #given candidates with reviewExcerpts
+    const candidates: Candidate[] = [
+      makeCandidate({mergeSha: `sha1${'0'.repeat(35)}`, reviewExcerpts: ['Fix the null check.']}),
+      makeCandidate({mergeSha: `sha2${'0'.repeat(35)}`, reviewExcerpts: ['Another correction.']}),
+    ]
+
+    // #when scan is unavailable (token load failed)
+    const result = applyEnrichmentScanAvailability(candidates, false)
+
+    // #then all reviewExcerpts are cleared — no unscanned prose reaches the digest
+    expect(result[0]?.reviewExcerpts).toEqual([])
+    expect(result[1]?.reviewExcerpts).toEqual([])
+    // #then other candidate fields are preserved
+    expect(result[0]?.mergeSha).toBe(candidates[0]?.mergeSha)
+    expect(result[1]?.mergeSha).toBe(candidates[1]?.mergeSha)
+  })
+
+  it('mutation proof: removing the clearing makes the false-case test fail', () => {
+    // #given a candidate with reviewExcerpts
+    const candidates: Candidate[] = [
+      makeCandidate({mergeSha: `sha1${'0'.repeat(35)}`, reviewExcerpts: ['Sensitive prose.']}),
+    ]
+
+    // #when scan is unavailable
+    const result = applyEnrichmentScanAvailability(candidates, false)
+
+    // #then reviewExcerpts must be empty — if the clearing logic were removed,
+    // result[0].reviewExcerpts would still be ['Sensitive prose.'] and this assertion fails
+    expect(result[0]?.reviewExcerpts).toEqual([])
+  })
+
+  it('scanAvailable=false with empty reviewExcerpts → still returns empty (no-op, no crash)', () => {
+    // #given candidates already with empty reviewExcerpts
+    const candidates: Candidate[] = [makeCandidate({mergeSha: `sha1${'0'.repeat(35)}`, reviewExcerpts: []})]
+
+    // #when scan is unavailable
+    const result = applyEnrichmentScanAvailability(candidates, false)
+
+    // #then still empty — no crash
+    expect(result[0]?.reviewExcerpts).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
 // I/O shell: harvestCandidates — enrichment fetch
 // ---------------------------------------------------------------------------
 
@@ -1460,13 +1526,14 @@ describe('harvestCandidates — enrichment fetch', () => {
     // #when harvesting
     const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
 
-    // #then the candidate has reviewExcerpts populated
+    // #then the candidate has exactly 3 reviewExcerpts (2 review bodies + 1 thread comment)
     expect(candidates).toHaveLength(1)
-    expect(candidates[0]?.reviewExcerpts).toBeDefined()
-    expect(candidates[0]?.reviewExcerpts.length).toBeGreaterThan(0)
-    // #then correction prose appears in the excerpts
-    const excerptText = candidates[0]?.reviewExcerpts.join(' ') ?? ''
-    expect(excerptText).toContain('null check')
+    const excerpts = candidates[0]?.reviewExcerpts ?? []
+    expect(excerpts).toHaveLength(3)
+    // #then ranked order: CHANGES_REQUESTED (rank 0) first, thread comment (rank 0) second, APPROVED (rank 2) last
+    expect(excerpts[0]).toBe('Please fix the null check in the handler.')
+    expect(excerpts[1]).toBe('This line needs a guard clause.')
+    expect(excerpts[2]).toBe('LGTM, looks good now.')
   })
 
   it('correction-signal prose ranked first: CHANGES_REQUESTED body before APPROVED body', async () => {
@@ -1533,6 +1600,64 @@ describe('harvestCandidates — enrichment fetch', () => {
     // #then the correction sentence survives (ranked first, not clipped)
     const excerptText = excerpts.join(' ')
     expect(excerptText).toContain('null check')
+  })
+
+  it('budget: first ranked item alone exceeds MAX_EXCERPT_CHARS_PER_CANDIDATE → truncated to exactly MAX_EXCERPT_CHARS_PER_CANDIDATE chars', async () => {
+    // #given a PR where the FIRST ranked item (CHANGES_REQUESTED body) alone overflows the budget
+    const sha = 'budgetfirst1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    const pr = makePullsListItem({merge_commit_sha: sha})
+
+    // A CHANGES_REQUESTED body that is larger than the entire budget
+    const oversizedCorrectionBody = 'C'.repeat(MAX_EXCERPT_CHARS_PER_CANDIDATE + 200)
+
+    const reviews: ReviewItem[] = [
+      makeReviewItem('CHANGES_REQUESTED', 'fro-bot', oversizedCorrectionBody),
+      makeReviewItem('APPROVED', 'fro-bot', 'LGTM'),
+    ]
+
+    const octokit = mockOctokit({
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => reviews,
+      paginateListReviewComments: async () => [],
+    })
+
+    // #when harvesting
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then exactly one excerpt (the truncated first item)
+    const excerpts = candidates[0]?.reviewExcerpts ?? []
+    expect(excerpts).toHaveLength(1)
+    // #then it is truncated to exactly MAX_EXCERPT_CHARS_PER_CANDIDATE chars
+    expect(excerpts[0]).toHaveLength(MAX_EXCERPT_CHARS_PER_CANDIDATE)
+    expect(excerpts[0]).toBe('C'.repeat(MAX_EXCERPT_CHARS_PER_CANDIDATE))
+  })
+
+  it('DISMISSED ranking: reviews [APPROVED, DISMISSED, CHANGES_REQUESTED] → excerpt order CHANGES_REQUESTED → DISMISSED → APPROVED', async () => {
+    // #given a PR with three review states in non-ranked chronological order
+    const sha = 'dismissedrank1aaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    const pr = makePullsListItem({merge_commit_sha: sha})
+
+    const reviews: ReviewItem[] = [
+      makeReviewItem('APPROVED', 'fro-bot', 'Looks good to me.'),
+      makeReviewItem('DISMISSED', 'fro-bot', 'This was dismissed due to scope change.'),
+      makeReviewItem('CHANGES_REQUESTED', 'fro-bot', 'Please fix the null check.'),
+    ]
+
+    const octokit = mockOctokit({
+      paginatePrList: async () => [pr],
+      paginateListReviews: async () => reviews,
+      paginateListReviewComments: async () => [],
+    })
+
+    // #when harvesting
+    const {candidates} = await harvestCandidates(octokit, 'fro-bot', '.github', new Date())
+
+    // #then excerpts are ordered by correction signal rank: CHANGES_REQUESTED (0) → DISMISSED (1) → APPROVED (2)
+    const excerpts = candidates[0]?.reviewExcerpts ?? []
+    expect(excerpts).toHaveLength(3)
+    expect(excerpts[0]).toBe('Please fix the null check.')
+    expect(excerpts[1]).toBe('This was dismissed due to scope change.')
+    expect(excerpts[2]).toBe('Looks good to me.')
   })
 
   it('thread comments pagination: multi-page comments are all included', async () => {

--- a/scripts/capture-learnings-harvest.ts
+++ b/scripts/capture-learnings-harvest.ts
@@ -16,7 +16,7 @@ import process from 'node:process'
 import {Octokit} from '@octokit/rest'
 import {parse} from 'yaml'
 
-import {learningBodyHasPrivateLeak, loadPrivateTokensFromDisk} from './capture-learnings-privacy.ts'
+import {isRecord, learningBodyHasPrivateLeak, loadPrivateTokensFromDisk} from './capture-learnings-privacy.ts'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -281,6 +281,21 @@ export function buildCandidateDigest(input: BuildCandidateDigestInput): Candidat
 }
 
 /**
+ * Apply fail-closed enrichment scan availability to a list of candidates.
+ *
+ * When `scanAvailable` is false (private token load failed), all `reviewExcerpts`
+ * are cleared so no unscanned prose reaches the digest. When `scanAvailable` is
+ * true, candidates are returned unchanged.
+ *
+ * Pure function: no I/O, fully unit-testable. Extracted so the fail-closed
+ * composition can be tested independently of the I/O shell.
+ */
+export function applyEnrichmentScanAvailability(candidates: Candidate[], scanAvailable: boolean): Candidate[] {
+  if (scanAvailable) return candidates
+  return candidates.map(c => ({...c, reviewExcerpts: [] as string[]}))
+}
+
+/**
  * Returns true if the candidate's signals overlap any existing solutions doc
  * above the SOLUTIONS_OVERLAP_THRESHOLD.
  *
@@ -451,14 +466,6 @@ export async function createOctokitFromEnv(): Promise<OctokitClient> {
   }
   const LoadedOctokit = await loadOctokitConstructor()
   return new LoadedOctokit({auth: token})
-}
-
-// ---------------------------------------------------------------------------
-// Type guards
-// ---------------------------------------------------------------------------
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 // ---------------------------------------------------------------------------
@@ -674,7 +681,7 @@ export async function harvestCandidates(
     }
 
     // Fetch line-level thread comments for enrichment.
-    // A transient error here degrades this candidate to title-only (empty reviewExcerpts)
+    // A transient error here degrades this candidate to review-bodies-only (no thread comments)
     // without aborting the run — mirrors the listReviews skip pattern but continues WITH
     // the candidate rather than skipping it entirely.
     let threadCommentBodies: string[] = []
@@ -692,7 +699,7 @@ export async function harvestCandidates(
     } catch (error: unknown) {
       const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
       process.stderr.write(
-        `capture-learnings-harvest: PR #${pr.number} — listReviewComments failed (status=${status}), proceeding title-only\n`,
+        `capture-learnings-harvest: PR #${pr.number} — listReviewComments failed (status=${status}), proceeding with review bodies only\n`,
       )
       // threadCommentBodies stays [] — candidate proceeds with review bodies only
     }
@@ -784,9 +791,9 @@ async function main(): Promise<void> {
     try {
       privateTokens = await loadPrivateTokensFromDisk()
     } catch (error: unknown) {
-      const errorName = error instanceof Error ? error.name : 'unknown'
+      const errorMessage = error instanceof Error ? error.message : 'unknown'
       process.stderr.write(
-        `capture-learnings-harvest: private token load failed (${errorName}), proceeding title-only — no enriched content will be emitted\n`,
+        `capture-learnings-harvest: private token load failed (${errorMessage}), proceeding title-only — no enriched content will be emitted\n`,
       )
       privateTokens = new Set()
       enrichmentScanAvailable = false
@@ -794,9 +801,7 @@ async function main(): Promise<void> {
 
     // If the scan is unavailable, clear all reviewExcerpts before passing to the pure core.
     // This ensures no unscanned prose reaches the digest under any path.
-    const safeMergedPrs = enrichmentScanAvailable
-      ? mergedPrs
-      : mergedPrs.map(pr => ({...pr, reviewExcerpts: [] as string[]}))
+    const safeMergedPrs = applyEnrichmentScanAvailability(mergedPrs, enrichmentScanAvailable)
 
     const digest = buildCandidateDigest({
       mergedPrs: safeMergedPrs,

--- a/scripts/capture-learnings-harvest.ts
+++ b/scripts/capture-learnings-harvest.ts
@@ -516,6 +516,11 @@ function reviewStateRank(state: string): number {
  * is reached, truncating the last item that would overflow. Skips empty/whitespace bodies.
  *
  * Returns a string[] — array form gives the agent clearer structure than a single string.
+ *
+ * Privacy ordering invariant: this truncation runs in the harvest I/O shell, BEFORE the
+ * upstream privacy scan in `buildCandidateDigest`. The scan must always read the final,
+ * already-truncated excerpt array. Never move truncation after the scan — scanning a token
+ * and then truncating around it could leave a surviving tail that escapes the gate.
  */
 function buildReviewExcerpts(reviewBodies: {state: string; body: string}[], threadCommentBodies: string[]): string[] {
   // Collect all prose items with their rank

--- a/scripts/capture-learnings-harvest.ts
+++ b/scripts/capture-learnings-harvest.ts
@@ -16,6 +16,8 @@ import process from 'node:process'
 import {Octokit} from '@octokit/rest'
 import {parse} from 'yaml'
 
+import {learningBodyHasPrivateLeak, loadPrivateTokensFromDisk} from './capture-learnings-privacy.ts'
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -37,6 +39,13 @@ const MIN_CORRECTION_SIGNALS = 1
 
 /** Maximum number of candidates to emit per run. */
 const MAX_LEARNINGS_PER_RUN = 5
+
+/**
+ * Maximum total characters of review-prose excerpts per candidate.
+ * Ranked by correction signal so the correction sentence is never clipped first.
+ * Exported so tests can assert budget enforcement without hardcoding the value.
+ */
+export const MAX_EXCERPT_CHARS_PER_CANDIDATE = 1800
 
 /** Label used to identify learning-proposal issues. */
 export const LEARNING_PROPOSAL_LABEL = 'learning-proposal'
@@ -105,6 +114,12 @@ export interface CandidateSignals {
  * fully sanitized here. The deterministic open step is the privacy chokepoint: it scans
  * the final authored body for private identifiers and blocks before posting, so a private
  * token surfacing in a title token is gated downstream rather than leaked.
+ *
+ * `reviewExcerpts` carries privacy-scanned review prose (review bodies + line-level thread
+ * comments), ranked by correction signal (CHANGES_REQUESTED / thread replies first) and
+ * bounded to MAX_EXCERPT_CHARS_PER_CANDIDATE. Empty when enrichment was blocked by the
+ * upstream privacy scan or when no prose was available. Array form gives the agent clearer
+ * structure than a single concatenated string.
  */
 export interface Candidate {
   mergeSha: string
@@ -115,6 +130,14 @@ export interface Candidate {
    */
   reviewRounds: number
   signals: CandidateSignals
+  /**
+   * Privacy-scanned review-prose excerpts, ranked by correction signal.
+   * CHANGES_REQUESTED bodies and thread-comment bodies appear first (highest correction
+   * signal); DISMISSED next; APPROVED boilerplate last. Truncated to
+   * MAX_EXCERPT_CHARS_PER_CANDIDATE total. Empty when the upstream privacy scan blocked
+   * the enriched content or when no non-empty prose was available.
+   */
+  reviewExcerpts: string[]
 }
 
 /**
@@ -137,6 +160,12 @@ export interface DigestTelemetry {
   afterSeenDedup: number
   afterSolutionsDedup: number
   emitted: number
+  /**
+   * Number of candidates whose enriched review-prose content was dropped by the
+   * upstream privacy scan. The candidate itself is kept (title-only); only the
+   * reviewExcerpts are cleared. Counts-only — no private names logged.
+   */
+  enrichmentBlocked: number
 }
 
 /** Result of `buildCandidateDigest`. */
@@ -157,6 +186,15 @@ export interface BuildCandidateDigestInput {
   solutionsDocs: SolutionDoc[]
   /** Maximum candidates to emit. */
   maxLearnings: number
+  /**
+   * Private identifier token set for the upstream enrichment scan.
+   * Loaded from metadata/repos.yaml by main() before calling buildCandidateDigest.
+   * If loadPrivateTokensFromDisk threw, main() passes an empty Set and clears all
+   * reviewExcerpts before calling — so the pure core always receives a valid Set.
+   * An empty Set means no tokens to match (no private repos configured), which is
+   * distinct from "scan unavailable" — the latter is handled in main().
+   */
+  privateTokens: Set<string>
 }
 
 /** Minimal solutions doc shape needed for dedup. */
@@ -199,9 +237,13 @@ export function parseMergeShaMarker(body: string): string | null {
  * 1. Drop candidates whose mergeSha is already in openedLearningShas (seen-set dedup).
  * 2. Drop candidates whose signals strongly overlap an existing solutions doc (solutions dedup).
  * 3. Cap to maxLearnings.
- * 4. Return candidates + counts-only telemetry (harvest stage counts + dedup stage counts).
+ * 4. Upstream privacy scan: for each candidate's reviewExcerpts, scan with the private
+ *    token set. On a hit, clear reviewExcerpts (drop enriched content, keep the candidate
+ *    title-only) and increment enrichmentBlocked. Never logs private names — counts only.
+ * 5. Return candidates + counts-only telemetry (harvest stage counts + dedup stage counts
+ *    + enrichmentBlocked).
  *
- * No I/O. Fully unit-testable.
+ * No I/O. Fully unit-testable. The private token set is injected so the scan is pure.
  */
 export function buildCandidateDigest(input: BuildCandidateDigestInput): CandidateDigest {
   // drop already-proposed merge SHAs
@@ -211,7 +253,20 @@ export function buildCandidateDigest(input: BuildCandidateDigestInput): Candidat
   const afterSolutionsDedup = afterSeenDedup.filter(pr => !overlapsAnySolutionsDoc(pr.signals, input.solutionsDocs))
 
   // cap to maxLearnings
-  const candidates = afterSolutionsDedup.slice(0, input.maxLearnings)
+  const capped = afterSolutionsDedup.slice(0, input.maxLearnings)
+
+  // upstream privacy scan: scan each candidate's reviewExcerpts fail-closed
+  // on a hit → drop enriched content (empty reviewExcerpts), keep the candidate
+  let enrichmentBlocked = 0
+  const candidates = capped.map(pr => {
+    if (pr.reviewExcerpts.length === 0) return pr
+    const excerptText = pr.reviewExcerpts.join('\n')
+    if (learningBodyHasPrivateLeak(excerptText, input.privateTokens)) {
+      enrichmentBlocked++
+      return {...pr, reviewExcerpts: []}
+    }
+    return pr
+  })
 
   return {
     candidates,
@@ -220,6 +275,7 @@ export function buildCandidateDigest(input: BuildCandidateDigestInput): Candidat
       afterSeenDedup: afterSeenDedup.length,
       afterSolutionsDedup: afterSolutionsDedup.length,
       emitted: candidates.length,
+      enrichmentBlocked,
     },
   }
 }
@@ -432,6 +488,69 @@ export interface HarvestResult {
 }
 
 /**
+ * Rank value for a review state when building excerpts.
+ * Lower number = higher priority (appears first in the ranked list).
+ * CHANGES_REQUESTED and thread comments (treated as correction-signal-high) rank first.
+ * DISMISSED next. APPROVED boilerplate last.
+ */
+function reviewStateRank(state: string): number {
+  if (state === 'CHANGES_REQUESTED') return 0
+  if (state === 'DISMISSED') return 1
+  if (state === 'APPROVED') return 2
+  return 3
+}
+
+/**
+ * Build ranked, budgeted review-prose excerpts for a candidate.
+ *
+ * Collects review bodies (tagged with their state for ranking) and thread-comment bodies
+ * (treated as correction-signal-high, rank 0). Ranks by correction signal so truncation
+ * does not clip the correction sentence. Concatenates items until MAX_EXCERPT_CHARS_PER_CANDIDATE
+ * is reached, truncating the last item that would overflow. Skips empty/whitespace bodies.
+ *
+ * Returns a string[] — array form gives the agent clearer structure than a single string.
+ */
+function buildReviewExcerpts(reviewBodies: {state: string; body: string}[], threadCommentBodies: string[]): string[] {
+  // Collect all prose items with their rank
+  const items: {rank: number; text: string}[] = []
+
+  // Review bodies — ranked by state
+  for (const {state, body} of reviewBodies) {
+    const trimmed = body.trim()
+    if (trimmed === '') continue
+    items.push({rank: reviewStateRank(state), text: trimmed})
+  }
+
+  // Thread comment bodies — correction-signal-high (rank 0, same as CHANGES_REQUESTED)
+  for (const body of threadCommentBodies) {
+    const trimmed = body.trim()
+    if (trimmed === '') continue
+    items.push({rank: 0, text: trimmed})
+  }
+
+  // Sort by rank (stable sort preserves chronological order within same rank)
+  items.sort((a, b) => a.rank - b.rank)
+
+  // Apply per-candidate char budget
+  const excerpts: string[] = []
+  let remaining = MAX_EXCERPT_CHARS_PER_CANDIDATE
+
+  for (const {text} of items) {
+    if (remaining <= 0) break
+    if (text.length <= remaining) {
+      excerpts.push(text)
+      remaining -= text.length
+    } else {
+      // Truncate the last item to fit within budget
+      excerpts.push(text.slice(0, remaining))
+      remaining = 0
+    }
+  }
+
+  return excerpts
+}
+
+/**
  * Fetch all merged PRs in the lookback window and return those where Fro Bot's
  * substantive reviews meet the predicate:
  *   substantiveReviewCount >= MIN_SUBSTANTIVE_REVIEW_ROUNDS
@@ -442,6 +561,11 @@ export interface HarvestResult {
  *
  * Only reviews by logins in FRO_BOT_REVIEWER_LOGINS are counted.
  * Dependency-automation PRs (by author login or label) are excluded before counting.
+ *
+ * For each qualifying candidate, retains review bodies from the already-fetched listReviews
+ * and fetches line-level thread comments via listReviewComments. Builds ranked, budgeted
+ * reviewExcerpts (correction prose first). A transient listReviewComments error for one
+ * candidate degrades it to title-only (empty reviewExcerpts) without aborting the run.
  *
  * Transient listReviews errors for a single PR are caught and that PR is skipped.
  * Returns candidates alongside explicit harvest-stage counts for honest telemetry.
@@ -504,8 +628,10 @@ export async function harvestCandidates(
 
     // Fetch Fro Bot's reviews and apply the predicate.
     // Paginate to avoid undercounting when reviews span >1 page (default page = 30).
+    // Retain r.body for enrichment — zero new calls, already fetched for the count.
     let substantiveReviewCount: number
     let correctionSignalCount: number
+    let reviewBodies: {state: string; body: string}[]
     try {
       const reviews = await octokit.paginate(octokit.rest.pulls.listReviews, {
         owner,
@@ -529,6 +655,12 @@ export async function harvestCandidates(
       correctionSignalCount = froBotReviews.filter(r => {
         return r.state === 'DISMISSED' || r.state === 'CHANGES_REQUESTED'
       }).length
+
+      // Retain review bodies for enrichment (all fro-bot reviews, not just substantive)
+      reviewBodies = froBotReviews.map(r => ({
+        state: r.state,
+        body: typeof r.body === 'string' ? r.body : '',
+      }))
     } catch (error: unknown) {
       const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
       process.stderr.write(
@@ -541,6 +673,32 @@ export async function harvestCandidates(
       continue
     }
 
+    // Fetch line-level thread comments for enrichment.
+    // A transient error here degrades this candidate to title-only (empty reviewExcerpts)
+    // without aborting the run — mirrors the listReviews skip pattern but continues WITH
+    // the candidate rather than skipping it entirely.
+    let threadCommentBodies: string[] = []
+    try {
+      const reviewComments = await octokit.paginate(octokit.rest.pulls.listReviewComments, {
+        owner,
+        repo,
+        pull_number: pr.number,
+        per_page: 100,
+      } as unknown as Parameters<OctokitClient['rest']['pulls']['listReviewComments']>[0])
+
+      threadCommentBodies = reviewComments
+        .map(c => (typeof c.body === 'string' ? c.body : ''))
+        .filter(b => b.trim() !== '')
+    } catch (error: unknown) {
+      const status = isRecord(error) && typeof error.status === 'number' ? error.status : 'unknown'
+      process.stderr.write(
+        `capture-learnings-harvest: PR #${pr.number} — listReviewComments failed (status=${status}), proceeding title-only\n`,
+      )
+      // threadCommentBodies stays [] — candidate proceeds with review bodies only
+    }
+
+    const reviewExcerpts = buildReviewExcerpts(reviewBodies, threadCommentBodies)
+
     candidates.push({
       mergeSha: pr.merge_commit_sha,
       reviewRounds: substantiveReviewCount,
@@ -548,6 +706,7 @@ export async function harvestCandidates(
         title: pr.title,
         labels: prLabels.map(name => ({name})),
       }),
+      reviewExcerpts,
     })
   }
 
@@ -616,12 +775,36 @@ async function main(): Promise<void> {
 
     const solutionsDocs = collectSolutionDocs(solutionsFiles)
 
+    // Load private tokens BEFORE building the digest — fail-closed.
+    // If loadPrivateTokensFromDisk throws (metadata unreadable), we must NOT emit any
+    // enriched content. Catch the throw, log counts-only, and proceed with all candidates
+    // title-only (reviewExcerpts cleared). Never pass unscanned prose to the digest.
+    let privateTokens: Set<string>
+    let enrichmentScanAvailable = true
+    try {
+      privateTokens = await loadPrivateTokensFromDisk()
+    } catch (error: unknown) {
+      const errorName = error instanceof Error ? error.name : 'unknown'
+      process.stderr.write(
+        `capture-learnings-harvest: private token load failed (${errorName}), proceeding title-only — no enriched content will be emitted\n`,
+      )
+      privateTokens = new Set()
+      enrichmentScanAvailable = false
+    }
+
+    // If the scan is unavailable, clear all reviewExcerpts before passing to the pure core.
+    // This ensures no unscanned prose reaches the digest under any path.
+    const safeMergedPrs = enrichmentScanAvailable
+      ? mergedPrs
+      : mergedPrs.map(pr => ({...pr, reviewExcerpts: [] as string[]}))
+
     const digest = buildCandidateDigest({
-      mergedPrs,
+      mergedPrs: safeMergedPrs,
       stageCounts,
       openedLearningShas,
       solutionsDocs,
       maxLearnings: MAX_LEARNINGS_PER_RUN,
+      privateTokens,
     })
 
     await writeDigestFile(digest)
@@ -641,6 +824,7 @@ async function main(): Promise<void> {
         afterSeenDedup: 0,
         afterSolutionsDedup: 0,
         emitted: 0,
+        enrichmentBlocked: 0,
       },
     }
     try {

--- a/scripts/capture-learnings-open.test.ts
+++ b/scripts/capture-learnings-open.test.ts
@@ -37,6 +37,7 @@ function makeCandidate(overrides: Partial<Candidate> = {}): Candidate {
     mergeSha: 'abc123def456abc123def456abc123def456abc1',
     reviewRounds: 2,
     signals: {titleTokens: ['feat', 'scripts'], labels: []},
+    reviewExcerpts: [],
     ...overrides,
   }
 }

--- a/scripts/capture-learnings-open.test.ts
+++ b/scripts/capture-learnings-open.test.ts
@@ -2,12 +2,11 @@
  * Tests for capture-learnings-open.ts
  *
  * Structure:
- * - Pure function tests: `learningBodyHasPrivateLeak`, `planLearnings`
- * - Disk loader tests: `loadPrivateTokensFromDisk` (injectable readFile)
+ * - Integration test: open.ts still blocks private-laden bodies via the shared privacy module
+ * - Pure function tests: `planLearnings`
  * - I/O shell tests: `openLearningIssues`, `ensureLabelsExist` (mocked Octokit)
  *
- * Privacy mutation-proof: each privacy test includes a "without the gate" assertion
- * that proves removing the check would let the learning through.
+ * Privacy gate unit tests live in capture-learnings-privacy.test.ts (single source of truth).
  */
 
 import {describe, expect, it, vi} from 'vitest'
@@ -20,14 +19,13 @@ import {
 } from './capture-learnings-harvest.ts'
 import {
   ensureLabelsExist,
-  learningBodyHasPrivateLeak,
-  loadPrivateTokensFromDisk,
   openLearningIssues,
   planLearnings,
   type LabelDescriptor,
   type LearningToOpen,
   type PlanLearningsInput,
 } from './capture-learnings-open.ts'
+import {learningBodyHasPrivateLeak, loadPrivateTokensFromDisk} from './capture-learnings-privacy.ts'
 import {buildPrivateTokenSet} from './wiki-slug.ts'
 
 // ---------------------------------------------------------------------------
@@ -68,81 +66,43 @@ function makeToCreate(overrides: Partial<LearningToOpen> = {}): LearningToOpen {
 }
 
 // ---------------------------------------------------------------------------
-// learningBodyHasPrivateLeak — pure function tests
+// Integration: open.ts blocks private-laden authored bodies via the shared privacy module
 // ---------------------------------------------------------------------------
 
-describe('learningBodyHasPrivateLeak', () => {
-  describe('detection', () => {
-    it('detects the owner/name form (slash-separated)', () => {
-      // #given a body containing the owner/name form of a private repo
-      const tokens = makePrivateTokens('testowner/secret-repo')
-      const body = 'This PR touched testowner/secret-repo in the changes.'
+describe('open.ts privacy integration', () => {
+  it('planLearnings blocks a body containing a private token (gate imported from shared module)', () => {
+    // #given a body containing a private identifier and a token set from the shared module
+    const sha = 'abc123def456abc123def456abc123def456abc1'
+    const privateTokens = makePrivateTokens('testowner/secret-repo')
+    const body = 'This learning references testowner/secret-repo.'
 
-      // #when scanning
-      // #then the leak is detected
-      expect(learningBodyHasPrivateLeak(body, tokens)).toBe(true)
-    })
+    // #when the gate function (imported from capture-learnings-privacy) is used directly
+    // #then it detects the leak — proving open.ts behavior is unchanged after the move
+    expect(learningBodyHasPrivateLeak(body, privateTokens)).toBe(true)
 
-    it('detects the owner--name form (double-dash)', () => {
-      // #given a body containing the double-dash form
-      const tokens = makePrivateTokens('testowner/secret-repo')
-      const body = 'See testowner--secret-repo for context.'
-
-      // #when scanning
-      // #then the leak is detected
-      expect(learningBodyHasPrivateLeak(body, tokens)).toBe(true)
-    })
-
-    it('detects mixed-case occurrences (case-insensitive scan)', () => {
-      // #given a body with the token in mixed case
-      const tokens = makePrivateTokens('testowner/secret-repo')
-      const body = 'The repo TESTOWNER/SECRET-REPO was involved.'
-
-      // #when scanning
-      // #then the leak is detected (body is lowercased before scan)
-      expect(learningBodyHasPrivateLeak(body, tokens)).toBe(true)
-    })
-
-    it('detects the slug form produced by computeRepoSlug', () => {
-      // #given a body containing the wiki-slug form
-      const tokens = makePrivateTokens('testowner/secret-repo')
-      // The slug form is testowner--secret-repo (same as double-dash for simple names)
-      const body = 'Wiki page at testowner--secret-repo.'
-
-      // #when scanning
-      // #then the leak is detected
-      expect(learningBodyHasPrivateLeak(body, tokens)).toBe(true)
-    })
+    // #and planLearnings (which calls the same gate internally) also blocks it
+    const result = planLearnings(
+      makePlanInput({
+        candidates: [makeCandidate({mergeSha: sha})],
+        learningBodies: new Map([[sha, body]]),
+        privateTokens,
+      }),
+    )
+    expect(result.toCreate).toHaveLength(0)
+    expect(result.blockedOnPrivacy).toBe(1)
   })
 
-  describe('clean body', () => {
-    it('returns false for a body with no private tokens', () => {
-      // #given a body with no private identifiers
-      const tokens = makePrivateTokens('testowner/secret-repo')
-      const body = 'This is a clean learning about CI improvements.'
+  it('loadPrivateTokensFromDisk (shared module) still throws fail-closed when file is unreadable', async () => {
+    // #given the file cannot be read
+    const readFileFn = async (): Promise<string> => {
+      throw new Error('ENOENT: no such file or directory')
+    }
 
-      // #when scanning
-      // #then no leak is detected
-      expect(learningBodyHasPrivateLeak(body, tokens)).toBe(false)
-    })
-
-    it('returns false when the private token set is empty', () => {
-      // #given an empty token set (e.g. no private repos in metadata)
-      const body = 'Any body content here.'
-
-      // #when scanning with an empty token set
-      // #then no leak is detected (vacuously safe)
-      expect(learningBodyHasPrivateLeak(body, new Set())).toBe(false)
-    })
-
-    it('returns false for an empty body', () => {
-      // #given an empty body
-      const tokens = makePrivateTokens('testowner/secret-repo')
-
-      // #when scanning
-      // #then no leak is detected
-      expect(learningBodyHasPrivateLeak('', tokens)).toBe(false)
-    })
+    // #when loading private tokens via the shared module
+    // #then it throws — open.ts callers must not post proposals
+    await expect(loadPrivateTokensFromDisk(readFileFn)).rejects.toThrow(
+      'capture-learnings-privacy: could not read metadata/repos.yaml',
+    )
   })
 })
 
@@ -375,115 +335,6 @@ describe('planLearnings', () => {
       expect(result.blockedOnPrivacy).toBe(1)
       expect(result.skippedDuplicate).toBe(1)
     })
-  })
-})
-
-// ---------------------------------------------------------------------------
-// loadPrivateTokensFromDisk — fail-closed behavior (injectable readFile)
-// ---------------------------------------------------------------------------
-
-describe('loadPrivateTokensFromDisk', () => {
-  it('throws when metadata/repos.yaml cannot be read (fail-closed)', async () => {
-    // #given the file cannot be read
-    const readFileFn = async () => {
-      throw new Error('ENOENT: no such file or directory')
-    }
-
-    // #when loading private tokens
-    // #then it throws — the caller must not post proposals
-    await expect(loadPrivateTokensFromDisk(readFileFn)).rejects.toThrow(
-      'capture-learnings-open: could not read metadata/repos.yaml — privacy gate cannot operate; no learnings will be posted',
-    )
-  })
-
-  it('throws when metadata/repos.yaml cannot be parsed (fail-closed)', async () => {
-    // #given the file contains invalid YAML
-    const readFileFn = async () => '{ invalid yaml: [unclosed'
-
-    // #when loading private tokens
-    // #then it throws — the caller must not post proposals
-    await expect(loadPrivateTokensFromDisk(readFileFn)).rejects.toThrow(
-      'capture-learnings-open: could not parse metadata/repos.yaml — privacy gate cannot operate; no learnings will be posted',
-    )
-  })
-
-  it('throws when repos.yaml has unexpected shape (not a record)', async () => {
-    // #given the file parses to a non-record (e.g. a list)
-    const readFileFn = async () => '- item1\n- item2\n'
-
-    // #when loading private tokens
-    // #then it throws
-    await expect(loadPrivateTokensFromDisk(readFileFn)).rejects.toThrow(
-      'capture-learnings-open: metadata/repos.yaml has unexpected shape',
-    )
-  })
-
-  it('throws when repos.yaml is missing the repos array', async () => {
-    // #given the file has no repos key
-    const readFileFn = async () => 'other_key: value\n'
-
-    // #when loading private tokens
-    // #then it throws
-    await expect(loadPrivateTokensFromDisk(readFileFn)).rejects.toThrow(
-      'capture-learnings-open: metadata/repos.yaml missing repos array',
-    )
-  })
-
-  it('returns a token set built from private non-redacted repos', async () => {
-    // #given a valid repos.yaml with one private repo and one public repo
-    const yaml = `
-repos:
-  - owner: testowner
-    name: secret-repo
-    private: true
-  - owner: testowner
-    name: public-repo
-    private: false
-`
-    const readFileFn = async () => yaml
-
-    // #when loading private tokens
-    const tokens = await loadPrivateTokensFromDisk(readFileFn)
-
-    // #then tokens include forms of the private repo but not the public one
-    expect(tokens.has('testowner/secret-repo')).toBe(true)
-    expect(tokens.has('testowner--secret-repo')).toBe(true)
-    // Public repo should not be in the token set
-    expect(tokens.has('testowner/public-repo')).toBe(false)
-  })
-
-  it('skips redacted entries', async () => {
-    // #given a repos.yaml with a redacted private entry
-    const yaml = `
-repos:
-  - owner: '[REDACTED]'
-    name: '[REDACTED]'
-    private: true
-`
-    const readFileFn = async () => yaml
-
-    // #when loading private tokens
-    const tokens = await loadPrivateTokensFromDisk(readFileFn)
-
-    // #then the token set is empty (redacted entries are skipped)
-    expect(tokens.size).toBe(0)
-  })
-
-  it('returns an empty set when there are no private repos', async () => {
-    // #given a repos.yaml with only public repos
-    const yaml = `
-repos:
-  - owner: testowner
-    name: public-repo
-    private: false
-`
-    const readFileFn = async () => yaml
-
-    // #when loading private tokens
-    const tokens = await loadPrivateTokensFromDisk(readFileFn)
-
-    // #then the token set is empty
-    expect(tokens.size).toBe(0)
   })
 })
 

--- a/scripts/capture-learnings-open.ts
+++ b/scripts/capture-learnings-open.ts
@@ -20,7 +20,6 @@
 
 import {readFile, writeFile} from 'node:fs/promises'
 import process from 'node:process'
-import {parse} from 'yaml'
 
 import {
   buildMergeShaMarker,
@@ -30,7 +29,7 @@ import {
   type CandidateDigest,
   type OctokitClient,
 } from './capture-learnings-harvest.ts'
-import {buildPrivateTokenSet} from './wiki-slug.ts'
+import {isRecord, learningBodyHasPrivateLeak, loadPrivateTokensFromDisk} from './capture-learnings-privacy.ts'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -88,111 +87,11 @@ export interface OpenLearningsCounts {
 }
 
 // ---------------------------------------------------------------------------
-// Privacy gate — pure, fail-closed
+// Type guards (local — used by ensureLabelsExist / openLearningIssues)
 // ---------------------------------------------------------------------------
-
-/**
- * Returns true if the learning body contains any private identifier token.
- *
- * The body is lowercased before scanning. The caller MUST block (skip) the
- * learning on true. Never redacts — block only. Counts-only telemetry.
- *
- * Pure function: no I/O, fully testable.
- */
-export function learningBodyHasPrivateLeak(body: string, privateTokens: Set<string>): boolean {
-  const lower = body.toLowerCase()
-  for (const token of privateTokens) {
-    if (lower.includes(token)) return true
-  }
-  return false
-}
-
-// ---------------------------------------------------------------------------
-// Type guards
-// ---------------------------------------------------------------------------
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
 
 function isApiStatus(error: unknown, status: number): boolean {
   return isRecord(error) && typeof error.status === 'number' && error.status === status
-}
-
-// ---------------------------------------------------------------------------
-// Disk loader for private token set
-// ---------------------------------------------------------------------------
-
-/**
- * Load the private identifier token set from `metadata/repos.yaml`.
- *
- * Reads the overlay-checked-out metadata file, filters `private: true` non-redacted
- * entries, and builds the token set via `buildPrivateNameTokens`.
- *
- * Fail-closed contract:
- * - If the file cannot be read or parsed, this function THROWS.
- * - The caller MUST NOT post any proposals when this throws (no private set ⇒ no proposals).
- * - This is intentional: a missing overlay means the privacy gate cannot operate,
- *   and posting unscanned proposals would violate the privacy-gate contract.
- *
- * Counts-only: private names are never logged; only counts appear in stderr.
- *
- * @param readFileFn - Injectable readFile for testing (defaults to node:fs/promises readFile).
- */
-export async function loadPrivateTokensFromDisk(
-  readFileFn: (path: string, encoding: BufferEncoding) => Promise<string> = readFile,
-): Promise<Set<string>> {
-  let reposYaml: string
-
-  try {
-    reposYaml = await readFileFn('metadata/repos.yaml', 'utf8')
-  } catch (error: unknown) {
-    throw new Error(
-      'capture-learnings-open: could not read metadata/repos.yaml — privacy gate cannot operate; no learnings will be posted',
-      {cause: error},
-    )
-  }
-
-  let parsed: unknown
-  try {
-    parsed = parse(reposYaml)
-  } catch (error: unknown) {
-    throw new Error(
-      'capture-learnings-open: could not parse metadata/repos.yaml — privacy gate cannot operate; no learnings will be posted',
-      {cause: error},
-    )
-  }
-
-  if (!isRecord(parsed)) {
-    throw new TypeError(
-      'capture-learnings-open: metadata/repos.yaml has unexpected shape — privacy gate cannot operate; no learnings will be posted',
-    )
-  }
-
-  const repos = parsed.repos
-  if (!Array.isArray(repos)) {
-    throw new TypeError(
-      'capture-learnings-open: metadata/repos.yaml missing repos array — privacy gate cannot operate; no learnings will be posted',
-    )
-  }
-
-  const privateNames: string[] = []
-  for (const entry of repos) {
-    if (!isRecord(entry)) continue
-    if (entry.private !== true) continue
-    const owner = entry.owner
-    const name = entry.name
-    if (typeof owner !== 'string' || typeof name !== 'string' || owner === '[REDACTED]' || name === '[REDACTED]') {
-      continue
-    }
-    privateNames.push(`${owner}/${name}`)
-  }
-
-  const tokenSet = buildPrivateTokenSet(privateNames)
-  process.stderr.write(
-    `capture-learnings-open: loaded private token set (private-repo count=${privateNames.length}, token-count=${tokenSet.size})\n`,
-  )
-  return tokenSet
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/capture-learnings-privacy.test.ts
+++ b/scripts/capture-learnings-privacy.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for capture-learnings-privacy.ts
+ *
+ * Structure:
+ * - Pure function tests: `learningBodyHasPrivateLeak`
+ * - Disk loader tests: `loadPrivateTokensFromDisk` (injectable readFile, fail-closed)
+ *
+ * Privacy mutation-proof: each privacy test includes a "without the gate" assertion
+ * that proves removing the check would let the content through.
+ */
+
+import {describe, expect, it} from 'vitest'
+
+import {learningBodyHasPrivateLeak, loadPrivateTokensFromDisk} from './capture-learnings-privacy.ts'
+import {buildPrivateTokenSet} from './wiki-slug.ts'
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+/** Build a private token set from a synthetic owner/name for test isolation. */
+function makePrivateTokens(nameWithOwner: string): Set<string> {
+  return buildPrivateTokenSet([nameWithOwner])
+}
+
+// ---------------------------------------------------------------------------
+// learningBodyHasPrivateLeak — pure function tests
+// ---------------------------------------------------------------------------
+
+describe('learningBodyHasPrivateLeak', () => {
+  describe('detection', () => {
+    it('detects the owner/name form (slash-separated)', () => {
+      // #given a body containing the owner/name form of a private repo
+      const tokens = makePrivateTokens('testowner/secret-repo')
+      const body = 'This PR touched testowner/secret-repo in the changes.'
+
+      // #when scanning
+      // #then the leak is detected
+      expect(learningBodyHasPrivateLeak(body, tokens)).toBe(true)
+    })
+
+    it('detects the owner--name form (double-dash)', () => {
+      // #given a body containing the double-dash form
+      const tokens = makePrivateTokens('testowner/secret-repo')
+      const body = 'See testowner--secret-repo for context.'
+
+      // #when scanning
+      // #then the leak is detected
+      expect(learningBodyHasPrivateLeak(body, tokens)).toBe(true)
+    })
+
+    it('detects mixed-case occurrences (case-insensitive scan)', () => {
+      // #given a body with the token in mixed case
+      const tokens = makePrivateTokens('testowner/secret-repo')
+      const body = 'The repo TESTOWNER/SECRET-REPO was involved.'
+
+      // #when scanning
+      // #then the leak is detected (body is lowercased before scan)
+      expect(learningBodyHasPrivateLeak(body, tokens)).toBe(true)
+    })
+
+    it('detects the slug form produced by computeRepoSlug', () => {
+      // #given a body containing the wiki-slug form
+      const tokens = makePrivateTokens('testowner/secret-repo')
+      // The slug form is testowner--secret-repo (same as double-dash for simple names)
+      const body = 'Wiki page at testowner--secret-repo.'
+
+      // #when scanning
+      // #then the leak is detected
+      expect(learningBodyHasPrivateLeak(body, tokens)).toBe(true)
+    })
+  })
+
+  describe('clean body', () => {
+    it('returns false for a body with no private tokens', () => {
+      // #given a body with no private identifiers
+      const tokens = makePrivateTokens('testowner/secret-repo')
+      const body = 'This is a clean learning about CI improvements.'
+
+      // #when scanning
+      // #then no leak is detected
+      expect(learningBodyHasPrivateLeak(body, tokens)).toBe(false)
+    })
+
+    it('returns false when the private token set is empty', () => {
+      // #given an empty token set (e.g. no private repos in metadata)
+      const body = 'Any body content here.'
+
+      // #when scanning with an empty token set
+      // #then no leak is detected (vacuously safe)
+      expect(learningBodyHasPrivateLeak(body, new Set())).toBe(false)
+    })
+
+    it('returns false for an empty body', () => {
+      // #given an empty body
+      const tokens = makePrivateTokens('testowner/secret-repo')
+
+      // #when scanning
+      // #then no leak is detected
+      expect(learningBodyHasPrivateLeak('', tokens)).toBe(false)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// loadPrivateTokensFromDisk — fail-closed behavior (injectable readFile)
+// ---------------------------------------------------------------------------
+
+describe('loadPrivateTokensFromDisk', () => {
+  it('throws when metadata/repos.yaml cannot be read (fail-closed)', async () => {
+    // #given the file cannot be read
+    const readFileFn = async () => {
+      throw new Error('ENOENT: no such file or directory')
+    }
+
+    // #when loading private tokens
+    // #then it throws — the caller must not post proposals
+    await expect(loadPrivateTokensFromDisk(readFileFn)).rejects.toThrow(
+      'capture-learnings-privacy: could not read metadata/repos.yaml — privacy gate cannot operate; no learnings will be posted',
+    )
+  })
+
+  it('throws when metadata/repos.yaml cannot be parsed (fail-closed)', async () => {
+    // #given the file contains invalid YAML
+    const readFileFn = async () => '{ invalid yaml: [unclosed'
+
+    // #when loading private tokens
+    // #then it throws — the caller must not post proposals
+    await expect(loadPrivateTokensFromDisk(readFileFn)).rejects.toThrow(
+      'capture-learnings-privacy: could not parse metadata/repos.yaml — privacy gate cannot operate; no learnings will be posted',
+    )
+  })
+
+  it('throws when repos.yaml has unexpected shape (not a record)', async () => {
+    // #given the file parses to a non-record (e.g. a list)
+    const readFileFn = async () => '- item1\n- item2\n'
+
+    // #when loading private tokens
+    // #then it throws
+    await expect(loadPrivateTokensFromDisk(readFileFn)).rejects.toThrow(
+      'capture-learnings-privacy: metadata/repos.yaml has unexpected shape',
+    )
+  })
+
+  it('throws when repos.yaml is missing the repos array', async () => {
+    // #given the file has no repos key
+    const readFileFn = async () => 'other_key: value\n'
+
+    // #when loading private tokens
+    // #then it throws
+    await expect(loadPrivateTokensFromDisk(readFileFn)).rejects.toThrow(
+      'capture-learnings-privacy: metadata/repos.yaml missing repos array',
+    )
+  })
+
+  it('returns a token set built from private non-redacted repos', async () => {
+    // #given a valid repos.yaml with one private repo and one public repo
+    const yaml = `
+repos:
+  - owner: testowner
+    name: secret-repo
+    private: true
+  - owner: testowner
+    name: public-repo
+    private: false
+`
+    const readFileFn = async () => yaml
+
+    // #when loading private tokens
+    const tokens = await loadPrivateTokensFromDisk(readFileFn)
+
+    // #then tokens include forms of the private repo but not the public one
+    expect(tokens.has('testowner/secret-repo')).toBe(true)
+    expect(tokens.has('testowner--secret-repo')).toBe(true)
+    // Public repo should not be in the token set
+    expect(tokens.has('testowner/public-repo')).toBe(false)
+  })
+
+  it('skips redacted entries', async () => {
+    // #given a repos.yaml with a redacted private entry
+    const yaml = `
+repos:
+  - owner: '[REDACTED]'
+    name: '[REDACTED]'
+    private: true
+`
+    const readFileFn = async () => yaml
+
+    // #when loading private tokens
+    const tokens = await loadPrivateTokensFromDisk(readFileFn)
+
+    // #then the token set is empty (redacted entries are skipped)
+    expect(tokens.size).toBe(0)
+  })
+
+  it('returns an empty set when there are no private repos', async () => {
+    // #given a repos.yaml with only public repos
+    const yaml = `
+repos:
+  - owner: testowner
+    name: public-repo
+    private: false
+`
+    const readFileFn = async () => yaml
+
+    // #when loading private tokens
+    const tokens = await loadPrivateTokensFromDisk(readFileFn)
+
+    // #then the token set is empty
+    expect(tokens.size).toBe(0)
+  })
+})

--- a/scripts/capture-learnings-privacy.ts
+++ b/scripts/capture-learnings-privacy.ts
@@ -1,0 +1,126 @@
+/**
+ * Shared fail-closed privacy gate for the learning-capture pipeline.
+ *
+ * Provides the pure privacy-scan function and the fail-closed disk loader for the
+ * private identifier token set. Both the open step (authored-body scan) and the
+ * harvest step (upstream enrichment scan) import from here — single source of truth.
+ *
+ * Fail-closed contract:
+ * - If `loadPrivateTokensFromDisk` throws, the caller MUST NOT post or emit any
+ *   unscanned content (no private set loaded ⇒ no proposals / no enriched content).
+ * - The privacy gate blocks on a hit; it never redacts. Counts-only telemetry.
+ * - Private names are never logged; only counts appear in output.
+ *
+ * Strip-only safe: no parameter properties, enums, or namespaces.
+ */
+
+import {readFile} from 'node:fs/promises'
+import process from 'node:process'
+import {parse} from 'yaml'
+
+import {buildPrivateTokenSet} from './wiki-slug.ts'
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+// ---------------------------------------------------------------------------
+// Privacy gate — pure, fail-closed
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if the body contains any private identifier token.
+ *
+ * The body is lowercased before scanning. The caller MUST block (skip) the
+ * content on true. Never redacts — block only. Counts-only telemetry.
+ *
+ * Pure function: no I/O, fully testable.
+ */
+export function learningBodyHasPrivateLeak(body: string, privateTokens: Set<string>): boolean {
+  const lower = body.toLowerCase()
+  for (const token of privateTokens) {
+    if (lower.includes(token)) return true
+  }
+  return false
+}
+
+// ---------------------------------------------------------------------------
+// Disk loader for private token set
+// ---------------------------------------------------------------------------
+
+/**
+ * Load the private identifier token set from `metadata/repos.yaml`.
+ *
+ * Reads the overlay-checked-out metadata file, filters `private: true` non-redacted
+ * entries, and builds the token set via `buildPrivateTokenSet`.
+ *
+ * Fail-closed contract:
+ * - If the file cannot be read or parsed, this function THROWS.
+ * - The caller MUST NOT post any proposals or emit enriched content when this throws
+ *   (no private set ⇒ no unscanned content passes through).
+ * - This is intentional: a missing overlay means the privacy gate cannot operate,
+ *   and passing unscanned content would violate the privacy-gate contract.
+ *
+ * Counts-only: private names are never logged; only counts appear in stderr.
+ *
+ * @param readFileFn - Injectable readFile for testing (defaults to node:fs/promises readFile).
+ */
+export async function loadPrivateTokensFromDisk(
+  readFileFn: (path: string, encoding: BufferEncoding) => Promise<string> = readFile,
+): Promise<Set<string>> {
+  let reposYaml: string
+
+  try {
+    reposYaml = await readFileFn('metadata/repos.yaml', 'utf8')
+  } catch (error: unknown) {
+    throw new Error(
+      'capture-learnings-privacy: could not read metadata/repos.yaml — privacy gate cannot operate; no learnings will be posted',
+      {cause: error},
+    )
+  }
+
+  let parsed: unknown
+  try {
+    parsed = parse(reposYaml)
+  } catch (error: unknown) {
+    throw new Error(
+      'capture-learnings-privacy: could not parse metadata/repos.yaml — privacy gate cannot operate; no learnings will be posted',
+      {cause: error},
+    )
+  }
+
+  if (!isRecord(parsed)) {
+    throw new TypeError(
+      'capture-learnings-privacy: metadata/repos.yaml has unexpected shape — privacy gate cannot operate; no learnings will be posted',
+    )
+  }
+
+  const repos = parsed.repos
+  if (!Array.isArray(repos)) {
+    throw new TypeError(
+      'capture-learnings-privacy: metadata/repos.yaml missing repos array — privacy gate cannot operate; no learnings will be posted',
+    )
+  }
+
+  const privateNames: string[] = []
+  for (const entry of repos) {
+    if (!isRecord(entry)) continue
+    if (entry.private !== true) continue
+    const owner = entry.owner
+    const name = entry.name
+    if (typeof owner !== 'string' || typeof name !== 'string' || owner === '[REDACTED]' || name === '[REDACTED]') {
+      continue
+    }
+    privateNames.push(`${owner}/${name}`)
+  }
+
+  const tokenSet = buildPrivateTokenSet(privateNames)
+  process.stderr.write(
+    `capture-learnings-privacy: loaded private token set (private-repo count=${privateNames.length}, token-count=${tokenSet.size})\n`,
+  )
+  return tokenSet
+}


### PR DESCRIPTION
The learning-capture run gave the agent only a merge SHA, a review-round count, and PR-title tokens — so it inferred learnings from titles rather than reading what the review rounds said. This gives it the review prose, with the privacy boundary placed before the agent ever sees it.

## What changes

- **Enrichment** — the harvest retains review bodies (already fetched, previously discarded) and adds line-level review comments, ranked so the correction feedback survives truncation ahead of approval boilerplate, bounded per candidate. The agent prompt now distills the learning from this prose; title and labels are secondary.
- **Upstream privacy gate** — review prose carries private-repo cross-references, so the fail-closed privacy scan runs at harvest time, in the pure core, *before* the prose enters the digest. A private-token hit drops the enriched content and the candidate proceeds with its public title signal only. If the private-name set can't load, every candidate goes title-only — review prose is never emitted unscanned.
- **Shared gate** — the gate is extracted to a shared module so the harvest-time scan and the open-step authored-body scan use one source and can't drift.

## Verification

Types, lint, actionlint, strip-only load all clean; full suite green. The upstream scan, the fail-closed clearing, and the correction-survives-truncation behavior are covered, including a mutation proof that removing the scan lets private prose into the digest. The enrichment-blocked count is surfaced in the run summary.

Closes #3552