### PR TITLE
docs: capture five learnings from multi-round review

### DIFF
--- a/docs/solutions/best-practices/credential-mint-time-permission-scoping-2026-06-22.md
+++ b/docs/solutions/best-practices/credential-mint-time-permission-scoping-2026-06-22.md
@@ -1,0 +1,98 @@
+---
+title: A Second Credential Gives Rotation Isolation, Not Permission Isolation — Scope at Mint Time
+date: 2026-06-22
+last_updated: 2026-06-22
+problem_type: best_practice
+component: development_workflow
+module: github-workflows
+severity: high
+verified: 2026-06-22
+tags:
+  - credentials
+  - least-privilege
+  - mint-time-scoping
+  - app-installation-tokens
+  - token-scope
+applies_when:
+  - a second credential or key is added to isolate a use case from a broader-scoped principal
+  - a GitHub App installation token is minted for a specific workflow step
+  - a planning document describes a security invariant that needs verification against live data
+  - least-privilege access is required but the parent App or principal has a broader registered scope
+---
+
+# A Second Credential Gives Rotation Isolation, Not Permission Isolation — Scope at Mint Time
+
+## Context
+
+A planning PR described adding a second GitHub App key to isolate a read-only use case from a
+broader-scoped App. The intent was least-privilege access: the new key would be "read-only" by
+virtue of being separate from the primary key. The review caught the flaw: adding another key
+does not narrow what that key can do. Both keys mint tokens from the same App installation,
+which has the same registered permission set. The second key gives rotation isolation — you can
+rotate it independently — but not permission isolation.
+
+The correct mechanism is to mint installation tokens with an explicit `permissions` subset at
+mint time, regardless of what the parent App has registered. GitHub's Apps API supports this:
+pass a `permissions` object to the token endpoint and the resulting token is constrained to
+exactly those permissions, even if the App installation has broader access. Read-only by
+construction, not by assumption.
+
+The review also demonstrated a secondary discipline: when assessing a planning document with no
+executable surface yet, verify its security invariants against live source rather than its prose.
+Here that meant confirming that redacted entries in the live metadata used `owner: '[REDACTED]'`
+and `name == node_id` as the stable join key — grounding the plan's leak-prevention design in
+reality before trusting it.
+
+Merged at `e88432c4223e2d7442ba2307407f7bb80b040f35`.
+
+## Guidance
+
+### 1. A second credential gives rotation isolation, not permission isolation
+
+Adding a new key, secret, or credential for a principal does not change what that principal can
+do. All keys for the same GitHub App installation mint tokens from the same registered permission
+set. Conflating "different key" with "narrower key" is a common and dangerous shortcut.
+
+Use a second credential when you need independent rotation. Use mint-time scoping when you need
+least privilege. These are orthogonal concerns.
+
+### 2. Enforce least privilege by scoping at mint time
+
+When minting a GitHub App installation token, pass an explicit `permissions` object. The
+resulting token is constrained to exactly those permissions, regardless of the App's broader
+registered scope:
+
+```ts
+// Mint a read-only token regardless of what the App installation has registered
+const {data: {token}} = await octokit.rest.apps.createInstallationAccessToken({
+  installation_id: installationId,
+  permissions: {
+    contents: 'read',
+    metadata: 'read',
+  },
+  // No 'issues', 'pull_requests', 'administration', etc.
+})
+```
+
+This is the correct mechanism for least-privilege access with GitHub Apps. A token minted
+without an explicit `permissions` object inherits the full installation scope.
+
+### 3. Validate a plan's security invariants against live data, not its prose
+
+A planning document can describe a correct security design while the live implementation
+diverges from it. When reviewing a plan, pick one or two invariants the plan asserts and verify
+them against the actual source or data:
+
+- If the plan says "redacted entries use `node_id` as the stable join key," read the live
+  metadata and confirm the shape.
+- If the plan says "no canonical identifier is rendered publicly," check the committed files.
+- If the plan says "the token is read-only," check what permissions the App installation has
+  registered and whether mint-time scoping is in place.
+
+Prose describes intent. Live data describes reality. Ground the review in reality.
+
+## Related
+
+- [Agent and automation steps need their GitHub token wired explicitly](../workflow-issues/required-github-token-for-agent-steps-2026-06-22.md) — the companion pattern: restrict capability by token scope, not by token absence; keep privileged operations in a separate step with its own credential.
+- [Survey workflow-side privacy gate](../security-issues/survey-workflow-side-privacy-gate-2026-05-16.md) — the same separate-step-with-its-own-credential pattern, where a privacy gate runs under a distinct token so the boundary is enforced by which step holds which credential.
+- [Diagnostic patches observability discipline](../best-practices/diagnostic-patches-observability-discipline-2026-05-20.md) — verify behavior against live state rather than assumptions; the same discipline applied to observability patches.

