### PR TITLE
fix(solutions): drop auth/token from the security-event token set

### DIFF
--- a/scripts/solutions-query.test.ts
+++ b/scripts/solutions-query.test.ts
@@ -628,7 +628,7 @@ describe('assembleSolutionsContext', () => {
       'Handle tokens carefully to avoid leaks.',
     )
 
-    // #when the event is security-flavored (contains 'token' which is in SECURITY_EVENT_TOKENS)
+    // #when the event is security-flavored (contains 'leak' which is in SECURITY_EVENT_TOKENS)
     const result = assembleSolutionsContext({
       files: {...securityBonusDoc, ...bestPracticeEqualDoc},
       event: {
@@ -697,6 +697,54 @@ describe('assembleSolutionsContext', () => {
     expect(securityIdx).toBeGreaterThanOrEqual(0)
     expect(bestPracticeIdx).toBeGreaterThanOrEqual(0)
     // Without bonus, best-practice (inserted first) appears before security_issue
+    expect(bestPracticeIdx).toBeLessThan(securityIdx)
+  })
+
+  it('does not apply the security bonus on an ordinary token/auth event with no genuine security word', () => {
+    // #given two equal-scoring docs, best-practice inserted first
+    const bestPracticeEqualDoc = makeDoc(
+      'docs/solutions/best-practices/equal-score-best-practice.md',
+      {
+        title: 'Token Handling Pattern',
+        module: 'scripts/token-handler.ts',
+        problem_type: 'best_practice',
+        last_updated: '2026-06-01',
+        verified: '2026-06-01',
+        tags: ['token', 'handler'],
+      },
+      'Handle tokens carefully.',
+    )
+    const securityBonusDoc = makeDoc(
+      'docs/solutions/security-issues/equal-score-security.md',
+      {
+        title: 'Token Handling Pattern',
+        module: 'scripts/token-handler.ts',
+        problem_type: 'security_issue',
+        last_updated: '2026-06-01',
+        verified: '2026-06-01',
+        tags: ['token', 'handler'],
+      },
+      'Handle tokens carefully.',
+    )
+
+    // #when the event reads as routine token/auth work — 'token' and 'auth' alone must
+    // NOT be treated as security-flavored (they fire on ordinary PRs like OAuth refresh)
+    const result = assembleSolutionsContext({
+      files: {...bestPracticeEqualDoc, ...securityBonusDoc},
+      event: {
+        eventName: 'pull_request',
+        title: 'refactor: OAuth token refresh handler',
+        body: 'Updating the auth token refresh path.',
+      },
+      privateNames: [],
+      now: new Date('2026-06-22'),
+    })
+
+    // #then no bonus applies → best-practice (inserted first) ranks before security_issue
+    const securityIdx = result.selectedPaths.indexOf('docs/solutions/security-issues/equal-score-security.md')
+    const bestPracticeIdx = result.selectedPaths.indexOf('docs/solutions/best-practices/equal-score-best-practice.md')
+    expect(securityIdx).toBeGreaterThanOrEqual(0)
+    expect(bestPracticeIdx).toBeGreaterThanOrEqual(0)
     expect(bestPracticeIdx).toBeLessThan(securityIdx)
   })
 

--- a/scripts/solutions-query.ts
+++ b/scripts/solutions-query.ts
@@ -20,8 +20,10 @@ const SOLUTIONS_SUBDIRS = [
 
 const STALENESS_DAYS_DEFAULT = 60
 
-// Security-flavored tokens that boost problem_type: security_issue docs
-const SECURITY_EVENT_TOKENS = new Set(['security', 'private', 'leak', 'auth', 'token', 'secret', 'credential'])
+// Security-flavored tokens that boost problem_type: security_issue docs.
+// Deliberately excludes 'auth' and 'token' — they fire on ordinary PRs (OAuth token
+// refresh, GitHub token scope) that aren't security work, over-weighting security docs.
+const SECURITY_EVENT_TOKENS = new Set(['security', 'private', 'leak', 'secret', 'credential'])
 
 export interface SolutionsQueryEvent {
   eventName: string


### PR DESCRIPTION
The solutions-retrieval scorer adds a bonus to `security_issue` docs when an event reads as security-flavored. Two of the trigger tokens — `auth` and `token` — fired on ordinary PRs ("OAuth token refresh", "GitHub token scope") that aren't security work, over-weighting security docs on borderline events.

Drop those two; keep the unambiguous tokens (`security`, `private`, `leak`, `secret`, `credential`).

A mutation-proven test confirms an OAuth-token-refresh event no longer ranks a `security_issue` doc ahead of an equal-scoring best-practice doc. Purely a retrieval-scoring refinement — no privacy-gate impact.

Closes #3541