### PR TITLE
docs: mark grow-and-learn shipped in the north-star

### DIFF
--- a/docs/brainstorms/2026-06-15-fro-bot-personal-agent-north-star-requirements.md
+++ b/docs/brainstorms/2026-06-15-fro-bot-personal-agent-north-star-requirements.md
@@ -48,6 +48,10 @@ this note rebaselines it:
   typed mock operator-client merged; `#26` mock operator UI skeleton open) — but this is
   **gated on `fro-bot/agent` owning and freezing the canonical operator API contract**. The
   mock must remain a non-canonical fixture, never the de facto API design.
+- **A1 (Tier 2, grow-and-learn): SHIPPED + validated 2026-06-22.** The control-plane-native
+  autonomy capability landed independently of the spine, as the dependency model predicted.
+  Retrieve + propose-only capture + review-prose enrichment are all live. A2
+  (self-maintenance) is the next control-plane-native Tier-2 thread.
 
 So the operating truth is **concurrent workstreams**, not strict serial phases. The serial
 roadmap below is retained as the original strategic recommendation, not the current schedule.
@@ -130,13 +134,20 @@ effort/risk signal (L/M/H). Effort/risk are directional, for sequencing — not 
 
 ### Tier 2 — Autonomy depth (mostly control-plane-native)
 
-- **A1 — Skill saving / "grow and learn."** Fro Bot captures reusable skills (Hermes-style)
-  into the built-in wiki and applies them in later runs. **Most control-plane-native of all
-  capabilities — can start without the spine.** _Owner: control plane. Depends on: nothing
-  new (builds on wiki + compound docs). Effort/risk: M._
+- **A1 — Skill saving / "grow and learn." SHIPPED + validated 2026-06-22.** Fro Bot
+  retrieves prior learnings (`docs/solutions/`) into its run context and captures new ones
+  from its own multi-round-review history as proposals a human authors. Delivered as three
+  validated phases: retrieve-and-apply (injects relevant solution docs into agent prompts),
+  propose-only capture (opens labeled learning-proposal issues from PRs that needed real
+  review iteration, with an upstream fail-closed privacy gate), and review-prose enrichment
+  (the agent distills from what the rounds actually said, not the PR title). All three were
+  proven live; the first enriched batch yielded five authored learnings. _Owner: control
+  plane. Most control-plane-native of all capabilities — shipped without the spine, as
+  predicted._
 - **A2 — Self-maintenance & good-GitHub-citizen depth.** Extend autoheal into broader
-  self-improvement of repo + control-plane operation. _Owner: control plane. Depends on:
-  nothing new (autoheal is the seed). Effort/risk: M._
+  self-improvement of repo + control-plane operation. The natural next Tier-2 thread now
+  that A1 is done — also control-plane-native and startable without the spine. _Owner:
+  control plane. Depends on: nothing new (autoheal is the seed). Effort/risk: M._
 - **A3 — Cross-repo planning & agent dispatch.** Plan work spanning related repos and
   dispatch agents in those repos to coordinate. _Owner: control plane + Systematic +
   agent. Depends on: A1/A2 maturity; partial on S1 for cross-agent coordination.


### PR DESCRIPTION
Records that the grow-and-learn capability shipped and was validated in production: retrieval of prior learnings into run context, propose-only capture from multi-round-review history behind an upstream fail-closed privacy gate, and review-prose enrichment so proposals distill from what the review rounds actually said. The first enriched batch yielded five authored learnings.

Updates the capability entry and the rebaseline section, and notes self-maintenance as the next control-plane-native thread now that this one is done.