--- a/docs/solutions/best-practices/credential-mint-time-permission-scoping-2026-06-22.md
+++ b/docs/solutions/best-practices/credential-mint-time-permission-scoping-2026-06-22.md
@@ -3,6 +3,7 @@ title: A Second Credential Gives Rotation Isolation, Not Permission Isolation â€
 date: 2026-06-22
 last_updated: 2026-06-22
 problem_type: best_practice
+category: best-practices
 component: development_workflow
 module: github-workflows
 severity: high

--- a/docs/solutions/best-practices/derive-state-safely-without-widening-injection-2026-06-22.md
+++ b/docs/solutions/best-practices/derive-state-safely-without-widening-injection-2026-06-22.md
@@ -1,0 +1,112 @@
+---
+title: Derive State from the System of Record Without Widening Shell Injection Surface
+date: 2026-06-22
+last_updated: 2026-06-22
+problem_type: best_practice
+component: development_workflow
+module: github-workflows
+severity: high
+verified: 2026-06-22
+tags:
+  - system-of-record
+  - derived-state
+  - injection-surface
+  - argv-form
+  - shell-safety
+applies_when:
+  - a previously hardcoded or static value is replaced with one derived from live data (e.g. a Project board query)
+  - the derived value flows into a shell command or child process invocation
+  - a filter or transform runs across multiple call paths and may emit duplicate output
+  - switching from a static list to a derived set could silently drop entries
+---
+
+# Derive State from the System of Record Without Widening Shell Injection Surface
+
+## Context
+
+A rollout tracker script maintained a hardcoded list of repositories to operate on. When items
+move through a workflow, that list drifts — someone has to edit the script on every transition.
+The right fix is to derive the set from the live Project board: query the board, filter by
+column/status, and operate on whatever is there. The static list becomes dead weight.
+
+The PR that made this change earned praise for the derivation itself. The review also caught a
+security regression it introduced: `repo` now flowed from Project board data into
+`execSync(\`gh ... --repo ${repo} ...\`)`. A previously-trusted constant became a data-derived
+value interpolated into a shell string — widening the injection surface to anything the Project
+board could return.
+
+The fix is argv form: `execFileSync('gh', ['...', '--repo', repo, '...'])`. No shell, no
+interpolation, no injection surface. The test file already used this form; the implementation
+just hadn't caught up.
+
+Two secondary issues rounded out the review: the filter ran in multiple call paths and emitted
+duplicate warnings on the env-injected path; and switching from a static list to a derived set
+quietly dropped entries that weren't Project items — a behavior change worth auditing before
+shipping.
+
+Merged at `f6df711b11cc7360f90a1a698edebe97c2903e21`.
+
+## Guidance
+
+### 1. Prefer the system of record over hand-maintained state lists
+
+When state changes as items move through a workflow, derive it from the authoritative source
+(a Project board, a database, a config file) rather than encoding it in a script that must be
+edited on every transition. The static list is a maintenance liability and a drift risk.
+
+```ts
+// Before: hardcoded, drifts on every transition
+const ROLLOUT_REPOS = ['owner/repo-a', 'owner/repo-b']
+
+// After: derived from the live Project board
+const rolloutRepos = await queryProjectBoard(projectId, {status: 'In Progress'})
+```
+
+### 2. Switch to argv form when a derived value feeds a shell call
+
+When a previously-trusted constant becomes data-derived, re-evaluate every place it is
+interpolated into a shell. Template-string interpolation into `execSync` is an injection surface
+regardless of where the value came from. Switch to `execFileSync` with an explicit argv array:
+
+```ts
+// Wrong: data-derived value interpolated into a shell string
+execSync(`gh issue edit --repo ${repo} --add-label rollout`)
+
+// Right: argv form — no shell, no interpolation
+execFileSync('gh', ['issue', 'edit', '--repo', repo, '--add-label', 'rollout'])
+```
+
+This is not a theoretical concern. Project board data is user-controlled. A repo name with
+shell metacharacters (`$(...)`, backticks, semicolons) would execute in the shell context.
+
+### 3. Avoid re-running filters across call paths
+
+If a filter or transform (e.g. "exclude archived repos") runs in multiple call paths, it will
+emit duplicate warnings or side effects on paths that hit it more than once. Derive from the
+already-filtered set once, at the top of the call graph, and pass the result down:
+
+```ts
+// Derive and filter once
+const activeRepos = rolloutRepos.filter(r => !r.isArchived)
+
+// Pass activeRepos to all downstream call paths — don't re-filter inside each
+```
+
+### 4. Audit the derived set against the static list before shipping
+
+Switching from a static list to a derived set can silently drop entries that aren't represented
+in the source of record. Before shipping, diff the two sets and confirm nothing downstream
+depends on the dropped entries:
+
+```ts
+const staticSet = new Set(ROLLOUT_REPOS)
+const derivedSet = new Set(rolloutRepos.map(r => r.nameWithOwner))
+const dropped = [...staticSet].filter(r => !derivedSet.has(r))
+if (dropped.length > 0) console.warn('Entries in static list not in derived set:', dropped)
+```
+
+## Related
+
+- [GitHub Actions step output interpolation](../workflow-issues/github-actions-step-output-interpolation-2026-04-21.md) — the same injection-surface concern in workflow YAML: untrusted values interpolated into `run:` steps.
+- [Autonomous rollout tracker workflow](../workflow-issues/autonomous-rollout-tracker-workflow-2026-06-17.md) — the workflow this derivation pattern was applied to.
+- [Observability before structural change](../best-practices/observability-before-structural-change-2026-06-09.md) — audit behavior before refactoring; the same discipline applies to verifying the derived set covers the static list's entries.

--- a/docs/solutions/best-practices/derive-state-safely-without-widening-injection-2026-06-22.md
+++ b/docs/solutions/best-practices/derive-state-safely-without-widening-injection-2026-06-22.md
@@ -3,6 +3,7 @@ title: Derive State from the System of Record Without Widening Shell Injection S
 date: 2026-06-22
 last_updated: 2026-06-22
 problem_type: best_practice
+category: best-practices
 component: development_workflow
 module: github-workflows
 severity: high

--- a/docs/solutions/best-practices/identity-guard-stable-scalar-fallback-2026-06-22.md
+++ b/docs/solutions/best-practices/identity-guard-stable-scalar-fallback-2026-06-22.md
@@ -3,6 +3,7 @@ title: Anchor Identity Guards on a Stable Scalar Fallback, Captured Defensively
 date: 2026-06-22
 last_updated: 2026-06-22
 problem_type: best_practice
+category: best-practices
 component: development_workflow
 module: github-workflows
 severity: medium

--- a/docs/solutions/best-practices/identity-guard-stable-scalar-fallback-2026-06-22.md
+++ b/docs/solutions/best-practices/identity-guard-stable-scalar-fallback-2026-06-22.md
@@ -1,0 +1,119 @@
+---
+title: Anchor Identity Guards on a Stable Scalar Fallback, Captured Defensively
+date: 2026-06-22
+last_updated: 2026-06-22
+problem_type: best_practice
+component: development_workflow
+module: github-workflows
+severity: medium
+verified: 2026-06-22
+tags:
+  - identity-guard
+  - denylist
+  - format-migration
+  - defensive-capture
+  - optional-field
+applies_when:
+  - a denylist or redaction guard keys on a migratable identifier (e.g. node_id whose format has changed)
+  - a secondary probe field is added to survive format migrations
+  - a probe can transiently fail and the result feeds an equality or refresh check
+  - a sub-probe failure must not crash the parent probe or weaken the primary guard
+---
+
+# Anchor Identity Guards on a Stable Scalar Fallback, Captured Defensively
+
+## Context
+
+A redaction denylist keyed on `node_id` to identify private repositories. GitHub's `node_id`
+format has migrated before and will again — a legacy base64 entry stops matching after a format
+change, silently dropping the guard for that entry. The fix: add a stable scalar fallback (the
+numeric `repository.id` / `database_id`) so the guard still matches after a `node_id` migration.
+When `node_id` migrates again, the old-format entry stops matching but the integer holds the
+line.
+
+The fallback field is optional everywhere — not all entries will have it, and that is fine. The
+primary guard is still `node_id`; the scalar is a belt-and-suspenders anchor for format
+migrations. It must never be rendered publicly (a `database_id` resolves back to owner/name via
+public API — see the companion doc on canonical-id leaks).
+
+A secondary issue surfaced during review: an equality check comparing a stored `database_id`
+against a freshly probed value can falsely register a change when the probe transiently returns
+`undefined`. If the stored value is `12345` and the probe returns `undefined`, the check
+`entry.database_id !== probe.database_id` evaluates to `true` — inflating a "refreshed" counter
+with phantom updates.
+
+Merged at `8d7735dbed00db9f835b7029fa8f93d03d0ffbe5`.
+
+## Guidance
+
+### 1. Add a stable scalar fallback for migratable identifiers
+
+When a guard keys on an identifier whose format can change (e.g. `node_id`), add a second
+anchor that is format-independent. A numeric integer id is a good choice: it is stable across
+format migrations, unambiguous, and not subject to encoding changes.
+
+```ts
+interface DenylistEntry {
+  node_id: string          // primary key; may become stale after format migration
+  database_id?: number     // stable fallback; optional, never rendered publicly
+}
+
+function isBlocked(repo: Repo, denylist: DenylistEntry[]): boolean {
+  return denylist.some(
+    e => e.node_id === repo.node_id || (e.database_id !== undefined && e.database_id === repo.database_id)
+  )
+}
+```
+
+### 2. Make the fallback sticky on transient probe failure
+
+When probing for the scalar value, a transient API failure must not clear a previously stored
+value. Use `?? stored` to preserve the existing value on a failed probe:
+
+```ts
+const probed = await fetchDatabaseId(nodeId).catch(() => undefined)
+entry.database_id = probed ?? entry.database_id  // sticky: keep stored value on probe failure
+```
+
+### 3. Capture defensively — probe errors → undefined, never crash
+
+A sub-probe failure must not fail the parent probe or produce a malformed entry. Catch all
+errors from the sub-probe and return `undefined`. The parent continues with the primary
+identifier intact.
+
+```ts
+async function probeDatabaseId(nodeId: string): Promise<number | undefined> {
+  try {
+    const result = await api.getRepo(nodeId)
+    return result?.databaseId ?? undefined
+  } catch {
+    return undefined  // transient failure; primary guard is unaffected
+  }
+}
+```
+
+### 4. Treat undefined probe results as "no information" in equality checks
+
+An optional probe field that returns `undefined` means the probe didn't run or failed — not
+that the value changed. Equality and refresh checks must skip the comparison when either side
+is `undefined`:
+
+```ts
+// Wrong: undefined !== 12345 → falsely registers a change
+if (entry.database_id !== probe.database_id) markRefreshed()
+
+// Right: skip comparison when probe result is absent
+if (probe.database_id !== undefined && entry.database_id !== probe.database_id) markRefreshed()
+```
+
+### 5. Never render the scalar publicly
+
+The numeric `database_id` resolves back to owner/name via `GET /repositories/{id}`. It must
+not appear in committed files, PR bodies, review comments, or logs. Store it only in internal
+state (e.g. the `data` branch metadata) and exclude it from any public-facing output.
+
+## Related
+
+- [Loose-then-tight schema migration pattern](../best-practices/loose-then-tight-schema-migration-pattern-2026-05-05.md) — the same incremental approach to identifier migrations: accept both formats during transition, tighten after.
+- [Wiki page structured attribution](../best-practices/wiki-page-structured-attribution-2026-06-04.md) — the present-but-empty vs absent distinction recurs here; encode it as a habit across all optional fields.
+- [Private repo dispatch visibility gate](../security-issues/private-repo-dispatch-visibility-gate-2026-05-08.md) — the fail-closed predicate and opaque-identifier redaction that the denylist this fallback anchors is part of.

--- a/docs/solutions/best-practices/pure-core-privacy-gates-shared-module-2026-06-22.md
+++ b/docs/solutions/best-practices/pure-core-privacy-gates-shared-module-2026-06-22.md
@@ -1,0 +1,122 @@
+---
+title: Pure-Core Privacy Gates with a Shared Module and Mutation-Proof Tests
+date: 2026-06-22
+last_updated: 2026-06-22
+problem_type: best_practice
+component: development_workflow
+module: github-workflows
+severity: high
+verified: 2026-06-22
+tags:
+  - privacy-gate
+  - fail-closed
+  - pure-core
+  - shared-module
+  - mutation-test
+  - defense-in-depth
+applies_when:
+  - a pipeline enriches shared state (e.g. a digest or prompt) with content that may contain sensitive identifiers
+  - two independent chokepoints must enforce the same privacy invariant without diverging
+  - the gate must distinguish "no private repos configured" from "token load failed"
+  - coverage exists but does not prove the gate is load-bearing
+---
+
+# Pure-Core Privacy Gates with a Shared Module and Mutation-Proof Tests
+
+## Context
+
+A capture pipeline enriches an agent prompt with review prose: raw review comments are
+collected, then assembled into a digest that feeds downstream processing. Private repository
+names must never enter the digest or the authored body that follows.
+
+The naive placement puts the gate at the output boundary — scan the final body before it is
+committed. That is too late: by the time the body is authored, the private prose has already
+entered shared state and influenced the agent's output. The gate needs to sit **upstream in the
+pure core**, before enriched content enters the digest, with a second independent scan on the
+authored body as a backstop.
+
+Two separate gate call sites create a divergence risk: if each builds its own token set from
+scratch, a future change to one path can silently leave the other stale. The fix is to extract
+the scan into a single shared module (e.g. `capture-learnings-privacy.ts`) that both call sites
+import. One module, two chokepoints — they cannot diverge.
+
+A subtler correctness trap: the gate received a `Set<string>` of private tokens. An empty set
+(no private repos configured) is not the same as a failed load (the token set could not be
+built). If the gate treats both as "nothing to scan," a load failure silently disables it. The
+distinction must be handled in the I/O shell so the pure core always receives a valid, populated
+`Set` or a hard error — never an empty set that masks a failure.
+
+Merged at `19b566ef82bfbc7d5e32f1060df7bd37cd719676`.
+
+## Guidance
+
+### 1. Gate in the pure core before sensitive data enters shared state
+
+Place the privacy scan at the earliest point where sensitive content could enter a shared
+structure — not at the final output boundary. If a digest or prompt is assembled from enriched
+content, scan before assembly. A downstream gate on the authored body is a backstop, not the
+primary control.
+
+```ts
+// pure core: scan before prose enters the digest
+const scanResult = scanForPrivateTokens(reviewProse, privateTokenSet)
+if (!scanResult.clean) throw new PrivacyGateError(scanResult)
+digest.push(reviewProse)
+```
+
+### 2. Extract one shared module so chokepoints can't diverge
+
+Two independent call sites that each build their own token set will eventually drift. Extract
+the scan logic and token-set construction into a single module. Both chokepoints import it.
+A change to the scan logic propagates to both automatically.
+
+```ts
+// capture-learnings-privacy.ts — one module, imported by both gate call sites
+export function buildPrivateTokenSet(repos: PrivateRepo[]): Set<string> { ... }
+export function scanForPrivateTokens(text: string, tokens: Set<string>): ScanResult { ... }
+```
+
+### 3. Handle empty-vs-absent in the I/O shell, not the pure core
+
+The pure core should never decide what an empty token set means. That decision belongs in the
+shell that loads the token set:
+
+- **Empty set (no private repos configured):** pass an empty `Set` — the scan is a no-op, which
+  is correct.
+- **Load failed (probe error, missing credential, malformed data):** throw before calling the
+  pure core. Never pass an empty `Set` as a proxy for a failed load.
+
+```ts
+// I/O shell
+const privateRepos = await loadPrivateRepos()  // throws on failure
+const tokenSet = buildPrivateTokenSet(privateRepos)  // empty Set is valid if no repos
+```
+
+### 4. Add a mutation-proof test that fails when the gate is removed
+
+A test that only checks the happy path ("gate present, clean input → passes") does not prove
+the gate is load-bearing. Add a test that asserts private prose reaches the output **when the
+gate is bypassed** — and that the gate prevents it. This test fails if the gate is deleted or
+short-circuited, proving it is structural rather than decorative.
+
+```ts
+it('blocks private prose from entering the digest', () => {
+  const prose = 'see acme/private-repo for context'
+  const tokens = buildPrivateTokenSet([{nameWithOwner: 'acme/private-repo', ...}])
+  expect(() => scanForPrivateTokens(prose, tokens)).toThrow(PrivacyGateError)
+})
+
+it('mutation proof: removing the gate lets private prose through', () => {
+  // Directly push prose into the digest without scanning — asserts the gate is the only barrier
+  const digest: string[] = []
+  digest.push('see acme/private-repo for context')
+  expect(digest[0]).toContain('acme/private-repo')  // proves the gate is what stops this
+})
+```
+
+## Related
+
+- [Privacy-gate promotion leak prevention](../best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md) — the trusted-chokepoint and fail-closed-resolution patterns this gate extends into the pure core.
+- [Wiki page structured attribution](../best-practices/wiki-page-structured-attribution-2026-06-04.md) — the present-but-empty vs absent distinction recurs here; encode it as a habit.
+- [Survey workflow-side privacy gate](../security-issues/survey-workflow-side-privacy-gate-2026-05-16.md) — verify privacy inside the trusted workflow before any public side effect.
+- [Private repo dispatch visibility gate](../security-issues/private-repo-dispatch-visibility-gate-2026-05-08.md) — the fail-closed predicate and opaque-identifier redaction this gate builds on.

--- a/docs/solutions/best-practices/pure-core-privacy-gates-shared-module-2026-06-22.md
+++ b/docs/solutions/best-practices/pure-core-privacy-gates-shared-module-2026-06-22.md
@@ -3,6 +3,7 @@ title: Pure-Core Privacy Gates with a Shared Module and Mutation-Proof Tests
 date: 2026-06-22
 last_updated: 2026-06-22
 problem_type: best_practice
+category: best-practices
 component: development_workflow
 module: github-workflows
 severity: high
@@ -106,11 +107,12 @@ it('blocks private prose from entering the digest', () => {
   expect(() => scanForPrivateTokens(prose, tokens)).toThrow(PrivacyGateError)
 })
 
-it('mutation proof: removing the gate lets private prose through', () => {
-  // Directly push prose into the digest without scanning — asserts the gate is the only barrier
-  const digest: string[] = []
-  digest.push('see acme/private-repo for context')
-  expect(digest[0]).toContain('acme/private-repo')  // proves the gate is what stops this
+it('mutation proof: digest assembly drops private prose', () => {
+  // Exercise the REAL assembly path. This goes green only while the gate is wired
+  // into assembleDigest; delete or short-circuit the gate and this turns red.
+  const tokens = buildPrivateTokenSet([{nameWithOwner: 'acme/private-repo'}])
+  const digest = assembleDigest(['see acme/private-repo for context'], tokens)
+  expect(digest.join('\n')).not.toContain('acme/private-repo')
 })
 ```
 

--- a/docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md
+++ b/docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md
@@ -3,6 +3,7 @@ title: Verify the Whole Public Perimeter Before Declaring a Value Non-Leaking
 date: 2026-06-22
 last_updated: 2026-06-22
 problem_type: security_issue
+category: security-issues
 component: development_workflow
 module: github-workflows
 severity: high

--- a/docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md
+++ b/docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md
@@ -1,0 +1,90 @@
+---
+title: Verify the Whole Public Perimeter Before Declaring a Value Non-Leaking
+date: 2026-06-22
+last_updated: 2026-06-22
+problem_type: security_issue
+component: development_workflow
+module: github-workflows
+severity: high
+verified: 2026-06-22
+tags:
+  - privacy
+  - redaction
+  - public-surface
+  - verification
+  - canonical-id
+  - review-habit
+applies_when:
+  - a change writes or derives a value that could identify a redacted entity
+  - a PR body or review claims a sensitive value "appears on no public surface"
+  - a redacted entity's stable canonical identifier (node_id, numeric database_id) is present anywhere in the change
+  - a denylist or redaction guard has a design invariant about which identifiers are retained vs rendered
+---
+
+# Verify the Whole Public Perimeter Before Declaring a Value Non-Leaking
+
+## Context
+
+A PR committed canonical `database_id` values for redacted repositories into a markdown file in
+a public repo. The PR body claimed the values "appear on no public surface," having checked run
+logs and confirmed the summary output was counts-only. That verification was incomplete.
+
+Run logs are one surface. The committed file itself is another. The diff is another. The PR body
+and review comments are others. Checking only run logs and concluding "not public" missed the
+most obvious surface: the file being committed.
+
+The deeper issue: a `database_id` is a stable canonical identifier. It resolves directly via
+`GET /repositories/{id}` back to the repo's current owner and name — defeating the entire point
+of redaction. A redacted entity's stable canonical id (whether `node_id` or numeric
+`database_id`) is a leak by construction, regardless of where it appears. The denylist's design
+invariant is that only the internal `node_id` is retained and nothing canonical is rendered
+publicly. Writing a `database_id` to a tracked public file violates that invariant, full stop.
+
+Merged at `fce8bd5439696f906221b38302e3c65bdda03654`.
+
+## Guidance
+
+### 1. Enumerate every public surface before claiming non-exposure
+
+Before declaring a value non-leaking, list every surface the change touches and confirm absence
+on each:
+
+| Surface | How to check |
+|---|---|
+| Committed file contents | `git show HEAD:<path>` or read the file |
+| Diff | `git diff HEAD~1` — values in context lines count |
+| PR body | Read the PR description |
+| Review comments | Read all review threads |
+| Run logs | Check workflow run output |
+| Issue/comment bodies | Any issue or comment created by the change |
+
+Checking one surface and stopping is not verification. The surface you didn't check is where the
+leak will be.
+
+### 2. Treat a redacted entity's stable canonical id as a leak by construction
+
+A `node_id` in its legacy base64 form or a numeric `database_id` both resolve back to the
+repo's owner and name via public GitHub APIs. Storing either in a public file defeats redaction,
+regardless of intent or context. The test is not "is this value sensitive-looking?" but "does
+this value resolve to a redacted entity?" If yes, it must not appear on any public surface.
+
+When a denylist or redaction guard has a design invariant (e.g. "only internal `node_id` is
+retained; no canonical identifier is rendered"), treat any change that writes a canonical
+identifier to a tracked public file as a privacy boundary violation — not a style nit, not a
+minor issue.
+
+### 3. Treat the invariant as the gate, not the intent
+
+A change can have good intent and still violate a privacy invariant. The invariant is the
+authoritative check. If the invariant says "no canonical id in public files" and the change
+writes one, the change is wrong — even if the author believed the value was safe, even if the
+run logs look clean.
+
+When reviewing a change that touches redaction or denylist logic, state the invariant explicitly
+and verify the change against it, not against the author's description of what they checked.
+
+## Related
+
+- [Survey workflow-side privacy gate](../security-issues/survey-workflow-side-privacy-gate-2026-05-16.md) — the same fail-closed discipline applied to workflow-side privacy checks before any public side effect.
+- [Privacy-gate promotion leak prevention](../best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md) — scanning the full promotion diff (not just filenames) to catch in-body mentions of private identifiers.
+- [Byte-exact gateway signing and fail-soft telemetry](../best-practices/byte-exact-gateway-signing-and-fail-soft-telemetry-2026-06-04.md) — a related pattern of verifying exact values at a trust boundary rather than relying on prose descriptions.


### PR DESCRIPTION
Five reusable learnings distilled from pull requests that went through several review rounds, each cross-referenced to the related existing docs so the corpus reads as a navigable graph rather than standalone notes.

- **Pure-core privacy gates** — place a safety gate in the pure core before sensitive data enters shared state, with two independent fail-closed chokepoints reading one shared module, and a mutation-proof test that fails when the gate is removed.
- **Verify the whole public perimeter** — enumerate every public surface (files, diffs, PR/issue bodies, reviews, logs) before declaring a value non-leaking; a redacted entity's stable canonical id is a leak by construction.
- **Identity-guard stable scalar fallback** — anchor a guard on a defensively-captured stable scalar so it survives an identifier-format migration; treat a missing probe value as no information, not a change.
- **Derive state without widening injection** — prefer the system of record over hand-maintained lists, but move derived values that feed a shell call to argv form.
- **Credential mint-time scoping** — a second credential isolates rotation, not permission; scope least privilege by minting tokens with an explicit permissions subset.

Closes #3557
Closes #3558
Closes #3559
Closes #3560
Closes #3561