### PR TITLE
feat: add status-truth maintenance loop

### DIFF
--- a/.github/workflows/status-truth.yaml
+++ b/.github/workflows/status-truth.yaml
@@ -79,8 +79,10 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: status-truth-report
-          # Artifact contains only machine-safe fields and counters.
-          # No raw claim text, source snippets, private identity, or rendered bodies.
+          # Artifact is workflow-internal (detect → open). It may contain public
+          # finding fields needed by the open step (e.g. fingerprints, verdicts,
+          # proposal-eligible flags). It must not contain private identity, source
+          # snippets, API responses, credentials, or rendered proposal bodies.
           path: ${{ runner.temp }}/status-truth-report.json
           retention-days: 7
 
@@ -231,3 +233,56 @@ jobs:
               echo "| Status | (open result unavailable) |"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
+  # PRs job: Bounded correction PR graduation gate.
+  #
+  # DISABLED PLACEHOLDER: This job is intentionally a no-op. It exists to
+  # document the intended future shape of the PR graduation gate. Enabling real
+  # PR execution requires a reviewed workflow and script change — not just
+  # flipping the `if: false` condition below. The job steps are stubs only.
+  #
+  # Graduation criteria (all must be met before a real implementation is added):
+  # 1. Phase 1 proposal issues have produced accepted/rejected outcome signal.
+  # 2. A claim kind has been added to GRADUATED_CLAIM_KINDS in status-truth-prs.ts
+  #    via a reviewed repo change.
+  # 3. The workflow steps below have been replaced with a real implementation
+  #    (script invocation, artifact download, token minting, etc.) in a
+  #    separate reviewed PR — toggling `if: false` alone is not sufficient.
+  #
+  # Safety constraints (enforced in scripts/status-truth-prs.ts):
+  # - enabled=false → all candidates downgrade to proposal-only (no PR actions).
+  # - Forbidden paths (workflows, hooks, metadata, knowledge, persona, etc.) → proposal-only.
+  # - Privacy gate blocks PR metadata containing private tokens → proposal-only.
+  # - Existing PR rediscovery requires opaque digest match + bot ownership + main target.
+  # - No merge, approve, automerge, force-push, or retarget actions are possible.
+  # ---------------------------------------------------------------------------
+  prs:
+    name: Plan status-truth correction PRs (disabled placeholder)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: open
+    # Disabled: this is a no-op placeholder. Enabling real PR execution requires
+    # a reviewed workflow and script change, not just removing `if: false`.
+    if: false
+    permissions:
+      contents: read
+
+    steps:
+      - name: ⤵ Checkout Branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: 📦 Setup
+        uses: ./.github/actions/setup
+
+      - name: 🔍 Plan status-truth correction PRs (dry-run only)
+        # Placeholder only. A future implementation must replace this step with
+        # reviewed script invocation, artifact download, and scoped credentials.
+        env:
+          STATUS_TRUTH_PRS_ENABLED: 'false'
+        run: |
+          echo "PR graduation gate: disabled (no claim kinds graduated yet)"
+          echo "PR actions planned: 0"
+          echo "Downgraded to proposal-only: 0"

--- a/.github/workflows/status-truth.yaml
+++ b/.github/workflows/status-truth.yaml
@@ -1,0 +1,218 @@
+---
+name: Status Truth
+
+on:
+  schedule:
+    - cron: '0 21 * * 0' # Every Sunday at 21:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry-run mode: count planned actions but open no issues'
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+# Default permissions: read-only. The open job overrides to issues: write.
+permissions:
+  contents: read
+
+# Serialize runs; never cancel an in-progress run so a detect-to-open sequence
+# is never interrupted halfway through proposal planning.
+concurrency:
+  group: status-truth
+  cancel-in-progress: false
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Detect job: read-only scan of public status-truth claims.
+  # Emits a structured report artifact and counts-only summary.
+  # No write credentials; no issue mutations.
+  # ---------------------------------------------------------------------------
+  detect:
+    name: Detect status-truth drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Detect job uses only the default read-only permissions.
+    permissions:
+      contents: read
+
+    steps:
+      - name: ⤵ Checkout Branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: 📦 Setup
+        uses: ./.github/actions/setup
+
+      # Overlay metadata/ from the data branch so the privacy gate reads the
+      # authoritative private-repo list from metadata/repos.yaml.
+      # Tolerate a missing data branch (first run, fresh clone).
+      - name: ⤵ Overlay metadata from data branch
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code origin data >/dev/null 2>&1; then
+            git fetch --no-tags origin data
+            git checkout origin/data -- metadata/
+          else
+            echo "data branch not yet established; skipping metadata overlay."
+          fi
+
+      - name: 🔍 Detect status-truth drift
+        id: detect
+        env:
+          # Read-only GITHUB_TOKEN: detect step resolves current-repo PR/issue/release
+          # state. Cross-repo references are classified as unavailable (unresolved).
+          # Without a token, all API claims are unresolved (no fake clean report).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          STATUS_TRUTH_REPORT_PATH: ${{ runner.temp }}/status-truth-report.json
+          # Scheduled runs default to dry-run=true; only workflow_dispatch can set false.
+          STATUS_TRUTH_DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+        run: node scripts/status-truth-detect.ts
+
+      - name: 📤 Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: status-truth-report
+          # Artifact contains only machine-safe fields and counters.
+          # No raw claim text, source snippets, private identity, or rendered bodies.
+          path: ${{ runner.temp }}/status-truth-report.json
+          retention-days: 7
+
+      - name: 📋 Write detect summary
+        if: always()
+        env:
+          STATUS_TRUTH_REPORT_PATH: ${{ runner.temp }}/status-truth-report.json
+        run: |
+          set -euo pipefail
+          report="$STATUS_TRUTH_REPORT_PATH"
+
+          {
+            echo "## Status Truth Detect Summary"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+
+            if [[ -s "$report" ]]; then
+              echo "| Status | $(jq -r '.status // "unknown"' "$report") |"
+              echo "| Scan complete | $(jq -r '.scan_complete // false' "$report") |"
+              echo "| Total claims | $(jq '.counts.total // 0' "$report") |"
+              echo "| Current | $(jq '.counts.current // 0' "$report") |"
+              echo "| Drifted | $(jq '.counts.drifted // 0' "$report") |"
+              echo "| Unresolved | $(jq '.counts.unresolved // 0' "$report") |"
+              echo "| Unsafe | $(jq '.counts.unsafe // 0' "$report") |"
+              echo "| Proposal eligible | $(jq '.counts.proposal_eligible // 0' "$report") |"
+            else
+              echo "| Status | (report unavailable) |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
+  # Open job: consume the report artifact, validate it, and perform proposal
+  # issue actions. In dry-run mode (the default for scheduled runs) no issues
+  # are mutated and no app write token is minted.
+  # Separated from detect to enforce credential isolation.
+  # ---------------------------------------------------------------------------
+  open:
+    name: Open status-truth proposals
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: detect
+    if: always()
+    # Read-only GITHUB_TOKEN permissions for the open job.
+    # Live issue writes use the scoped app token minted in the "Mint write token"
+    # step (workflow_dispatch + dry_run=false only). Scheduled dry-runs never
+    # mint the app token and never mutate issues, so issues:write on the job
+    # token is not needed and would grant unnecessary privilege.
+    permissions:
+      contents: read
+      issues: read
+
+    steps:
+      - name: ⤵ Checkout Branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: 📦 Setup
+        uses: ./.github/actions/setup
+
+      # Overlay metadata/ from the data branch so the privacy gate reads the
+      # authoritative private-repo list from metadata/repos.yaml.
+      # Hard-fail if the data branch exists but the overlay fails — the privacy
+      # gate cannot operate without metadata/repos.yaml (fail-closed by design).
+      - name: ⤵ Overlay metadata from data branch
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code origin data >/dev/null 2>&1; then
+            git fetch --no-tags origin data
+            git checkout origin/data -- metadata/
+          else
+            echo "data branch not yet established; skipping metadata overlay."
+          fi
+
+      - name: 📥 Download report artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: status-truth-report
+          path: ${{ runner.temp }}
+
+      # Mint a scoped app token only for live writes. Scheduled runs default to dry-run
+      # and use the job token for read-only planning.
+      - name: 🔑 Mint write token
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == 'false' }}
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          # Scope to this repo only — smallest blast radius.
+          repositories: ${{ github.event.repository.name }}
+          # Phase 1 permissions: issue-write + read-only content access.
+          permission-issues: write
+          permission-contents: read
+
+      - name: 📬 Open status-truth proposals
+        id: open
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          STATUS_TRUTH_REPORT_PATH: ${{ runner.temp }}/status-truth-report.json
+          STATUS_TRUTH_OPEN_RESULT_PATH: ${{ runner.temp }}/status-truth-open-result.json
+          # Scheduled runs default to dry-run=true; only workflow_dispatch can set false.
+          STATUS_TRUTH_DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+        run: node scripts/status-truth-proposals.ts
+
+      - name: 📋 Write open summary
+        if: always()
+        env:
+          STATUS_TRUTH_OPEN_RESULT_PATH: ${{ runner.temp }}/status-truth-open-result.json
+        run: |
+          set -euo pipefail
+          result="$STATUS_TRUTH_OPEN_RESULT_PATH"
+
+          {
+            echo "## Status Truth Open Summary"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+
+            if [[ -s "$result" ]]; then
+              echo "| Dry run | $(jq -r '.dryRun // false' "$result") |"
+              echo "| Label gate failed | $(jq -r '.labelGateFailed // false' "$result") |"
+              echo "| Opened | $(jq '.counts.opened // 0' "$result") |"
+              echo "| Updated | $(jq '.counts.updated // 0' "$result") |"
+              echo "| Reopened | $(jq '.counts.reopened // 0' "$result") |"
+              echo "| Closed | $(jq '.counts.closed // 0' "$result") |"
+              echo "| Suppressed | $(jq '.counts.suppressed // 0' "$result") |"
+              echo "| Failed | $(jq '.counts.failed // 0' "$result") |"
+              echo "| Same-run deduplicated | $(jq '.counts.sameRunDeduplicated // 0' "$result") |"
+            else
+              echo "| Status | (open result unavailable) |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/status-truth.yaml
+++ b/.github/workflows/status-truth.yaml
@@ -212,6 +212,21 @@ jobs:
               echo "| Suppressed | $(jq '.counts.suppressed // 0' "$result") |"
               echo "| Failed | $(jq '.counts.failed // 0' "$result") |"
               echo "| Same-run deduplicated | $(jq '.counts.sameRunDeduplicated // 0' "$result") |"
+
+              # Planned per-kind counts (from planner; counts-only, no paths or fingerprints)
+              kind_count=$(jq '.plannedCountsByKind | length' "$result" 2>/dev/null || echo 0)
+              if [[ "$kind_count" -gt 0 ]]; then
+                echo ""
+                echo "### Planned counts by claim kind"
+                echo ""
+                echo "| Kind | Opened | Updated | Reopened | Closed | Suppressed |"
+                echo "| --- | --- | --- | --- | --- | --- |"
+                jq -r '
+                  .plannedCountsByKind
+                  | to_entries[]
+                  | "| \(.key) | \(.value.opened // 0) | \(.value.updated // 0) | \(.value.reopened // 0) | \(.value.closed // 0) | \(.value.suppressed // 0) |"
+                ' "$result"
+              fi
             else
               echo "| Status | (open result unavailable) |"
             fi

--- a/.github/workflows/status-truth.yaml
+++ b/.github/workflows/status-truth.yaml
@@ -240,7 +240,8 @@ jobs:
   # DISABLED PLACEHOLDER: This job is intentionally a no-op. It exists to
   # document the intended future shape of the PR graduation gate. Enabling real
   # PR execution requires a reviewed workflow and script change — not just
-  # flipping the `if: false` condition below. The job steps are stubs only.
+  # setting the STATUS_TRUTH_PRS_ENABLED variable below. The job steps are
+  # stubs only.
   #
   # Graduation criteria (all must be met before a real implementation is added):
   # 1. Phase 1 proposal issues have produced accepted/rejected outcome signal.
@@ -248,7 +249,7 @@ jobs:
   #    via a reviewed repo change.
   # 3. The workflow steps below have been replaced with a real implementation
   #    (script invocation, artifact download, token minting, etc.) in a
-  #    separate reviewed PR — toggling `if: false` alone is not sufficient.
+  #    separate reviewed PR — toggling the variable alone is not sufficient.
   #
   # Safety constraints (enforced in scripts/status-truth-prs.ts):
   # - enabled=false → all candidates downgrade to proposal-only (no PR actions).
@@ -262,9 +263,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: open
-    # Disabled: this is a no-op placeholder. Enabling real PR execution requires
-    # a reviewed workflow and script change, not just removing `if: false`.
-    if: false
+    # Disabled placeholder: the variable STATUS_TRUTH_PRS_ENABLED is not set in
+    # this repo, so this job never runs. Enabling real PR execution requires a
+    # reviewed workflow and script change — setting the variable alone is not
+    # sufficient to produce real PR actions.
+    if: ${{ vars.STATUS_TRUTH_PRS_ENABLED == 'true' }}
     permissions:
       contents: read
 

--- a/.github/workflows/status-truth.yaml
+++ b/.github/workflows/status-truth.yaml
@@ -48,9 +48,8 @@ jobs:
       - name: 📦 Setup
         uses: ./.github/actions/setup
 
-      # Overlay metadata/ from the data branch so the privacy gate reads the
-      # authoritative private-repo list from metadata/repos.yaml.
-      # Tolerate a missing data branch (first run, fresh clone).
+      # Best-effort metadata overlay for parity with workflow consumers. The detect
+      # step does not load private-token metadata; public writes are gated in `open`.
       - name: ⤵ Overlay metadata from data branch
         run: |
           set -euo pipefail
@@ -145,9 +144,8 @@ jobs:
         uses: ./.github/actions/setup
 
       # Overlay metadata/ from the data branch so the privacy gate reads the
-      # authoritative private-repo list from metadata/repos.yaml.
-      # Hard-fail if the data branch exists but the overlay fails — the privacy
-      # gate cannot operate without metadata/repos.yaml (fail-closed by design).
+      # authoritative private-repo list from metadata/repos.yaml. The overlay is
+      # best-effort; `loadPrivateTokensFromDisk()` is the fail-closed chokepoint.
       - name: ⤵ Overlay metadata from data branch
         run: |
           set -euo pipefail
@@ -205,8 +203,8 @@ jobs:
             echo "| --- | --- |"
 
             if [[ -s "$result" ]]; then
-              echo "| Dry run | $(jq -r '.dryRun // false' "$result") |"
-              echo "| Label gate failed | $(jq -r '.labelGateFailed // false' "$result") |"
+              echo "| Dry run | $(jq -r 'if .dryRun then "true" else "false" end' "$result") |"
+              echo "| Label gate failed | $(jq -r 'if .labelGateFailed then "true" else "false" end' "$result") |"
               echo "| Opened | $(jq '.counts.opened // 0' "$result") |"
               echo "| Updated | $(jq '.counts.updated // 0' "$result") |"
               echo "| Reopened | $(jq '.counts.reopened // 0' "$result") |"
@@ -214,6 +212,8 @@ jobs:
               echo "| Suppressed | $(jq '.counts.suppressed // 0' "$result") |"
               echo "| Failed | $(jq '.counts.failed // 0' "$result") |"
               echo "| Same-run deduplicated | $(jq '.counts.sameRunDeduplicated // 0' "$result") |"
+              echo "| Version rejected | $(jq '.plannedCounts.versionRejected // 0' "$result") |"
+              echo "| Blocked | $(jq '(.plannedCounts.blocked // 0)' "$result") |"
 
               # Planned per-kind counts (from planner; counts-only, no paths or fingerprints)
               kind_count=$(jq '.plannedCountsByKind | length' "$result" 2>/dev/null || echo 0)

--- a/README.md
+++ b/README.md
@@ -261,6 +261,49 @@ gh workflow run survey-repo.yaml -f node_id=<node_id>
 
 The `node_id` for each tracked repo is stored in `metadata/repos.yaml` on the `data` branch.
 
+### Status-Truth Proposals
+
+The **Status Truth** workflow detects drift between documented status claims and live GitHub state, then opens fingerprinted proposal issues for review. Each proposal contains structured evidence fields (kind, claimed state, live state, proposed correction) and a hidden fingerprint marker for lifecycle tracking.
+
+**Reviewing a proposal:**
+
+Apply one of the following labels to record your decision. The loop reads these labels on the next run.
+
+| Label | Meaning | Effect on future runs |
+| --- | --- | --- |
+| `status-truth:accepted` | Drift is real; correction is valid | Non-terminal: issue may reopen if drift recurs |
+| `status-truth:rejected` | Claim was correct; finding was wrong | **Terminal:** suppresses future matching findings |
+| `status-truth:false-positive` | Finding is a systematic false alarm | **Terminal:** suppresses future matching findings |
+| `status-truth:manually-fixed` | Drift corrected by hand | Non-terminal: auto-closes when drift clears |
+| `status-truth:superseded` | A newer finding replaces this one | Non-terminal: preserved for history; may reopen if the same drift recurs |
+
+**Terminal labels** (`rejected`, `false-positive`) permanently suppress future findings with the same fingerprint. Use them when the claim kind is systematically wrong for this source, not just transiently stale.
+
+**Non-terminal labels** (`accepted`, `manually-fixed`, `superseded`) preserve history and allow the loop to reopen the issue if the same drift returns, or auto-close it when the drift clears.
+
+**Marking a proposal false-positive:**
+
+1. Open the proposal issue.
+2. Apply the `status-truth:false-positive` label.
+3. Optionally add a comment explaining why (e.g., "this PR reference is intentionally historical").
+4. Close the issue. The loop will not reopen it for the same fingerprint.
+
+**Marking a proposal accepted:**
+
+1. Apply the `status-truth:accepted` label.
+2. Make the correction (update the doc, close the PR, etc.).
+3. Close the issue or leave it open — the loop will auto-close it when the drift clears on the next complete scan.
+
+**Marking a proposal superseded:**
+
+Use `status-truth:superseded` when a newer finding or a broader correction makes this specific proposal obsolete, but you want to preserve the history.
+
+1. Apply the `status-truth:superseded` label.
+2. Optionally add a comment linking to the replacement issue or correction.
+3. Close the issue. The loop treats `superseded` as non-terminal: if the same drift fingerprint returns, the issue will be reopened.
+
+**Workflow summary:** Each run emits aggregate counts by claim kind (opened, updated, reopened, closed, suppressed). No file paths, fingerprints, or claim text appear in workflow logs — evidence lives in the proposal issues after privacy gating.
+
 ## Development
 
 ### Code Quality Standards

--- a/docs/brainstorms/2026-06-26-a2-self-maintenance-portfolio-requirements.md
+++ b/docs/brainstorms/2026-06-26-a2-self-maintenance-portfolio-requirements.md
@@ -1,0 +1,264 @@
+---
+date: 2026-06-26
+topic: a2-self-maintenance-portfolio
+title: A2 — Semantic truth maintenance
+---
+
+# A2 — Semantic truth maintenance
+
+## Summary
+
+A2 turns Fro Bot into a proactive maintainer of its own control-plane truth. The first slice is
+status-truth maintenance: Fro Bot detects public claims about issue, PR, release, plan, and
+rollout state that have drifted from live GitHub reality, then creates durable proposals for
+operator review. Bounded correction PRs are a graduation path after the claim kind proves useful.
+
+---
+
+## Problem Frame
+
+The personal-agent north-star names A2 as the next Tier-2 thread after A1 grow-and-learn:
+broader self-improvement of repo and control-plane operation, seeded by autoheal. A1 captures
+what Fro Bot learns from solved work. A2 should verify that the repo’s public coordination layer
+still matches shipped reality.
+
+Recent rollout work exposed the gap. Plans, issues, and docs drifted around #3512, #48, #907,
+#1033, release-versus-deploy state, and live verification. The operator had to manually reconcile
+the board, tracker body, comments, memories, release state, and project docs before trusting the
+next action. That reconciliation loop is exactly the kind of ongoing repo maintenance Fro Bot
+should own.
+
+This is not a generic docs linter. Existing wiki lint checks structural integrity, and existing
+docs skills help regenerate prose when asked. A2 adds semantic truth maintenance: typed factual
+claims, live source-of-truth checks, durable proposals, measured false-positive learning, and a
+future path to bounded correction PRs.
+
+---
+
+## Actors
+
+- Marcus: reviews proposals, closes false positives, merges future bounded PRs, and decides when
+  a claim kind graduates to more autonomy.
+- Fro Bot: inventories status-truth claims, checks live GitHub reality, proposes truth-maintenance
+  work, and learns which claim kinds are reliable.
+- Maintained repository: the `.github` control plane, including public docs, plans, issues, PRs,
+  releases, workflow runs, and project tracker artifacts used as truth sources.
+
+---
+
+## Key Flows
+
+- F1. Status-truth scan
+  - **Trigger:** A scheduled or manual A2 run evaluates supported status-truth claim kinds for
+    the `.github` control plane.
+  - **Actors:** Fro Bot, Maintained repository
+  - **Steps:** Fro Bot inventories typed status claims, fetches live public GitHub state,
+    classifies each claim as current, drifted, unresolved, or unsafe to emit, then records
+    counts-only telemetry.
+  - **Outcome:** Fro Bot knows which public coordination claims are stale without leaking private
+    state or writing to authority surfaces.
+  - **Covered by:** R1, R2, R3, R4, R5, R6, R7
+- F2. Proposal queue
+  - **Trigger:** A status claim is drifted and safe to discuss on public GitHub surfaces.
+  - **Actors:** Marcus, Fro Bot
+  - **Steps:** Fro Bot creates or updates a fingerprinted proposal issue with the claim, source of
+    truth, confidence, severity, proposed correction, and current outcome state.
+  - **Outcome:** Stale coordination knowledge becomes reviewable work instead of latent operator
+    memory.
+  - **Covered by:** R8, R9, R10, R11, R12, R13, R14
+- F3. Bounded PR graduation
+  - **Trigger:** A claim kind has demonstrated low false-positive rates and a drifted claim has a
+    mechanically provable correction inside an approved docs path.
+  - **Actors:** Marcus, Fro Bot
+  - **Steps:** Fro Bot applies the exact correction, opens at most one bounded PR, links it to the
+    proposal state, and waits for human review and merge.
+  - **Outcome:** Repeatedly reliable truth-maintenance work can move from proposal to small
+    reviewable diff without allowing autonomous merge.
+  - **Covered by:** R15, R16, R17, R18, R19
+
+---
+
+## Requirements
+
+**First claim kind: status truth**
+
+- R1. A2 v1 must focus on public status-truth claims that affect the next operator action.
+- R2. The first inventory must cover public issue state, PR state, release state, plan status, and
+  rollout-tracker status when those claims appear in `.github` docs, plans, or issue bodies.
+- R3. A2 v1 must not scan arbitrary prose for “still accurate?” judgments.
+- R4. Each supported claim kind must define its claim pattern, live source of truth, confidence
+  rule, suppression rule, and proposal body fields.
+- R5. Adding a new claim kind must be a reviewable repo change so false-positive history and
+  safety rules can shape expansion.
+
+**Source-of-truth checks**
+
+- R6. A2 must prefer live public GitHub state and current repo files over generated, historical,
+  or narrative docs.
+- R7. A2 must classify each claim as current, drifted, unresolved, or unsafe to emit.
+- R8. When sources conflict, source data is unavailable, the resource is not definitively public,
+  or the claim depends on private or unknown identity, A2 must fail closed and not emit a public
+  proposal or PR.
+
+**Proposal queue and learning loop**
+
+- R9. Drifted claims that are safe to discuss publicly must become fingerprinted proposal issues
+  or updates to existing proposal issues.
+- R10. Proposal state must live on GitHub issue surfaces using hidden fingerprint markers, labels,
+  and comments; no new metadata file is introduced in v1.
+- R11. Each proposal must include the public claim location, sanitized claim excerpt, checked
+  public source of truth, confidence, severity, proposed correction, fingerprint, and outcome
+  state.
+- R12. A2 must track proposed, accepted, rejected, false-positive, superseded, and manually-fixed
+  outcomes in the proposal issue thread.
+- R13. A2 must suppress repeated proposals for rejected, false-positive, or superseded findings
+  until the claim text or source-of-truth reference materially changes.
+- R14. A2 must measure accepted-versus-rejected outcomes by claim kind so bad heuristics become
+  visible and correctable.
+
+**Bounded PR graduation**
+
+- R15. Bounded PRs are not required for the first proposal-only implementation, but the design
+  must leave a clear graduation path for reliable claim kinds.
+- R16. A2 may open a correction PR only when the change is a literal or tightly bounded
+  substitution over a cited claim location.
+- R17. A2 PRs must be limited to approved public docs paths and must never touch `knowledge/`,
+  `metadata/`, repo settings, workflows, hooks, persona files, secrets, release config, or other
+  authority-bearing surfaces.
+- R18. Human merge remains required for every A2 PR.
+- R19. A2 must not approve, merge, enable automerge, force-push, retarget, or bypass branch
+  protection for its own PRs.
+
+**Privacy and public artifact safety**
+
+- R20. Before any public issue, comment, PR title, PR body, branch name, or workflow summary is
+  emitted, A2 must run the shared privacy gate over the rendered content.
+- R21. A2 public output must use a strict schema: public claim path, short sanitized excerpt,
+  public source reference, confidence, severity, fingerprint, and proposed correction.
+- R22. A2 must omit private or unknown repo names, branch names, issue titles, PR links, node IDs,
+  database IDs, inferred identities, and secret-like content from public output.
+- R23. A2 must treat privacy-gate failure, ambiguous public/private status, auth failure, API
+  timeout, stale cached identity, or missing source-of-truth data as a block, not as a redaction
+  opportunity.
+- R24. A2 must keep workflow telemetry counts-only: claim counts, drift counts, proposal counts,
+  blocked counts, and false-positive counts without paths, issue titles, repo names, branch names,
+  fingerprints, or PR links.
+- R25. A2 must separate read-only scan credentials from write credentials for proposal or PR
+  creation, and credential values must never enter rendered proposals, PR metadata, logs, or
+  workflow summaries.
+- R26. Future correction PR branch names, titles, and labels must be generated from opaque
+  fingerprints and fixed prefixes, never from claim text, source URLs, repo names, branch names,
+  issue titles, or PR titles.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R6, R9, R11.** Given a rollout tracker says PR #907 is open but GitHub
+  shows it closed, when A2 scans public tracker claims, it creates or updates one proposal citing
+  the stale claim and the live PR state.
+- AE2. **Covers R7, R8.** Given a plan claim conflicts with one public source while another public
+  source is unavailable, when A2 evaluates the claim, it records unresolved evidence in counts
+  only and emits no public proposal or PR.
+- AE3. **Covers R10, R12, R13, R14.** Given Marcus closes a proposal as false-positive, when the
+  same fingerprint appears on the next run, A2 suppresses it and increments the false-positive
+  count for that claim kind.
+- AE4. **Covers R15, R16, R18, R19.** Given a future graduated claim kind has a verifiably wrong
+  public status phrase in an approved docs path, A2 may open one small correction PR and wait for
+  human merge.
+- AE5. **Covers R20, R21, R22, R23, R24, R25.** Given a claim references a private repo or
+  private PR URL, when A2 evaluates it, all public output is blocked and workflow telemetry
+  records only aggregate blocked counts.
+- AE6. **Covers R26.** Given a future bounded PR is opened for a public status correction, when A2
+  creates its branch and title, both use a fixed docs-drift prefix plus an opaque fingerprint
+  instead of source-derived text.
+
+---
+
+## Success Criteria
+
+- Fro Bot identifies stale public coordination claims before Marcus manually reconciles them.
+- Every emitted proposal is reviewable from its claim tuple without trusting agent vibes.
+- The first implementation improves repo truthfulness through accepted proposals or documented
+  false-positive reductions.
+- A2 produces a measurable accuracy signal per status claim kind so the system can graduate useful
+  checks and retire noisy ones.
+- Human approval and existing authority boundaries remain intact.
+
+---
+
+## Scope Boundaries
+
+- First implementation is `.github` control-plane only; no org-wide repo scanning.
+- First implementation covers public status-truth claims, not broad prose quality or style.
+- General issue/PR lifecycle management is out of scope except proposal tracking for A2 findings.
+- Bounded correction PRs are a graduation path, not required for the first proposal-only version.
+- No dependency hygiene, broad CI/test hardening, review-to-fix, or metadata/wiki authority repair
+  in this slice.
+- No A1 capture, autonomous authoring, quarantine-doc design, or A3 cross-repo dispatch.
+- No dashboard/operator UI work.
+- No autonomous merges or automerge enablement.
+- No new write authority path around `data`, wiki, metadata, repo settings, secrets, workflows,
+  or release configuration.
+
+---
+
+## Key Decisions
+
+- **Status truth is the first wedge:** Stale public status claims caused recent operator
+  reconciliation pain, and they have clean public GitHub sources of truth.
+- **Semantic truth maintenance, not docs lint:** A2 checks factual coordination claims against
+  live reality; structural wiki lint and prose regeneration stay separate.
+- **Typed claims before semantic comparison:** The system starts with claim kinds that have named
+  sources of truth so findings are auditable and measurable.
+- **Proposal queue as the safety primitive:** Proposals are durable review artifacts and carry the
+  state machine that prevents repeated stale work.
+- **PRs are a graduation path:** The intended product is proactive repo maintenance, but PR
+  autonomy should be earned by claim-kind accuracy rather than granted before signal exists.
+- **Privacy gate is the chokepoint:** Public output is blocked when identity, source-of-truth, or
+  rendered content safety is uncertain.
+- **Credentials do not cross output boundaries:** Scan credentials, write credentials, and
+  rendered public artifacts stay separated so secret values cannot leak through proposals, PRs, or
+  telemetry.
+
+---
+
+## Dependencies / Assumptions
+
+- The personal-agent north-star remains the parent strategy document.
+- Existing wiki lint, issue fingerprinting, privacy gates, data-branch authority rules, and docs
+  skills remain load-bearing primitives.
+- Public GitHub issues are the right proposal queue surface for `.github`-scoped status claims.
+- Planning will define the first status-claim inventory, proposal labels, fingerprint shape,
+  privacy-gate adapter, workflow shape, and future PR graduation rule.
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- [Affects R2, R4][Product/technical] Which exact status claim kinds belong in the first
+  inventory?
+- [Affects R10, R12][Technical] Which labels and hidden markers encode proposal outcome state?
+- [Affects R20, R21, R22, R23][Technical] What shared privacy-gate adapter protects every public
+  output surface?
+- [Affects R25, R26][Technical] What exact workflow credential split and opaque PR metadata
+  format should the implementation use?
+
+### Deferred to Planning
+
+- [Affects R14, R24][Technical] What minimum accuracy counters should appear in the workflow
+  summary without creating public noise?
+- [Affects R15, R16, R17][Technical] What accepted-proposal threshold promotes a claim kind from
+  proposal-only to PR-eligible later?
+
+---
+
+## Sources / Research
+
+- Personal-agent north-star: `docs/brainstorms/2026-06-15-fro-bot-personal-agent-north-star-requirements.md`
+- A1 grow-and-learn requirements: `docs/brainstorms/2026-06-22-skill-saving-grow-and-learn-requirements.md`
+- Existing structural and lifecycle primitives: `scripts/wiki-lint.ts`, `scripts/wiki-lint-issues.ts`, `scripts/capture-learnings-privacy.ts`, `scripts/merge-data-pr.ts`
+- Related maintenance patterns: `docs/solutions/documentation-gaps/doc-drift-cleanup-pattern-2026-04-18.md`, `docs/solutions/best-practices/github-issues-api-same-run-eventual-consistency-2026-05-20.md`, `docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md`
+- External patterns reviewed: Renovate/Dependabot confidence-tiered PR automation, GitHub Copilot coding agent approval boundaries, API/docs drift tools, durable workflow control planes, and verification-first self-improving agent research.

--- a/docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md
+++ b/docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md
@@ -390,7 +390,7 @@ open step.
 **Verification:**
 - Lifecycle planning is deterministic from report plus existing issue state.
 
-- [ ] **Unit 4: Detect/open CLI shells and workflow wiring**
+- [x] **Unit 4: Detect/open CLI shells and workflow wiring**
 
 **Goal:** Add runnable scripts and a scheduled/manual workflow that detects status-truth drift and
 opens proposal issues with separated credentials.

--- a/docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md
+++ b/docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md
@@ -208,7 +208,7 @@ flowchart TD
 
 ## Implementation Units
 
-- [ ] **Unit 1: Status-claim model and detector core**
+- [x] **Unit 1: Status-claim model and detector core**
 
 **Goal:** Define the typed claim inventory and pure detection core for public status-truth claims.
 

--- a/docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md
+++ b/docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md
@@ -462,7 +462,7 @@ opens proposal issues with separated credentials.
 - The workflow can run in dry or mocked mode during tests without public writes.
 - Script-load CI can import every new production script under Node 24 strip-only execution.
 
-- [ ] **Unit 5: Accuracy signal and operator-facing proposal UX**
+- [x] **Unit 5: Accuracy signal and operator-facing proposal UX**
 
 **Goal:** Make accepted/rejected outcomes visible enough for Fro Bot to improve claim-kind quality.
 
@@ -505,7 +505,7 @@ opens proposal issues with separated credentials.
 **Verification:**
 - A reviewer can classify proposal usefulness without reading workflow logs.
 
-- [ ] **Unit 6: Bounded PR graduation gate**
+- [x] **Unit 6: Bounded PR graduation gate**
 
 **Goal:** Add the second-phase pathway for reliable claim kinds to open tightly scoped correction
 PRs after proposal signal exists.

--- a/docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md
+++ b/docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md
@@ -1,0 +1,645 @@
+---
+title: 'feat: Add status-truth maintenance loop'
+type: feat
+status: active
+date: 2026-06-26
+deepened: 2026-06-27
+origin: docs/brainstorms/2026-06-26-a2-self-maintenance-portfolio-requirements.md
+---
+
+# feat: Add status-truth maintenance loop
+
+## Overview
+
+Add the first A2 semantic truth-maintenance loop for the `.github` control plane. The loop scans
+public status claims, checks them against live public GitHub reality, opens or updates
+fingerprinted proposal issues, and records counts-only accuracy signals before any correction PR
+autonomy is enabled.
+
+Bounded PRs stay in this plan as a second phase: once proposal outcomes show a claim kind is
+reliable, Fro Bot can open small human-reviewed correction PRs under strict privacy, branch, path,
+and diff gates.
+
+## Problem Frame
+
+Recent rollout work around #3512, #48, #907, #1033, release-versus-deploy state, and live
+verification required manual reconciliation before the next action was safe. The repo already has
+structural wiki lint, learning capture, issue dedupe, privacy gates, and data-branch authority
+rules. It lacks a loop that verifies public coordination claims against live state and turns drift
+into reviewable work.
+
+## Requirements Trace
+
+- R1. Status-truth claims that affect the next operator action are the first A2 slice.
+- R2. The first inventory covers public issue, PR, release, plan, and rollout-tracker status
+  claims in `.github` docs, plans, and issue bodies.
+- R3. The loop rejects vague prose audits; every finding comes from a typed claim kind.
+- R4. Each claim kind defines a pattern, source of truth, confidence rule, suppression rule, and
+  proposal body fields.
+- R5. New claim kinds are reviewable repo changes.
+- R6-R8. Live public GitHub state and current files win; conflicts, unavailable state, and private
+  or unknown identity fail closed.
+- R9-R14. Drift becomes fingerprinted proposal issues with outcome state and accuracy counters.
+- R15-R19. Bounded PRs are a later phase gated by observed signal, tight diff rules, human merge,
+  and no branch-protection bypass.
+- R20-R26. All public output is privacy-gated, schema-limited, credential-separated, and free of
+  private identity or secret-bearing data.
+
+## Scope Boundaries
+
+- First implementation targets only `fro-bot/.github` public status-truth claims.
+- Supported v1 sources are public repo docs, public plan/brainstorm files, public `.github` issue
+  bodies/comments, and public GitHub issue/PR/release state needed to verify those claims.
+- Deferred sources are Project board field state, private repo references, memory stores,
+  dashboard/operator runtime state, Discord/social surfaces, and non-public workflow logs.
+- Proposal issues are in scope; broad issue/PR lifecycle management is not.
+- Phase 1 does not open correction PRs.
+- Phase 2 can open bounded correction PRs only after Phase 1 produces accepted/rejected signal.
+- No writes to `knowledge/`, `metadata/`, wiki authority surfaces, repo settings, secrets,
+  workflows, hooks, persona files, or release configuration.
+- No org-wide scanning, dependency hygiene, broad CI hardening, review-to-fix, A1 capture,
+  autonomous authoring, dashboard UI, autonomous merges, or automerge enablement.
+
+### Deferred to Separate Tasks
+
+- Claim kinds beyond status truth: separate A2 follow-up after the first loop proves useful.
+- Metadata/wiki authority repair: separate loop because it touches authority semantics.
+- Bounded PR graduation for additional claim kinds: later expansion after the first PR-capable
+  claim kind demonstrates accuracy.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/wiki-lint.ts`: pure core plus I/O shell, structured JSON report, deterministic and
+  advisory finding separation, markdown report output.
+- `scripts/wiki-lint-issues.ts`: fingerprint markers, open/update/reopen/close lifecycle, and
+  issue body helpers.
+- `scripts/capture-learnings-privacy.ts`: shared privacy primitives for private-token and secret
+  scanning.
+- `scripts/capture-learnings-open.ts`: proposal issue creation, runtime label creation, and
+  same-run dedupe discipline.
+- `scripts/merge-data-pr.ts`: PR lifecycle resilience, rediscovery, branch comparison, labeling,
+  and explicit no-automerge posture.
+- `.github/workflows/main.yaml`: shared setup action, Node 24 strip-only script-load gate, and
+  required verification shape.
+
+### Institutional Learnings
+
+- `docs/solutions/documentation-gaps/doc-drift-cleanup-pattern-2026-04-18.md`: derive live facts
+  before updating docs; split drift work into small reviewable units.
+- `docs/solutions/best-practices/github-issues-api-same-run-eventual-consistency-2026-05-20.md`:
+  carry an in-memory created-key set because GitHub issue listing can lag same-run writes.
+- `docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md`: verify every
+  public surface before claiming a value is non-leaking.
+- `docs/solutions/best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md`: enforce
+  privacy gates at the trusted chokepoint and fail closed on ambiguous identity.
+
+### External References
+
+- Renovate and Dependabot validate the broad pattern: confidence-tiered bot PRs, durable tracking,
+  human merge, and branch protection as the hard boundary.
+- GitHub Copilot coding agent validates the safety boundary: bot-created branches and PRs are
+  reviewable artifacts, not self-merged changes.
+- API/docs drift tools validate typed claim tuples over vague AI comparison.
+- Verification-first agent research validates the premise that self-improvement compounds only
+  where success is machine-checkable.
+
+## Key Technical Decisions
+
+- **Two-phase delivery:** Phase 1 ships proposal issues and accuracy signal; Phase 2 adds bounded
+  PRs only after the signal exists.
+- **Typed claim inventory:** Claim kinds are code-level definitions, not prompt-only instructions.
+  The first inventory includes PR state, issue state, release/tag state, plan status, and
+  rollout-tracker status.
+- **Source resolver typology:** Claim resolvers are not one generic shape. API resolvers (PR,
+  issue, release/tag) are network-dependent and rate-limit-aware. File-parse resolvers (plan
+  status) are deterministic and local. Compound resolvers (rollout-tracker) compose sub-resolvers
+  and inherit their failure modes. Each resolver declares its type and failure policy.
+- **Proposal issues as state:** V1 stores proposal state in GitHub issues using hidden markers,
+  labels, and comments. No metadata file is added.
+- **Source and identity gates before rendering:** Claim sources are classified as public,
+  ambiguous, or non-public before extraction proceeds. Referenced repos, issues, PRs, and authors
+  pass an identity gate before any proposal text is rendered. Ambiguous or non-public sources
+  become blocked counters, not rendered artifacts.
+- **Privacy gate before every public emit:** Proposal titles, bodies, comments, workflow summaries,
+  run display names, future PR titles/bodies/labels, future PR commit messages, and branch names
+  pass through the same public-output gate.
+- **Versioned report contract:** The detect step emits a typed report with schema and fingerprint
+  versions before the open step can write. Unknown versions, malformed reports, prohibited fields,
+  or count mismatches block the write step.
+- **Counts-only workflow telemetry:** Workflow summaries carry aggregate counters only. Evidence
+  lives in proposal issues after privacy gating.
+- **Read/write credential split:** Detect runs with read-only credentials. Proposal/PR creation
+  uses a separate app token restricted to this repository and the minimum issue/contents scopes
+  needed for the active phase. Tokens are constrained at mint time to the permitted phase scope;
+  missing, over-scoped, or non-introspectable write credentials fail closed before any write.
+- **Sanitized artifacts only:** Structured handoff artifacts contain machine-safe verdict fields and
+  counters, not raw private identity, secrets, source snippets, workflow logs, or ungated rendered
+  proposal content.
+- **Per-claim isolation:** One blocked or unresolved claim does not prevent unrelated safe claims
+  from becoming proposals. A privacy-gate module or configuration failure blocks the whole write
+  phase; a per-claim gate failure blocks only that claim.
+- **No LLM comparison in v1:** The first loop is deterministic. LLM-authored semantic comparison
+  can be considered after typed claim extraction proves signal.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should bounded PRs be part of v1?** Yes, but only as Phase 2 after Phase 1 creates accepted
+  versus rejected signal.
+- **Where does proposal state live?** GitHub issue surfaces: hidden fingerprint markers, labels,
+  and state-transition comments.
+- **Which claim kinds start the inventory?** PR state, issue state, release/tag state, plan status,
+  and rollout-tracker status.
+- **Should v1 add a metadata state file?** No; proposal issues are enough and avoid a new write
+  authority path.
+
+### Deferred to Implementation
+
+- Exact parser boundaries for natural-language status phrases may be adjusted while writing
+  claim-kind tests.
+- Exact label color/description can follow existing label conventions when runtime label creation
+  is implemented.
+- Exact accuracy threshold for Phase 2 graduation should be encoded conservatively after Phase 1
+  behavior is observable.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not
+> implementation specification. The implementing agent should treat it as context, not code to
+> reproduce.*
+
+```mermaid
+flowchart TD
+  scan[Status-truth detect]
+  source{Source publicity}
+  resolve[Typed resolver]
+  classify{Claim verdict}
+  identity{Identity gate}
+  current[Current: count only]
+  drifted[Drifted: proposal candidate]
+  unresolved[Unresolved or unsafe: count only]
+  artifact[Versioned safe report]
+  privacy{Content privacy gate}
+  proposal[Open/update proposal issue]
+  signal[Accepted/rejected signal]
+  prgate{Claim kind graduated?}
+  pr[Bounded correction PR]
+
+  scan --> source
+  source -->|public| resolve
+  source -->|ambiguous/non-public| unresolved
+  resolve --> classify
+  classify --> current
+  classify --> unresolved
+  classify --> drifted
+  drifted --> identity
+  identity -->|public| artifact
+  identity -->|private/unknown| unresolved
+  artifact --> privacy
+  privacy -->|safe| proposal
+  privacy -->|blocked| unresolved
+  proposal --> signal
+  signal --> prgate
+  prgate -->|later phase| pr
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Status-claim model and detector core**
+
+**Goal:** Define the typed claim inventory and pure detection core for public status-truth claims.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7, R8
+
+**Dependencies:** None
+
+**Files:**
+- Create: `scripts/status-truth-detect.ts`
+- Test: `scripts/status-truth-detect.test.ts`
+
+**Approach:**
+- Model each claim kind as a declarative definition with claim pattern, source resolver, confidence
+  rule, suppression rule, and proposal fields.
+- Define the status-truth report envelope before implementing any resolver: schema version,
+  fingerprint version, report status (`clean`, `findings`, or `execution-failure`), scan-complete
+  flag, failure class, repair eligibility, findings, and aggregate counts.
+- Each resolver definition declares whether it is API, file-parse, or compound. Compound resolvers
+  list their sub-resolvers so dependency ordering and cascade-failure rules are explicit.
+- Start with public PR state, issue state, release/tag state, plan status, and rollout-tracker
+  status.
+- Use this v1 source precedence:
+  - PR state: GitHub PR API state wins over narrative status text; unavailable or inaccessible PRs
+    are unresolved.
+  - Issue state: GitHub issue API state wins over narrative status text; unavailable or inaccessible
+    issues are unresolved.
+  - Release/tag state: GitHub release/tag API state wins over plan or issue status text; published
+    release does not imply deployed runtime state.
+  - Plan status: current plan frontmatter wins over prose references to the same plan; conflicting
+    frontmatter/prose is unresolved.
+  - Rollout-tracker status: use the existing rollout-tracker snapshot shape instead of re-deriving
+    tracker truth. Project access failure, snapshot failure, or referenced-state disagreement is
+    unresolved rather than drifted.
+- Process claim kinds in dependency order: file-parse resolvers first, API resolvers second,
+  compound resolvers last. Compound claims become unresolved when any required sub-resolver is
+  unavailable.
+- Keep line numbers out of fingerprints; use path, claim kind, source reference, and a one-way hash
+  of normalized claim text so unrelated line shifts do not create duplicate proposals without
+  exposing reconstructable claim text.
+- Treat the fingerprint as a public identifier. Every fingerprint input is privacy-checked as a
+  unit, and blocked inputs prevent proposal, label, branch, or PR metadata generation.
+- Classify checks as current, drifted, unresolved, or unsafe to emit.
+- Treat unavailable source state, conflicting source state, and private/unknown identity as blocked
+  rather than drifted.
+
+**Execution note:** Implement new domain behavior test-first; this is the core correctness seam.
+
+**Patterns to follow:**
+- `scripts/wiki-lint.ts` for pure report construction and deterministic finding shape.
+- `scripts/wiki-lint-issues.ts` for stable fingerprinting discipline.
+
+**Test scenarios:**
+- Happy path: a public PR-open claim whose live PR is closed becomes a drifted claim with a stable
+  fingerprint and proposed correction.
+- Happy path: a current release/tag claim is classified as current and produces no proposal.
+- Happy path: a report with known schema/fingerprint versions is accepted by the lifecycle planner.
+- Edge case: a claim line moves but the normalized text and source reference stay the same; the
+  fingerprint stays stable.
+- Edge case: a rollout-tracker claim is unresolved when its snapshot source fails or any required
+  sub-resolver is unavailable.
+- Error path: an unknown report schema or fingerprint version is rejected before any write planning.
+- Error path: GitHub state is unavailable; the claim is unresolved and not proposal-eligible.
+- Error path: the source resolves to private or unknown identity; the claim is unsafe to emit.
+- Edge case: no supported claims are present; the report contains zero findings and zero
+  proposal-eligible actions.
+- Integration: multiple claim kinds in one document produce distinct report entries and aggregate
+  counts.
+
+**Verification:**
+- The detector can produce a structured report without performing any GitHub writes.
+
+- [ ] **Unit 2: Public-output privacy gate adapter**
+
+**Goal:** Centralize the rendering safety gate for every proposal, comment, summary, and future PR
+surface.
+
+**Requirements:** R20, R21, R22, R23, R24, R25, R26
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `scripts/status-truth-public-output.ts`
+- Modify: `scripts/status-truth-detect.ts`
+- Test: `scripts/status-truth-public-output.test.ts`
+
+**Approach:**
+- Wrap the existing privacy helpers instead of forking their logic.
+- Keep source-publicity classification and identity resolution separate from content scanning.
+  Source and identity gates run before rendering; content gates run only over already-safe rendered
+  strings.
+- Load private-token and redacted canonical-id token sets in the I/O shell before the pure gate is
+  called. Load failure blocks proposal/PR output rather than treating the token set as empty.
+- Gate every rendered public artifact after rendering, not just raw claim data.
+- Expose a strict public-output schema for proposal title/body/comment, recurrence comment,
+  workflow job summary, workflow step summary, workflow run display name, future PR title/body,
+  future PR commit messages, future PR branch name, and future PR labels.
+- Reserve Phase 2 surfaces in the Phase 1 schema so future PR metadata cannot bypass the gate when
+  PR support is enabled later.
+- Keep fingerprints out of workflow summaries, run display names, and step summaries; those surfaces
+  are counts-only even when the fingerprint is opaque.
+- Return blocked counters without returning blocked claim text.
+- Reserve opaque fixed-prefix metadata generation for Phase 2 PR branch/title surfaces.
+
+**Execution note:** Add mutation-style tests for blocked content before wiring the adapter into the
+open step.
+
+**Patterns to follow:**
+- `scripts/capture-learnings-privacy.ts` for private-token and secret detection.
+- `docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md` for public-surface
+  enumeration.
+
+**Test scenarios:**
+- Happy path: a known-public claim proposal passes and returns sanitized title/body fields.
+- Happy path: source-publicity and identity gates run before proposal rendering.
+- Error path: private repo token appears in a rendered proposal body; output is blocked and only a
+  counter remains.
+- Error path: secret-like content appears in a proposed correction; output is blocked.
+- Error path: privacy token loading fails; no proposal or PR output is emitted.
+- Error path: replacing the gate with an identity passthrough fails a private-identity mutation test.
+- Edge case: a fingerprint appears in a proposal issue body but never in workflow summary output.
+- Integration: proposal title, proposal body, recurrence comment, workflow summary row, future PR
+  title/body, commit message, label, and future branch name all pass through the same gate function.
+
+**Verification:**
+- No public-render helper can bypass the shared gate.
+
+- [ ] **Unit 3: Proposal lifecycle planner**
+
+**Goal:** Convert drifted, privacy-safe status claims into GitHub issue lifecycle actions.
+
+**Requirements:** R9, R10, R11, R12, R13, R14
+
+**Dependencies:** Units 1 and 2
+
+**Files:**
+- Create: `scripts/status-truth-proposals.ts`
+- Test: `scripts/status-truth-proposals.test.ts`
+
+**Approach:**
+- Parse existing proposal issues using hidden markers, outcome labels, and state-transition
+  comments. Fetch open proposal issues plus recent closed proposal issues so terminal state survives
+  across runs.
+- Map one unique fingerprint to one proposal issue. Multiple drifted claims in the same file remain
+  separate issues so outcomes can differ per claim.
+- Plan open, update, reopen, suppress, and close-on-clear actions without touching GitHub.
+- If a matching open issue exists and drift details are unchanged, plan no action to avoid comment
+  spam. If live-state details changed, plan one update comment.
+- Treat closed issues labeled false-positive or rejected as terminal suppression unless claim text
+  or source reference materially changes.
+- Treat closed issues without terminal labels as non-terminal. If the exact drift returns, plan a
+  reopen action, recurrence comment, and removal of resolved/manually-fixed labels.
+- Plan close-on-clear only when the latest scan is complete and not an execution failure; partial
+  scans never close proposals.
+- Maintain a same-run created-key set so GitHub list-after-create lag cannot duplicate proposals.
+- Track accepted, rejected, false-positive, superseded, manually-fixed, resolved, and recurring
+  outcomes via labels and hidden markers rather than prose parsing.
+
+**Execution note:** Implement lifecycle behavior with pure tests before adding Octokit calls.
+
+**Patterns to follow:**
+- `scripts/wiki-lint-issues.ts` for issue lifecycle planning and hidden marker parsing.
+- `scripts/capture-learnings-open.ts` for same-run dedupe and runtime label creation.
+
+**Test scenarios:**
+- Happy path: a new drifted claim plans one new proposal issue.
+- Happy path: an open matching proposal with unchanged drift plans zero comments or updates.
+- Happy path: an open matching proposal whose live-state details changed plans one update comment.
+- Edge case: a recently created key is not returned by GitHub listing; a second proposal is still
+  suppressed in the same run.
+- Edge case: an open proposal missing from a complete non-failure scan plans a close action with a
+  resolved label.
+- Edge case: a closed non-terminal proposal whose drift returns plans reopen and clears resolving
+  labels.
+- Error path: a matching false-positive proposal exists; the finding is suppressed and counted.
+- Error path: malformed outcome markers are ignored and counted for operator attention.
+- Integration: resolved drift closes or comments on the matching open proposal without closing
+  unrelated proposals.
+
+**Verification:**
+- Lifecycle planning is deterministic from report plus existing issue state.
+
+- [ ] **Unit 4: Detect/open CLI shells and workflow wiring**
+
+**Goal:** Add runnable scripts and a scheduled/manual workflow that detects status-truth drift and
+opens proposal issues with separated credentials.
+
+**Requirements:** R6-R14, R20-R25
+
+**Dependencies:** Units 1-3
+
+**Files:**
+- Create: `.github/workflows/status-truth.yaml`
+- Modify: `scripts/status-truth-detect.ts`
+- Modify: `scripts/status-truth-proposals.ts`
+- Test: `scripts/status-truth-detect.test.ts`
+- Test: `scripts/status-truth-proposals.test.ts`
+
+**Approach:**
+- Keep detect read-only: checkout, setup, scan repo docs/issues, fetch live public GitHub state,
+  emit structured report and counts-only summary.
+- Detect-step auth is intentionally current-repo scoped for Phase 1. Cross-repo references are
+  classified as unavailable unless explicitly supported by a later read-only App-token design.
+- Keep open write-scoped: consume the report artifact, mint a minimally scoped app token, and
+  perform proposal issue actions only after privacy gating.
+- Mint write credentials with explicit phase-scoped permissions: Phase 1 gets issue-write plus
+  read-only content access for this repository; Phase 2 adds content-write and pull-request-write
+  only when bounded PR creation is enabled.
+- Treat missing, malformed, or unexpectedly broad write credentials as a hard failure before any
+  public output is emitted.
+- Use workflow dispatch and schedule triggers, plus workflow_call if later orchestration needs it.
+- Serialize workflow runs with `cancel-in-progress: false` so a detect-to-open sequence is never
+  interrupted halfway through proposal planning.
+- Define a dry-run mode that runs detect, planning, gating, and reporting, but never creates,
+  updates, closes, or comments on GitHub issues. The summary clearly marks dry-run status and
+  reports action counts only.
+- Use sanitized file artifacts for structured handoff rather than multiline GitHub outputs; artifacts
+  must omit claim text, source snippets, private identity, secret-like content, and raw rendered
+  proposal bodies.
+- Validate the artifact before any write planning: expected schema version, fingerprint version,
+  required fields, prohibited-field absence, and aggregate count consistency.
+- Keep console output counts-only. Script stdout/stderr must not include raw claim text, source
+  paths, rendered bodies, fingerprints, or credential values; runtime errors use claim kind and
+  opaque counters only.
+- Add runtime label creation for `status-truth` and outcome labels only if they are missing.
+- Fail closed if required labels cannot be confirmed; unlabeled proposals would evade future
+  seen-set queries and repeat forever.
+- Exclude existing `status-truth` proposal issues from claim extraction so the loop does not scan
+  and propose corrections to its own proposal state.
+
+**Patterns to follow:**
+- `.github/actions/setup/action.yaml` for bootstrap.
+- `scripts/wiki-lint-issues.ts` and `scripts/capture-learnings-open.ts` for Octokit shell style.
+- `.github/workflows/wiki-lint.yaml` and `.github/workflows/capture-learnings.yaml` patterns where
+  applicable.
+
+**Test scenarios:**
+- Integration: detect output feeds open planning without reading claim text from workflow summary.
+- Integration: detect output artifact contains safe machine fields and counters but no raw claim text
+  or source snippets.
+- Integration: dry-run emits planned action counts and performs no issue mutations.
+- Error path: app token creation or write API failure leaves report artifacts intact and does not
+  mutate partial state beyond completed issue actions.
+- Error path: artifact schema mismatch, prohibited fields, or count mismatch blocks the open step.
+- Error path: required label creation/confirmation fails; no proposal opens.
+- Error path: stdout/stderr from script failure does not contain test claim text, source paths, or
+  fingerprint-like values.
+- Error path: privacy gate blocks one proposal but does not block unrelated safe proposals.
+- Edge case: workflow runs with no findings and emits zero counts without opening issues.
+
+**Verification:**
+- The workflow can run in dry or mocked mode during tests without public writes.
+- Script-load CI can import every new production script under Node 24 strip-only execution.
+
+- [ ] **Unit 5: Accuracy signal and operator-facing proposal UX**
+
+**Goal:** Make accepted/rejected outcomes visible enough for Fro Bot to improve claim-kind quality.
+
+**Requirements:** R10, R12, R13, R14, R24
+
+**Dependencies:** Units 3 and 4
+
+**Files:**
+- Modify: `scripts/status-truth-proposals.ts`
+- Test: `scripts/status-truth-proposals.test.ts`
+- Modify: `README.md`
+
+**Approach:**
+- Define outcome labels and comment markers for accepted, rejected, false-positive, superseded,
+  manually-fixed, and recurring findings.
+- Distinguish terminal labels from non-terminal labels: rejected and false-positive suppress future
+  matching findings; accepted, manually-fixed, resolved, and recurring preserve history but allow
+  re-open or auto-close transitions.
+- Summarize aggregate counts by claim kind in workflow summary without emitting paths or
+  fingerprints.
+- Calculate per-kind usefulness from accepted versus rejected/false-positive outcomes, excluding
+  malformed or unknown labels from automated accuracy math while still counting them for operator
+  attention.
+- Document how Marcus marks a proposal as false-positive, accepted, or superseded.
+- Ensure proposal bodies are concise, evidence-backed, and free of internal session narration.
+
+**Patterns to follow:**
+- `scripts/wiki-lint-issues.ts` recurrence comments.
+- `scripts/capture-learnings-open.ts` proposal labels and issue bodies.
+
+**Test scenarios:**
+- Happy path: accepted and rejected proposal labels produce per-kind accuracy counters.
+- Happy path: manually-fixed proposals auto-close with a resolved label when drift clears.
+- Edge case: a closed proposal without an outcome marker is treated conservatively and not
+  silently re-opened as a brand-new finding.
+- Error path: malformed outcome markers are ignored and counted for operator attention.
+- Integration: proposal body has enough evidence for review while workflow summary remains
+  counts-only.
+
+**Verification:**
+- A reviewer can classify proposal usefulness without reading workflow logs.
+
+- [ ] **Unit 6: Bounded PR graduation gate**
+
+**Goal:** Add the second-phase pathway for reliable claim kinds to open tightly scoped correction
+PRs after proposal signal exists.
+
+**Requirements:** R15, R16, R17, R18, R19, R20, R21, R22, R23, R25, R26
+
+**Dependencies:** Units 1-5
+
+**Files:**
+- Create: `scripts/status-truth-prs.ts`
+- Test: `scripts/status-truth-prs.test.ts`
+- Modify: `.github/workflows/status-truth.yaml`
+
+**Approach:**
+- Gate PR eligibility on claim-kind graduation, privacy-safe output, approved docs path, literal or
+  tightly bounded substitution, and one PR per run.
+- Run path authorization before computing any correction diff. Disallowed paths downgrade to
+  proposal-only without extracting correction text, rendering PR metadata, or creating a branch.
+- Use a reviewed path allowlist defined by claim kind. Path traversal segments or prompt-provided
+  path overrides are automatic blocks.
+- Use opaque branch names and fixed-prefix titles generated from fingerprints, never source text.
+- Refuse force-push, retargeting, automerge, or approval actions.
+- Abort PR creation on any ambiguity in branch naming, title generation, diff eligibility, path
+  validation, base branch, existing branch ownership, or privacy-gate result; leave only proposal
+  state behind.
+- Never mutate an existing branch or PR unless its opaque fingerprint, bot ownership, target branch,
+  and planned diff all match the current finding.
+- Link PRs back to proposal issues and let branch protection plus human review remain the merge
+  boundary.
+- Downgrade all non-eligible or overflow candidates to proposal-only output.
+
+**Execution note:** Treat this unit as dependent on observable Phase 1 signal; if implemented in
+the same PR, keep the feature disabled until graduation criteria are met.
+
+**Patterns to follow:**
+- `scripts/merge-data-pr.ts` for PR rediscovery and retry boundaries.
+- GitHub Copilot coding agent and Renovate safety patterns: bot branch, human review, no self-merge.
+
+**Test scenarios:**
+- Happy path: a graduated claim kind produces one correction PR with opaque branch/title metadata.
+- Edge case: two PR-eligible findings appear in one run; one PR is opened and the rest become
+  proposals.
+- Error path: proposed diff touches a forbidden path; no PR opens and a proposal is created.
+- Error path: branch or title candidate fails the privacy gate; no PR opens.
+- Error path: existing branch metadata does not match the current fingerprint; no branch is mutated
+  and the finding remains proposal-only.
+- Integration: existing open status-truth PR is rediscovered instead of creating a duplicate.
+
+**Verification:**
+- No code path can merge, approve, enable automerge, force-push, or target non-main branches.
+
+## System-Wide Impact
+
+- **Interaction graph:** The loop reads public repo files and public GitHub issue/PR/release state,
+  emits reports, then writes proposal issues and future PRs through separated workflow steps.
+- **Error propagation:** Detection uncertainty blocks public output. Write-step failures report
+  counts and leave already-completed issue actions auditable.
+- **Privacy-gate failure semantics:** Per-claim gate errors block that claim and increment a
+  gate-error counter. Module-load or configuration failures block the entire write phase before any
+  proposal is emitted.
+- **State lifecycle risks:** Proposal state lives in GitHub issue surfaces, so dedupe must account
+  for same-run eventual consistency and closed terminal states.
+- **Artifact boundary:** Handoff artifacts are internal workflow plumbing and still use the public
+  output safety model. The detect-to-open artifact is a declared schema with safe fields only;
+  raw claim text, source snippets, API response bodies, node IDs, database IDs, and credential data
+  are prohibited rather than merely hidden by artifact retention.
+- **API surface parity:** Future agent workflows can invoke the same status-truth workflow rather
+  than embedding status reconciliation in prompts.
+- **Integration coverage:** Tests must cover detect-to-proposal handoff, privacy gating, proposal
+  lifecycle state, and future PR gating.
+- **Unchanged invariants:** `data` branch writes, wiki authority, metadata writes, branch
+  protection, and human merge controls are unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Proposal spam from noisy claim kinds | Start with typed status claims, cap outputs, track accepted/rejected and false-positive outcomes by claim kind. |
+| Proposal overload from unexpected drift volume | Cap new proposals per run and per rolling window; excess findings stay counted-only until the operator raises the cap. |
+| Noisy claim kind erodes trust before measurement | Auto-suspend claim kinds whose accepted rate falls below the configured threshold until operator action re-enables them. |
+| Private identity leak through public proposals | Gate rendered output, fail closed on unknown identity, and keep workflow summaries counts-only. |
+| Private identity leak through artifacts or logs | Sanitize artifacts, avoid raw claim/source snippets, and keep logs limited to aggregate counters and error codes. |
+| Over-scoped write token | Split read/write credentials, restrict write credentials to this repo and active-phase scopes, and fail before output if scope is wrong or unavailable. |
+| Duplicate proposals from GitHub eventual consistency | Carry same-run created fingerprints and parse existing open/closed proposal issues. |
+| Circular detection from the loop's own proposals | Exclude issues labeled `status-truth` from claim extraction. |
+| GitHub API incident or rate limiting | Classify affected claims as unresolved, emit counts-only health signal, and write no proposal based on incomplete state. |
+| PR autonomy before signal exists | Ship Phase 1 first; gate Phase 2 on claim-kind accuracy and keep human merge required. |
+| Authority surface mutation | Forbid writes to metadata, wiki authority, workflows, settings, hooks, secrets, persona files, and release config. |
+
+## Rollout Sequence
+
+| Gate | Check | Duration |
+|------|-------|----------|
+| 1. Manual dry-run | Run detect and proposal planning with no issue writes; review planned actions before enabling writes. | 1-2 runs |
+| 2. Single claim kind | Enable one low-risk claim kind manually and review proposal quality before adding the next kind. | 3-7 days per kind |
+| 3. Full claim inventory | Enable all v1 claim kinds, still manually triggered. | Until every kind has at least one observed cycle |
+| 4. Scheduled low cadence | Enable the schedule at low frequency with proposal caps and pause controls active. | 1-2 weeks |
+| 5. Desired cadence | Increase only if proposal volume and false-positive rate stay reviewable. | Ongoing |
+
+Hard gates between steps:
+
+- Step 2 requires zero blocker-class false positives for the chosen kind.
+- Step 3 requires each enabled kind to have acceptable per-kind signal, not just good aggregate
+  accuracy.
+- Step 4 requires proposal volume to stay reviewable within normal operator flow.
+- Any unexpected failure mode reverts to the prior gate until the claim kind or lifecycle state
+  machine is fixed.
+
+## Documentation / Operational Notes
+
+- Update `README.md` once the workflow exists, using live workflow names only.
+- Phase 1 status-truth is advisory and must not be added as a required `main` check. If a future
+  iteration promotes it to a required check, the exact check name must be byte-identical across the
+  workflow, `.github/settings.yml`, and operator docs, with YAML quoting when needed.
+- Add a short operator note explaining proposal outcome labels and false-positive handling.
+- Document the pause controls: repository-level pause, per-claim-kind suspension, and workflow
+  disable as the hard stop.
+- Document first-30-day health signals: proposals per run, accepted/rejected/false-positive rate by
+  kind, workflow failure rate, proposal review latency, and repeated proposal recurrence.
+- Record a `docs/solutions/` learning after implementation if the proposal state machine or PR
+  graduation gate reveals a reusable pattern.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-06-26-a2-self-maintenance-portfolio-requirements.md](../brainstorms/2026-06-26-a2-self-maintenance-portfolio-requirements.md)
+- Related scripts: `scripts/wiki-lint.ts`, `scripts/wiki-lint-issues.ts`,
+  `scripts/capture-learnings-privacy.ts`, `scripts/capture-learnings-open.ts`,
+  `scripts/merge-data-pr.ts`, `scripts/rollout-tracker-snapshot.ts`
+- Related workflows: `.github/workflows/main.yaml`, `.github/actions/setup/action.yaml`,
+  `.github/workflows/wiki-lint.yaml`, `.github/workflows/capture-learnings.yaml`
+- Related learnings: `docs/solutions/documentation-gaps/doc-drift-cleanup-pattern-2026-04-18.md`,
+  `docs/solutions/best-practices/github-issues-api-same-run-eventual-consistency-2026-05-20.md`,
+  `docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md`,
+  `docs/solutions/best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md`,
+  `docs/solutions/best-practices/pure-core-privacy-gates-shared-module-2026-06-22.md`,
+  `docs/solutions/best-practices/credential-mint-time-permission-scoping-2026-06-22.md`,
+  `docs/solutions/workflow-issues/quoted-required-status-check-context-2026-06-09.md`

--- a/docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md
+++ b/docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md
@@ -335,7 +335,7 @@ open step.
 **Verification:**
 - No public-render helper can bypass the shared gate.
 
-- [ ] **Unit 3: Proposal lifecycle planner**
+- [x] **Unit 3: Proposal lifecycle planner**
 
 **Goal:** Convert drifted, privacy-safe status claims into GitHub issue lifecycle actions.
 

--- a/docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md
+++ b/docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md
@@ -280,7 +280,7 @@ flowchart TD
 **Verification:**
 - The detector can produce a structured report without performing any GitHub writes.
 
-- [ ] **Unit 2: Public-output privacy gate adapter**
+- [x] **Unit 2: Public-output privacy gate adapter**
 
 **Goal:** Centralize the rendering safety gate for every proposal, comment, summary, and future PR
 surface.

--- a/scripts/status-truth-detect.test.ts
+++ b/scripts/status-truth-detect.test.ts
@@ -1154,6 +1154,23 @@ describe('scanStatusTruthClaims', () => {
     expect(report.scan_complete).toBe(false)
     expect(report.failure_class).toBe('execution-error')
   })
+
+  it('excludes docs/brainstorms/ paths so example prose like "PR #907 is open" produces zero claims', async () => {
+    // Brainstorm documents may contain illustrative status-truth patterns as examples.
+    // These must not self-trigger proposals. The path is excluded before file reading.
+    const brainstormPath = 'docs/brainstorms/2026-06-26-a2-self-maintenance-portfolio-requirements.md'
+    const fileLister: FileLister = async () => [brainstormPath, 'README.md']
+    const fileReader: FileReader = async (path: string) => {
+      if (path === brainstormPath) return 'Acceptance example: PR #907 is open and issue #908 is closed.'
+      if (path === 'README.md') return 'No claims here.'
+      return ''
+    }
+
+    const {claims, scanErrors} = await scanStatusTruthClaims({fileLister, fileReader})
+    // The brainstorm file must be excluded entirely — zero claims from it
+    expect(claims.filter(c => c.path === brainstormPath)).toHaveLength(0)
+    expect(scanErrors).toBe(0)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/scripts/status-truth-detect.test.ts
+++ b/scripts/status-truth-detect.test.ts
@@ -1,6 +1,9 @@
 import type {
   ClaimKind,
   ClaimVerdict,
+  DetectOctokitClient,
+  FileLister,
+  FileReader,
   PublicStatusTruthFinding,
   ResolverResult,
   ResolverType,
@@ -16,10 +19,16 @@ import {
   CLAIM_KIND_DEFINITIONS,
   computeClaimFingerprint,
   detectStatusTruthClaims,
+  extractStatusTruthClaimsFromText,
   isKnownReportVersion,
   KNOWN_FINGERPRINT_VERSION,
   KNOWN_SCHEMA_VERSION,
   normalizeClaimText,
+  resolveAllClaims,
+  resolveClaimLiveState,
+  scanStatusTruthClaims,
+  selectFailureClass,
+  validateStatusTruthArtifact,
 } from './status-truth-detect.ts'
 
 function makeClaim(overrides: Partial<StatusTruthClaim> = {}): StatusTruthClaim {
@@ -702,5 +711,769 @@ describe('type contracts', () => {
   it('ClaimKind union covers all five expected values', () => {
     const kinds: ClaimKind[] = ['pr-state', 'issue-state', 'release-tag-state', 'plan-status', 'rollout-tracker-status']
     expect(kinds).toHaveLength(5)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Unit 4: validateStatusTruthArtifact tests
+// ---------------------------------------------------------------------------
+
+describe('validateStatusTruthArtifact', () => {
+  it('accepts a valid clean report', () => {
+    const report = makeReport()
+    const result = validateStatusTruthArtifact(report)
+    expect(result.valid).toBe(true)
+    if (result.valid) {
+      expect(result.report.schema_version).toBe(KNOWN_SCHEMA_VERSION)
+    }
+  })
+
+  it('accepts a valid findings report with correct count', () => {
+    const finding = makeFinding()
+    const report = makeReport({
+      status: 'findings',
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const result = validateStatusTruthArtifact(report)
+    expect(result.valid).toBe(true)
+  })
+
+  it('rejects non-object input', () => {
+    expect(validateStatusTruthArtifact(null).valid).toBe(false)
+    expect(validateStatusTruthArtifact('string').valid).toBe(false)
+    expect(validateStatusTruthArtifact(42).valid).toBe(false)
+    expect(validateStatusTruthArtifact([]).valid).toBe(false)
+  })
+
+  it('rejects unknown schema version', () => {
+    const result = validateStatusTruthArtifact({...makeReport(), schema_version: 99})
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.reason).toContain('unknown artifact version')
+    }
+  })
+
+  it('rejects unknown fingerprint version', () => {
+    const result = validateStatusTruthArtifact({...makeReport(), fingerprint_version: 99})
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.reason).toContain('unknown artifact version')
+    }
+  })
+
+  it('rejects artifact missing required field', () => {
+    const reportWithoutStatus = (({status: _s, ...rest}) => rest)(makeReport())
+    const result = validateStatusTruthArtifact(reportWithoutStatus)
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.reason).toContain('missing required field')
+    }
+  })
+
+  it('rejects artifact with prohibited field normalizedText', () => {
+    const report = {...makeReport(), normalizedText: 'raw claim text'}
+    const result = validateStatusTruthArtifact(report)
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.reason).toContain('prohibited field')
+    }
+  })
+
+  it('rejects artifact with prohibited field in finding', () => {
+    const finding = {...makeFinding(), normalizedText: 'raw claim text'}
+    const report = makeReport({
+      status: 'findings',
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const result = validateStatusTruthArtifact(report)
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.reason).toContain('prohibited field')
+    }
+  })
+
+  it('rejects artifact with count mismatch (counts.total !== findings.length)', () => {
+    const finding = makeFinding()
+    const report = makeReport({
+      status: 'findings',
+      findings: [finding],
+      // Intentionally wrong count
+      counts: {total: 99, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const result = validateStatusTruthArtifact(report)
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.reason).toContain('count mismatch')
+    }
+  })
+
+  it('rejects artifact with findings as non-array', () => {
+    const report = {...makeReport(), findings: 'not-an-array'}
+    const result = validateStatusTruthArtifact(report)
+    expect(result.valid).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Unit 4: Artifact safety contract tests
+// ---------------------------------------------------------------------------
+
+describe('Unit 4: artifact safety contract', () => {
+  it('detect output artifact contains safe machine fields and counters but no raw claim text or source snippets', () => {
+    // The report envelope must not expose raw claim text or source snippets.
+    // Findings carry typed fields (kind, path, sourceRef, verdict, fingerprint,
+    // claimedState, liveState) but NOT raw document text or API response bodies.
+    const claim = makeClaim({
+      kind: 'pr-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'fro-bot/.github#42',
+      claimedState: 'open',
+      normalizedText: 'pr #42 is open',
+    })
+
+    const resolverResults = makeResolverResults([
+      {kind: 'pr-state', sourceRef: 'fro-bot/.github#42', result: {status: 'resolved', state: 'closed'}},
+    ])
+
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+    const report = buildStatusTruthReport({
+      findings,
+      scanComplete: true,
+      generatedAt: '2026-06-28T00:00:00Z',
+      failureClass: null,
+    })
+
+    // Serialize to JSON (as the artifact would be written)
+    const artifactJson = JSON.stringify(report)
+
+    // The artifact must contain machine-safe fields
+    expect(artifactJson).toContain('"schema_version"')
+    expect(artifactJson).toContain('"fingerprint_version"')
+    expect(artifactJson).toContain('"status"')
+    expect(artifactJson).toContain('"counts"')
+
+    // The artifact must NOT contain raw claim text (normalizedText is not in the report)
+    // normalizedText is an input to fingerprint computation but is not stored in the report
+    expect(artifactJson).not.toContain('"normalizedText"')
+
+    // The report findings contain typed fields, not raw document snippets
+    const finding = report.findings[0]
+    expect(finding).toBeDefined()
+    if (finding !== undefined && finding.verdict !== 'unsafe') {
+      // These are typed machine fields, not raw text
+      expect(typeof finding.kind).toBe('string')
+      expect(typeof finding.path).toBe('string')
+      expect(typeof finding.sourceRef).toBe('string')
+      expect(typeof finding.fingerprint).toBe('string')
+    }
+  })
+
+  it('detect output feeds open planning without requiring workflow summary raw claim text', () => {
+    // The report is the sole handoff artifact; the open step reads it directly.
+    // Counts-only summary is derived from report.counts, not from raw claim text.
+    const finding = makeFinding({
+      kind: 'pr-state',
+      verdict: 'drifted',
+      proposalEligible: true,
+    })
+    const report = buildStatusTruthReport({
+      findings: [finding],
+      scanComplete: true,
+      generatedAt: '2026-06-28T00:00:00Z',
+      failureClass: null,
+    })
+
+    // The open step only needs counts from the report, not raw claim text
+    const summary = {
+      total: report.counts.total,
+      drifted: report.counts.drifted,
+      proposal_eligible: report.counts.proposal_eligible,
+    }
+
+    expect(summary.total).toBe(1)
+    expect(summary.drifted).toBe(1)
+    expect(summary.proposal_eligible).toBe(1)
+
+    // Verify the report can be serialized and deserialized without losing machine fields
+    const roundTripped = JSON.parse(JSON.stringify(report)) as StatusTruthJsonReport
+    expect(isKnownReportVersion(roundTripped)).toBe(true)
+    expect(roundTripped.counts.proposal_eligible).toBe(1)
+  })
+
+  it('no findings emits zero counts and opens nothing', () => {
+    const report = buildStatusTruthReport({
+      findings: [],
+      scanComplete: true,
+      generatedAt: '2026-06-28T00:00:00Z',
+      failureClass: null,
+    })
+
+    expect(report.status).toBe('clean')
+    expect(report.counts.total).toBe(0)
+    expect(report.counts.drifted).toBe(0)
+    expect(report.counts.proposal_eligible).toBe(0)
+    expect(report.repair_eligible).toBe(false)
+  })
+
+  it('validateArtifact rejects report with unknown schema version', () => {
+    const report = makeReport({schema_version: 99})
+    expect(isKnownReportVersion(report)).toBe(false)
+  })
+
+  it('validateArtifact rejects report with unknown fingerprint version', () => {
+    const report = makeReport({fingerprint_version: 99})
+    expect(isKnownReportVersion(report)).toBe(false)
+  })
+
+  it('stdout/stderr from script failure does not contain raw normalizedText or fingerprint-like values in the report envelope', () => {
+    // This is a structural test: the report envelope does not store normalizedText
+    // (the raw claim text used for fingerprinting). Only the fingerprint hash is stored.
+    // The normalizedText is an input to computeClaimFingerprint but is NOT persisted
+    // in the report — it is intentionally excluded from the artifact.
+    const uniqueNormalizedText = 'pr #42 is open'
+    const claim = makeClaim({
+      kind: 'pr-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'fro-bot/.github#42',
+      claimedState: 'open',
+      normalizedText: uniqueNormalizedText,
+    })
+
+    const resolverResults = makeResolverResults([
+      {kind: 'pr-state', sourceRef: 'fro-bot/.github#42', result: {status: 'resolved', state: 'closed'}},
+    ])
+
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+    const report = buildStatusTruthReport({
+      findings,
+      scanComplete: true,
+      generatedAt: '2026-06-28T00:00:00Z',
+      failureClass: null,
+    })
+
+    // The report must NOT contain a 'normalizedText' field (raw claim text is not stored)
+    const artifactJson = JSON.stringify(report)
+    expect(artifactJson).not.toContain('"normalizedText"')
+
+    // The fingerprint is a hex hash, not the raw text
+    const finding = report.findings[0]
+    if (finding !== undefined && finding.verdict !== 'unsafe') {
+      expect(finding.fingerprint).toMatch(/^[a-f0-9]{16}$/)
+      // The fingerprint is an opaque hash — it does not contain the raw text
+      expect(finding.fingerprint).not.toBe(uniqueNormalizedText)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Unit 4 corrections: extractStatusTruthClaimsFromText tests
+// ---------------------------------------------------------------------------
+
+describe('extractStatusTruthClaimsFromText', () => {
+  it('extracts a pr-state claim from text containing "PR #42 is open"', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'See PR #42 is open for details.',
+    })
+    expect(claims).toHaveLength(1)
+    const claim = claims[0]
+    expect(claim?.kind).toBe('pr-state')
+    expect(claim?.sourceRef).toBe('#42')
+    expect(claim?.claimedState).toBe('open')
+    expect(claim?.path).toBe('README.md')
+    expect(claim?.normalizedText).toBe('pr #42 is open')
+  })
+
+  it('extracts an issue-state claim from text containing "issue #100 is closed"', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/foo.md',
+      text: 'Tracked in issue #100 is closed.',
+    })
+    expect(claims).toHaveLength(1)
+    const claim = claims[0]
+    expect(claim?.kind).toBe('issue-state')
+    expect(claim?.sourceRef).toBe('#100')
+    expect(claim?.claimedState).toBe('closed')
+  })
+
+  it('extracts a release-tag-state claim from text containing "release v1.2.3 is published"', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'SECURITY.md',
+      text: 'The release v1.2.3 is published.',
+    })
+    expect(claims).toHaveLength(1)
+    const claim = claims[0]
+    expect(claim?.kind).toBe('release-tag-state')
+    expect(claim?.sourceRef).toBe('@v1.2.3')
+    expect(claim?.claimedState).toBe('published')
+  })
+
+  it('extracts a plan-status claim from frontmatter "status: active"', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/my-plan.md',
+      text: '---\nstatus: active\ntitle: My Plan\n---\n\nContent.',
+    })
+    expect(claims).toHaveLength(1)
+    const claim = claims[0]
+    expect(claim?.kind).toBe('plan-status')
+    expect(claim?.sourceRef).toBe('docs/plans/my-plan.md#status')
+    expect(claim?.claimedState).toBe('active')
+  })
+
+  it('extracts multiple claims from a single document', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/multi.md',
+      text: 'PR #1 is open and issue #2 is closed.',
+    })
+    expect(claims).toHaveLength(2)
+    const kinds = claims.map(c => c.kind)
+    expect(kinds).toContain('pr-state')
+    expect(kinds).toContain('issue-state')
+  })
+
+  it('returns empty array for text with no matching claims', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'No status claims here.',
+    })
+    expect(claims).toHaveLength(0)
+  })
+
+  it('normalizes claim text (lowercases, trims whitespace)', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'PR #42 is OPEN',
+    })
+    expect(claims[0]?.normalizedText).toBe('pr #42 is open')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Unit 4 corrections: scanStatusTruthClaims tests
+// ---------------------------------------------------------------------------
+
+describe('scanStatusTruthClaims', () => {
+  it('scans files returned by fileLister and extracts claims', async () => {
+    const fileLister: FileLister = async () => ['README.md', 'docs/plans/foo.md']
+    const fileReader: FileReader = async (path: string) => {
+      if (path === 'README.md') return 'PR #42 is open'
+      if (path === 'docs/plans/foo.md') return 'issue #10 is closed'
+      return ''
+    }
+
+    const {claims, scanErrors} = await scanStatusTruthClaims({fileLister, fileReader})
+    expect(claims).toHaveLength(2)
+    expect(scanErrors).toBe(0)
+    const kinds = claims.map(c => c.kind)
+    expect(kinds).toContain('pr-state')
+    expect(kinds).toContain('issue-state')
+  })
+
+  it('counts per-file read errors without aborting the scan', async () => {
+    const fileLister: FileLister = async () => ['README.md', 'docs/plans/broken.md']
+    const fileReader: FileReader = async (path: string) => {
+      if (path === 'README.md') return 'PR #42 is open'
+      throw new Error('read error')
+    }
+
+    const {claims, scanErrors} = await scanStatusTruthClaims({fileLister, fileReader})
+    expect(claims).toHaveLength(1)
+    expect(scanErrors).toBe(1)
+  })
+
+  it('returns empty claims and zero errors when no files are listed', async () => {
+    const fileLister: FileLister = async () => []
+    const fileReader: FileReader = async () => ''
+
+    const {claims, scanErrors} = await scanStatusTruthClaims({fileLister, fileReader})
+    expect(claims).toHaveLength(0)
+    expect(scanErrors).toBe(0)
+  })
+
+  it('throws when fileLister itself fails (caller emits execution-failure)', async () => {
+    const fileLister: FileLister = async () => {
+      throw new Error('glob failure')
+    }
+    const fileReader: FileReader = async () => ''
+
+    await expect(scanStatusTruthClaims({fileLister, fileReader})).rejects.toThrow('glob failure')
+  })
+
+  it('scan failure produces execution-failure report when wrapped in runDetect logic', async () => {
+    // Simulate the runDetect catch path: fileLister throws
+    const generatedAt = '2026-06-28T00:00:00Z'
+    let report
+    try {
+      const fileLister: FileLister = async () => {
+        throw new Error('unexpected failure')
+      }
+      await scanStatusTruthClaims({fileLister, fileReader: async () => ''})
+      report = buildStatusTruthReport({findings: [], scanComplete: true, generatedAt, failureClass: null})
+    } catch {
+      report = buildStatusTruthReport({findings: [], scanComplete: false, generatedAt, failureClass: 'execution-error'})
+    }
+    expect(report.status).toBe('execution-failure')
+    expect(report.scan_complete).toBe(false)
+    expect(report.failure_class).toBe('execution-error')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Unit 4 corrections: resolveClaimLiveState tests
+// ---------------------------------------------------------------------------
+
+function makeMockDetectOctokit(
+  overrides: {
+    prState?: string
+    prMerged?: boolean
+    issueState?: string
+    releaseDraft?: boolean
+    prThrows?: boolean
+    issueThrows?: boolean
+    releaseThrows?: boolean
+  } = {},
+): DetectOctokitClient {
+  return {
+    rest: {
+      pulls: {
+        get: async () => {
+          if (overrides.prThrows === true) throw new Error('API error')
+          return {data: {state: overrides.prState ?? 'open', merged: overrides.prMerged ?? false}}
+        },
+      },
+      issues: {
+        get: async () => {
+          if (overrides.issueThrows === true) throw new Error('API error')
+          return {data: {state: overrides.issueState ?? 'open'}}
+        },
+      },
+      repos: {
+        getReleaseByTag: async () => {
+          if (overrides.releaseThrows === true) throw new Error('API error')
+          return {data: {draft: overrides.releaseDraft ?? false, prerelease: false}}
+        },
+      },
+    },
+  }
+}
+
+function makeTestClaim(overrides: Partial<StatusTruthClaim> = {}): StatusTruthClaim {
+  return {
+    kind: 'pr-state',
+    path: 'README.md',
+    sourceRef: '#42',
+    claimedState: 'open',
+    normalizedText: 'pr #42 is open',
+    ...overrides,
+  }
+}
+
+describe('resolveClaimLiveState', () => {
+  it('resolves pr-state claim with bare #N sourceRef to live PR state', async () => {
+    const octokit = makeMockDetectOctokit({prState: 'closed'})
+    const claim = makeTestClaim({kind: 'pr-state', sourceRef: '#42', claimedState: 'open'})
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') expect(result.state).toBe('closed')
+  })
+
+  it('resolves merged PR to state "merged"', async () => {
+    const octokit = makeMockDetectOctokit({prState: 'closed', prMerged: true})
+    const claim = makeTestClaim({kind: 'pr-state', sourceRef: '#42', claimedState: 'open'})
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') expect(result.state).toBe('merged')
+  })
+
+  it('returns unavailable for cross-repo pr-state sourceRef (not bare #N)', async () => {
+    const octokit = makeMockDetectOctokit()
+    const claim = makeTestClaim({kind: 'pr-state', sourceRef: 'other-org/other-repo#42'})
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('unavailable')
+  })
+
+  it('returns unavailable when PR API throws', async () => {
+    const octokit = makeMockDetectOctokit({prThrows: true})
+    const claim = makeTestClaim({kind: 'pr-state', sourceRef: '#42'})
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('unavailable')
+  })
+
+  it('resolves issue-state claim with bare #N sourceRef', async () => {
+    const octokit = makeMockDetectOctokit({issueState: 'closed'})
+    const claim = makeTestClaim({kind: 'issue-state', sourceRef: '#10', claimedState: 'open'})
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') expect(result.state).toBe('closed')
+  })
+
+  it('returns unavailable for cross-repo issue-state sourceRef', async () => {
+    const octokit = makeMockDetectOctokit()
+    const claim = makeTestClaim({kind: 'issue-state', sourceRef: 'other-org/other-repo#10'})
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('unavailable')
+  })
+
+  it('resolves release-tag-state claim with @tag sourceRef', async () => {
+    const octokit = makeMockDetectOctokit({releaseDraft: false})
+    const claim = makeTestClaim({kind: 'release-tag-state', sourceRef: '@v1.0.0', claimedState: 'published'})
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') expect(result.state).toBe('published')
+  })
+
+  it('resolves draft release to state "draft"', async () => {
+    const octokit = makeMockDetectOctokit({releaseDraft: true})
+    const claim = makeTestClaim({kind: 'release-tag-state', sourceRef: '@v1.0.0', claimedState: 'published'})
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') expect(result.state).toBe('draft')
+  })
+
+  it('returns unavailable when release API throws', async () => {
+    const octokit = makeMockDetectOctokit({releaseThrows: true})
+    const claim = makeTestClaim({kind: 'release-tag-state', sourceRef: '@v1.0.0'})
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('unavailable')
+  })
+
+  it('plan-status resolves to current (file-parse: claimedState is live state)', async () => {
+    const octokit = makeMockDetectOctokit()
+    const claim = makeTestClaim({kind: 'plan-status', sourceRef: 'docs/plans/foo.md#status', claimedState: 'active'})
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') expect(result.state).toBe('active')
+  })
+
+  it('rollout-tracker-status returns unavailable (Phase 1 scope cut)', async () => {
+    const octokit = makeMockDetectOctokit()
+    const claim = makeTestClaim({kind: 'rollout-tracker-status', sourceRef: '#3512', claimedState: 'active'})
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('unavailable')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Unit 4 corrections: end-to-end extract → resolve → detect pipeline tests
+// ---------------------------------------------------------------------------
+
+describe('Unit 4: extract → resolve → detect pipeline', () => {
+  it('text fixture "PR #42 is open" extracts pr-state claim; when resolver says closed, report contains one drifted finding', async () => {
+    // Extract
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'PR #42 is open',
+    })
+    expect(claims).toHaveLength(1)
+
+    // Resolve with injected resolver that says PR is closed
+    const octokit = makeMockDetectOctokit({prState: 'closed'})
+    const {resolverResults} = await resolveAllClaims({
+      claims,
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+    })
+
+    // Detect
+    const findings = detectStatusTruthClaims(claims, resolverResults)
+    const report = buildStatusTruthReport({
+      findings,
+      scanComplete: true,
+      generatedAt: '2026-06-28T00:00:00Z',
+      failureClass: null,
+    })
+
+    expect(report.counts.drifted).toBe(1)
+    expect(report.counts.total).toBe(1)
+    expect(report.status).toBe('findings')
+    const finding = report.findings[0]
+    expect(finding?.verdict).toBe('drifted')
+    if (finding?.verdict === 'drifted') {
+      expect(finding.claimedState).toBe('open')
+      expect(finding.liveState).toBe('closed')
+      expect(finding.proposalEligible).toBe(true)
+    }
+  })
+
+  it('cross-repo sourceRef is unavailable and does not become drifted or fake clean', async () => {
+    // A claim with a cross-repo sourceRef (not bare #N)
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'PR #42 is open',
+    })
+    // Manually override sourceRef to simulate cross-repo
+    const crossRepoClaims = claims.map(c => ({...c, sourceRef: 'other-org/other-repo#42'}))
+
+    const octokit = makeMockDetectOctokit()
+    const {resolverResults} = await resolveAllClaims({
+      claims: crossRepoClaims,
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+    })
+
+    const findings = detectStatusTruthClaims(crossRepoClaims, resolverResults)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.verdict).toBe('unresolved')
+    expect(findings[0]?.proposalEligible).toBe(false)
+  })
+
+  it('detect with no claims emits clean zero counts', () => {
+    const findings = detectStatusTruthClaims([], {})
+    const report = buildStatusTruthReport({
+      findings,
+      scanComplete: true,
+      generatedAt: '2026-06-28T00:00:00Z',
+      failureClass: null,
+    })
+    expect(report.status).toBe('clean')
+    expect(report.counts.total).toBe(0)
+    expect(report.counts.drifted).toBe(0)
+    expect(report.counts.proposal_eligible).toBe(0)
+  })
+
+  it('error output remains sanitized: report JSON does not contain raw claim text or source path', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/secret-plan.md',
+      text: 'PR #42 is open',
+    })
+    const findings = detectStatusTruthClaims(claims, {})
+    const report = buildStatusTruthReport({
+      findings,
+      scanComplete: true,
+      generatedAt: '2026-06-28T00:00:00Z',
+      failureClass: null,
+    })
+
+    const json = JSON.stringify(report)
+    // normalizedText must not appear in the report
+    expect(json).not.toContain('"normalizedText"')
+    // Raw claim text must not appear as a top-level field
+    expect(json).not.toContain('"rawText"')
+    expect(json).not.toContain('"sourceSnippet"')
+    // The fingerprint is a hex hash, not the raw text
+    const finding = report.findings[0]
+    if (finding !== undefined && finding.verdict !== 'unsafe') {
+      expect(finding.fingerprint).toMatch(/^[a-f0-9]{16}$/)
+    }
+  })
+
+  it('resolveAllClaims deduplicates by kind:sourceRef to avoid redundant API calls', async () => {
+    let callCount = 0
+    const octokit: DetectOctokitClient = {
+      rest: {
+        pulls: {
+          get: async () => {
+            callCount++
+            return {data: {state: 'open', merged: false}}
+          },
+        },
+        issues: {get: async () => ({data: {state: 'open'}})},
+        repos: {getReleaseByTag: async () => ({data: {draft: false, prerelease: false}})},
+      },
+    }
+
+    // Two claims with the same kind:sourceRef
+    const claims: StatusTruthClaim[] = [
+      {kind: 'pr-state', path: 'README.md', sourceRef: '#42', claimedState: 'open', normalizedText: 'pr #42 is open'},
+      {kind: 'pr-state', path: 'docs/foo.md', sourceRef: '#42', claimedState: 'open', normalizedText: 'pr #42 is open'},
+    ]
+
+    await resolveAllClaims({claims, octokit, owner: 'fro-bot', repo: '.github'})
+    // Should only call the API once despite two claims with same kind:sourceRef
+    expect(callCount).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Unit 4 fix 1: buildProposedCorrection uses replacement function ($ safety)
+// ---------------------------------------------------------------------------
+
+describe('buildProposedCorrection: $ token safety via detectStatusTruthClaims', () => {
+  it('live state containing $& is inserted literally, not expanded as a replacement token', () => {
+    // If String.replace used a string replacement, '$&' would expand to the matched text.
+    // With a replacement function it is inserted verbatim.
+    const claim: StatusTruthClaim = {
+      kind: 'pr-state',
+      path: 'README.md',
+      sourceRef: '#42',
+      claimedState: 'open',
+      normalizedText: 'pr #42 is open',
+    }
+    const resolverResults = makeResolverResults([
+      {kind: 'pr-state', sourceRef: '#42', result: {status: 'resolved', state: '$&'}},
+    ])
+
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+    expect(findings).toHaveLength(1)
+    const finding = findings[0]
+    expect(finding?.verdict).toBe('drifted')
+    if (finding?.verdict === 'drifted') {
+      // proposedCorrection must contain the literal string '$&', not the matched text 'open'
+      expect(finding.proposedCorrection).toContain('$&')
+      expect(finding.proposedCorrection).not.toBe('pr #42 is open') // must have changed
+    }
+  })
+
+  it('live state containing $1 is inserted literally, not expanded as a capture-group reference', () => {
+    const claim: StatusTruthClaim = {
+      kind: 'pr-state',
+      path: 'README.md',
+      sourceRef: '#42',
+      claimedState: 'open',
+      normalizedText: 'pr #42 is open',
+    }
+    const resolverResults = makeResolverResults([
+      {kind: 'pr-state', sourceRef: '#42', result: {status: 'resolved', state: '$1'}},
+    ])
+
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+    const finding = findings[0]
+    if (finding?.verdict === 'drifted') {
+      expect(finding.proposedCorrection).toContain('$1')
+    }
+  })
+})
+
+describe('runDetect failure-class selection logic', () => {
+  it('returns file-parse-error when scanErrors > 0 regardless of resolveErrors', () => {
+    expect(selectFailureClass(1, 0)).toBe('file-parse-error')
+    expect(selectFailureClass(3, 2)).toBe('file-parse-error')
+  })
+
+  it('returns api-unavailable when scanErrors === 0 and resolveErrors > 0', () => {
+    expect(selectFailureClass(0, 1)).toBe('api-unavailable')
+    expect(selectFailureClass(0, 5)).toBe('api-unavailable')
+  })
+
+  it('returns null when both scanErrors and resolveErrors are 0', () => {
+    expect(selectFailureClass(0, 0)).toBeNull()
+  })
+
+  it('buildStatusTruthReport with file-parse-error failureClass produces execution-failure status', () => {
+    const report = buildStatusTruthReport({
+      findings: [],
+      scanComplete: false,
+      generatedAt: '2026-06-28T00:00:00Z',
+      failureClass: 'file-parse-error',
+    })
+    expect(report.status).toBe('execution-failure')
+    expect(report.failure_class).toBe('file-parse-error')
+    expect(report.scan_complete).toBe(false)
+    expect(report.repair_eligible).toBe(false)
+  })
+
+  it('buildStatusTruthReport with api-unavailable failureClass produces execution-failure status', () => {
+    const report = buildStatusTruthReport({
+      findings: [],
+      scanComplete: false,
+      generatedAt: '2026-06-28T00:00:00Z',
+      failureClass: 'api-unavailable',
+    })
+    expect(report.status).toBe('execution-failure')
+    expect(report.failure_class).toBe('api-unavailable')
   })
 })

--- a/scripts/status-truth-detect.test.ts
+++ b/scripts/status-truth-detect.test.ts
@@ -1048,6 +1048,42 @@ describe('extractStatusTruthClaimsFromText', () => {
     })
     expect(claims[0]?.normalizedText).toBe('pr #42 is open')
   })
+
+  // Fix #1: Cross-repo PR/issue references must not resolve as current-repo references.
+  // When text contains "fro-bot/agent#1033 PR #1033 is open", the extractor must NOT
+  // produce a bare #1033 sourceRef that the resolver would treat as current-repo.
+  it('cross-repo PR reference: text with owner/repo prefix near claim does not produce bare #N sourceRef', () => {
+    // This text has a cross-repo context: "fro-bot/agent#1033" followed by "PR #1033 is open"
+    // The extractor currently produces bare #1033 which the resolver treats as current-repo.
+    // After fix: either the sourceRef is prefixed (fro-bot/agent#1033) or the claim is skipped.
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/example.md',
+      text: 'See fro-bot/agent#1033 PR #1033 is open for context.',
+    })
+    // Assert directly: no bare #1033 sourceRef must be extracted
+    expect(claims.filter(c => c.sourceRef === '#1033')).toHaveLength(0)
+    // If a claim is extracted, its sourceRef must NOT be bare #1033
+    for (const claim of claims) {
+      if (claim.kind === 'pr-state' && claim.claimedState === 'open') {
+        expect(claim.sourceRef).not.toBe('#1033')
+      }
+    }
+  })
+
+  it('cross-repo issue reference: text with owner/repo prefix near claim does not produce bare #N sourceRef', () => {
+    // "fro-bot/dashboard#48 issue #48 is open" — must not produce bare #48
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/example.md',
+      text: 'Tracked in fro-bot/dashboard#48 issue #48 is open.',
+    })
+    // Assert directly: no bare #48 sourceRef must be extracted
+    expect(claims.filter(c => c.sourceRef === '#48')).toHaveLength(0)
+    for (const claim of claims) {
+      if (claim.kind === 'issue-state' && claim.claimedState === 'open') {
+        expect(claim.sourceRef).not.toBe('#48')
+      }
+    }
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -1239,18 +1275,19 @@ describe('resolveClaimLiveState', () => {
     expect(result.status).toBe('unavailable')
   })
 
-  it('plan-status resolves to current (file-parse: claimedState is live state)', async () => {
-    const octokit = makeMockDetectOctokit()
-    const claim = makeTestClaim({kind: 'plan-status', sourceRef: 'docs/plans/foo.md#status', claimedState: 'active'})
-    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
-    expect(result.status).toBe('resolved')
-    if (result.status === 'resolved') expect(result.state).toBe('active')
-  })
-
   it('rollout-tracker-status returns unavailable (Phase 1 scope cut)', async () => {
     const octokit = makeMockDetectOctokit()
     const claim = makeTestClaim({kind: 'rollout-tracker-status', sourceRef: '#3512', claimedState: 'active'})
     const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('unavailable')
+  })
+
+  // Fix #3: plan-status resolver must not return claimedState as live state
+  it('plan-status returns unavailable (not resolved with claimedState as live state)', async () => {
+    const octokit = makeMockDetectOctokit()
+    const claim = makeTestClaim({kind: 'plan-status', sourceRef: 'docs/plans/foo.md#status', claimedState: 'active'})
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    // plan-status has no real file-parse resolver yet; must be unavailable, not resolved
     expect(result.status).toBe('unavailable')
   })
 })
@@ -1319,6 +1356,35 @@ describe('Unit 4: extract → resolve → detect pipeline', () => {
     expect(findings).toHaveLength(1)
     expect(findings[0]?.verdict).toBe('unresolved')
     expect(findings[0]?.proposalEligible).toBe(false)
+  })
+
+  // Fix #1: cross-repo text that produces a bare #N must not classify as current-repo drifted
+  it('cross-repo context text: extracted claim (if any) classifies as unresolved, not drifted', async () => {
+    // Text: "fro-bot/agent#1033 PR #1033 is open" — if extractor produces bare #1033,
+    // the resolver must return unavailable (not resolved), so detect classifies as unresolved.
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/example.md',
+      text: 'See fro-bot/agent#1033 PR #1033 is open for context.',
+    })
+
+    const octokit = makeMockDetectOctokit({prState: 'closed'}) // would drift if resolved as current-repo
+    const {resolverResults} = await resolveAllClaims({
+      claims,
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+    })
+
+    const findings = detectStatusTruthClaims(claims, resolverResults)
+    // Any pr-state finding for #1033 must be unresolved (not drifted/current)
+    for (const finding of findings) {
+      if (finding.kind === 'pr-state' && finding.verdict !== 'unsafe') {
+        // If a bare #1033 was extracted and resolved as current-repo, it would be drifted.
+        // After fix: either no claim extracted, or sourceRef is non-bare and verdict is unresolved.
+        expect(finding.verdict).not.toBe('drifted')
+        expect(finding.verdict).not.toBe('current')
+      }
+    }
   })
 
   it('detect with no claims emits clean zero counts', () => {

--- a/scripts/status-truth-detect.test.ts
+++ b/scripts/status-truth-detect.test.ts
@@ -1,0 +1,706 @@
+import type {
+  ClaimKind,
+  ClaimVerdict,
+  PublicStatusTruthFinding,
+  ResolverResult,
+  ResolverType,
+  StatusTruthClaim,
+  StatusTruthFinding,
+  StatusTruthJsonReport,
+} from './status-truth-detect.ts'
+
+import {describe, expect, it} from 'vitest'
+
+import {
+  buildStatusTruthReport,
+  CLAIM_KIND_DEFINITIONS,
+  computeClaimFingerprint,
+  detectStatusTruthClaims,
+  isKnownReportVersion,
+  KNOWN_FINGERPRINT_VERSION,
+  KNOWN_SCHEMA_VERSION,
+  normalizeClaimText,
+} from './status-truth-detect.ts'
+
+function makeClaim(overrides: Partial<StatusTruthClaim> = {}): StatusTruthClaim {
+  return {
+    kind: 'pr-state',
+    path: 'docs/plans/example.md',
+    sourceRef: 'fro-bot/.github#42',
+    claimedState: 'open',
+    normalizedText: 'PR #42 is open',
+    ...overrides,
+  }
+}
+
+function makeReport(overrides: Partial<StatusTruthJsonReport> = {}): StatusTruthJsonReport {
+  return {
+    schema_version: KNOWN_SCHEMA_VERSION,
+    fingerprint_version: KNOWN_FINGERPRINT_VERSION,
+    status: 'clean',
+    scan_complete: true,
+    generated_at: '2026-06-28T00:00:00Z',
+    failure_class: null,
+    repair_eligible: false,
+    findings: [],
+    counts: {
+      total: 0,
+      current: 0,
+      drifted: 0,
+      unresolved: 0,
+      unsafe: 0,
+      proposal_eligible: 0,
+    },
+    ...overrides,
+  }
+}
+
+/** Build a public (non-unsafe) finding for test setup. */
+function makeFinding(overrides: Partial<PublicStatusTruthFinding> = {}): PublicStatusTruthFinding {
+  return {
+    kind: 'pr-state',
+    path: 'docs/plans/example.md',
+    sourceRef: 'fro-bot/.github#42',
+    verdict: 'drifted',
+    fingerprint: 'abcdef0123456789',
+    claimedState: 'open',
+    liveState: 'closed',
+    proposalEligible: true,
+    proposedCorrection: 'PR #42 is closed',
+    ...overrides,
+  }
+}
+
+/** Build a resolver result map keyed by `kind:sourceRef`. */
+function makeResolverResults(
+  entries: {kind: ClaimKind; sourceRef: string; result: ResolverResult}[],
+): Record<string, ResolverResult> {
+  const map: Record<string, ResolverResult> = {}
+  for (const {kind, sourceRef, result} of entries) {
+    map[`${kind}:${sourceRef}`] = result
+  }
+  return map
+}
+
+describe('CLAIM_KIND_DEFINITIONS', () => {
+  it('defines all five required claim kinds', () => {
+    const kinds = CLAIM_KIND_DEFINITIONS.map(d => d.kind)
+    expect(kinds).toContain('pr-state')
+    expect(kinds).toContain('issue-state')
+    expect(kinds).toContain('release-tag-state')
+    expect(kinds).toContain('plan-status')
+    expect(kinds).toContain('rollout-tracker-status')
+  })
+
+  it('each definition has required fields: kind, resolverType, pattern, confidenceRule, suppressionRule, proposalFields', () => {
+    for (const def of CLAIM_KIND_DEFINITIONS) {
+      expect(def.kind).toBeTruthy()
+      expect(def.resolverType).toMatch(/^(api|file-parse|compound)$/)
+      expect(def.pattern).toBeInstanceOf(RegExp)
+      expect(typeof def.confidenceRule).toBe('string')
+      expect(typeof def.suppressionRule).toBe('string')
+      expect(Array.isArray(def.proposalFields)).toBe(true)
+    }
+  })
+
+  it('compound resolvers declare sub-resolvers', () => {
+    const compound = CLAIM_KIND_DEFINITIONS.filter(d => d.resolverType === 'compound')
+    for (const def of compound) {
+      expect(Array.isArray(def.subResolvers)).toBe(true)
+      expect((def.subResolvers ?? []).length).toBeGreaterThan(0)
+    }
+  })
+
+  it('rollout-tracker-status is a compound resolver', () => {
+    const def = CLAIM_KIND_DEFINITIONS.find(d => d.kind === 'rollout-tracker-status')
+    expect(def?.resolverType).toBe('compound')
+  })
+
+  it('pr-state and issue-state are API resolvers', () => {
+    const prDef = CLAIM_KIND_DEFINITIONS.find(d => d.kind === 'pr-state')
+    const issueDef = CLAIM_KIND_DEFINITIONS.find(d => d.kind === 'issue-state')
+    expect(prDef?.resolverType).toBe('api')
+    expect(issueDef?.resolverType).toBe('api')
+  })
+
+  it('plan-status is a file-parse resolver', () => {
+    const def = CLAIM_KIND_DEFINITIONS.find(d => d.kind === 'plan-status')
+    expect(def?.resolverType).toBe('file-parse')
+  })
+
+  it('release-tag-state is an API resolver', () => {
+    const def = CLAIM_KIND_DEFINITIONS.find(d => d.kind === 'release-tag-state')
+    expect(def?.resolverType).toBe('api')
+  })
+})
+
+describe('computeClaimFingerprint', () => {
+  it('produces a stable hex string for the same inputs', () => {
+    const fp1 = computeClaimFingerprint('pr-state', 'docs/plans/foo.md', 'fro-bot/.github#42', 'PR #42 is open')
+    const fp2 = computeClaimFingerprint('pr-state', 'docs/plans/foo.md', 'fro-bot/.github#42', 'PR #42 is open')
+    expect(fp1).toBe(fp2)
+    expect(fp1).toMatch(/^[a-f0-9]{16}$/)
+  })
+
+  it('changes when claim kind changes', () => {
+    const fp1 = computeClaimFingerprint('pr-state', 'docs/plans/foo.md', 'fro-bot/.github#42', 'PR #42 is open')
+    const fp2 = computeClaimFingerprint('issue-state', 'docs/plans/foo.md', 'fro-bot/.github#42', 'PR #42 is open')
+    expect(fp1).not.toBe(fp2)
+  })
+
+  it('changes when path changes', () => {
+    const fp1 = computeClaimFingerprint('pr-state', 'docs/plans/foo.md', 'fro-bot/.github#42', 'PR #42 is open')
+    const fp2 = computeClaimFingerprint('pr-state', 'docs/plans/bar.md', 'fro-bot/.github#42', 'PR #42 is open')
+    expect(fp1).not.toBe(fp2)
+  })
+
+  it('changes when source reference changes', () => {
+    const fp1 = computeClaimFingerprint('pr-state', 'docs/plans/foo.md', 'fro-bot/.github#42', 'PR #42 is open')
+    const fp2 = computeClaimFingerprint('pr-state', 'docs/plans/foo.md', 'fro-bot/.github#99', 'PR #42 is open')
+    expect(fp1).not.toBe(fp2)
+  })
+
+  it('edge: line move with same normalized text and source reference keeps same fingerprint', () => {
+    const fp1 = computeClaimFingerprint('pr-state', 'docs/plans/foo.md', 'fro-bot/.github#42', 'PR #42 is open')
+    const fp2 = computeClaimFingerprint('pr-state', 'docs/plans/foo.md', 'fro-bot/.github#42', 'PR #42 is open')
+    expect(fp1).toBe(fp2)
+  })
+})
+
+describe('normalizeClaimText', () => {
+  it('lowercases and trims whitespace', () => {
+    expect(normalizeClaimText('  PR #42 is OPEN  ')).toBe('pr #42 is open')
+  })
+
+  it('collapses internal whitespace', () => {
+    expect(normalizeClaimText('PR  #42   is   open')).toBe('pr #42 is open')
+  })
+
+  it('is idempotent', () => {
+    const text = 'pr #42 is open'
+    expect(normalizeClaimText(text)).toBe(normalizeClaimText(normalizeClaimText(text)))
+  })
+})
+
+describe('buildStatusTruthReport', () => {
+  it('happy path: produces a clean report with zero findings', () => {
+    const report = buildStatusTruthReport({
+      findings: [],
+      scanComplete: true,
+      generatedAt: '2026-06-28T00:00:00Z',
+      failureClass: null,
+    })
+
+    expect(report.schema_version).toBe(KNOWN_SCHEMA_VERSION)
+    expect(report.fingerprint_version).toBe(KNOWN_FINGERPRINT_VERSION)
+    expect(report.status).toBe('clean')
+    expect(report.scan_complete).toBe(true)
+    expect(report.failure_class).toBeNull()
+    expect(report.repair_eligible).toBe(false)
+    expect(report.findings).toEqual([])
+    expect(report.counts.total).toBe(0)
+    expect(report.counts.current).toBe(0)
+    expect(report.counts.drifted).toBe(0)
+    expect(report.counts.unresolved).toBe(0)
+    expect(report.counts.unsafe).toBe(0)
+    expect(report.counts.proposal_eligible).toBe(0)
+  })
+
+  it('happy path: report with drifted findings has status=findings and repair_eligible=true', () => {
+    const finding = makeFinding()
+    const report = buildStatusTruthReport({
+      findings: [finding],
+      scanComplete: true,
+      generatedAt: '2026-06-28T00:00:00Z',
+      failureClass: null,
+    })
+
+    expect(report.status).toBe('findings')
+    expect(report.repair_eligible).toBe(true)
+    expect(report.counts.total).toBe(1)
+    expect(report.counts.drifted).toBe(1)
+    expect(report.counts.proposal_eligible).toBe(1)
+  })
+
+  it('repair_eligible: report with only current findings has status=findings but repair_eligible=false', () => {
+    const finding = makeFinding({
+      verdict: 'current',
+      proposalEligible: false,
+      liveState: 'open',
+      claimedState: 'open',
+      proposedCorrection: undefined,
+    })
+    const report = buildStatusTruthReport({
+      findings: [finding],
+      scanComplete: true,
+      generatedAt: '2026-06-28T00:00:00Z',
+      failureClass: null,
+    })
+
+    expect(report.status).toBe('findings')
+    expect(report.repair_eligible).toBe(false)
+    expect(report.counts.proposal_eligible).toBe(0)
+  })
+
+  it('execution-failure: scan_complete=false, status=execution-failure, repair_eligible=false', () => {
+    const report = buildStatusTruthReport({
+      findings: [],
+      scanComplete: false,
+      generatedAt: '2026-06-28T00:00:00Z',
+      failureClass: 'api-unavailable',
+    })
+
+    expect(report.status).toBe('execution-failure')
+    expect(report.scan_complete).toBe(false)
+    expect(report.failure_class).toBe('api-unavailable')
+    expect(report.repair_eligible).toBe(false)
+  })
+
+  it('integration: multiple claim kinds produce distinct findings and correct aggregate counts', () => {
+    const findings: StatusTruthFinding[] = [
+      makeFinding({kind: 'pr-state', verdict: 'drifted', proposalEligible: true}),
+      makeFinding({
+        kind: 'issue-state',
+        verdict: 'current',
+        proposalEligible: false,
+        liveState: 'open',
+        claimedState: 'open',
+        proposedCorrection: undefined,
+      }),
+      makeFinding({
+        kind: 'release-tag-state',
+        verdict: 'unresolved',
+        proposalEligible: false,
+        liveState: undefined,
+        proposedCorrection: undefined,
+      }),
+      {kind: 'plan-status', verdict: 'unsafe', proposalEligible: false} satisfies StatusTruthFinding,
+    ]
+
+    const report = buildStatusTruthReport({
+      findings,
+      scanComplete: true,
+      generatedAt: '2026-06-28T00:00:00Z',
+      failureClass: null,
+    })
+
+    expect(report.status).toBe('findings')
+    expect(report.counts.total).toBe(4)
+    expect(report.counts.drifted).toBe(1)
+    expect(report.counts.current).toBe(1)
+    expect(report.counts.unresolved).toBe(1)
+    expect(report.counts.unsafe).toBe(1)
+    expect(report.counts.proposal_eligible).toBe(1)
+    const kinds = report.findings.map(f => f.kind)
+    expect(new Set(kinds).size).toBe(4)
+  })
+
+  it('edge: no supported claims produces zero findings and zero proposal-eligible actions', () => {
+    const report = buildStatusTruthReport({
+      findings: [],
+      scanComplete: true,
+      generatedAt: '2026-06-28T00:00:00Z',
+      failureClass: null,
+    })
+
+    expect(report.findings).toHaveLength(0)
+    expect(report.counts.proposal_eligible).toBe(0)
+  })
+})
+
+describe('isKnownReportVersion', () => {
+  it('happy path: known schema and fingerprint versions are accepted', () => {
+    const report = makeReport()
+    expect(isKnownReportVersion(report)).toBe(true)
+  })
+
+  it('error: unknown schema_version is rejected', () => {
+    const report = makeReport({schema_version: 99})
+    expect(isKnownReportVersion(report)).toBe(false)
+  })
+
+  it('error: unknown fingerprint_version is rejected', () => {
+    const report = makeReport({fingerprint_version: 99})
+    expect(isKnownReportVersion(report)).toBe(false)
+  })
+
+  it('error: both unknown versions are rejected', () => {
+    const report = makeReport({schema_version: 0, fingerprint_version: 0})
+    expect(isKnownReportVersion(report)).toBe(false)
+  })
+})
+
+describe('detectStatusTruthClaims', () => {
+  it('happy path: public PR-open claim whose live PR is closed becomes drifted with stable fingerprint and proposed correction', () => {
+    const claim = makeClaim({
+      kind: 'pr-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'fro-bot/.github#42',
+      claimedState: 'open',
+      normalizedText: 'pr #42 is open',
+    })
+
+    const resolverResults = makeResolverResults([
+      {kind: 'pr-state', sourceRef: 'fro-bot/.github#42', result: {status: 'resolved', state: 'closed'}},
+    ])
+
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+
+    expect(findings).toHaveLength(1)
+    const finding = findings[0]
+    expect(finding?.verdict).toBe('drifted')
+    // Public finding fields are accessible
+    if (finding?.verdict === 'drifted') {
+      expect(finding.claimedState).toBe('open')
+      expect(finding.liveState).toBe('closed')
+      expect(finding.proposalEligible).toBe(true)
+      expect(finding.proposedCorrection).toBeTruthy()
+      const fp = computeClaimFingerprint('pr-state', 'docs/plans/example.md', 'fro-bot/.github#42', 'pr #42 is open')
+      expect(finding.fingerprint).toBe(fp)
+    }
+  })
+
+  it('happy path: current release/tag claim is classified as current and produces no proposal', () => {
+    const claim = makeClaim({
+      kind: 'release-tag-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'fro-bot/.github@v1.0.0',
+      claimedState: 'published',
+      normalizedText: 'release v1.0.0 is published',
+    })
+
+    const resolverResults = makeResolverResults([
+      {
+        kind: 'release-tag-state',
+        sourceRef: 'fro-bot/.github@v1.0.0',
+        result: {status: 'resolved', state: 'published'},
+      },
+    ])
+
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+
+    expect(findings).toHaveLength(1)
+    const finding = findings[0]
+    expect(finding?.verdict).toBe('current')
+    expect(finding?.proposalEligible).toBe(false)
+    if (finding?.verdict === 'current') {
+      expect(finding.proposedCorrection).toBeUndefined()
+    }
+  })
+
+  it('error: GitHub state unavailable => unresolved and not proposal-eligible', () => {
+    const claim = makeClaim({
+      kind: 'pr-state',
+      sourceRef: 'fro-bot/.github#42',
+      claimedState: 'open',
+    })
+
+    const resolverResults: Record<string, ResolverResult> = {}
+
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+
+    expect(findings).toHaveLength(1)
+    const finding = findings[0]
+    expect(finding?.verdict).toBe('unresolved')
+    expect(finding?.proposalEligible).toBe(false)
+    if (finding?.verdict === 'unresolved') {
+      expect(finding.liveState).toBeUndefined()
+    }
+  })
+
+  it('error: source resolves to private/unknown identity => unsafe and not proposal-eligible', () => {
+    const claim = makeClaim({
+      kind: 'pr-state',
+      sourceRef: 'fro-bot/.github#42',
+      claimedState: 'open',
+    })
+
+    const resolverResults = makeResolverResults([
+      {kind: 'pr-state', sourceRef: 'fro-bot/.github#42', result: {status: 'private'}},
+    ])
+
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+
+    expect(findings).toHaveLength(1)
+    const finding = findings[0]
+    expect(finding?.verdict).toBe('unsafe')
+    expect(finding?.proposalEligible).toBe(false)
+  })
+
+  it('edge: rollout-tracker claim is unresolved when snapshot source fails (sub-resolver unavailable)', () => {
+    const claim = makeClaim({
+      kind: 'rollout-tracker-status',
+      sourceRef: 'fro-bot/.github#3512',
+      claimedState: 'active',
+      normalizedText: 'rollout tracker #3512 is active',
+    })
+
+    const resolverResults = makeResolverResults([
+      {kind: 'rollout-tracker-status', sourceRef: 'fro-bot/.github#3512', result: {status: 'unavailable'}},
+    ])
+
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+
+    expect(findings).toHaveLength(1)
+    const finding = findings[0]
+    expect(finding?.verdict).toBe('unresolved')
+    expect(finding?.proposalEligible).toBe(false)
+  })
+
+  it('edge: no supported claims produces empty findings array', () => {
+    const findings = detectStatusTruthClaims([], {})
+    expect(findings).toHaveLength(0)
+  })
+
+  it('dependency order: mixed resolver-type claims are emitted file-parse first, api second, compound last', () => {
+    const claims: StatusTruthClaim[] = [
+      makeClaim({
+        kind: 'rollout-tracker-status',
+        sourceRef: 'fro-bot/.github#3512',
+        claimedState: 'active',
+        normalizedText: 'rollout tracker #3512 is active',
+      }),
+      makeClaim({
+        kind: 'pr-state',
+        sourceRef: 'fro-bot/.github#42',
+        claimedState: 'open',
+        normalizedText: 'pr #42 is open',
+      }),
+      makeClaim({
+        kind: 'plan-status',
+        sourceRef: 'docs/plans/example.md#status',
+        claimedState: 'active',
+        normalizedText: 'status: active',
+      }),
+    ]
+
+    const resolverResults = makeResolverResults([
+      {
+        kind: 'rollout-tracker-status',
+        sourceRef: 'fro-bot/.github#3512',
+        result: {status: 'resolved', state: 'active'},
+      },
+      {kind: 'pr-state', sourceRef: 'fro-bot/.github#42', result: {status: 'resolved', state: 'open'}},
+      {kind: 'plan-status', sourceRef: 'docs/plans/example.md#status', result: {status: 'resolved', state: 'active'}},
+    ])
+
+    const findings = detectStatusTruthClaims(claims, resolverResults)
+
+    expect(findings).toHaveLength(3)
+    expect(findings[0]?.kind).toBe('plan-status')
+    expect(findings[1]?.kind).toBe('pr-state')
+    expect(findings[2]?.kind).toBe('rollout-tracker-status')
+  })
+
+  it('integration: multiple claim kinds in one document produce distinct report entries', () => {
+    const claims: StatusTruthClaim[] = [
+      makeClaim({
+        kind: 'pr-state',
+        path: 'docs/plans/example.md',
+        sourceRef: 'fro-bot/.github#42',
+        claimedState: 'open',
+        normalizedText: 'pr #42 is open',
+      }),
+      makeClaim({
+        kind: 'issue-state',
+        path: 'docs/plans/example.md',
+        sourceRef: 'fro-bot/.github#100',
+        claimedState: 'open',
+        normalizedText: 'issue #100 is open',
+      }),
+      makeClaim({
+        kind: 'release-tag-state',
+        path: 'docs/plans/example.md',
+        sourceRef: 'fro-bot/.github@v2.0.0',
+        claimedState: 'published',
+        normalizedText: 'release v2.0.0 is published',
+      }),
+    ]
+
+    const resolverResults = makeResolverResults([
+      {kind: 'pr-state', sourceRef: 'fro-bot/.github#42', result: {status: 'resolved', state: 'closed'}},
+      {kind: 'issue-state', sourceRef: 'fro-bot/.github#100', result: {status: 'resolved', state: 'open'}},
+      {
+        kind: 'release-tag-state',
+        sourceRef: 'fro-bot/.github@v2.0.0',
+        result: {status: 'resolved', state: 'published'},
+      },
+    ])
+
+    const findings = detectStatusTruthClaims(claims, resolverResults)
+
+    expect(findings).toHaveLength(3)
+    const verdicts = findings.map(f => f.verdict)
+    expect(verdicts).toContain('drifted')
+    expect(verdicts.filter(v => v === 'current')).toHaveLength(2)
+
+    const fingerprints = findings
+      .filter((f): f is PublicStatusTruthFinding => f.verdict !== 'unsafe')
+      .map(f => f.fingerprint)
+    expect(new Set(fingerprints).size).toBe(3)
+  })
+
+  it('integration: multiple claim kinds produce correct aggregate counts via buildStatusTruthReport', () => {
+    const claims: StatusTruthClaim[] = [
+      makeClaim({
+        kind: 'pr-state',
+        sourceRef: 'fro-bot/.github#1',
+        claimedState: 'open',
+        normalizedText: 'pr #1 is open',
+      }),
+      makeClaim({
+        kind: 'issue-state',
+        sourceRef: 'fro-bot/.github#2',
+        claimedState: 'open',
+        normalizedText: 'issue #2 is open',
+      }),
+    ]
+
+    const resolverResults = makeResolverResults([
+      {kind: 'pr-state', sourceRef: 'fro-bot/.github#1', result: {status: 'resolved', state: 'closed'}},
+      {kind: 'issue-state', sourceRef: 'fro-bot/.github#2', result: {status: 'resolved', state: 'open'}},
+    ])
+
+    const findings = detectStatusTruthClaims(claims, resolverResults)
+    const report = buildStatusTruthReport({
+      findings,
+      scanComplete: true,
+      generatedAt: '2026-06-28T00:00:00Z',
+      failureClass: null,
+    })
+
+    expect(report.counts.total).toBe(2)
+    expect(report.counts.drifted).toBe(1)
+    expect(report.counts.current).toBe(1)
+    expect(report.counts.proposal_eligible).toBe(1)
+  })
+
+  it('unsafe finding does not expose path, sourceRef, claimedState, fingerprint, or proposedCorrection', () => {
+    const claim = makeClaim({
+      kind: 'pr-state',
+      path: 'docs/plans/secret.md',
+      sourceRef: 'private-org/private-repo#99',
+      claimedState: 'open',
+      normalizedText: 'pr #99 is open',
+    })
+
+    const resolverResults = makeResolverResults([
+      {kind: 'pr-state', sourceRef: 'private-org/private-repo#99', result: {status: 'private'}},
+    ])
+
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+
+    expect(findings).toHaveLength(1)
+    const finding = findings[0]
+    expect(finding?.verdict).toBe('unsafe')
+    expect(finding?.proposalEligible).toBe(false)
+
+    expect('path' in (finding ?? {})).toBe(false)
+    expect('sourceRef' in (finding ?? {})).toBe(false)
+    expect('claimedState' in (finding ?? {})).toBe(false)
+    expect('fingerprint' in (finding ?? {})).toBe(false)
+    expect('proposedCorrection' in (finding ?? {})).toBe(false)
+    expect('liveState' in (finding ?? {})).toBe(false)
+  })
+
+  it('PR and issue claims sharing the same sourceRef do not cross-wire states', () => {
+    const prClaim = makeClaim({
+      kind: 'pr-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'fro-bot/.github#42',
+      claimedState: 'open',
+      normalizedText: 'pr #42 is open',
+    })
+    const issueClaim = makeClaim({
+      kind: 'issue-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'fro-bot/.github#42',
+      claimedState: 'open',
+      normalizedText: 'issue #42 is open',
+    })
+
+    const resolverResults = makeResolverResults([
+      {kind: 'pr-state', sourceRef: 'fro-bot/.github#42', result: {status: 'resolved', state: 'closed'}},
+      {kind: 'issue-state', sourceRef: 'fro-bot/.github#42', result: {status: 'resolved', state: 'open'}},
+    ])
+
+    const findings = detectStatusTruthClaims([prClaim, issueClaim], resolverResults)
+
+    expect(findings).toHaveLength(2)
+
+    const prFinding = findings.find(f => f.kind === 'pr-state')
+    const issueFinding = findings.find(f => f.kind === 'issue-state')
+
+    expect(prFinding?.verdict).toBe('drifted')
+    if (prFinding?.verdict === 'drifted') {
+      expect(prFinding.liveState).toBe('closed')
+    }
+
+    expect(issueFinding?.verdict).toBe('current')
+    if (issueFinding?.verdict === 'current') {
+      expect(issueFinding.liveState).toBe('open')
+    }
+  })
+
+  it('rollout-tracker with top-level resolved state but missing required sub-resolver is unresolved and proposal-ineligible', () => {
+    const rolloutClaim = makeClaim({
+      kind: 'rollout-tracker-status',
+      path: 'docs/plans/rollout.md',
+      sourceRef: 'fro-bot/.github#3512',
+      claimedState: 'active',
+      normalizedText: 'rollout tracker #3512 is active',
+    })
+
+    const resolverResults = makeResolverResults([
+      {
+        kind: 'rollout-tracker-status',
+        sourceRef: 'fro-bot/.github#3512',
+        result: {
+          status: 'resolved',
+          state: 'active',
+          subResolverResults: {
+            'issue-state': {status: 'unavailable'},
+            'pr-state': {status: 'unavailable'},
+          },
+        },
+      },
+    ])
+
+    const findings = detectStatusTruthClaims([rolloutClaim], resolverResults)
+
+    expect(findings).toHaveLength(1)
+    const finding = findings[0]
+    expect(finding?.verdict).toBe('unresolved')
+    expect(finding?.proposalEligible).toBe(false)
+  })
+
+  it('buildStatusTruthReport with scanComplete:false and failureClass:null returns execution-failure and repair_eligible:false', () => {
+    const report = buildStatusTruthReport({
+      findings: [],
+      scanComplete: false,
+      generatedAt: '2026-06-28T00:00:00Z',
+      failureClass: null,
+    })
+
+    expect(report.status).toBe('execution-failure')
+    expect(report.repair_eligible).toBe(false)
+    expect(report.scan_complete).toBe(false)
+  })
+})
+
+describe('type contracts', () => {
+  it('ClaimVerdict union covers all expected values', () => {
+    const verdicts: ClaimVerdict[] = ['current', 'drifted', 'unresolved', 'unsafe']
+    expect(verdicts).toHaveLength(4)
+  })
+
+  it('ResolverType union covers all expected values', () => {
+    const types: ResolverType[] = ['api', 'file-parse', 'compound']
+    expect(types).toHaveLength(3)
+  })
+
+  it('ClaimKind union covers all five expected values', () => {
+    const kinds: ClaimKind[] = ['pr-state', 'issue-state', 'release-tag-state', 'plan-status', 'rollout-tracker-status']
+    expect(kinds).toHaveLength(5)
+  })
+})

--- a/scripts/status-truth-detect.ts
+++ b/scripts/status-truth-detect.ts
@@ -399,10 +399,16 @@ export const SCAN_GLOB_PATTERNS: readonly string[] = [
 ]
 
 /**
- * Paths to exclude from scanning (generated/proposal state).
- * These paths may contain status-truth proposal bodies that would self-reference.
+ * Paths to exclude from scanning (generated/proposal state, and example/brainstorm
+ * prose that may contain illustrative status-truth patterns that must not trigger
+ * real proposals).
  */
-const SCAN_EXCLUDE_PATTERNS: readonly RegExp[] = [/^metadata\//u, /^\.github\/workflows\//u, /^node_modules\//u]
+const SCAN_EXCLUDE_PATTERNS: readonly RegExp[] = [
+  /^metadata\//u,
+  /^\.github\/workflows\//u,
+  /^node_modules\//u,
+  /^docs\/brainstorms\//u,
+]
 
 function isExcludedPath(filePath: string): boolean {
   return SCAN_EXCLUDE_PATTERNS.some(pattern => pattern.test(filePath))

--- a/scripts/status-truth-detect.ts
+++ b/scripts/status-truth-detect.ts
@@ -409,6 +409,29 @@ function isExcludedPath(filePath: string): boolean {
 }
 
 /**
+ * Pattern to detect cross-repo references in text (owner/repo#N format).
+ * Used to suppress bare #N extraction when the same number appears in a
+ * cross-repo context nearby, preventing misresolution as current-repo.
+ */
+const CROSS_REPO_REF_PATTERN = /\b[\w.-]+\/[\w.-]+#(\d+)\b/gu
+
+/**
+ * Build a set of issue/PR numbers that appear in cross-repo references
+ * within the given text. These numbers must not be extracted as bare #N
+ * current-repo references.
+ *
+ * Example: "fro-bot/agent#1033 PR #1033 is open" → Set{'1033'}
+ */
+function extractCrossRepoNumbers(text: string): Set<string> {
+  const crossRepoNumbers = new Set<string>()
+  for (const match of text.matchAll(CROSS_REPO_REF_PATTERN)) {
+    const num = match[1]
+    if (num !== undefined) crossRepoNumbers.add(num)
+  }
+  return crossRepoNumbers
+}
+
+/**
  * Extract status-truth claims from a single document's text.
  *
  * Pure function: no I/O. Exported for testing.
@@ -421,11 +444,17 @@ function isExcludedPath(filePath: string): boolean {
  * - claimedState: the state captured in the match
  * - normalizedText: the normalized match text
  *
- * Cross-repo references are NOT filtered here — the resolver handles them.
+ * Cross-repo references: if a number appears in an owner/repo#N context
+ * anywhere in the text, bare #N claims for that number are skipped to
+ * prevent misresolution as current-repo references.
  */
 export function extractStatusTruthClaimsFromText(params: {path: string; text: string}): StatusTruthClaim[] {
   const {path, text} = params
   const claims: StatusTruthClaim[] = []
+
+  // Pre-compute numbers that appear in cross-repo references (owner/repo#N).
+  // These must not be extracted as bare current-repo #N references.
+  const crossRepoNumbers = extractCrossRepoNumbers(text)
 
   for (const def of CLAIM_KIND_DEFINITIONS) {
     // Use global flag for multi-match scanning
@@ -446,6 +475,10 @@ export function extractStatusTruthClaimsFromText(params: {path: string; text: st
         const number = match[1]
         const state = match[2]
         if (number === undefined || state === undefined) continue
+        // Skip if this number appears in a cross-repo reference in the same text.
+        // This prevents "fro-bot/agent#1033 PR #1033 is open" from producing
+        // a bare #1033 that the resolver would treat as a current-repo reference.
+        if (crossRepoNumbers.has(number)) continue
         sourceRef = `#${number}`
         claimedState = state.toLowerCase()
       } else if (def.kind === 'release-tag-state') {
@@ -569,11 +602,11 @@ export async function resolveClaimLiveState(params: {
   const {claim, octokit, owner, repo} = params
 
   if (claim.kind === 'plan-status') {
-    // plan-status is resolved via file-parse: the claimedState IS the live state
-    // (the frontmatter is the source of truth for itself). Mark as resolved with
-    // the claimed state so it shows as 'current' — drift detection for plan-status
-    // requires cross-file comparison which is out of Phase 1 scope.
-    return {status: 'resolved', state: claim.claimedState}
+    // plan-status requires cross-file comparison to detect drift, which is out of
+    // Phase 1 scope. Returning the claimedState as live state would always show
+    // 'current' and mask real drift. Mark as unavailable so the finding is
+    // classified as unresolved (honest scope-cut, same as rollout-tracker).
+    return {status: 'unavailable'}
   }
 
   if (claim.kind === 'rollout-tracker-status') {
@@ -833,7 +866,7 @@ async function runDetect(): Promise<void> {
 
     if (token !== undefined && token !== '') {
       const {Octokit} = await import('@octokit/rest')
-      const octokit = new Octokit({auth: token}) as unknown as DetectOctokitClient
+      const octokit = new Octokit({auth: token, request: {timeout: 10_000}}) as unknown as DetectOctokitClient
       const resolved = await resolveAllClaims({claims, octokit, owner, repo})
       resolverResults = resolved.resolverResults
       resolveErrors = resolved.resolveErrors

--- a/scripts/status-truth-detect.ts
+++ b/scripts/status-truth-detect.ts
@@ -1,4 +1,6 @@
 import {createHash} from 'node:crypto'
+import {readFile, writeFile} from 'node:fs/promises'
+import process from 'node:process'
 
 export type ClaimKind = 'pr-state' | 'issue-state' | 'release-tag-state' | 'plan-status' | 'rollout-tracker-status'
 
@@ -165,6 +167,12 @@ export function normalizeClaimText(text: string): string {
   return text.trim().toLowerCase().replaceAll(/\s+/gu, ' ')
 }
 
+export function selectFailureClass(scanErrors: number, resolveErrors: number): FailureClass | null {
+  if (scanErrors > 0) return 'file-parse-error'
+  if (resolveErrors > 0) return 'api-unavailable'
+  return null
+}
+
 /**
  * Compute a stable 16-hex-char fingerprint for a claim.
  *
@@ -187,10 +195,12 @@ export function computeClaimFingerprint(
  * Replaces the claimed state with the live state in the normalized text.
  */
 function buildProposedCorrection(claim: StatusTruthClaim, liveState: string): string {
-  // Replace the claimed state token in the normalized text with the live state
+  // Replace the claimed state token in the normalized text with the live state.
+  // Use a replacement function (not a string) so that live-state values containing
+  // special replacement tokens like `$&`, `$1`, `$$` are inserted literally.
   const escaped = claim.claimedState.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`)
   const pattern = new RegExp(String.raw`\b${escaped}\b`, 'iu')
-  const corrected = claim.normalizedText.replace(pattern, liveState)
+  const corrected = claim.normalizedText.replace(pattern, () => liveState)
   // If replacement didn't change anything, append the correction explicitly
   if (corrected === claim.normalizedText) {
     return `${claim.normalizedText} [live: ${liveState}]`
@@ -370,4 +380,513 @@ export function buildStatusTruthReport(params: BuildStatusTruthReportParams): St
  */
 export function isKnownReportVersion(report: StatusTruthJsonReport): boolean {
   return report.schema_version === KNOWN_SCHEMA_VERSION && report.fingerprint_version === KNOWN_FINGERPRINT_VERSION
+}
+
+// ---------------------------------------------------------------------------
+// Unit 4: Text extraction and file scanning
+// ---------------------------------------------------------------------------
+
+/**
+ * Bounded allowlist of glob patterns for public docs paths to scan.
+ * Excludes generated/proposal state (metadata/, data branch paths).
+ */
+export const SCAN_GLOB_PATTERNS: readonly string[] = [
+  'README.md',
+  'SECURITY.md',
+  'docs/**/*.md',
+  'knowledge/**/*.md',
+  '.github/**/*.md',
+]
+
+/**
+ * Paths to exclude from scanning (generated/proposal state).
+ * These paths may contain status-truth proposal bodies that would self-reference.
+ */
+const SCAN_EXCLUDE_PATTERNS: readonly RegExp[] = [/^metadata\//u, /^\.github\/workflows\//u, /^node_modules\//u]
+
+function isExcludedPath(filePath: string): boolean {
+  return SCAN_EXCLUDE_PATTERNS.some(pattern => pattern.test(filePath))
+}
+
+/**
+ * Extract status-truth claims from a single document's text.
+ *
+ * Pure function: no I/O. Exported for testing.
+ *
+ * For each CLAIM_KIND_DEFINITIONS pattern, scans the text for all matches.
+ * Returns one StatusTruthClaim per match with:
+ * - kind: the claim kind
+ * - path: the file path (caller-provided)
+ * - sourceRef: derived from the match groups (number or tag)
+ * - claimedState: the state captured in the match
+ * - normalizedText: the normalized match text
+ *
+ * Cross-repo references are NOT filtered here — the resolver handles them.
+ */
+export function extractStatusTruthClaimsFromText(params: {path: string; text: string}): StatusTruthClaim[] {
+  const {path, text} = params
+  const claims: StatusTruthClaim[] = []
+
+  for (const def of CLAIM_KIND_DEFINITIONS) {
+    // Use global flag for multi-match scanning
+    const globalPattern = new RegExp(
+      def.pattern.source,
+      def.pattern.flags.includes('g') ? def.pattern.flags : `${def.pattern.flags}g`,
+    )
+
+    for (const match of text.matchAll(globalPattern)) {
+      const fullMatch = match[0]
+      if (fullMatch === undefined) continue
+
+      let sourceRef: string
+      let claimedState: string
+
+      if (def.kind === 'pr-state' || def.kind === 'issue-state' || def.kind === 'rollout-tracker-status') {
+        // Groups: [number, state]
+        const number = match[1]
+        const state = match[2]
+        if (number === undefined || state === undefined) continue
+        sourceRef = `#${number}`
+        claimedState = state.toLowerCase()
+      } else if (def.kind === 'release-tag-state') {
+        // Groups: [tag, state]
+        const tag = match[1]
+        const state = match[2]
+        if (tag === undefined || state === undefined) continue
+        sourceRef = `@${tag}`
+        claimedState = state.toLowerCase()
+      } else if (def.kind === 'plan-status') {
+        // Groups: [state] — frontmatter status field
+        const state = match[1]
+        if (state === undefined) continue
+        sourceRef = `${path}#status`
+        claimedState = state.toLowerCase()
+      } else {
+        continue
+      }
+
+      const normalizedText = normalizeClaimText(fullMatch)
+      claims.push({kind: def.kind, path, sourceRef, claimedState, normalizedText})
+    }
+  }
+
+  return claims
+}
+
+/**
+ * Injected file reader type for testability.
+ * Production: reads from disk. Tests: returns fixture content.
+ */
+export type FileReader = (filePath: string) => Promise<string>
+
+/**
+ * Injected file lister type for testability.
+ * Production: globs the filesystem. Tests: returns fixture paths.
+ */
+export type FileLister = () => Promise<string[]>
+
+/**
+ * Scan a bounded set of public docs paths for status-truth claims.
+ *
+ * @param params - Scan parameters.
+ * @param params.fileLister - Injected function that returns the list of paths to scan.
+ * @param params.fileReader - Injected function that reads a file's text content.
+ * @returns All extracted claims from all scanned files.
+ *
+ * Scan failures for individual files are counted but do not abort the scan.
+ * If the file lister itself fails, throws so the caller can emit execution-failure.
+ */
+export async function scanStatusTruthClaims(params: {
+  fileLister: FileLister
+  fileReader: FileReader
+}): Promise<{claims: StatusTruthClaim[]; scanErrors: number}> {
+  const {fileLister, fileReader} = params
+  const paths = await fileLister()
+  const claims: StatusTruthClaim[] = []
+  let scanErrors = 0
+
+  for (const filePath of paths) {
+    if (isExcludedPath(filePath)) continue
+    try {
+      const text = await fileReader(filePath)
+      const fileClaims = extractStatusTruthClaimsFromText({path: filePath, text})
+      claims.push(...fileClaims)
+    } catch {
+      // Count per-file read errors; do not abort the scan
+      scanErrors++
+    }
+  }
+
+  return {claims, scanErrors}
+}
+
+// ---------------------------------------------------------------------------
+// Unit 4: Current-repo resolver helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal Octokit-like client for the detect step (read-only).
+ * Injected for testability; production code uses @octokit/rest Octokit.
+ */
+export interface DetectOctokitClient {
+  readonly rest: {
+    readonly pulls: {
+      readonly get: (params: {owner: string; repo: string; pull_number: number}) => Promise<{
+        data: {state: string; merged: boolean}
+      }>
+    }
+    readonly issues: {
+      readonly get: (params: {owner: string; repo: string; issue_number: number}) => Promise<{
+        data: {state: string}
+      }>
+    }
+    readonly repos: {
+      readonly getReleaseByTag: (params: {owner: string; repo: string; tag: string}) => Promise<{
+        data: {draft: boolean; prerelease: boolean}
+      }>
+    }
+  }
+}
+
+/**
+ * Resolve a single claim's live state using the injected Octokit client.
+ *
+ * Current-repo scoped: only resolves claims whose sourceRef is a bare `#N` or `@tag`
+ * (no `owner/repo` prefix). Cross-repo or unsupported refs return `unavailable`.
+ *
+ * PR state: 'open' | 'closed' | 'merged'
+ * Issue state: 'open' | 'closed'
+ * Release state: 'published' | 'draft'
+ * Plan-status: resolved via file-parse (not this function)
+ * Rollout-tracker: compound — returns unavailable (Phase 1 scope cut)
+ */
+export async function resolveClaimLiveState(params: {
+  claim: StatusTruthClaim
+  octokit: DetectOctokitClient
+  owner: string
+  repo: string
+}): Promise<ResolverResult> {
+  const {claim, octokit, owner, repo} = params
+
+  if (claim.kind === 'plan-status') {
+    // plan-status is resolved via file-parse: the claimedState IS the live state
+    // (the frontmatter is the source of truth for itself). Mark as resolved with
+    // the claimed state so it shows as 'current' — drift detection for plan-status
+    // requires cross-file comparison which is out of Phase 1 scope.
+    return {status: 'resolved', state: claim.claimedState}
+  }
+
+  if (claim.kind === 'rollout-tracker-status') {
+    // Compound resolver: Phase 1 scope cut — mark unavailable
+    return {status: 'unavailable'}
+  }
+
+  if (claim.kind === 'pr-state') {
+    // sourceRef must be bare `#N` for current-repo
+    const match = /^#(\d+)$/u.exec(claim.sourceRef)
+    if (match === null || match[1] === undefined) {
+      // Cross-repo or malformed ref — unavailable
+      return {status: 'unavailable'}
+    }
+    const prNumber = Number.parseInt(match[1], 10)
+    try {
+      const {data} = await octokit.rest.pulls.get({owner, repo, pull_number: prNumber})
+      if (data.merged) return {status: 'resolved', state: 'merged'}
+      return {status: 'resolved', state: data.state === 'open' ? 'open' : 'closed'}
+    } catch {
+      return {status: 'unavailable'}
+    }
+  }
+
+  if (claim.kind === 'issue-state') {
+    const match = /^#(\d+)$/u.exec(claim.sourceRef)
+    if (match === null || match[1] === undefined) {
+      return {status: 'unavailable'}
+    }
+    const issueNumber = Number.parseInt(match[1], 10)
+    try {
+      const {data} = await octokit.rest.issues.get({owner, repo, issue_number: issueNumber})
+      return {status: 'resolved', state: data.state === 'open' ? 'open' : 'closed'}
+    } catch {
+      return {status: 'unavailable'}
+    }
+  }
+
+  if (claim.kind === 'release-tag-state') {
+    const match = /^@(.+)$/u.exec(claim.sourceRef)
+    if (match === null || match[1] === undefined) {
+      return {status: 'unavailable'}
+    }
+    const tag = match[1]
+    try {
+      const {data} = await octokit.rest.repos.getReleaseByTag({owner, repo, tag})
+      return {status: 'resolved', state: data.draft ? 'draft' : 'published'}
+    } catch {
+      return {status: 'unavailable'}
+    }
+  }
+
+  return {status: 'unavailable'}
+}
+
+/**
+ * Resolve all claims against live state using the injected Octokit client.
+ *
+ * Returns a resolver results map keyed by `kind:sourceRef`.
+ * Resolution failures for individual claims are counted but do not abort.
+ */
+export async function resolveAllClaims(params: {
+  claims: readonly StatusTruthClaim[]
+  octokit: DetectOctokitClient
+  owner: string
+  repo: string
+}): Promise<{resolverResults: Record<string, ResolverResult>; resolveErrors: number}> {
+  const {claims, octokit, owner, repo} = params
+  const resolverResults: Record<string, ResolverResult> = {}
+  let resolveErrors = 0
+
+  // Deduplicate by kind:sourceRef to avoid redundant API calls
+  const seen = new Set<string>()
+
+  for (const claim of claims) {
+    const key = `${claim.kind}:${claim.sourceRef}`
+    if (seen.has(key)) continue
+    seen.add(key)
+
+    try {
+      resolverResults[key] = await resolveClaimLiveState({claim, octokit, owner, repo})
+    } catch {
+      resolveErrors++
+      resolverResults[key] = {status: 'unavailable'}
+    }
+  }
+
+  return {resolverResults, resolveErrors}
+}
+
+// ---------------------------------------------------------------------------
+// Unit 4: Artifact validation helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Prohibited fields that must not appear in a handoff artifact.
+ * These fields would expose raw claim text, source snippets, or private identity.
+ */
+const PROHIBITED_ARTIFACT_FIELDS: readonly string[] = ['normalizedText', 'rawText', 'sourceSnippet', 'apiResponse']
+
+/**
+ * Validate a parsed report artifact before the open step can write.
+ *
+ * Checks (in order):
+ * 1. Known schema and fingerprint versions.
+ * 2. Required top-level fields are present.
+ * 3. Prohibited fields are absent (sanitized artifact contract).
+ * 4. Aggregate count consistency: counts.total === findings.length.
+ *
+ * Returns an object with `valid: boolean` and `reason: string` on failure.
+ */
+export function validateStatusTruthArtifact(
+  raw: unknown,
+): {valid: true; report: StatusTruthJsonReport} | {valid: false; reason: string} {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    return {valid: false, reason: 'artifact is not an object'}
+  }
+
+  const obj = raw as Record<string, unknown>
+
+  // 1. Version check
+  if (typeof obj.schema_version !== 'number' || typeof obj.fingerprint_version !== 'number') {
+    return {valid: false, reason: 'artifact missing schema_version or fingerprint_version'}
+  }
+  if (obj.schema_version !== KNOWN_SCHEMA_VERSION || obj.fingerprint_version !== KNOWN_FINGERPRINT_VERSION) {
+    return {
+      valid: false,
+      reason: `unknown artifact version: schema=${obj.schema_version} fingerprint=${obj.fingerprint_version}`,
+    }
+  }
+
+  // 2. Required fields
+  const requiredFields = [
+    'status',
+    'scan_complete',
+    'generated_at',
+    'failure_class',
+    'repair_eligible',
+    'findings',
+    'counts',
+  ]
+  for (const field of requiredFields) {
+    if (!(field in obj)) {
+      return {valid: false, reason: `artifact missing required field: ${field}`}
+    }
+  }
+
+  if (!Array.isArray(obj.findings)) {
+    return {valid: false, reason: 'artifact findings is not an array'}
+  }
+
+  // 3. Prohibited fields (sanitized artifact contract)
+  for (const field of PROHIBITED_ARTIFACT_FIELDS) {
+    if (field in obj) {
+      return {valid: false, reason: `artifact contains prohibited field: ${field}`}
+    }
+    // Also check within each finding
+    for (const finding of obj.findings as unknown[]) {
+      if (typeof finding === 'object' && finding !== null && field in (finding as Record<string, unknown>)) {
+        return {valid: false, reason: `artifact finding contains prohibited field: ${field}`}
+      }
+    }
+  }
+
+  // 4. Count consistency
+  const counts = obj.counts as Record<string, unknown>
+  if (typeof counts !== 'object' || counts === null) {
+    return {valid: false, reason: 'artifact counts is not an object'}
+  }
+  if (typeof counts.total !== 'number') {
+    return {valid: false, reason: 'artifact counts.total is not a number'}
+  }
+  if (counts.total !== (obj.findings as unknown[]).length) {
+    return {
+      valid: false,
+      reason: `artifact count mismatch: counts.total=${counts.total} but findings.length=${(obj.findings as unknown[]).length}`,
+    }
+  }
+
+  return {valid: true, report: raw as StatusTruthJsonReport}
+}
+
+// ---------------------------------------------------------------------------
+// Unit 4: CLI shell
+// ---------------------------------------------------------------------------
+
+/**
+ * CLI entry point for the status-truth detect step.
+ *
+ * Environment variables:
+ * - STATUS_TRUTH_REPORT_PATH: path to write the JSON report artifact (required)
+ * - STATUS_TRUTH_DRY_RUN: set to 'true' for dry-run mode (optional)
+ * - GITHUB_TOKEN: read-only token for current-repo API resolution (optional;
+ *   without it, all API claims are classified as unavailable/unresolved)
+ * - GITHUB_REPOSITORY: owner/repo for current-repo resolution (optional;
+ *   defaults to 'fro-bot/.github')
+ *
+ * Behavior:
+ * - Scans public docs paths (README.md, SECURITY.md, docs/**, knowledge/**,
+ *   .github/**\/*.md) for status-truth claims using CLAIM_KIND_DEFINITIONS patterns.
+ * - Resolves live state for current-repo PR/issues/releases/tags using the
+ *   read-only GITHUB_TOKEN. Cross-repo references are classified as unavailable.
+ * - Emits a structured report artifact plus counts-only summary to stdout.
+ * - stdout/stderr carry counts only; no raw claim text, source paths, or fingerprints.
+ * - If scanning/resolution fails unexpectedly, emits an execution-failure report.
+ *   Never emits a fake clean report when scanning has not run.
+ *
+ * Strip-only safe: no parameter properties, enums, or namespaces.
+ */
+async function runDetect(): Promise<void> {
+  const reportPath = process.env.STATUS_TRUTH_REPORT_PATH
+
+  if (reportPath === undefined || reportPath === '') {
+    process.stderr.write('status-truth-detect: STATUS_TRUTH_REPORT_PATH is required\n')
+    process.exit(1)
+  }
+
+  const generatedAt = new Date().toISOString()
+
+  // Determine owner/repo from environment
+  const githubRepository = process.env.GITHUB_REPOSITORY ?? 'fro-bot/.github'
+  const slashIndex = githubRepository.indexOf('/')
+  const owner = slashIndex === -1 ? githubRepository : githubRepository.slice(0, slashIndex)
+  const repo = slashIndex === -1 ? '' : githubRepository.slice(slashIndex + 1)
+
+  if (owner === '' || repo === '') {
+    process.stderr.write('status-truth-detect: GITHUB_REPOSITORY must be in owner/repo format\n')
+    process.exit(1)
+  }
+
+  // Build file lister using Node 24 native glob
+  const fileLister: FileLister = async () => {
+    const {glob: fsGlob} = await import('node:fs/promises')
+    const paths: string[] = []
+    for (const pattern of SCAN_GLOB_PATTERNS) {
+      for await (const entry of fsGlob(pattern, {cwd: process.cwd()})) {
+        paths.push(entry)
+      }
+    }
+    return paths
+  }
+
+  // Build file reader
+  const fileReader: FileReader = async (filePath: string) => readFile(filePath, 'utf8')
+
+  let report: StatusTruthJsonReport
+
+  try {
+    // Step 1: Scan for claims
+    const {claims, scanErrors} = await scanStatusTruthClaims({fileLister, fileReader})
+
+    // Step 2: Resolve live state
+    // Build Octokit client if token is available; otherwise all claims become unavailable
+    const token = process.env.GITHUB_TOKEN
+    let resolverResults: Record<string, ResolverResult> = {}
+    let resolveErrors = 0
+
+    if (token !== undefined && token !== '') {
+      const {Octokit} = await import('@octokit/rest')
+      const octokit = new Octokit({auth: token}) as unknown as DetectOctokitClient
+      const resolved = await resolveAllClaims({claims, octokit, owner, repo})
+      resolverResults = resolved.resolverResults
+      resolveErrors = resolved.resolveErrors
+    }
+    // If no token: all API claims remain unresolved (resolverResults stays empty)
+
+    // Step 3: Classify claims into findings
+    const findings = detectStatusTruthClaims(claims, resolverResults)
+
+    // Scan is complete if no per-file or resolve errors occurred.
+    // Failure class distinguishes the error source:
+    // - file-parse-error: per-file read/parse errors during scanning
+    // - api-unavailable: resolver/API errors after scanning succeeded
+    const totalErrors = scanErrors + resolveErrors
+    const scanComplete = totalErrors === 0
+
+    const failureClass = selectFailureClass(scanErrors, resolveErrors)
+
+    report = buildStatusTruthReport({
+      findings,
+      scanComplete,
+      generatedAt,
+      failureClass,
+    })
+  } catch {
+    // Unexpected failure — emit execution-failure report, not fake clean
+    process.stderr.write('status-truth-detect: unexpected scan failure: error-class=execution-error\n')
+    report = buildStatusTruthReport({
+      findings: [],
+      scanComplete: false,
+      generatedAt,
+      failureClass: 'execution-error',
+    })
+  }
+
+  const reportJson = `${JSON.stringify(report, null, 2)}\n`
+
+  try {
+    await writeFile(reportPath, reportJson, {flag: 'w'})
+  } catch {
+    process.stderr.write('status-truth-detect: could not write report: error-class=write-failure\n')
+    process.exit(1)
+  }
+
+  // Counts-only summary to stdout — no raw claim text, source paths, or fingerprints
+  const summary = {
+    status: report.status,
+    scan_complete: report.scan_complete,
+    counts: report.counts,
+  }
+  process.stdout.write(`${JSON.stringify(summary)}\n`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await runDetect()
 }

--- a/scripts/status-truth-detect.ts
+++ b/scripts/status-truth-detect.ts
@@ -1,0 +1,373 @@
+import {createHash} from 'node:crypto'
+
+export type ClaimKind = 'pr-state' | 'issue-state' | 'release-tag-state' | 'plan-status' | 'rollout-tracker-status'
+
+export type ResolverType = 'api' | 'file-parse' | 'compound'
+
+export type ClaimVerdict = 'current' | 'drifted' | 'unresolved' | 'unsafe'
+
+export type FailureClass = 'api-unavailable' | 'file-parse-error' | 'sub-resolver-unavailable' | 'execution-error'
+
+/**
+ * Result from a live-state resolver for a single claim.
+ *
+ * - `resolved`: live state was successfully fetched; `state` holds the value.
+ *   Compound resolvers may include `subResolverResults` for required sub-resolvers.
+ * - `unavailable`: the source could not be reached (API down, file missing, etc.).
+ * - `private`: the source exists but identity is private/unknown — must not be
+ *   exposed in findings.
+ */
+export type ResolverResult =
+  | {
+      readonly status: 'resolved'
+      readonly state: string
+      readonly subResolverResults?: Readonly<Record<string, ResolverResult>>
+    }
+  | {readonly status: 'unavailable'}
+  | {readonly status: 'private'}
+
+export interface ClaimKindDefinition {
+  readonly kind: ClaimKind
+  readonly resolverType: ResolverType
+  /** Pattern used to extract claims of this kind from document text. */
+  readonly pattern: RegExp
+  /** Human-readable rule describing when a claim is considered confident. */
+  readonly confidenceRule: string
+  /** Human-readable rule describing when a claim is suppressed. */
+  readonly suppressionRule: string
+  /** Fields included in a proposal for this claim kind. */
+  readonly proposalFields: readonly string[]
+  /** Sub-resolvers required by compound resolvers. */
+  readonly subResolvers?: readonly ClaimKind[]
+}
+
+export const CLAIM_KIND_DEFINITIONS: readonly ClaimKindDefinition[] = [
+  {
+    kind: 'pr-state',
+    resolverType: 'api',
+    pattern: /\bPR\s+#(\d+)\s+is\s+(open|closed|merged)\b/iu,
+    confidenceRule: 'GitHub PR API state wins over narrative status text.',
+    suppressionRule: 'Unavailable or inaccessible PRs are unresolved, not drifted.',
+    proposalFields: ['kind', 'path', 'sourceRef', 'claimedState', 'liveState', 'proposedCorrection'],
+  },
+  {
+    kind: 'issue-state',
+    resolverType: 'api',
+    pattern: /\bissue\s+#(\d+)\s+is\s+(open|closed)\b/iu,
+    confidenceRule: 'GitHub issue API state wins over narrative status text.',
+    suppressionRule: 'Unavailable or inaccessible issues are unresolved, not drifted.',
+    proposalFields: ['kind', 'path', 'sourceRef', 'claimedState', 'liveState', 'proposedCorrection'],
+  },
+  {
+    kind: 'release-tag-state',
+    resolverType: 'api',
+    pattern: /\brelease\s+(v[\w.-]+)\s+is\s+(published|draft|unpublished)\b/iu,
+    confidenceRule:
+      'GitHub release/tag API state wins over plan or issue status text. Published release does not imply deployed runtime state.',
+    suppressionRule: 'Unavailable release/tag state is unresolved, not drifted.',
+    proposalFields: ['kind', 'path', 'sourceRef', 'claimedState', 'liveState', 'proposedCorrection'],
+  },
+  {
+    kind: 'plan-status',
+    resolverType: 'file-parse',
+    pattern: /^status:\s*(active|complete|draft|cancelled|superseded)\s*$/imu,
+    confidenceRule: 'Current plan frontmatter wins over prose references to the same plan.',
+    suppressionRule: 'Conflicting frontmatter/prose is unresolved, not drifted.',
+    proposalFields: ['kind', 'path', 'sourceRef', 'claimedState', 'liveState', 'proposedCorrection'],
+  },
+  {
+    kind: 'rollout-tracker-status',
+    resolverType: 'compound',
+    pattern: /\brollout\s+tracker\s+#(\d+)\s+is\s+(\w+)\b/iu,
+    confidenceRule:
+      'Use the existing rollout-tracker snapshot shape instead of re-deriving tracker truth. Snapshot/source/reference disagreement is unresolved.',
+    suppressionRule:
+      'Project access failure, snapshot failure, or referenced-state disagreement is unresolved rather than drifted.',
+    proposalFields: ['kind', 'path', 'sourceRef', 'claimedState', 'liveState'],
+    subResolvers: ['issue-state', 'pr-state'],
+  },
+]
+
+export interface StatusTruthClaim {
+  readonly kind: ClaimKind
+  readonly path: string
+  readonly sourceRef: string
+  readonly claimedState: string
+  readonly normalizedText: string
+}
+
+/**
+ * A public finding (current/drifted/unresolved) — includes identity-bearing fields
+ * because the source is known and accessible.
+ */
+export interface PublicStatusTruthFinding {
+  readonly kind: ClaimKind
+  readonly path: string
+  readonly sourceRef: string
+  readonly verdict: 'current' | 'drifted' | 'unresolved'
+  readonly fingerprint: string
+  readonly claimedState: string
+  readonly liveState?: string
+  readonly proposalEligible: boolean
+  readonly proposedCorrection?: string
+}
+
+/**
+ * An unsafe finding (private/unknown identity) — identity-bearing fields are
+ * intentionally omitted to prevent leaking private repo/user/issue references.
+ * Fingerprint and proposal metadata are only generated after public identity is proven.
+ */
+export interface UnsafeStatusTruthFinding {
+  readonly kind: ClaimKind
+  readonly verdict: 'unsafe'
+  readonly proposalEligible: false
+}
+
+/** Discriminated union of all finding shapes. */
+export type StatusTruthFinding = PublicStatusTruthFinding | UnsafeStatusTruthFinding
+
+export interface StatusTruthCounts {
+  readonly total: number
+  readonly current: number
+  readonly drifted: number
+  readonly unresolved: number
+  readonly unsafe: number
+  readonly proposal_eligible: number
+}
+
+export interface StatusTruthJsonReport {
+  readonly schema_version: number
+  readonly fingerprint_version: number
+  readonly status: 'clean' | 'findings' | 'execution-failure'
+  readonly scan_complete: boolean
+  readonly generated_at: string
+  readonly failure_class: FailureClass | null
+  readonly repair_eligible: boolean
+  readonly findings: readonly StatusTruthFinding[]
+  readonly counts: StatusTruthCounts
+}
+
+export interface BuildStatusTruthReportParams {
+  readonly findings: readonly StatusTruthFinding[]
+  readonly scanComplete: boolean
+  readonly generatedAt: string
+  readonly failureClass: FailureClass | null
+}
+
+export const KNOWN_SCHEMA_VERSION = 1
+export const KNOWN_FINGERPRINT_VERSION = 1
+
+/**
+ * Normalize claim text for stable fingerprinting.
+ * Lowercases, trims, and collapses internal whitespace.
+ */
+export function normalizeClaimText(text: string): string {
+  return text.trim().toLowerCase().replaceAll(/\s+/gu, ' ')
+}
+
+/**
+ * Compute a stable 16-hex-char fingerprint for a claim.
+ *
+ * Inputs: claim kind, file path, source reference, normalized claim text.
+ * Line numbers are intentionally excluded so unrelated line shifts do not
+ * create duplicate proposals.
+ */
+export function computeClaimFingerprint(
+  kind: ClaimKind,
+  path: string,
+  sourceRef: string,
+  normalizedText: string,
+): string {
+  const input = `${kind}\u0000${path}\u0000${sourceRef}\u0000${normalizedText}`
+  return createHash('sha256').update(input).digest('hex').slice(0, 16)
+}
+
+/**
+ * Build a proposed correction string for a drifted claim.
+ * Replaces the claimed state with the live state in the normalized text.
+ */
+function buildProposedCorrection(claim: StatusTruthClaim, liveState: string): string {
+  // Replace the claimed state token in the normalized text with the live state
+  const escaped = claim.claimedState.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`)
+  const pattern = new RegExp(String.raw`\b${escaped}\b`, 'iu')
+  const corrected = claim.normalizedText.replace(pattern, liveState)
+  // If replacement didn't change anything, append the correction explicitly
+  if (corrected === claim.normalizedText) {
+    return `${claim.normalizedText} [live: ${liveState}]`
+  }
+  return corrected
+}
+
+/**
+ * Check whether all required sub-resolvers for a compound claim are resolved.
+ *
+ * Returns true only when every required sub-resolver kind has a `resolved` result
+ * in the provided subResolverResults map. Missing or non-resolved sub-resolvers
+ * cause the compound claim to be treated as unresolved.
+ */
+function compoundSubResolversAllResolved(
+  kind: ClaimKind,
+  subResolverResults: Readonly<Record<string, ResolverResult>> | undefined,
+): boolean {
+  const def = CLAIM_KIND_DEFINITIONS.find(d => d.kind === kind)
+  if (!def?.subResolvers || def.subResolvers.length === 0) return true
+  if (!subResolverResults) return false
+
+  for (const subKind of def.subResolvers) {
+    const subResult = subResolverResults[subKind]
+    if (!subResult || subResult.status !== 'resolved') return false
+  }
+  return true
+}
+
+/**
+ * Classify a single claim against its resolver result.
+ *
+ * Source precedence rules:
+ * - Private/unknown identity → unsafe (identity-bearing fields not emitted)
+ * - Resolver unavailable → unresolved
+ * - Compound: any required sub-resolver not resolved → unresolved
+ * - Live state matches claimed state → current
+ * - Live state differs from claimed state → drifted
+ */
+function classifyClaim(
+  claim: StatusTruthClaim,
+  result: ResolverResult | undefined,
+): {verdict: ClaimVerdict; proposalEligible: boolean; proposedCorrection?: string; liveState?: string} {
+  if (!result) {
+    return {verdict: 'unresolved', proposalEligible: false}
+  }
+
+  if (result.status === 'private') {
+    return {verdict: 'unsafe', proposalEligible: false}
+  }
+
+  if (result.status === 'unavailable') {
+    return {verdict: 'unresolved', proposalEligible: false}
+  }
+
+  const {state: liveState, subResolverResults} = result
+
+  const def = CLAIM_KIND_DEFINITIONS.find(d => d.kind === claim.kind)
+  if (def?.resolverType === 'compound' && !compoundSubResolversAllResolved(claim.kind, subResolverResults)) {
+    return {verdict: 'unresolved', proposalEligible: false}
+  }
+
+  if (liveState === claim.claimedState) {
+    return {verdict: 'current', proposalEligible: false, liveState}
+  }
+
+  const proposedCorrection = buildProposedCorrection(claim, liveState)
+  return {verdict: 'drifted', proposalEligible: true, proposedCorrection, liveState}
+}
+
+/** Resolver type processing order: file-parse → api → compound. */
+const RESOLVER_ORDER: Record<ResolverType, number> = {'file-parse': 0, api: 1, compound: 2}
+
+function resolverTypeForKind(kind: ClaimKind): ResolverType {
+  return CLAIM_KIND_DEFINITIONS.find(d => d.kind === kind)?.resolverType ?? 'api'
+}
+
+/**
+ * Detect status-truth claims and classify each against live state.
+ *
+ * @param claims - Extracted claims from document scanning.
+ * @param resolverResults - Map from `kind:sourceRef` to ResolverResult.
+ *   Keys must be formatted as `${kind}:${sourceRef}` to prevent cross-wiring
+ *   between different claim kinds sharing the same source reference.
+ */
+export function detectStatusTruthClaims(
+  claims: readonly StatusTruthClaim[],
+  resolverResults: Readonly<Record<string, ResolverResult>>,
+): StatusTruthFinding[] {
+  const findings: StatusTruthFinding[] = []
+
+  const sorted = [...claims].sort(
+    (a, b) => RESOLVER_ORDER[resolverTypeForKind(a.kind)] - RESOLVER_ORDER[resolverTypeForKind(b.kind)],
+  )
+
+  for (const claim of sorted) {
+    const resultKey = `${claim.kind}:${claim.sourceRef}`
+    const result = resolverResults[resultKey]
+    const {verdict, proposalEligible, proposedCorrection, liveState} = classifyClaim(claim, result)
+
+    if (verdict === 'unsafe') {
+      const finding: UnsafeStatusTruthFinding = {
+        kind: claim.kind,
+        verdict: 'unsafe',
+        proposalEligible: false,
+      }
+      findings.push(finding)
+    } else {
+      const fingerprint = computeClaimFingerprint(claim.kind, claim.path, claim.sourceRef, claim.normalizedText)
+      const finding: PublicStatusTruthFinding = {
+        kind: claim.kind,
+        path: claim.path,
+        sourceRef: claim.sourceRef,
+        verdict,
+        fingerprint,
+        claimedState: claim.claimedState,
+        ...(liveState !== undefined && {liveState}),
+        proposalEligible,
+        ...(proposedCorrection !== undefined && {proposedCorrection}),
+      }
+      findings.push(finding)
+    }
+  }
+
+  return findings
+}
+
+/**
+ * Build the versioned status-truth report envelope.
+ *
+ * Status rules:
+ * - `execution-failure` when scan is incomplete (scanComplete:false) OR failureClass is non-null
+ * - `findings` when any finding is present and scan completed
+ * - `clean` otherwise
+ *
+ * repair_eligible: true only when scan is complete, status is `findings`, and at least one finding is proposal-eligible.
+ */
+export function buildStatusTruthReport(params: BuildStatusTruthReportParams): StatusTruthJsonReport {
+  const {findings, scanComplete, generatedAt, failureClass} = params
+
+  const isFailure = !scanComplete || failureClass !== null
+  const status: 'clean' | 'findings' | 'execution-failure' = isFailure
+    ? 'execution-failure'
+    : findings.length > 0
+      ? 'findings'
+      : 'clean'
+
+  const proposalEligibleCount = findings.filter(f => f.proposalEligible).length
+  const repairEligible = scanComplete && status === 'findings' && proposalEligibleCount > 0
+
+  const counts: StatusTruthCounts = {
+    total: findings.length,
+    current: findings.filter(f => f.verdict === 'current').length,
+    drifted: findings.filter(f => f.verdict === 'drifted').length,
+    unresolved: findings.filter(f => f.verdict === 'unresolved').length,
+    unsafe: findings.filter(f => f.verdict === 'unsafe').length,
+    proposal_eligible: proposalEligibleCount,
+  }
+
+  return {
+    schema_version: KNOWN_SCHEMA_VERSION,
+    fingerprint_version: KNOWN_FINGERPRINT_VERSION,
+    status,
+    scan_complete: scanComplete,
+    generated_at: generatedAt,
+    failure_class: failureClass,
+    repair_eligible: repairEligible,
+    findings,
+    counts,
+  }
+}
+
+/**
+ * Validate that a report's schema and fingerprint versions are known.
+ * Returns false for unknown versions; the lifecycle planner must reject
+ * unknown versions before any write planning.
+ */
+export function isKnownReportVersion(report: StatusTruthJsonReport): boolean {
+  return report.schema_version === KNOWN_SCHEMA_VERSION && report.fingerprint_version === KNOWN_FINGERPRINT_VERSION
+}

--- a/scripts/status-truth-proposals.test.ts
+++ b/scripts/status-truth-proposals.test.ts
@@ -1,19 +1,29 @@
 /**
- * Tests for the status-truth proposal lifecycle planner (Unit 3).
+ * Tests for the status-truth proposal lifecycle planner (Unit 3) and
+ * I/O executor (Unit 4).
  *
  * TDD: tests written before implementation.
  * All tests are pure — no Octokit, no disk I/O.
  */
 
 import type {StatusTruthJsonReport} from './status-truth-detect.ts'
-import type {ExistingProposalIssue, PlanStatusTruthProposalActionsInput} from './status-truth-proposals.ts'
+import type {
+  ExecuteStatusTruthProposalActionsInput,
+  ExistingProposalIssue,
+  IssueListItem,
+  PlanStatusTruthProposalActionsInput,
+  StatusTruthOctokitClient,
+} from './status-truth-proposals.ts'
 import type {PublicOutputTokens} from './status-truth-public-output.ts'
 import {describe, expect, it} from 'vitest'
 import {
+  executeStatusTruthProposalActions,
   extractProposalFingerprint,
+  fetchExistingProposalIssues,
   OUTCOME_LABELS,
   planStatusTruthProposalActions,
   PROPOSAL_LABEL,
+  REQUIRED_LABELS,
 } from './status-truth-proposals.ts'
 
 // ---------------------------------------------------------------------------
@@ -715,5 +725,951 @@ describe('planStatusTruthProposalActions', () => {
       expect(OUTCOME_LABELS.resolved).toBeTruthy()
       expect(OUTCOME_LABELS.recurring).toBeTruthy()
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Unit 4: executeStatusTruthProposalActions (I/O shell with injected client)
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Minimal Octokit mock for Unit 4 tests
+// ---------------------------------------------------------------------------
+
+interface MockIssueStore {
+  created: {title: string; body: string; labels: string[]}[]
+  comments: {issueNumber: number; body: string}[]
+  reopened: {issueNumber: number}[]
+  closed: {issueNumber: number; labels: string[]}[]
+  labelChecks: string[]
+  labelCreations: string[]
+}
+
+function makeMockOctokit(
+  overrides: {
+    labelExists?: boolean
+    labelCreateFails?: boolean
+    issueCreateFails?: boolean
+    commentFails?: boolean
+  } = {},
+): {octokit: StatusTruthOctokitClient; store: MockIssueStore} {
+  const store: MockIssueStore = {
+    created: [],
+    comments: [],
+    reopened: [],
+    closed: [],
+    labelChecks: [],
+    labelCreations: [],
+  }
+
+  const octokit = {
+    rest: {
+      issues: {
+        getLabel: async ({name}: {owner: string; repo: string; name: string}) => {
+          store.labelChecks.push(name)
+          if (overrides.labelExists === false) {
+            const err = Object.assign(new Error('Not Found'), {status: 404})
+            throw err
+          }
+          return {data: {name}}
+        },
+        createLabel: async ({
+          name,
+        }: {
+          owner: string
+          repo: string
+          name: string
+          color: string
+          description: string
+        }) => {
+          store.labelCreations.push(name)
+          if (overrides.labelCreateFails === true) {
+            const err = Object.assign(new Error('Unprocessable'), {status: 422})
+            throw err
+          }
+          return {data: {name}}
+        },
+        create: async (params: {owner: string; repo: string; title: string; body: string; labels: string[]}) => {
+          if (overrides.issueCreateFails === true) {
+            const err = Object.assign(new Error('Internal Server Error'), {status: 500})
+            throw err
+          }
+          store.created.push({title: params.title, body: params.body, labels: params.labels})
+          return {data: {number: 1000 + store.created.length}}
+        },
+        createComment: async (params: {owner: string; repo: string; issue_number: number; body: string}) => {
+          if (overrides.commentFails === true) {
+            const err = Object.assign(new Error('Internal Server Error'), {status: 500})
+            throw err
+          }
+          store.comments.push({issueNumber: params.issue_number, body: params.body})
+          return {data: {id: 1}}
+        },
+        update: async (params: {
+          owner: string
+          repo: string
+          issue_number: number
+          state?: string
+          labels?: string[]
+        }) => {
+          if (params.state === 'open') {
+            store.reopened.push({issueNumber: params.issue_number})
+          } else if (params.state === 'closed') {
+            store.closed.push({issueNumber: params.issue_number, labels: params.labels ?? []})
+          }
+          return {data: {number: params.issue_number}}
+        },
+        removeLabel: async (_params: {owner: string; repo: string; issue_number: number; name: string}) => {
+          return {data: []}
+        },
+        addLabels: async (_params: {owner: string; repo: string; issue_number: number; labels: string[]}) => {
+          return {data: []}
+        },
+      },
+    },
+  } as unknown as StatusTruthOctokitClient
+
+  return {octokit, store}
+}
+
+function makeExecuteInput(
+  overrides: Partial<ExecuteStatusTruthProposalActionsInput> = {},
+): ExecuteStatusTruthProposalActionsInput {
+  const {octokit} = makeMockOctokit()
+  return {
+    octokit,
+    owner: 'fro-bot',
+    repo: '.github',
+    actions: [],
+    dryRun: false,
+    sameRunCreatedFingerprints: new Set<string>(),
+    ...overrides,
+  }
+}
+
+describe('executeStatusTruthProposalActions', () => {
+  describe('REQUIRED_LABELS export', () => {
+    it('exports REQUIRED_LABELS array containing the proposal label and outcome labels', () => {
+      expect(Array.isArray(REQUIRED_LABELS)).toBe(true)
+      expect(REQUIRED_LABELS.length).toBeGreaterThan(0)
+      // Must include the primary proposal label
+      const names = REQUIRED_LABELS.map(l => l.name)
+      expect(names).toContain(PROPOSAL_LABEL)
+    })
+  })
+
+  describe('dry-run mode', () => {
+    it('dry-run: emits planned action counts and performs no issue mutations', async () => {
+      const {octokit, store} = makeMockOctokit()
+      const actions = [
+        {
+          type: 'open' as const,
+          fingerprint: 'abc123def456abcd',
+          title: 'Status truth: pr-state drift in docs/plans/example.md',
+          body: '<!-- status-truth:fingerprint=abc123def456abcd -->\n\nBody.',
+          labels: [PROPOSAL_LABEL],
+        },
+      ]
+
+      const result = await executeStatusTruthProposalActions({
+        octokit,
+        owner: 'fro-bot',
+        repo: '.github',
+        actions,
+        dryRun: true,
+        sameRunCreatedFingerprints: new Set<string>(),
+      })
+
+      // No mutations in dry-run
+      expect(store.created).toHaveLength(0)
+      expect(store.comments).toHaveLength(0)
+      expect(store.reopened).toHaveLength(0)
+      expect(store.closed).toHaveLength(0)
+
+      // But counts are reported
+      expect(result.dryRun).toBe(true)
+      expect(result.counts.opened).toBe(1)
+      expect(result.counts.failed).toBe(0)
+    })
+
+    it('dry-run: reports zero mutations even with multiple action types', async () => {
+      const {octokit, store} = makeMockOctokit()
+      const actions = [
+        {
+          type: 'open' as const,
+          fingerprint: 'fp1',
+          title: 'Title 1',
+          body: '<!-- status-truth:fingerprint=fp1 -->\n\nBody.',
+          labels: [PROPOSAL_LABEL],
+        },
+        {
+          type: 'update-comment' as const,
+          issueNumber: 100,
+          comment: 'Updated live state.',
+        },
+        {
+          type: 'close' as const,
+          issueNumber: 200,
+          labels: [OUTCOME_LABELS.resolved],
+          comment: 'Drift cleared.',
+        },
+      ]
+
+      const result = await executeStatusTruthProposalActions({
+        octokit,
+        owner: 'fro-bot',
+        repo: '.github',
+        actions,
+        dryRun: true,
+        sameRunCreatedFingerprints: new Set<string>(),
+      })
+
+      expect(store.created).toHaveLength(0)
+      expect(store.comments).toHaveLength(0)
+      expect(store.closed).toHaveLength(0)
+      expect(result.dryRun).toBe(true)
+      expect(result.counts.opened).toBe(1)
+      expect(result.counts.updated).toBe(1)
+      expect(result.counts.closed).toBe(1)
+    })
+  })
+
+  describe('label gating', () => {
+    it('fails closed when required label cannot be confirmed (label check fails non-404)', async () => {
+      const octokit = {
+        rest: {
+          issues: {
+            getLabel: async () => {
+              const err = Object.assign(new Error('Server Error'), {status: 500})
+              throw err
+            },
+            createLabel: async () => {
+              return {data: {name: 'status-truth'}}
+            },
+            create: async () => {
+              return {data: {number: 1}}
+            },
+            createComment: async () => {
+              return {data: {id: 1}}
+            },
+            update: async () => {
+              return {data: {number: 1}}
+            },
+            removeLabel: async () => {
+              return {data: []}
+            },
+            addLabels: async () => {
+              return {data: []}
+            },
+          },
+        },
+      } as unknown as StatusTruthOctokitClient
+
+      const actions = [
+        {
+          type: 'open' as const,
+          fingerprint: 'abc123def456abcd',
+          title: 'Status truth: pr-state drift',
+          body: '<!-- status-truth:fingerprint=abc123def456abcd -->\n\nBody.',
+          labels: [PROPOSAL_LABEL],
+        },
+      ]
+
+      const result = await executeStatusTruthProposalActions({
+        octokit,
+        owner: 'fro-bot',
+        repo: '.github',
+        actions,
+        dryRun: false,
+        sameRunCreatedFingerprints: new Set<string>(),
+      })
+
+      // No proposals opened when required label cannot be confirmed
+      expect(result.counts.opened).toBe(0)
+      expect(result.labelGateFailed).toBe(true)
+    })
+
+    it('creates label when it does not exist (404) and proceeds', async () => {
+      const {octokit, store} = makeMockOctokit({labelExists: false})
+      const actions = [
+        {
+          type: 'open' as const,
+          fingerprint: 'abc123def456abcd',
+          title: 'Status truth: pr-state drift',
+          body: '<!-- status-truth:fingerprint=abc123def456abcd -->\n\nBody.',
+          labels: [PROPOSAL_LABEL],
+        },
+      ]
+
+      const result = await executeStatusTruthProposalActions({
+        octokit,
+        owner: 'fro-bot',
+        repo: '.github',
+        actions,
+        dryRun: false,
+        sameRunCreatedFingerprints: new Set<string>(),
+      })
+
+      // Label was created
+      expect(store.labelCreations.length).toBeGreaterThan(0)
+      // Issue was opened after label creation
+      expect(result.counts.opened).toBe(1)
+      expect(result.labelGateFailed).toBe(false)
+    })
+  })
+
+  describe('issue mutations', () => {
+    it('opens a new proposal issue for an open action', async () => {
+      const {octokit, store} = makeMockOctokit()
+      const fingerprint = 'abc123def456abcd'
+      const actions = [
+        {
+          type: 'open' as const,
+          fingerprint,
+          title: 'Status truth: pr-state drift in docs/plans/example.md',
+          body: `<!-- status-truth:fingerprint=${fingerprint} -->\n\nBody.`,
+          labels: [PROPOSAL_LABEL],
+        },
+      ]
+
+      const result = await executeStatusTruthProposalActions(makeExecuteInput({octokit, actions}))
+
+      expect(store.created).toHaveLength(1)
+      expect(store.created[0]?.title).toContain('pr-state')
+      expect(result.counts.opened).toBe(1)
+      expect(result.counts.failed).toBe(0)
+    })
+
+    it('adds a comment for an update-comment action', async () => {
+      const {octokit, store} = makeMockOctokit()
+      const actions = [
+        {
+          type: 'update-comment' as const,
+          issueNumber: 100,
+          comment: 'Live-state details changed.',
+        },
+      ]
+
+      const result = await executeStatusTruthProposalActions(makeExecuteInput({octokit, actions}))
+
+      expect(store.comments).toHaveLength(1)
+      expect(store.comments[0]?.issueNumber).toBe(100)
+      expect(result.counts.updated).toBe(1)
+    })
+
+    it('reopens a closed issue for a reopen action', async () => {
+      const {octokit, store} = makeMockOctokit()
+      const actions = [
+        {
+          type: 'reopen' as const,
+          issueNumber: 200,
+          comment: 'Drift recurrence detected.',
+          removeLabels: [OUTCOME_LABELS.resolved],
+          addLabels: [OUTCOME_LABELS.recurring],
+        },
+      ]
+
+      const result = await executeStatusTruthProposalActions(makeExecuteInput({octokit, actions}))
+
+      expect(store.reopened).toHaveLength(1)
+      expect(store.reopened[0]?.issueNumber).toBe(200)
+      expect(result.counts.reopened).toBe(1)
+    })
+
+    it('closes an issue for a close action', async () => {
+      const {octokit, store} = makeMockOctokit()
+      const actions = [
+        {
+          type: 'close' as const,
+          issueNumber: 300,
+          labels: [OUTCOME_LABELS.resolved],
+          comment: 'Drift cleared.',
+        },
+      ]
+
+      const result = await executeStatusTruthProposalActions(makeExecuteInput({octokit, actions}))
+
+      expect(store.closed).toHaveLength(1)
+      expect(store.closed[0]?.issueNumber).toBe(300)
+      expect(result.counts.closed).toBe(1)
+    })
+
+    it('suppress action increments suppressed count without API calls', async () => {
+      const {octokit, store} = makeMockOctokit()
+      const actions = [
+        {
+          type: 'suppress' as const,
+          fingerprint: 'abc123def456abcd',
+          reason: 'terminal outcome label on closed proposal',
+        },
+      ]
+
+      const result = await executeStatusTruthProposalActions(makeExecuteInput({octokit, actions}))
+
+      expect(store.created).toHaveLength(0)
+      expect(result.counts.suppressed).toBe(1)
+    })
+  })
+
+  describe('error resilience', () => {
+    it('write API failure leaves report artifact intact and counts failure without leaking raw claim text', async () => {
+      const {octokit} = makeMockOctokit({issueCreateFails: true})
+      const actions = [
+        {
+          type: 'open' as const,
+          fingerprint: 'abc123def456abcd',
+          title: 'Status truth: pr-state drift',
+          body: '<!-- status-truth:fingerprint=abc123def456abcd -->\n\nBody.',
+          labels: [PROPOSAL_LABEL],
+        },
+      ]
+
+      const result = await executeStatusTruthProposalActions(makeExecuteInput({octokit, actions}))
+
+      // Failure is counted, not thrown
+      expect(result.counts.failed).toBe(1)
+      expect(result.counts.opened).toBe(0)
+      // Result is a structured counts object, not raw error text
+      expect(typeof result.counts.failed).toBe('number')
+    })
+
+    it('one failure does not block unrelated safe proposals', async () => {
+      let callCount = 0
+      const octokit = {
+        rest: {
+          issues: {
+            getLabel: async () => ({data: {name: PROPOSAL_LABEL}}),
+            createLabel: async () => ({data: {name: PROPOSAL_LABEL}}),
+            create: async (_params: {title: string; body: string; labels: string[]}) => {
+              callCount++
+              if (callCount === 1) {
+                const err = Object.assign(new Error('Server Error'), {status: 500})
+                throw err
+              }
+              return {data: {number: 1000 + callCount}}
+            },
+            createComment: async () => ({data: {id: 1}}),
+            update: async () => ({data: {number: 1}}),
+            removeLabel: async () => ({data: []}),
+            addLabels: async () => ({data: []}),
+          },
+        },
+      } as unknown as StatusTruthOctokitClient
+
+      const actions = [
+        {
+          type: 'open' as const,
+          fingerprint: 'fp1',
+          title: 'Title 1',
+          body: '<!-- status-truth:fingerprint=fp1 -->\n\nBody 1.',
+          labels: [PROPOSAL_LABEL],
+        },
+        {
+          type: 'open' as const,
+          fingerprint: 'fp2',
+          title: 'Title 2',
+          body: '<!-- status-truth:fingerprint=fp2 -->\n\nBody 2.',
+          labels: [PROPOSAL_LABEL],
+        },
+      ]
+
+      const result = await executeStatusTruthProposalActions(makeExecuteInput({octokit, actions}))
+
+      // First failed, second succeeded
+      expect(result.counts.failed).toBe(1)
+      expect(result.counts.opened).toBe(1)
+    })
+
+    it('privacy gate blocks one proposal but does not block unrelated safe proposal', async () => {
+      // This is tested at the planning layer (planStatusTruthProposalActions).
+      // At the execute layer, actions are already planned and gated.
+      // A suppress action for one fingerprint does not affect other open actions.
+      const {octokit, store} = makeMockOctokit()
+      const actions = [
+        {
+          type: 'suppress' as const,
+          fingerprint: 'blocked-fp',
+          reason: 'terminal outcome label on closed proposal',
+        },
+        {
+          type: 'open' as const,
+          fingerprint: 'safe-fp',
+          title: 'Status truth: safe proposal',
+          body: '<!-- status-truth:fingerprint=safe-fp -->\n\nSafe body.',
+          labels: [PROPOSAL_LABEL],
+        },
+      ]
+
+      const result = await executeStatusTruthProposalActions(makeExecuteInput({octokit, actions}))
+
+      expect(result.counts.suppressed).toBe(1)
+      expect(result.counts.opened).toBe(1)
+      expect(store.created).toHaveLength(1)
+    })
+  })
+
+  describe('same-run dedup in execute layer', () => {
+    it('does not open a proposal if fingerprint is already in sameRunCreatedFingerprints', async () => {
+      const {octokit, store} = makeMockOctokit()
+      const fingerprint = 'abc123def456abcd'
+      const actions = [
+        {
+          type: 'open' as const,
+          fingerprint,
+          title: 'Status truth: pr-state drift',
+          body: `<!-- status-truth:fingerprint=${fingerprint} -->\n\nBody.`,
+          labels: [PROPOSAL_LABEL],
+        },
+      ]
+
+      const result = await executeStatusTruthProposalActions(
+        makeExecuteInput({octokit, actions, sameRunCreatedFingerprints: new Set([fingerprint])}),
+      )
+
+      expect(store.created).toHaveLength(0)
+      expect(result.counts.sameRunDeduplicated).toBe(1)
+      expect(result.counts.opened).toBe(0)
+    })
+  })
+
+  describe('result shape', () => {
+    it('returns a complete ExecuteStatusTruthProposalActionsResult with all expected fields', async () => {
+      const result = await executeStatusTruthProposalActions(makeExecuteInput())
+
+      expect(typeof result.dryRun).toBe('boolean')
+      expect(typeof result.labelGateFailed).toBe('boolean')
+      expect(typeof result.counts.opened).toBe('number')
+      expect(typeof result.counts.updated).toBe('number')
+      expect(typeof result.counts.reopened).toBe('number')
+      expect(typeof result.counts.closed).toBe('number')
+      expect(typeof result.counts.suppressed).toBe('number')
+      expect(typeof result.counts.failed).toBe('number')
+      expect(typeof result.counts.sameRunDeduplicated).toBe('number')
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Unit 4 corrections: fetchExistingProposalIssues tests
+// ---------------------------------------------------------------------------
+
+function makeIssueListItem(
+  number: number,
+  state: 'open' | 'closed',
+  labels: string[],
+  body: string | null = null,
+): IssueListItem {
+  return {
+    number,
+    state,
+    title: `Status truth: pr-state drift in docs/plans/example.md`,
+    body,
+    labels: labels.map(name => ({name})),
+  }
+}
+
+function makeFetchOctokit(
+  overrides: {
+    openIssues?: IssueListItem[]
+    closedIssues?: IssueListItem[]
+    openThrows?: boolean
+    closedThrows?: boolean
+    closedPage2Throws?: boolean
+  } = {},
+): StatusTruthOctokitClient {
+  const openIssues = overrides.openIssues ?? []
+  const closedIssues = overrides.closedIssues ?? []
+
+  return {
+    rest: {
+      issues: {
+        getLabel: async ({name}: {owner: string; repo: string; name: string}) => ({data: {name}}),
+        createLabel: async ({
+          name,
+        }: {
+          owner: string
+          repo: string
+          name: string
+          color: string
+          description: string
+        }) => ({
+          data: {name},
+        }),
+        create: async () => ({data: {number: 1}}),
+        createComment: async () => ({data: {id: 1}}),
+        update: async (params: {owner: string; repo: string; issue_number: number}) => ({
+          data: {number: params.issue_number},
+        }),
+        removeLabel: async () => ({data: []}),
+        addLabels: async () => ({data: []}),
+        listForRepo: async (params: {
+          owner: string
+          repo: string
+          labels: string
+          state: 'open' | 'closed' | 'all'
+          per_page: number
+          page: number
+        }) => {
+          if (params.state === 'open') {
+            if (overrides.openThrows === true) throw new Error('API error')
+            return {data: openIssues}
+          }
+          if (overrides.closedThrows === true) throw new Error('API error')
+          if (overrides.closedPage2Throws === true && params.page === 2) throw new Error('API error page 2')
+          // Return closed issues only on page 1; empty on page 2
+          return {data: params.page === 1 ? closedIssues : []}
+        },
+      },
+    },
+  } as unknown as StatusTruthOctokitClient
+}
+
+describe('fetchExistingProposalIssues', () => {
+  it('fetches open proposal issues filtered by PROPOSAL_LABEL', async () => {
+    const fp = 'abc123def456abcd'
+    const openIssues = [makeIssueListItem(101, 'open', [PROPOSAL_LABEL], `<!-- status-truth:fingerprint=${fp} -->`)]
+    const octokit = makeFetchOctokit({openIssues})
+
+    const issues = await fetchExistingProposalIssues({octokit, owner: 'fro-bot', repo: '.github'})
+
+    expect(issues.filter(i => i.state === 'open')).toHaveLength(1)
+    expect(issues[0]?.number).toBe(101)
+    expect(issues[0]?.labels).toContain(PROPOSAL_LABEL)
+  })
+
+  it('fetches recent closed proposal issues filtered by PROPOSAL_LABEL', async () => {
+    const fp = 'deadbeef12345678'
+    const closedIssues = [
+      makeIssueListItem(
+        200,
+        'closed',
+        [PROPOSAL_LABEL, OUTCOME_LABELS.resolved],
+        `<!-- status-truth:fingerprint=${fp} -->`,
+      ),
+    ]
+    const octokit = makeFetchOctokit({closedIssues})
+
+    const issues = await fetchExistingProposalIssues({octokit, owner: 'fro-bot', repo: '.github'})
+
+    expect(issues.filter(i => i.state === 'closed')).toHaveLength(1)
+    expect(issues.find(i => i.number === 200)?.labels).toContain(OUTCOME_LABELS.resolved)
+  })
+
+  it('filters out issues that do not have PROPOSAL_LABEL', async () => {
+    const openIssues = [
+      makeIssueListItem(101, 'open', ['some-other-label']),
+      makeIssueListItem(102, 'open', [PROPOSAL_LABEL]),
+    ]
+    const octokit = makeFetchOctokit({openIssues})
+
+    const issues = await fetchExistingProposalIssues({octokit, owner: 'fro-bot', repo: '.github'})
+
+    // Only the issue with PROPOSAL_LABEL should be included
+    expect(issues.filter(i => i.state === 'open')).toHaveLength(1)
+    expect(issues[0]?.number).toBe(102)
+  })
+
+  it('throws when open fetch throws (fail-closed for live mode)', async () => {
+    const octokit = makeFetchOctokit({openThrows: true})
+
+    // fetchExistingProposalIssues now propagates errors so live runOpen can exit(1)
+    await expect(fetchExistingProposalIssues({octokit, owner: 'fro-bot', repo: '.github'})).rejects.toThrow()
+  })
+
+  it('throws when closed page-1 fetch throws (fail-closed for live mode)', async () => {
+    const fp = 'abc123def456abcd'
+    const openIssues = [makeIssueListItem(101, 'open', [PROPOSAL_LABEL], `<!-- status-truth:fingerprint=${fp} -->`)]
+    const octokit = makeFetchOctokit({openIssues, closedThrows: true})
+
+    // First closed page failure is fatal — propagated to caller
+    await expect(fetchExistingProposalIssues({octokit, owner: 'fro-bot', repo: '.github'})).rejects.toThrow()
+  })
+
+  it('returns empty list when no issues exist', async () => {
+    const octokit = makeFetchOctokit()
+
+    const issues = await fetchExistingProposalIssues({octokit, owner: 'fro-bot', repo: '.github'})
+
+    expect(issues).toHaveLength(0)
+  })
+
+  it('returns page-1 closed issues when page-2 closed fetch throws (best-effort pagination)', async () => {
+    const fp = 'abc123def456abcd'
+    const closedIssues = [
+      makeIssueListItem(
+        200,
+        'closed',
+        [PROPOSAL_LABEL, OUTCOME_LABELS.resolved],
+        `<!-- status-truth:fingerprint=${fp} -->`,
+      ),
+    ]
+    const octokit = makeFetchOctokit({closedIssues, closedPage2Throws: true})
+
+    // Page-2 failure is best-effort; page-1 results should still be returned
+    const issues = await fetchExistingProposalIssues({octokit, owner: 'fro-bot', repo: '.github'})
+
+    expect(issues.filter(i => i.state === 'closed')).toHaveLength(1)
+    expect(issues[0]?.number).toBe(200)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Unit 4 hardening: label gate must block on ANY missing required label
+// ---------------------------------------------------------------------------
+
+describe('executeStatusTruthProposalActions label gate — all required labels', () => {
+  it('fails closed when a non-primary outcome label cannot be confirmed (non-404 error)', async () => {
+    // Primary label (status-truth) succeeds; one outcome label fails with 500
+    const failingLabel = REQUIRED_LABELS.find(l => l.name !== PROPOSAL_LABEL)
+    if (failingLabel === undefined) throw new Error('No non-primary required label found')
+
+    const octokit = {
+      rest: {
+        issues: {
+          getLabel: async ({name}: {owner: string; repo: string; name: string}) => {
+            if (name === failingLabel.name) {
+              const err = Object.assign(new Error('Server Error'), {status: 500})
+              throw err
+            }
+            return {data: {name}}
+          },
+          createLabel: async ({
+            name,
+          }: {
+            owner: string
+            repo: string
+            name: string
+            color: string
+            description: string
+          }) => ({
+            data: {name},
+          }),
+          create: async () => ({data: {number: 1}}),
+          createComment: async () => ({data: {id: 1}}),
+          update: async () => ({data: {number: 1}}),
+          removeLabel: async () => ({data: []}),
+          addLabels: async () => ({data: []}),
+        },
+      },
+    } as unknown as StatusTruthOctokitClient
+
+    const actions = [
+      {
+        type: 'open' as const,
+        fingerprint: 'abc123def456abcd',
+        title: 'Status truth: pr-state drift',
+        body: '<!-- status-truth:fingerprint=abc123def456abcd -->\n\nBody.',
+        labels: [PROPOSAL_LABEL],
+      },
+    ]
+
+    const result = await executeStatusTruthProposalActions({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      actions,
+      dryRun: false,
+      sameRunCreatedFingerprints: new Set<string>(),
+    })
+
+    // No proposals opened when any required label cannot be confirmed
+    expect(result.labelGateFailed).toBe(true)
+    expect(result.counts.opened).toBe(0)
+  })
+
+  it('fails closed when a non-primary outcome label cannot be created (non-422 error)', async () => {
+    const failingLabel = REQUIRED_LABELS.find(l => l.name !== PROPOSAL_LABEL)
+    if (failingLabel === undefined) throw new Error('No non-primary required label found')
+
+    const octokit = {
+      rest: {
+        issues: {
+          getLabel: async (_params: {owner: string; repo: string; name: string}) => {
+            // All labels return 404 (not found)
+            const err = Object.assign(new Error('Not Found'), {status: 404})
+            throw err
+          },
+          createLabel: async ({
+            name,
+          }: {
+            owner: string
+            repo: string
+            name: string
+            color: string
+            description: string
+          }) => {
+            if (name === failingLabel.name) {
+              // Non-422 create failure — cannot confirm this label
+              const err = Object.assign(new Error('Forbidden'), {status: 403})
+              throw err
+            }
+            return {data: {name}}
+          },
+          create: async () => ({data: {number: 1}}),
+          createComment: async () => ({data: {id: 1}}),
+          update: async () => ({data: {number: 1}}),
+          removeLabel: async () => ({data: []}),
+          addLabels: async () => ({data: []}),
+        },
+      },
+    } as unknown as StatusTruthOctokitClient
+
+    const actions = [
+      {
+        type: 'open' as const,
+        fingerprint: 'abc123def456abcd',
+        title: 'Status truth: pr-state drift',
+        body: '<!-- status-truth:fingerprint=abc123def456abcd -->\n\nBody.',
+        labels: [PROPOSAL_LABEL],
+      },
+    ]
+
+    const result = await executeStatusTruthProposalActions({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      actions,
+      dryRun: false,
+      sameRunCreatedFingerprints: new Set<string>(),
+    })
+
+    expect(result.labelGateFailed).toBe(true)
+    expect(result.counts.opened).toBe(0)
+  })
+
+  it('proceeds when all required labels are confirmed (primary + all outcome labels)', async () => {
+    // All labels exist — gate should pass and proposal should open
+    const {octokit, store} = makeMockOctokit()
+    const actions = [
+      {
+        type: 'open' as const,
+        fingerprint: 'abc123def456abcd',
+        title: 'Status truth: pr-state drift',
+        body: '<!-- status-truth:fingerprint=abc123def456abcd -->\n\nBody.',
+        labels: [PROPOSAL_LABEL],
+      },
+    ]
+
+    const result = await executeStatusTruthProposalActions({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      actions,
+      dryRun: false,
+      sameRunCreatedFingerprints: new Set<string>(),
+    })
+
+    expect(result.labelGateFailed).toBe(false)
+    expect(result.counts.opened).toBe(1)
+    expect(store.created).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Unit 4 hardening: live fetch failure blocks mutations
+// ---------------------------------------------------------------------------
+
+describe('fetchExistingProposalIssues fail-closed behavior', () => {
+  it('propagates open-fetch error so live runOpen can exit before planning mutations', async () => {
+    const octokit = makeFetchOctokit({openThrows: true})
+
+    // Must throw — caller (live runOpen) catches and calls process.exit(1)
+    await expect(fetchExistingProposalIssues({octokit, owner: 'fro-bot', repo: '.github'})).rejects.toThrow('API error')
+  })
+
+  it('propagates closed page-1 error so live runOpen can exit before planning mutations', async () => {
+    const fp = 'abc123def456abcd'
+    const openIssues = [makeIssueListItem(101, 'open', [PROPOSAL_LABEL], `<!-- status-truth:fingerprint=${fp} -->`)]
+    const octokit = makeFetchOctokit({openIssues, closedThrows: true})
+
+    await expect(fetchExistingProposalIssues({octokit, owner: 'fro-bot', repo: '.github'})).rejects.toThrow('API error')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Unit 4 corrections: open planning uses fetched existing issues
+// ---------------------------------------------------------------------------
+
+describe('planStatusTruthProposalActions with fetched existing issues', () => {
+  it('no-ops when fetched existing open issue matches the drifted finding fingerprint', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    // Simulate fetched existing issue with matching fingerprint
+    const existingIssue = makeOpenIssue(fingerprint)
+
+    const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [existingIssue]}))
+
+    // Should not open a duplicate
+    expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+    expect(counts.noAction).toBeGreaterThanOrEqual(1)
+  })
+
+  it('reopens when fetched existing closed non-terminal issue matches the drifted finding fingerprint', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    // Simulate fetched closed issue with matching fingerprint (non-terminal)
+    const closedIssue = makeClosedIssue(fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.resolved])
+
+    const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]}))
+
+    expect(actions.filter(a => a.type === 'reopen')).toHaveLength(1)
+    expect(counts.reopened).toBe(1)
+  })
+
+  it('suppresses when fetched existing closed terminal issue matches the drifted finding fingerprint', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    // Simulate fetched closed issue with terminal label
+    const closedIssue = makeClosedIssue(fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.falsePositive])
+
+    const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]}))
+
+    expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+    expect(counts.suppressed).toBe(1)
+  })
+
+  it('dry-run with planned actions performs no mutations but reports counts', async () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const {actions} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+    expect(actions.filter(a => a.type === 'open')).toHaveLength(1)
+
+    // Execute in dry-run mode
+    const {octokit, store} = makeMockOctokit()
+    const result = await executeStatusTruthProposalActions({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      actions,
+      dryRun: true,
+      sameRunCreatedFingerprints: new Set<string>(),
+    })
+
+    // No mutations
+    expect(store.created).toHaveLength(0)
+    expect(store.comments).toHaveLength(0)
+    // But counts are reported
+    expect(result.dryRun).toBe(true)
+    expect(result.counts.opened).toBe(1)
   })
 })

--- a/scripts/status-truth-proposals.test.ts
+++ b/scripts/status-truth-proposals.test.ts
@@ -1,0 +1,719 @@
+/**
+ * Tests for the status-truth proposal lifecycle planner (Unit 3).
+ *
+ * TDD: tests written before implementation.
+ * All tests are pure — no Octokit, no disk I/O.
+ */
+
+import type {StatusTruthJsonReport} from './status-truth-detect.ts'
+import type {ExistingProposalIssue, PlanStatusTruthProposalActionsInput} from './status-truth-proposals.ts'
+import type {PublicOutputTokens} from './status-truth-public-output.ts'
+import {describe, expect, it} from 'vitest'
+import {
+  extractProposalFingerprint,
+  OUTCOME_LABELS,
+  planStatusTruthProposalActions,
+  PROPOSAL_LABEL,
+} from './status-truth-proposals.ts'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeReport(overrides: Partial<StatusTruthJsonReport> = {}): StatusTruthJsonReport {
+  return {
+    schema_version: 1,
+    fingerprint_version: 1,
+    status: 'findings',
+    scan_complete: true,
+    generated_at: '2026-06-28T00:00:00Z',
+    failure_class: null,
+    repair_eligible: true,
+    findings: [],
+    counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+    ...overrides,
+  }
+}
+
+function makeDriftedFinding(fingerprint = 'abc123def456abcd') {
+  return {
+    kind: 'pr-state' as const,
+    path: 'docs/plans/example.md',
+    sourceRef: '#42',
+    verdict: 'drifted' as const,
+    fingerprint,
+    claimedState: 'open',
+    liveState: 'closed',
+    proposalEligible: true,
+    proposedCorrection: 'pr #42 is closed',
+  }
+}
+
+function makeUnsafeFinding() {
+  return {
+    kind: 'pr-state' as const,
+    verdict: 'unsafe' as const,
+    proposalEligible: false as const,
+  }
+}
+
+function makeUnresolvedFinding(fingerprint = 'unresolved1234567') {
+  return {
+    kind: 'issue-state' as const,
+    path: 'docs/plans/example.md',
+    sourceRef: '#99',
+    verdict: 'unresolved' as const,
+    fingerprint,
+    claimedState: 'open',
+    proposalEligible: false,
+  }
+}
+
+function makeLoadedTokens(): PublicOutputTokens {
+  return {
+    loaded: true,
+    privateTokens: new Set<string>(),
+    redactedCanonicalIds: new Set<string>(),
+  }
+}
+
+function makeBlockingTokens(): PublicOutputTokens {
+  return {
+    loaded: true,
+    privateTokens: new Set(['private-repo-name']),
+    redactedCanonicalIds: new Set<string>(),
+  }
+}
+
+function makeFailedTokens(): PublicOutputTokens {
+  return {
+    loaded: false,
+    error: 'failed to load tokens',
+  }
+}
+
+function makeOpenIssue(fingerprint: string, overrides: Partial<ExistingProposalIssue> = {}): ExistingProposalIssue {
+  return {
+    number: 100,
+    state: 'open',
+    labels: [PROPOSAL_LABEL],
+    title: 'Status truth: pr-state drift in docs/plans/example.md',
+    body: `<!-- status-truth:fingerprint=${fingerprint} -->\n\nSome body text.`,
+    ...overrides,
+  }
+}
+
+function makeClosedIssue(
+  fingerprint: string,
+  labels: string[] = [PROPOSAL_LABEL],
+  overrides: Partial<ExistingProposalIssue> = {},
+): ExistingProposalIssue {
+  return {
+    number: 200,
+    state: 'closed',
+    labels,
+    title: 'Status truth: pr-state drift in docs/plans/example.md',
+    body: `<!-- status-truth:fingerprint=${fingerprint} -->\n\nSome body text.`,
+    ...overrides,
+  }
+}
+
+function makePlanInput(
+  overrides: Partial<PlanStatusTruthProposalActionsInput> = {},
+): PlanStatusTruthProposalActionsInput {
+  return {
+    report: makeReport(),
+    existingIssues: [],
+    publicOutputTokens: makeLoadedTokens(),
+    sameRunCreatedFingerprints: new Set<string>(),
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// extractProposalFingerprint
+// ---------------------------------------------------------------------------
+
+describe('extractProposalFingerprint', () => {
+  it('extracts fingerprint from a valid hidden marker', () => {
+    const body = '<!-- status-truth:fingerprint=abc123def456abcd -->\n\nBody text.'
+    expect(extractProposalFingerprint(body)).toBe('abc123def456abcd')
+  })
+
+  it('returns null for body without marker', () => {
+    expect(extractProposalFingerprint('No marker here.')).toBeNull()
+  })
+
+  it('returns null for null body', () => {
+    expect(extractProposalFingerprint(null)).toBeNull()
+  })
+
+  it('returns null for undefined body', () => {
+    expect(extractProposalFingerprint(undefined)).toBeNull()
+  })
+
+  it('returns null for empty body', () => {
+    expect(extractProposalFingerprint('')).toBeNull()
+  })
+
+  it('returns null for malformed marker (missing value)', () => {
+    expect(extractProposalFingerprint('<!-- status-truth:fingerprint= -->')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// planStatusTruthProposalActions — happy paths
+// ---------------------------------------------------------------------------
+
+describe('planStatusTruthProposalActions', () => {
+  describe('new drifted finding', () => {
+    it('plans one open action for a new drifted, proposal-eligible, gate-safe finding', () => {
+      const finding = makeDriftedFinding()
+      const report = makeReport({
+        findings: [finding],
+        counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+
+      const openActions = actions.filter(a => a.type === 'open')
+      expect(openActions).toHaveLength(1)
+      const openAction = openActions[0]
+      expect(openAction?.type).toBe('open')
+      if (openAction?.type === 'open') {
+        expect(openAction.fingerprint).toBe(finding.fingerprint)
+        expect(openAction.title).toContain('pr-state')
+        expect(openAction.body).toContain(`<!-- status-truth:fingerprint=${finding.fingerprint} -->`)
+        expect(openAction.labels).toContain(PROPOSAL_LABEL)
+      }
+      expect(counts.opened).toBe(1)
+      expect(counts.suppressed).toBe(0)
+      expect(counts.blocked).toBe(0)
+    })
+
+    it('includes proposed correction in the open action body', () => {
+      const finding = makeDriftedFinding()
+      const report = makeReport({
+        findings: [finding],
+        counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+      })
+
+      const {actions} = planStatusTruthProposalActions(makePlanInput({report}))
+      const openAction = actions.find(a => a.type === 'open')
+      if (openAction?.type === 'open') {
+        expect(openAction.body).toContain(finding.proposedCorrection)
+      }
+    })
+  })
+
+  describe('matching open issue with unchanged drift', () => {
+    it('plans no action when open issue exists and drift is unchanged', () => {
+      const finding = makeDriftedFinding()
+      const report = makeReport({
+        findings: [finding],
+        counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+      })
+      const existingIssue = makeOpenIssue(finding.fingerprint)
+
+      const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [existingIssue]}))
+
+      // No open, no update-comment, no reopen, no close for this fingerprint
+      const relevantActions = actions.filter(
+        a => a.type !== 'close' || ('issueNumber' in a && a.issueNumber === existingIssue.number),
+      )
+      expect(relevantActions.filter(a => a.type === 'open')).toHaveLength(0)
+      expect(relevantActions.filter(a => a.type === 'update-comment')).toHaveLength(0)
+      expect(counts.noAction).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  describe('matching open issue with changed drift details', () => {
+    it('plans one update-comment when live-state details changed', () => {
+      const fingerprint = 'abc123def456abcd'
+      const finding = makeDriftedFinding(fingerprint)
+      const report = makeReport({
+        findings: [finding],
+        counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+      })
+
+      // Existing issue has different live state recorded in body
+      const existingIssue = makeOpenIssue(fingerprint, {
+        body: `<!-- status-truth:fingerprint=${fingerprint} -->\n<!-- status-truth:live-state=open -->\n\nBody.`,
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [existingIssue]}))
+
+      const updateActions = actions.filter(a => a.type === 'update-comment')
+      expect(updateActions).toHaveLength(1)
+      const updateAction = updateActions[0]
+      if (updateAction?.type === 'update-comment') {
+        expect(updateAction.issueNumber).toBe(existingIssue.number)
+        expect(updateAction.comment).toBeTruthy()
+      }
+      expect(counts.updated).toBe(1)
+    })
+
+    it('increments blocked and emits no update-comment when gate blocks due to token-load failure', () => {
+      const fingerprint = 'abc123def456abcd'
+      const finding = makeDriftedFinding(fingerprint)
+      const report = makeReport({
+        findings: [finding],
+        counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+      })
+      const existingIssue = makeOpenIssue(fingerprint, {
+        body: `<!-- status-truth:fingerprint=${fingerprint} -->\n<!-- status-truth:live-state=open -->\n\nBody.`,
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(
+        makePlanInput({report, existingIssues: [existingIssue], publicOutputTokens: makeFailedTokens()}),
+      )
+
+      expect(actions.filter(a => a.type === 'update-comment')).toHaveLength(0)
+      expect(counts.blocked).toBeGreaterThanOrEqual(1)
+      expect(counts.updated).toBe(0)
+    })
+
+    it('increments blocked and emits no update-comment when gate blocks due to blocking tokens', () => {
+      const fingerprint = 'abc123def456abcd'
+      const finding = {
+        ...makeDriftedFinding(fingerprint),
+        proposedCorrection: 'pr #42 is closed (private-repo-name)',
+      }
+      const report = makeReport({
+        findings: [finding],
+        counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+      })
+      const existingIssue = makeOpenIssue(fingerprint, {
+        body: `<!-- status-truth:fingerprint=${fingerprint} -->\n<!-- status-truth:live-state=open -->\n\nBody.`,
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(
+        makePlanInput({report, existingIssues: [existingIssue], publicOutputTokens: makeBlockingTokens()}),
+      )
+
+      expect(actions.filter(a => a.type === 'update-comment')).toHaveLength(0)
+      expect(counts.blocked).toBeGreaterThanOrEqual(1)
+      expect(counts.updated).toBe(0)
+    })
+  })
+
+  describe('same-run created key deduplication', () => {
+    it('suppresses duplicate proposal when fingerprint is in sameRunCreatedFingerprints', () => {
+      const finding = makeDriftedFinding()
+      const report = makeReport({
+        findings: [finding],
+        counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+      })
+      const sameRunCreatedFingerprints = new Set([finding.fingerprint])
+
+      const {actions, counts} = planStatusTruthProposalActions(
+        makePlanInput({report, existingIssues: [], sameRunCreatedFingerprints}),
+      )
+
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+      expect(counts.sameRunDeduplicated).toBe(1)
+    })
+  })
+
+  describe('close-on-clear', () => {
+    it('plans close action for open proposal missing from a complete non-failure scan', () => {
+      const fingerprint = 'abc123def456abcd'
+      const report = makeReport({
+        findings: [],
+        status: 'clean',
+        scan_complete: true,
+        counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+      })
+      const existingIssue = makeOpenIssue(fingerprint)
+
+      const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [existingIssue]}))
+
+      const closeActions = actions.filter(a => a.type === 'close')
+      expect(closeActions).toHaveLength(1)
+      const closeAction = closeActions[0]
+      if (closeAction?.type === 'close') {
+        expect(closeAction.issueNumber).toBe(existingIssue.number)
+        expect(closeAction.labels).toContain(OUTCOME_LABELS.resolved)
+      }
+      expect(counts.closed).toBe(1)
+    })
+
+    it('does NOT plan close when status is execution-failure and scan_complete is false', () => {
+      const fingerprint = 'abc123def456abcd'
+      const report = makeReport({
+        findings: [],
+        status: 'execution-failure',
+        scan_complete: false,
+        failure_class: 'api-unavailable',
+        counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+      })
+      const existingIssue = makeOpenIssue(fingerprint)
+
+      const {actions} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [existingIssue]}))
+
+      expect(actions.filter(a => a.type === 'close')).toHaveLength(0)
+    })
+
+    it('does NOT plan close when status is clean but scan_complete is false', () => {
+      const fingerprint = 'abc123def456abcd'
+      const report = makeReport({
+        findings: [],
+        status: 'clean',
+        scan_complete: false,
+        counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+      })
+      const existingIssue = makeOpenIssue(fingerprint)
+
+      const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [existingIssue]}))
+
+      expect(actions.filter(a => a.type === 'close')).toHaveLength(0)
+      expect(counts.closed).toBe(0)
+    })
+
+    it('does NOT plan close when scan_complete is false (execution-error)', () => {
+      const fingerprint = 'abc123def456abcd'
+      const report = makeReport({
+        findings: [],
+        status: 'execution-failure',
+        scan_complete: false,
+        failure_class: 'execution-error',
+        counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+      })
+      const existingIssue = makeOpenIssue(fingerprint)
+
+      const {actions} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [existingIssue]}))
+
+      expect(actions.filter(a => a.type === 'close')).toHaveLength(0)
+    })
+
+    it('does NOT close when close-comment is blocked by token-load failure', () => {
+      const fingerprint = 'abc123def456abcd'
+      const report = makeReport({
+        findings: [],
+        status: 'clean',
+        scan_complete: true,
+        counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+      })
+      const existingIssue = makeOpenIssue(fingerprint)
+
+      const {actions, counts} = planStatusTruthProposalActions(
+        makePlanInput({report, existingIssues: [existingIssue], publicOutputTokens: makeFailedTokens()}),
+      )
+
+      expect(actions.filter(a => a.type === 'close')).toHaveLength(0)
+      expect(counts.blocked).toBeGreaterThanOrEqual(1)
+      expect(counts.closed).toBe(0)
+    })
+
+    it('does NOT close when close-comment is blocked by blocking tokens', () => {
+      const fingerprint = 'abc123def456abcd'
+      // The close comment contains the generated_at timestamp, not private tokens by default.
+      // We use a generated_at that contains the private token to trigger blocking.
+      const report = makeReport({
+        findings: [],
+        status: 'clean',
+        scan_complete: true,
+        generated_at: 'private-repo-name',
+        counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+      })
+      const existingIssue = makeOpenIssue(fingerprint)
+
+      const {actions, counts} = planStatusTruthProposalActions(
+        makePlanInput({report, existingIssues: [existingIssue], publicOutputTokens: makeBlockingTokens()}),
+      )
+
+      expect(actions.filter(a => a.type === 'close')).toHaveLength(0)
+      expect(counts.blocked).toBeGreaterThanOrEqual(1)
+      expect(counts.closed).toBe(0)
+    })
+  })
+
+  describe('reopen non-terminal closed proposal', () => {
+    it('plans reopen and clears resolving labels when drift returns for a non-terminal closed issue', () => {
+      const finding = makeDriftedFinding()
+      const report = makeReport({
+        findings: [finding],
+        counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+      })
+      // Closed without terminal labels (resolved is non-terminal)
+      const closedIssue = makeClosedIssue(finding.fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.resolved])
+
+      const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]}))
+
+      const reopenActions = actions.filter(a => a.type === 'reopen')
+      expect(reopenActions).toHaveLength(1)
+      const reopenAction = reopenActions[0]
+      if (reopenAction?.type === 'reopen') {
+        expect(reopenAction.issueNumber).toBe(closedIssue.number)
+        expect(reopenAction.comment).toContain('recurrence')
+        expect(reopenAction.removeLabels).toContain(OUTCOME_LABELS.resolved)
+      }
+      expect(counts.reopened).toBe(1)
+    })
+
+    it('plans reopen for closed issue with manually-fixed label (non-terminal)', () => {
+      const finding = makeDriftedFinding()
+      const report = makeReport({
+        findings: [finding],
+        counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+      })
+      const closedIssue = makeClosedIssue(finding.fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.manuallyFixed])
+
+      const {actions} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]}))
+
+      expect(actions.filter(a => a.type === 'reopen')).toHaveLength(1)
+    })
+
+    it('increments blocked and emits no reopen when gate blocks due to token-load failure', () => {
+      const finding = makeDriftedFinding()
+      const report = makeReport({
+        findings: [finding],
+        counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+      })
+      const closedIssue = makeClosedIssue(finding.fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.resolved])
+
+      const {actions, counts} = planStatusTruthProposalActions(
+        makePlanInput({report, existingIssues: [closedIssue], publicOutputTokens: makeFailedTokens()}),
+      )
+
+      expect(actions.filter(a => a.type === 'reopen')).toHaveLength(0)
+      expect(counts.blocked).toBeGreaterThanOrEqual(1)
+      expect(counts.reopened).toBe(0)
+    })
+
+    it('increments blocked and emits no reopen when gate blocks due to blocking tokens', () => {
+      const finding = makeDriftedFinding()
+      const report = makeReport({
+        findings: [finding],
+        generated_at: 'private-repo-name',
+        counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+      })
+      const closedIssue = makeClosedIssue(finding.fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.resolved])
+
+      const {actions, counts} = planStatusTruthProposalActions(
+        makePlanInput({report, existingIssues: [closedIssue], publicOutputTokens: makeBlockingTokens()}),
+      )
+
+      expect(actions.filter(a => a.type === 'reopen')).toHaveLength(0)
+      expect(counts.blocked).toBeGreaterThanOrEqual(1)
+      expect(counts.reopened).toBe(0)
+    })
+  })
+
+  describe('terminal suppression (false-positive / rejected)', () => {
+    it('suppresses finding and counts it when matching false-positive closed issue exists', () => {
+      const finding = makeDriftedFinding()
+      const report = makeReport({
+        findings: [finding],
+        counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+      })
+      const closedIssue = makeClosedIssue(finding.fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.falsePositive])
+
+      const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]}))
+
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+      expect(actions.filter(a => a.type === 'reopen')).toHaveLength(0)
+      const suppressActions = actions.filter(a => a.type === 'suppress')
+      expect(suppressActions).toHaveLength(1)
+      expect(counts.suppressed).toBe(1)
+    })
+
+    it('suppresses finding when matching rejected closed issue exists', () => {
+      const finding = makeDriftedFinding()
+      const report = makeReport({
+        findings: [finding],
+        counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+      })
+      const closedIssue = makeClosedIssue(finding.fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.rejected])
+
+      const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]}))
+
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+      expect(actions.filter(a => a.type === 'reopen')).toHaveLength(0)
+      expect(counts.suppressed).toBe(1)
+    })
+  })
+
+  describe('malformed outcome markers', () => {
+    it('ignores malformed markers and counts them for operator attention', () => {
+      const finding = makeDriftedFinding()
+      const report = makeReport({
+        findings: [finding],
+        counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+      })
+      // Issue with malformed fingerprint marker (non-hex chars)
+      const malformedIssue: ExistingProposalIssue = {
+        number: 300,
+        state: 'open',
+        labels: [PROPOSAL_LABEL],
+        title: 'Status truth: something',
+        body: '<!-- status-truth:fingerprint=INVALID!!! -->\n\nBody.',
+      }
+
+      const {counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [malformedIssue]}))
+
+      expect(counts.malformedMarkers).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  describe('integration: resolved drift closes only matching proposal', () => {
+    it('closes only the matching open proposal, not unrelated proposals', () => {
+      const fingerprint1 = 'abc123def456abcd'
+      const fingerprint2 = 'deadbeef12345678'
+
+      // Only fingerprint1 drift cleared; fingerprint2 still drifted
+      const finding2 = makeDriftedFinding(fingerprint2)
+      const report = makeReport({
+        findings: [finding2],
+        counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+      })
+
+      const openIssue1 = makeOpenIssue(fingerprint1, {number: 101})
+      const openIssue2 = makeOpenIssue(fingerprint2, {number: 102})
+
+      const {actions} = planStatusTruthProposalActions(
+        makePlanInput({report, existingIssues: [openIssue1, openIssue2]}),
+      )
+
+      const closeActions = actions.filter(a => a.type === 'close')
+      expect(closeActions).toHaveLength(1)
+      const closeAction = closeActions[0]
+      if (closeAction?.type === 'close') {
+        expect(closeAction.issueNumber).toBe(101) // Only issue1 closed
+      }
+
+      // Issue2 should have no-action (already open, drift unchanged)
+      const openActions = actions.filter(a => a.type === 'open')
+      expect(openActions).toHaveLength(0)
+    })
+  })
+
+  describe('gate-blocked proposals', () => {
+    it('produces blocked counter only, no action containing blocked text', () => {
+      const finding = makeDriftedFinding()
+
+      // Tokens that will block any content containing 'private-repo-name'
+      // We need the finding's proposedCorrection to contain the private token
+      const blockingFinding = {
+        ...finding,
+        proposedCorrection: 'pr #42 is closed (private-repo-name)',
+      }
+      const blockingReport = makeReport({
+        findings: [blockingFinding],
+        counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(
+        makePlanInput({report: blockingReport, publicOutputTokens: makeBlockingTokens()}),
+      )
+
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+      expect(counts.blocked).toBeGreaterThanOrEqual(1)
+
+      // Verify no action contains the blocked text
+      for (const action of actions) {
+        if (action.type === 'open') {
+          expect(action.body).not.toContain('private-repo-name')
+          expect(action.title).not.toContain('private-repo-name')
+        }
+        if (action.type === 'update-comment') {
+          expect(action.comment).not.toContain('private-repo-name')
+        }
+      }
+    })
+
+    it('blocks all output when token load fails', () => {
+      const finding = makeDriftedFinding()
+      const report = makeReport({
+        findings: [finding],
+        counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(
+        makePlanInput({report, publicOutputTokens: makeFailedTokens()}),
+      )
+
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+      expect(counts.blocked).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  describe('unsafe findings', () => {
+    it('never produces proposal actions for unsafe findings', () => {
+      const unsafeFinding = makeUnsafeFinding()
+      const report = makeReport({
+        findings: [unsafeFinding],
+        counts: {total: 1, current: 0, drifted: 0, unresolved: 0, unsafe: 1, proposal_eligible: 0},
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report}))
+
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+      expect(actions.filter(a => a.type === 'reopen')).toHaveLength(0)
+      expect(counts.opened).toBe(0)
+    })
+  })
+
+  describe('non-proposal-eligible findings', () => {
+    it('does not plan actions for unresolved findings (not proposal-eligible)', () => {
+      const finding = makeUnresolvedFinding()
+      const report = makeReport({
+        findings: [finding],
+        counts: {total: 1, current: 0, drifted: 0, unresolved: 1, unsafe: 0, proposal_eligible: 0},
+      })
+
+      const {actions} = planStatusTruthProposalActions(makePlanInput({report}))
+
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+    })
+  })
+
+  describe('unknown report version', () => {
+    it('returns empty actions and an error count for unknown schema version', () => {
+      const report = makeReport({schema_version: 99})
+
+      const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report}))
+
+      expect(actions).toHaveLength(0)
+      expect(counts.versionRejected).toBe(1)
+    })
+
+    it('returns empty actions and an error count for unknown fingerprint version', () => {
+      const report = makeReport({fingerprint_version: 99})
+
+      const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report}))
+
+      expect(actions).toHaveLength(0)
+      expect(counts.versionRejected).toBe(1)
+    })
+  })
+
+  describe('counts shape', () => {
+    it('returns a complete counts object with all expected fields', () => {
+      const {counts} = planStatusTruthProposalActions(makePlanInput())
+
+      expect(typeof counts.opened).toBe('number')
+      expect(typeof counts.updated).toBe('number')
+      expect(typeof counts.reopened).toBe('number')
+      expect(typeof counts.closed).toBe('number')
+      expect(typeof counts.suppressed).toBe('number')
+      expect(typeof counts.blocked).toBe('number')
+      expect(typeof counts.noAction).toBe('number')
+      expect(typeof counts.sameRunDeduplicated).toBe('number')
+      expect(typeof counts.malformedMarkers).toBe('number')
+      expect(typeof counts.versionRejected).toBe('number')
+    })
+  })
+
+  describe('OUTCOME_LABELS', () => {
+    it('exports all required outcome label keys', () => {
+      expect(OUTCOME_LABELS.accepted).toBeTruthy()
+      expect(OUTCOME_LABELS.rejected).toBeTruthy()
+      expect(OUTCOME_LABELS.falsePositive).toBeTruthy()
+      expect(OUTCOME_LABELS.superseded).toBeTruthy()
+      expect(OUTCOME_LABELS.manuallyFixed).toBeTruthy()
+      expect(OUTCOME_LABELS.resolved).toBeTruthy()
+      expect(OUTCOME_LABELS.recurring).toBeTruthy()
+    })
+  })
+})

--- a/scripts/status-truth-proposals.test.ts
+++ b/scripts/status-truth-proposals.test.ts
@@ -1673,3 +1673,397 @@ describe('planStatusTruthProposalActions with fetched existing issues', () => {
     expect(result.counts.opened).toBe(1)
   })
 })
+
+// ---------------------------------------------------------------------------
+// Unit 5: Accuracy signal and operator-facing proposal UX
+// ---------------------------------------------------------------------------
+
+describe('per-kind usefulness counters', () => {
+  it('accepted outcome label on a closed issue increments usefulnessByKind.accepted for that kind', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    // Closed issue with accepted label — non-terminal, so drift returns → reopen
+    const closedIssue = makeClosedIssue(fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.accepted])
+
+    const {counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]}))
+
+    // accepted is non-terminal so it reopens, but usefulness counter should be incremented
+    expect(counts.usefulnessByKind).toBeDefined()
+    expect(counts.usefulnessByKind?.['pr-state']?.accepted).toBeGreaterThanOrEqual(1)
+  })
+
+  it('rejected outcome label on a closed issue increments usefulnessByKind.rejected for that kind', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const closedIssue = makeClosedIssue(fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.rejected])
+
+    const {counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]}))
+
+    expect(counts.usefulnessByKind).toBeDefined()
+    expect(counts.usefulnessByKind?.['pr-state']?.rejected).toBeGreaterThanOrEqual(1)
+  })
+
+  it('false-positive outcome label on a closed issue increments usefulnessByKind.falsePositive for that kind', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const closedIssue = makeClosedIssue(fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.falsePositive])
+
+    const {counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]}))
+
+    expect(counts.usefulnessByKind).toBeDefined()
+    expect(counts.usefulnessByKind?.['pr-state']?.falsePositive).toBeGreaterThanOrEqual(1)
+  })
+
+  it('malformed outcome markers are excluded from usefulnessByKind accuracy math', () => {
+    const malformedIssue: ExistingProposalIssue = {
+      number: 300,
+      state: 'closed',
+      labels: [PROPOSAL_LABEL, 'status-truth:unknown-outcome'],
+      title: 'Status truth: something',
+      body: '<!-- status-truth:fingerprint=deadbeef12345678 -->\n\nBody.',
+    }
+    const report = makeReport({
+      findings: [],
+      counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+    })
+
+    const {counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [malformedIssue]}))
+
+    // Unknown/malformed outcome labels must not appear in usefulnessByKind
+    const kindCounts = counts.usefulnessByKind
+    if (kindCounts !== undefined) {
+      for (const kind of Object.keys(kindCounts)) {
+        const entry = kindCounts[kind]
+        if (entry !== undefined) {
+          // Only accepted/rejected/falsePositive are valid accuracy signals
+          expect(typeof entry.accepted).toBe('number')
+          expect(typeof entry.rejected).toBe('number')
+          expect(typeof entry.falsePositive).toBe('number')
+        }
+      }
+    }
+    // malformedOutcomeMarkers should be counted for operator attention
+    expect(counts.malformedOutcomeMarkers).toBeGreaterThanOrEqual(1)
+  })
+
+  it('closed proposal with BOTH a recognized accuracy signal label and an unrecognized status-truth:* label is treated as malformed — recognized label excluded from usefulnessByKind', () => {
+    // Conservative guard: mixed outcome markers make the issue ambiguous.
+    // The recognized label (accepted) must NOT be counted in usefulnessByKind.
+    const fingerprint = 'deadbeef12345678'
+    const mixedIssue: ExistingProposalIssue = {
+      number: 301,
+      state: 'closed',
+      labels: [PROPOSAL_LABEL, OUTCOME_LABELS.accepted, 'status-truth:unknown-extra'],
+      title: 'Status truth: pr-state drift in docs/plans/example.md',
+      body: `<!-- status-truth:fingerprint=${fingerprint} -->\n\nBody.`,
+    }
+    const report = makeReport({
+      findings: [],
+      counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+    })
+
+    const {counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [mixedIssue]}))
+
+    // Must be counted as malformed, not as an accuracy signal
+    expect(counts.malformedOutcomeMarkers).toBeGreaterThanOrEqual(1)
+    // The recognized accepted label must NOT appear in usefulnessByKind accuracy math
+    const kindCounts = counts.usefulnessByKind
+    if (kindCounts !== undefined) {
+      for (const kind of Object.keys(kindCounts)) {
+        const entry = kindCounts[kind]
+        if (entry !== undefined) {
+          // No accuracy signals should be counted from this malformed issue
+          expect(entry.accepted).toBe(0)
+          expect(entry.rejected).toBe(0)
+          expect(entry.falsePositive).toBe(0)
+        }
+      }
+    }
+  })
+
+  it('non-outcome labels (resolved, manually-fixed, recurring, superseded) are excluded from accuracy math', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    // resolved is non-terminal but not an accuracy signal
+    const closedIssue = makeClosedIssue(fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.resolved])
+
+    const {counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]}))
+
+    // resolved should not appear in usefulnessByKind accuracy counters
+    const kindCounts = counts.usefulnessByKind
+    if (kindCounts !== undefined) {
+      for (const kind of Object.keys(kindCounts)) {
+        const entry = kindCounts[kind]
+        if (entry !== undefined) {
+          // Accuracy counters should only reflect accepted/rejected/falsePositive
+          // resolved does not increment any of these
+          expect(entry.accepted + entry.rejected + entry.falsePositive).toBe(0)
+        }
+      }
+    }
+  })
+})
+
+describe('countsByKind in planner result', () => {
+  it('countsByKind aggregates opened proposals by claim kind', () => {
+    const finding = makeDriftedFinding()
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const {countsByKind} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+
+    expect(countsByKind).toBeDefined()
+    expect(countsByKind?.['pr-state']?.opened).toBeGreaterThanOrEqual(1)
+  })
+
+  it('countsByKind is counts-only and does not contain paths or fingerprints', () => {
+    const finding = makeDriftedFinding()
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const {countsByKind} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+
+    // countsByKind values must be numeric counts only
+    if (countsByKind !== undefined) {
+      for (const kind of Object.keys(countsByKind)) {
+        const entry = countsByKind[kind]
+        if (entry !== undefined) {
+          expect(typeof entry.opened).toBe('number')
+          expect(typeof entry.updated).toBe('number')
+          expect(typeof entry.reopened).toBe('number')
+          expect(typeof entry.closed).toBe('number')
+          expect(typeof entry.suppressed).toBe('number')
+          // No path or fingerprint fields — KindActionCounts only has numeric count fields
+          const entryKeys = Object.keys(entry as object)
+          expect(entryKeys).not.toContain('path')
+          expect(entryKeys).not.toContain('fingerprint')
+        }
+      }
+    }
+  })
+})
+
+describe('terminal vs non-terminal label semantics', () => {
+  it('rejected label suppresses future matching findings (terminal)', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const closedIssue = makeClosedIssue(fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.rejected])
+
+    const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]}))
+
+    // Terminal: no reopen, no open — only suppress
+    expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+    expect(actions.filter(a => a.type === 'reopen')).toHaveLength(0)
+    expect(counts.suppressed).toBe(1)
+  })
+
+  it('false-positive label suppresses future matching findings (terminal)', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const closedIssue = makeClosedIssue(fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.falsePositive])
+
+    const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]}))
+
+    expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+    expect(actions.filter(a => a.type === 'reopen')).toHaveLength(0)
+    expect(counts.suppressed).toBe(1)
+  })
+
+  it('accepted label does NOT suppress — allows reopen when drift returns (non-terminal)', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const closedIssue = makeClosedIssue(fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.accepted])
+
+    const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]}))
+
+    // Non-terminal: drift returned → reopen
+    expect(actions.filter(a => a.type === 'reopen')).toHaveLength(1)
+    expect(counts.suppressed).toBe(0)
+  })
+
+  it('manually-fixed label does NOT suppress — allows reopen when drift returns (non-terminal)', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const closedIssue = makeClosedIssue(fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.manuallyFixed])
+
+    const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]}))
+
+    expect(actions.filter(a => a.type === 'reopen')).toHaveLength(1)
+    expect(counts.suppressed).toBe(0)
+  })
+
+  it('recurring label does NOT suppress — allows reopen when drift returns (non-terminal)', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const closedIssue = makeClosedIssue(fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.recurring])
+
+    const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]}))
+
+    expect(actions.filter(a => a.type === 'reopen')).toHaveLength(1)
+    expect(counts.suppressed).toBe(0)
+  })
+
+  it('superseded label does NOT suppress — allows reopen when drift returns (non-terminal)', () => {
+    // superseded is a lifecycle state label, not a terminal suppressor.
+    // If the same drift returns after a proposal was superseded, the loop reopens it.
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const closedIssue = makeClosedIssue(fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.superseded])
+
+    const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]}))
+
+    expect(actions.filter(a => a.type === 'reopen')).toHaveLength(1)
+    expect(counts.suppressed).toBe(0)
+  })
+})
+
+describe('manually-fixed auto-close when drift clears', () => {
+  it('closes a manually-fixed open proposal with resolved label when drift clears (scan complete)', () => {
+    const fingerprint = 'abc123def456abcd'
+    // No findings in report — drift cleared
+    const report = makeReport({
+      findings: [],
+      status: 'clean',
+      scan_complete: true,
+      counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+    })
+    // Open proposal with manually-fixed label (drift was manually fixed but issue still open)
+    const openIssue = makeOpenIssue(fingerprint, {
+      labels: [PROPOSAL_LABEL, OUTCOME_LABELS.manuallyFixed],
+    })
+
+    const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [openIssue]}))
+
+    const closeActions = actions.filter(a => a.type === 'close')
+    expect(closeActions).toHaveLength(1)
+    const closeAction = closeActions[0]
+    if (closeAction?.type === 'close') {
+      expect(closeAction.issueNumber).toBe(openIssue.number)
+      expect(closeAction.labels).toContain(OUTCOME_LABELS.resolved)
+    }
+    expect(counts.closed).toBe(1)
+  })
+})
+
+describe('closed proposal without outcome marker — conservative treatment', () => {
+  it('closed proposal with fingerprint but no outcome label is treated as non-terminal (reopen when drift returns)', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    // Closed with only the proposal label — no outcome label
+    const closedIssue = makeClosedIssue(fingerprint, [PROPOSAL_LABEL])
+
+    const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]}))
+
+    // Conservative: no brand-new open; reopen instead
+    expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+    expect(actions.filter(a => a.type === 'reopen')).toHaveLength(1)
+    expect(counts.reopened).toBe(1)
+  })
+
+  it('closed proposal without outcome marker is NOT silently treated as clean (counted for operator attention)', () => {
+    const fingerprint = 'abc123def456abcd'
+    // No findings — drift cleared
+    const report = makeReport({
+      findings: [],
+      status: 'clean',
+      scan_complete: true,
+      counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+    })
+    // Closed with only the proposal label — no outcome label
+    const closedIssue = makeClosedIssue(fingerprint, [PROPOSAL_LABEL])
+
+    const {counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]}))
+
+    // The closed issue without outcome marker should be counted for operator attention
+    expect(counts.closedWithoutOutcome).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe('proposal body conciseness', () => {
+  it('proposal body contains evidence fields but no raw claim text or session narration', () => {
+    const finding = makeDriftedFinding()
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const {actions} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+
+    const openAction = actions.find(a => a.type === 'open')
+    if (openAction?.type === 'open') {
+      // Must contain structured evidence fields
+      expect(openAction.body).toContain('Kind')
+      expect(openAction.body).toContain('Claimed state')
+      // Must NOT contain session narration phrases
+      expect(openAction.body).not.toMatch(/I (found|detected|noticed|analyzed|checked)/i)
+      expect(openAction.body).not.toMatch(/session|agent|workflow log/i)
+      // Must contain the fingerprint marker (machine-readable, not raw claim text)
+      expect(openAction.body).toContain(`<!-- status-truth:fingerprint=${finding.fingerprint} -->`)
+    }
+  })
+
+  it('workflow/open result summary is counts-only by claim kind — no paths or fingerprints', () => {
+    const finding = makeDriftedFinding()
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const result = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+
+    // countsByKind must be present and counts-only
+    expect(result.countsByKind).toBeDefined()
+    const json = JSON.stringify(result.countsByKind)
+    // Must not contain file paths or fingerprint-like hex strings
+    expect(json).not.toMatch(/docs\/plans|scripts\/|\.github\//)
+    expect(json).not.toMatch(/[a-f0-9]{16,}/)
+  })
+})

--- a/scripts/status-truth-proposals.test.ts
+++ b/scripts/status-truth-proposals.test.ts
@@ -323,6 +323,40 @@ describe('planStatusTruthProposalActions', () => {
       expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
       expect(counts.sameRunDeduplicated).toBe(1)
     })
+
+    it('same-fingerprint second finding is deduplicated when first was blocked by privacy gate', () => {
+      // Two drifted findings with the same fingerprint.
+      // First has a private token in proposedCorrection → privacy gate blocks it.
+      // Second has a safe correction.
+      // Expected: zero open actions, blocked=1, sameRunDeduplicated=1.
+      // The fingerprint must be tracked as "seen" even when the first attempt is blocked,
+      // so the second attempt does not slip through as a new open.
+      const fingerprint = 'abc123def456abcd'
+      const blockedFinding = {
+        ...makeDriftedFinding(fingerprint),
+        proposedCorrection: 'pr #42 is closed (private-repo-name)',
+      }
+      const safeFinding = {
+        ...makeDriftedFinding(fingerprint),
+        path: 'docs/plans/other.md', // different path, same fingerprint
+        proposedCorrection: 'pr #42 is closed',
+      }
+      const report = makeReport({
+        findings: [blockedFinding, safeFinding],
+        counts: {total: 2, current: 0, drifted: 2, unresolved: 0, unsafe: 0, proposal_eligible: 2},
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(
+        makePlanInput({report, existingIssues: [], publicOutputTokens: makeBlockingTokens()}),
+      )
+
+      // Zero open actions: first was blocked, second was deduplicated
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+      // First finding was blocked by privacy gate
+      expect(counts.blocked).toBe(1)
+      // Second finding was deduplicated (fingerprint already seen)
+      expect(counts.sameRunDeduplicated).toBe(1)
+    })
   })
 
   describe('close-on-clear', () => {
@@ -2065,5 +2099,224 @@ describe('proposal body conciseness', () => {
     // Must not contain file paths or fingerprint-like hex strings
     expect(json).not.toMatch(/docs\/plans|scripts\/|\.github\//)
     expect(json).not.toMatch(/[a-f0-9]{16,}/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fix #2: Incomplete/failed scans must not create public proposals
+// ---------------------------------------------------------------------------
+
+describe('Fix #2: execution-failure or scan_complete=false blocks all proposal actions', () => {
+  it('execution-failure report with drifted proposal-eligible findings yields zero open/reopen/update/close actions', () => {
+    const finding = makeDriftedFinding()
+    const report = makeReport({
+      status: 'execution-failure',
+      scan_complete: false,
+      failure_class: 'api-unavailable',
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+
+    // No open/reopen/update/close actions when scan is incomplete
+    expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+    expect(actions.filter(a => a.type === 'reopen')).toHaveLength(0)
+    expect(actions.filter(a => a.type === 'update-comment')).toHaveLength(0)
+    expect(actions.filter(a => a.type === 'close')).toHaveLength(0)
+    // Findings should be counted as blocked
+    expect(counts.blocked).toBeGreaterThanOrEqual(1)
+    expect(counts.opened).toBe(0)
+  })
+
+  it('scan_complete=false with drifted findings yields zero proposal actions regardless of status field', () => {
+    const finding = makeDriftedFinding()
+    // Even if status is somehow 'findings' but scan_complete is false
+    const report = makeReport({
+      status: 'findings',
+      scan_complete: false,
+      failure_class: null,
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+
+    expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+    expect(counts.blocked).toBeGreaterThanOrEqual(1)
+    expect(counts.opened).toBe(0)
+  })
+
+  it('versionRejected behavior is preserved when scan is also incomplete', () => {
+    const report = makeReport({
+      schema_version: 99,
+      status: 'execution-failure',
+      scan_complete: false,
+    })
+
+    const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report}))
+
+    expect(actions).toHaveLength(0)
+    expect(counts.versionRejected).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fix #4: Label preflight 422 must not silently pass unless label truly exists
+// ---------------------------------------------------------------------------
+
+describe('Fix #4: createLabel 422 requires getLabel confirmation', () => {
+  it('createLabel returns 422 and follow-up getLabel fails (non-404) => label gate fails', async () => {
+    // Scenario: label does not exist (404 on first getLabel), createLabel returns 422 (race),
+    // but follow-up getLabel also fails (non-404 error) => cannot confirm => gate fails
+    const octokit = {
+      rest: {
+        issues: {
+          getLabel: async ({name}: {owner: string; repo: string; name: string}) => {
+            // First call: 404 (not found). Second call (confirmation after 422): 500 error
+            // We track call count per label name
+            const callKey = `getLabel:${name}`
+            const count = ((octokit as unknown as Record<string, number>)[callKey] ?? 0) + 1
+            ;(octokit as unknown as Record<string, number>)[callKey] = count
+            if (count === 1) {
+              // First call: label not found
+              const err = Object.assign(new Error('Not Found'), {status: 404})
+              throw err
+            }
+            // Second call (confirmation): non-404 error
+            const err = Object.assign(new Error('Server Error'), {status: 500})
+            throw err
+          },
+          createLabel: async (_params: {
+            owner: string
+            repo: string
+            name: string
+            color: string
+            description: string
+          }) => {
+            // Returns 422 (race condition — label already exists)
+            const err = Object.assign(new Error('Unprocessable'), {status: 422})
+            throw err
+          },
+          create: async () => ({data: {number: 1}}),
+          createComment: async () => ({data: {id: 1}}),
+          update: async () => ({data: {number: 1}}),
+          removeLabel: async () => ({data: []}),
+          addLabels: async () => ({data: []}),
+        },
+      },
+    } as unknown as StatusTruthOctokitClient
+
+    const actions = [
+      {
+        type: 'open' as const,
+        fingerprint: 'abc123def456abcd',
+        title: 'Status truth: pr-state drift',
+        body: '<!-- status-truth:fingerprint=abc123def456abcd -->\n\nBody.',
+        labels: [PROPOSAL_LABEL],
+      },
+    ]
+
+    const result = await executeStatusTruthProposalActions({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      actions,
+      dryRun: false,
+      sameRunCreatedFingerprints: new Set<string>(),
+    })
+
+    // Cannot confirm label => gate fails
+    expect(result.labelGateFailed).toBe(true)
+    expect(result.counts.opened).toBe(0)
+  })
+
+  it('createLabel returns 422 and follow-up getLabel succeeds => label confirmed', async () => {
+    // Scenario: label does not exist (404 on first getLabel), createLabel returns 422 (race),
+    // follow-up getLabel succeeds => label confirmed => gate passes
+    const callCounts: Record<string, number> = {}
+    const octokit = {
+      rest: {
+        issues: {
+          getLabel: async ({name}: {owner: string; repo: string; name: string}) => {
+            callCounts[name] = (callCounts[name] ?? 0) + 1
+            if (callCounts[name] === 1) {
+              // First call: label not found
+              const err = Object.assign(new Error('Not Found'), {status: 404})
+              throw err
+            }
+            // Second call (confirmation after 422): label exists
+            return {data: {name}}
+          },
+          createLabel: async (_params: {
+            owner: string
+            repo: string
+            name: string
+            color: string
+            description: string
+          }) => {
+            // Returns 422 (race condition — label already exists)
+            const err = Object.assign(new Error('Unprocessable'), {status: 422})
+            throw err
+          },
+          create: async (params: {owner: string; repo: string; title: string; body: string; labels: string[]}) => ({
+            data: {number: 1001, title: params.title},
+          }),
+          createComment: async () => ({data: {id: 1}}),
+          update: async () => ({data: {number: 1}}),
+          removeLabel: async () => ({data: []}),
+          addLabels: async () => ({data: []}),
+        },
+      },
+    } as unknown as StatusTruthOctokitClient
+
+    const actions = [
+      {
+        type: 'open' as const,
+        fingerprint: 'abc123def456abcd',
+        title: 'Status truth: pr-state drift',
+        body: '<!-- status-truth:fingerprint=abc123def456abcd -->\n\nBody.',
+        labels: [PROPOSAL_LABEL],
+      },
+    ]
+
+    const result = await executeStatusTruthProposalActions({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      actions,
+      dryRun: false,
+      sameRunCreatedFingerprints: new Set<string>(),
+    })
+
+    // Label confirmed via getLabel after 422 => gate passes
+    expect(result.labelGateFailed).toBe(false)
+    expect(result.counts.opened).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fix #9: Same-run duplicate proposal test
+// ---------------------------------------------------------------------------
+
+describe('Fix #9: same-run duplicate proposal deduplication', () => {
+  it('two drifted findings with same fingerprint in one report result in only one open proposal and sameRunDeduplicated=1', () => {
+    const fingerprint = 'abc123def456abcd'
+    // Two findings with the same fingerprint (e.g. same claim in two places)
+    const finding1 = makeDriftedFinding(fingerprint)
+    const finding2 = {...makeDriftedFinding(fingerprint), path: 'docs/plans/other.md'}
+    const report = makeReport({
+      findings: [finding1, finding2],
+      counts: {total: 2, current: 0, drifted: 2, unresolved: 0, unsafe: 0, proposal_eligible: 2},
+    })
+
+    const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+
+    // Only one open action (first occurrence)
+    const openActions = actions.filter(a => a.type === 'open')
+    expect(openActions).toHaveLength(1)
+    // Second occurrence is deduplicated
+    expect(counts.sameRunDeduplicated).toBe(1)
+    expect(counts.opened).toBe(1)
   })
 })

--- a/scripts/status-truth-proposals.ts
+++ b/scripts/status-truth-proposals.ts
@@ -68,6 +68,32 @@ const TERMINAL_LABELS: readonly string[] = [OUTCOME_LABELS.rejected, OUTCOME_LAB
 /** Labels that are removed when a non-terminal closed issue is reopened. */
 const RESOLVING_LABELS: readonly string[] = [OUTCOME_LABELS.resolved, OUTCOME_LABELS.manuallyFixed]
 
+/**
+ * Outcome labels that count as accuracy signals for per-kind usefulness math.
+ * Only accepted, rejected, and false-positive are accuracy signals.
+ * Other outcome labels (resolved, manually-fixed, recurring, superseded) are lifecycle
+ * state labels, not accuracy signals.
+ */
+const ACCURACY_SIGNAL_LABELS: readonly string[] = [
+  OUTCOME_LABELS.accepted,
+  OUTCOME_LABELS.rejected,
+  OUTCOME_LABELS.falsePositive,
+]
+
+/**
+ * All recognized outcome labels (accuracy signals + lifecycle state labels).
+ * Labels outside this set on a proposal issue are malformed outcome markers.
+ */
+const ALL_RECOGNIZED_OUTCOME_LABELS: readonly string[] = [
+  OUTCOME_LABELS.accepted,
+  OUTCOME_LABELS.rejected,
+  OUTCOME_LABELS.falsePositive,
+  OUTCOME_LABELS.superseded,
+  OUTCOME_LABELS.manuallyFixed,
+  OUTCOME_LABELS.resolved,
+  OUTCOME_LABELS.recurring,
+]
+
 // ---------------------------------------------------------------------------
 // Hidden marker constants
 // ---------------------------------------------------------------------------
@@ -142,6 +168,22 @@ export interface SuppressAction {
 /** Discriminated union of all proposal lifecycle actions. */
 export type ProposalAction = OpenAction | UpdateCommentAction | ReopenAction | CloseAction | SuppressAction
 
+/** Per-kind accuracy signal from accepted/rejected/false-positive outcomes. */
+export interface KindUsefulnessCounts {
+  readonly accepted: number
+  readonly rejected: number
+  readonly falsePositive: number
+}
+
+/** Per-kind action counts for workflow/open result summary (counts-only, no paths or fingerprints). */
+export interface KindActionCounts {
+  readonly opened: number
+  readonly updated: number
+  readonly reopened: number
+  readonly closed: number
+  readonly suppressed: number
+}
+
 /** Aggregate counts returned by the planner. */
 export interface ProposalCounts {
   readonly opened: number
@@ -154,6 +196,22 @@ export interface ProposalCounts {
   readonly sameRunDeduplicated: number
   readonly malformedMarkers: number
   readonly versionRejected: number
+  /**
+   * Closed issues with a valid fingerprint but no recognized outcome label.
+   * Counted for operator attention; not included in accuracy math.
+   */
+  readonly closedWithoutOutcome: number
+  /**
+   * Closed issues with a valid fingerprint but an unrecognized/malformed outcome label.
+   * Counted for operator attention; excluded from usefulnessByKind accuracy math.
+   */
+  readonly malformedOutcomeMarkers: number
+  /**
+   * Per-kind accuracy signal from accepted/rejected/false-positive outcomes.
+   * Computed from all existing issues with recognized outcome labels.
+   * Excludes malformed/unknown labels.
+   */
+  readonly usefulnessByKind: Readonly<Record<string, KindUsefulnessCounts>>
 }
 
 /** Input to the pure lifecycle planner. */
@@ -175,6 +233,11 @@ export interface PlanStatusTruthProposalActionsInput {
 export interface PlanStatusTruthProposalActionsResult {
   readonly actions: readonly ProposalAction[]
   readonly counts: ProposalCounts
+  /**
+   * Per-kind action counts for workflow/open result summary.
+   * Counts-only: no paths, fingerprints, or claim text.
+   */
+  readonly countsByKind: Readonly<Record<string, KindActionCounts>>
 }
 
 // ---------------------------------------------------------------------------
@@ -324,7 +387,11 @@ export function planStatusTruthProposalActions(
         sameRunDeduplicated: 0,
         malformedMarkers: 0,
         versionRejected: 1,
+        closedWithoutOutcome: 0,
+        malformedOutcomeMarkers: 0,
+        usefulnessByKind: {},
       },
+      countsByKind: {},
     }
   }
 
@@ -332,6 +399,10 @@ export function planStatusTruthProposalActions(
   const openByFingerprint = new Map<string, ExistingProposalIssue>()
   const closedByFingerprint = new Map<string, ExistingProposalIssue>()
   let malformedMarkers = 0
+
+  const usefulnessByKind: Record<string, {accepted: number; rejected: number; falsePositive: number}> = {}
+  let closedWithoutOutcome = 0
+  let malformedOutcomeMarkers = 0
 
   for (const issue of existingIssues) {
     const fp = extractProposalFingerprint(issue.body)
@@ -348,6 +419,49 @@ export function planStatusTruthProposalActions(
     } else {
       // Closed: keep the most recently seen (map will hold last one; caller should sort by updated desc)
       closedByFingerprint.set(fp, issue)
+
+      // Only accuracy signal labels (accepted, rejected, false-positive) count for usefulness math.
+      // Malformed/unknown outcome labels are counted for operator attention but excluded from math.
+      const outcomeLabels = issue.labels.filter(l => l !== PROPOSAL_LABEL && l.startsWith('status-truth:'))
+      const recognizedOutcomeLabels = outcomeLabels.filter(l => ALL_RECOGNIZED_OUTCOME_LABELS.includes(l))
+      const unrecognizedOutcomeLabels = outcomeLabels.filter(l => !ALL_RECOGNIZED_OUTCOME_LABELS.includes(l))
+
+      if (unrecognizedOutcomeLabels.length > 0) {
+        // Mixed or malformed outcome markers: increment counter and skip accuracy math entirely.
+        // Conservative: if ANY unrecognized status-truth:* label is present alongside a recognized
+        // accuracy signal label, the issue is treated as malformed for accuracy purposes.
+        // The recognized label is NOT included in usefulnessByKind to avoid polluting accuracy math
+        // with ambiguous outcome state.
+        malformedOutcomeMarkers++
+      } else if (outcomeLabels.length === 0) {
+        // Closed with no outcome label at all — count for operator attention
+        closedWithoutOutcome++
+      } else {
+        // Only accumulate accuracy signals when there are NO unrecognized outcome labels.
+        // This is intentionally conservative: we only count recognized accuracy signal labels
+        // on issues that have no malformed/unknown outcome markers.
+        for (const label of recognizedOutcomeLabels) {
+          if (!ACCURACY_SIGNAL_LABELS.includes(label)) continue
+
+          // Infer kind from issue title: "Status truth: <kind> drift in <path>"
+          const titleMatch = /^Status truth: ([\w-]+) drift/u.exec(issue.title)
+          const kind = titleMatch?.[1] ?? 'unknown'
+
+          if (usefulnessByKind[kind] === undefined) {
+            usefulnessByKind[kind] = {accepted: 0, rejected: 0, falsePositive: 0}
+          }
+          const entry = usefulnessByKind[kind]
+          if (entry !== undefined) {
+            if (label === OUTCOME_LABELS.accepted) {
+              usefulnessByKind[kind] = {...entry, accepted: entry.accepted + 1}
+            } else if (label === OUTCOME_LABELS.rejected) {
+              usefulnessByKind[kind] = {...entry, rejected: entry.rejected + 1}
+            } else if (label === OUTCOME_LABELS.falsePositive) {
+              usefulnessByKind[kind] = {...entry, falsePositive: entry.falsePositive + 1}
+            }
+          }
+        }
+      }
     }
   }
 
@@ -360,6 +474,22 @@ export function planStatusTruthProposalActions(
   let noAction = 0
   let sameRunDeduplicated = 0
 
+  // Per-kind action counts for workflow/open result summary (counts-only, no paths or fingerprints).
+  const countsByKind: Record<
+    string,
+    {opened: number; updated: number; reopened: number; closed: number; suppressed: number}
+  > = {}
+
+  function incrementKindCount(kind: string, field: 'opened' | 'updated' | 'reopened' | 'closed' | 'suppressed'): void {
+    if (countsByKind[kind] === undefined) {
+      countsByKind[kind] = {opened: 0, updated: 0, reopened: 0, closed: 0, suppressed: 0}
+    }
+    const entry = countsByKind[kind]
+    if (entry !== undefined) {
+      countsByKind[kind] = {...entry, [field]: entry[field] + 1}
+    }
+  }
+
   // Track which fingerprints are active in this report (for close-on-clear)
   const activeFingerprintsInReport = new Set<string>()
 
@@ -371,7 +501,7 @@ export function planStatusTruthProposalActions(
     // Skip non-proposal-eligible findings (unresolved, current)
     if (!finding.proposalEligible) continue
 
-    const {fingerprint} = finding
+    const {fingerprint, kind} = finding
     activeFingerprintsInReport.add(fingerprint)
 
     // a. Same-run dedup: skip if already created this run
@@ -389,6 +519,7 @@ export function planStatusTruthProposalActions(
         reason: 'terminal outcome label on closed proposal',
       })
       suppressed++
+      incrementKindCount(kind, 'suppressed')
       continue
     }
 
@@ -418,6 +549,7 @@ export function planStatusTruthProposalActions(
           comment: gateResult.sanitizedContent,
         })
         updated++
+        incrementKindCount(kind, 'updated')
       } else {
         // Drift unchanged — no action to avoid comment spam
         noAction++
@@ -447,6 +579,7 @@ export function planStatusTruthProposalActions(
         addLabels: [OUTCOME_LABELS.recurring],
       })
       reopened++
+      incrementKindCount(kind, 'reopened')
       continue
     }
 
@@ -484,6 +617,7 @@ export function planStatusTruthProposalActions(
       labels: [PROPOSAL_LABEL],
     })
     opened++
+    incrementKindCount(kind, 'opened')
   }
 
   // 4. Close-on-clear: only when scan is complete and not execution-failure
@@ -511,6 +645,10 @@ export function planStatusTruthProposalActions(
           comment: gateResult.sanitizedContent,
         })
         closed++
+        // Infer kind from open issue title for countsByKind
+        const titleMatch = /^Status truth: ([\w-]+) drift/u.exec(openIssue.title)
+        const kind = titleMatch?.[1] ?? 'unknown'
+        incrementKindCount(kind, 'closed')
       }
     }
   }
@@ -528,7 +666,11 @@ export function planStatusTruthProposalActions(
       sameRunDeduplicated,
       malformedMarkers,
       versionRejected: 0,
+      closedWithoutOutcome,
+      malformedOutcomeMarkers,
+      usefulnessByKind,
     },
+    countsByKind,
   }
 }
 
@@ -1061,6 +1203,13 @@ interface OpenResult {
   dryRun: boolean
   labelGateFailed: boolean
   counts: ExecuteStatusTruthProposalActionsCounts
+  /**
+   * Planned per-kind action counts from the planner (counts-only, no paths or fingerprints).
+   * These are the counts the planner intended to execute, not the executed counts.
+   * Allows downstream workflow steps to report per-kind summaries without exposing
+   * any identity-bearing fields.
+   */
+  plannedCountsByKind: Readonly<Record<string, KindActionCounts>>
 }
 
 /**
@@ -1217,6 +1366,7 @@ async function runOpen(): Promise<void> {
     dryRun: executeResult.dryRun,
     labelGateFailed: executeResult.labelGateFailed,
     counts: executeResult.counts,
+    plannedCountsByKind: planResult.countsByKind,
   }
 
   const resultJson = `${JSON.stringify(result)}\n`

--- a/scripts/status-truth-proposals.ts
+++ b/scripts/status-truth-proposals.ts
@@ -395,6 +395,36 @@ export function planStatusTruthProposalActions(
     }
   }
 
+  // 1b. Fail-closed on incomplete/failed scans.
+  // Detection uncertainty (execution-failure or scan_complete=false) blocks all
+  // public proposal actions. Findings from an incomplete scan cannot be trusted
+  // as ground truth — opening/reopening/updating proposals on uncertain data
+  // would create noise and potentially incorrect lifecycle transitions.
+  // Close-on-clear is also blocked (handled separately below via canClose).
+  if (!report.scan_complete || report.status === 'execution-failure') {
+    // Count proposal-eligible findings as blocked for operator visibility
+    const blockedCount = report.findings.filter(f => f.proposalEligible).length
+    return {
+      actions: [],
+      counts: {
+        opened: 0,
+        updated: 0,
+        reopened: 0,
+        closed: 0,
+        suppressed: 0,
+        blocked: blockedCount,
+        noAction: 0,
+        sameRunDeduplicated: 0,
+        malformedMarkers: 0,
+        versionRejected: 0,
+        closedWithoutOutcome: 0,
+        malformedOutcomeMarkers: 0,
+        usefulnessByKind: {},
+      },
+      countsByKind: {},
+    }
+  }
+
   // 2. Build lookup maps from existing issues
   const openByFingerprint = new Map<string, ExistingProposalIssue>()
   const closedByFingerprint = new Map<string, ExistingProposalIssue>()
@@ -493,6 +523,11 @@ export function planStatusTruthProposalActions(
   // Track which fingerprints are active in this report (for close-on-clear)
   const activeFingerprintsInReport = new Set<string>()
 
+  // Track fingerprints planned for open in this planner call (same-run dedup within one report).
+  // Prevents duplicate open actions when the same fingerprint appears in multiple findings
+  // (e.g. same claim text in two files) within a single report.
+  const plannedOpenFingerprints = new Set<string>(sameRunCreatedFingerprints)
+
   // 3. Process proposal-eligible findings
   for (const finding of report.findings) {
     // Skip unsafe findings — they have no identity-bearing fields and are never proposal-eligible
@@ -504,8 +539,9 @@ export function planStatusTruthProposalActions(
     const {fingerprint, kind} = finding
     activeFingerprintsInReport.add(fingerprint)
 
-    // a. Same-run dedup: skip if already created this run
-    if (sameRunCreatedFingerprints.has(fingerprint)) {
+    // a. Same-run dedup: skip if already created this run or already planned in this call.
+    // plannedOpenFingerprints starts with sameRunCreatedFingerprints and grows as we plan opens.
+    if (plannedOpenFingerprints.has(fingerprint)) {
       sameRunDeduplicated++
       continue
     }
@@ -584,6 +620,12 @@ export function planStatusTruthProposalActions(
     }
 
     // e. New finding — open a proposal after privacy gating
+    // Mark this fingerprint as seen before gating so that if the gate blocks,
+    // subsequent same-fingerprint findings in this report are still deduplicated.
+    // Without this, a second finding with the same fingerprint but a safe correction
+    // would slip through after the first was blocked, opening an unintended proposal.
+    plannedOpenFingerprints.add(fingerprint)
+
     const title = buildProposalTitle(finding)
     const body = buildProposalBody(finding, report.generated_at)
 
@@ -620,8 +662,10 @@ export function planStatusTruthProposalActions(
     incrementKindCount(kind, 'opened')
   }
 
-  // 4. Close-on-clear: only when scan is complete and not execution-failure
-  const canClose = report.status !== 'execution-failure' && report.scan_complete
+  // 4. Close-on-clear: only when scan is complete and not execution-failure.
+  // At this point we have already returned early for execution-failure and scan_complete=false,
+  // so report.scan_complete is always true here. The check is kept for clarity.
+  const canClose = report.scan_complete
   let closed = 0
 
   if (canClose) {
@@ -687,7 +731,7 @@ export interface IssueListItem {
   readonly state: string
   readonly title: string
   readonly body: string | null | undefined
-  readonly labels: readonly {readonly name?: string | null | undefined}[]
+  readonly labels: readonly (string | {readonly name?: string | null | undefined})[]
 }
 
 /**
@@ -978,8 +1022,15 @@ async function ensureStatusTruthLabels(
       confirmed.add(name)
     } catch (createError: unknown) {
       if (isApiStatus(createError, 422)) {
-        // Race with another writer — label now exists
-        confirmed.add(name)
+        // Race with another writer — label may now exist. Confirm with getLabel
+        // before adding to confirmed set. A 422 alone is not sufficient proof
+        // because it could also indicate a validation error on the label name.
+        try {
+          await octokit.rest.issues.getLabel({owner, repo, name})
+          confirmed.add(name)
+        } catch {
+          // getLabel failed after 422 — cannot confirm label exists
+        }
       }
       // Other failure: label not confirmed
     }
@@ -1180,7 +1231,7 @@ export async function executeStatusTruthProposalActions(
 // Unit 4: CLI shell for the open/proposals step
 // ---------------------------------------------------------------------------
 
-type OctokitConstructor = new (params: {auth: string}) => StatusTruthOctokitClient
+type OctokitConstructor = new (params: {auth: string; request?: {timeout?: number}}) => StatusTruthOctokitClient
 
 async function loadOctokitConstructor(): Promise<OctokitConstructor> {
   if (typeof Octokit !== 'function') {
@@ -1195,7 +1246,7 @@ async function createOctokitFromEnv(): Promise<StatusTruthOctokitClient> {
     throw new Error('status-truth-proposals: GITHUB_TOKEN is required in the environment')
   }
   const LoadedOctokit = await loadOctokitConstructor()
-  return new LoadedOctokit({auth: token})
+  return new LoadedOctokit({auth: token, request: {timeout: 10_000}})
 }
 
 /** Counts-only result written to stdout and STATUS_TRUTH_OPEN_RESULT_PATH. */
@@ -1210,6 +1261,11 @@ interface OpenResult {
    * any identity-bearing fields.
    */
   plannedCountsByKind: Readonly<Record<string, KindActionCounts>>
+  /**
+   * Aggregate planned counts from the planner (counts-only).
+   * Includes versionRejected and other planner-level counters not present in executor counts.
+   */
+  plannedCounts: Pick<ProposalCounts, 'versionRejected' | 'blocked' | 'sameRunDeduplicated'>
 }
 
 /**
@@ -1307,7 +1363,7 @@ async function runOpen(): Promise<void> {
     if (dryRunToken !== undefined && dryRunToken !== '' && owner !== '' && repo !== '') {
       try {
         const LoadedOctokit = await loadOctokitConstructor()
-        const dryRunOctokit = new LoadedOctokit({auth: dryRunToken})
+        const dryRunOctokit = new LoadedOctokit({auth: dryRunToken, request: {timeout: 10_000}})
         existingIssues = await fetchExistingProposalIssues({octokit: dryRunOctokit, owner, repo})
       } catch {
         // Non-fatal in dry-run: proceed with empty list (counts may over-estimate opens)
@@ -1367,6 +1423,11 @@ async function runOpen(): Promise<void> {
     labelGateFailed: executeResult.labelGateFailed,
     counts: executeResult.counts,
     plannedCountsByKind: planResult.countsByKind,
+    plannedCounts: {
+      versionRejected: planResult.counts.versionRejected,
+      blocked: planResult.counts.blocked,
+      sameRunDeduplicated: planResult.counts.sameRunDeduplicated,
+    },
   }
 
   const resultJson = `${JSON.stringify(result)}\n`

--- a/scripts/status-truth-proposals.ts
+++ b/scripts/status-truth-proposals.ts
@@ -1,0 +1,519 @@
+/**
+ * Proposal lifecycle planner for the status-truth maintenance loop (Unit 3).
+ *
+ * Converts drifted, privacy-safe status claims into deterministic GitHub issue
+ * lifecycle actions without touching GitHub.
+ *
+ * Design invariants:
+ * - Pure function: no I/O, no Octokit dependency.
+ * - One fingerprint → one proposal issue. Multiple drifted claims in the same
+ *   file remain separate issues so outcomes can differ per claim.
+ * - Terminal labels (false-positive, rejected) suppress future matching findings
+ *   unless claim text or source reference materially changes.
+ * - Non-terminal closed issues (resolved, manually-fixed) are reopened when
+ *   exact drift returns.
+ * - Close-on-clear only when scan is complete and not an execution failure.
+ * - Same-run created-key set prevents duplicate proposals from GitHub list lag.
+ * - All proposal content passes through the public-output privacy gate.
+ * - Unknown report schema/fingerprint versions are rejected before any planning.
+ *
+ * Strip-only safe: no parameter properties, enums, or namespaces.
+ */
+
+import type {PublicStatusTruthFinding, StatusTruthFinding, StatusTruthJsonReport} from './status-truth-detect.ts'
+import {KNOWN_FINGERPRINT_VERSION, KNOWN_SCHEMA_VERSION} from './status-truth-detect.ts'
+import {applyPublicOutputGate, type PublicOutputTokens} from './status-truth-public-output.ts'
+
+// ---------------------------------------------------------------------------
+// Label constants
+// ---------------------------------------------------------------------------
+
+/** Primary label applied to all status-truth proposal issues. */
+export const PROPOSAL_LABEL = 'status-truth'
+
+/**
+ * Outcome labels for tracking proposal lifecycle state.
+ *
+ * Terminal labels (false-positive, rejected): suppress future matching findings.
+ * Non-terminal labels (accepted, manually-fixed, resolved, recurring, superseded):
+ *   allow reopen or auto-close transitions.
+ */
+export const OUTCOME_LABELS = {
+  accepted: 'status-truth:accepted',
+  rejected: 'status-truth:rejected',
+  falsePositive: 'status-truth:false-positive',
+  superseded: 'status-truth:superseded',
+  manuallyFixed: 'status-truth:manually-fixed',
+  resolved: 'status-truth:resolved',
+  recurring: 'status-truth:recurring',
+} as const
+
+/** Labels that permanently suppress future matching findings. */
+const TERMINAL_LABELS: readonly string[] = [OUTCOME_LABELS.rejected, OUTCOME_LABELS.falsePositive]
+
+/** Labels that are removed when a non-terminal closed issue is reopened. */
+const RESOLVING_LABELS: readonly string[] = [OUTCOME_LABELS.resolved, OUTCOME_LABELS.manuallyFixed]
+
+// ---------------------------------------------------------------------------
+// Hidden marker constants
+// ---------------------------------------------------------------------------
+
+/** Marker prefix for fingerprint in issue body. */
+const FINGERPRINT_MARKER_PREFIX = 'status-truth:fingerprint='
+
+/** Marker prefix for live-state in issue body. */
+const LIVE_STATE_MARKER_PREFIX = 'status-truth:live-state='
+
+/** Pattern to extract fingerprint from hidden marker. Must be lowercase hex. */
+const FINGERPRINT_MARKER_PATTERN = /<!-- status-truth:fingerprint=([a-f0-9]+) -->/u
+
+/** Pattern to extract live-state from hidden marker. */
+const LIVE_STATE_MARKER_PATTERN = /<!-- status-truth:live-state=([\w-]+) -->/u
+
+// ---------------------------------------------------------------------------
+// Input/output types
+// ---------------------------------------------------------------------------
+
+/** Simplified GitHub issue shape — no Octokit dependency. */
+export interface ExistingProposalIssue {
+  readonly number: number
+  readonly state: 'open' | 'closed'
+  readonly labels: readonly string[]
+  readonly title: string
+  readonly body: string | null | undefined
+}
+
+/** Open a new proposal issue. */
+export interface OpenAction {
+  readonly type: 'open'
+  readonly fingerprint: string
+  readonly title: string
+  readonly body: string
+  readonly labels: readonly string[]
+}
+
+/** Add an update comment to an existing open proposal. */
+export interface UpdateCommentAction {
+  readonly type: 'update-comment'
+  readonly issueNumber: number
+  readonly comment: string
+}
+
+/** Reopen a closed non-terminal proposal and add a recurrence comment. */
+export interface ReopenAction {
+  readonly type: 'reopen'
+  readonly issueNumber: number
+  readonly comment: string
+  /** Labels to remove when reopening (e.g. resolved, manually-fixed). */
+  readonly removeLabels: readonly string[]
+  /** Labels to add when reopening (e.g. recurring). */
+  readonly addLabels: readonly string[]
+}
+
+/** Close a proposal whose drift has cleared. */
+export interface CloseAction {
+  readonly type: 'close'
+  readonly issueNumber: number
+  readonly labels: readonly string[]
+  readonly comment: string
+}
+
+/** Suppress a finding due to terminal label (false-positive / rejected). */
+export interface SuppressAction {
+  readonly type: 'suppress'
+  readonly fingerprint: string
+  readonly reason: string
+}
+
+/** Discriminated union of all proposal lifecycle actions. */
+export type ProposalAction = OpenAction | UpdateCommentAction | ReopenAction | CloseAction | SuppressAction
+
+/** Aggregate counts returned by the planner. */
+export interface ProposalCounts {
+  readonly opened: number
+  readonly updated: number
+  readonly reopened: number
+  readonly closed: number
+  readonly suppressed: number
+  readonly blocked: number
+  readonly noAction: number
+  readonly sameRunDeduplicated: number
+  readonly malformedMarkers: number
+  readonly versionRejected: number
+}
+
+/** Input to the pure lifecycle planner. */
+export interface PlanStatusTruthProposalActionsInput {
+  /** The status-truth report from the detect step. */
+  readonly report: StatusTruthJsonReport
+  /** Open and recently-closed proposal issues fetched from GitHub. */
+  readonly existingIssues: readonly ExistingProposalIssue[]
+  /** Loaded public-output token sets for privacy gating. */
+  readonly publicOutputTokens: PublicOutputTokens
+  /**
+   * Fingerprints already created in this run (same-run dedup guard).
+   * Prevents duplicate proposals when GitHub issue listing lags same-run writes.
+   */
+  readonly sameRunCreatedFingerprints: ReadonlySet<string>
+}
+
+/** Result of the pure lifecycle planner. */
+export interface PlanStatusTruthProposalActionsResult {
+  readonly actions: readonly ProposalAction[]
+  readonly counts: ProposalCounts
+}
+
+// ---------------------------------------------------------------------------
+// Hidden marker helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the fingerprint from a proposal issue body hidden marker.
+ * Returns null if the body is absent, empty, or the marker is malformed.
+ */
+export function extractProposalFingerprint(body: string | null | undefined): string | null {
+  if (body === null || body === undefined || body === '') return null
+  const match = FINGERPRINT_MARKER_PATTERN.exec(body)
+  if (match === null) return null
+  const value = match[1]
+  // Require at least one hex character (empty value is malformed)
+  if (value === undefined || value === '') return null
+  return value
+}
+
+/**
+ * Extract the recorded live-state from a proposal issue body hidden marker.
+ * Returns null if absent or malformed.
+ */
+function extractRecordedLiveState(body: string | null | undefined): string | null {
+  if (body === null || body === undefined || body === '') return null
+  const match = LIVE_STATE_MARKER_PATTERN.exec(body)
+  if (match === null) return null
+  const value = match[1]
+  if (value === undefined || value === '') return null
+  return value
+}
+
+/**
+ * Build the hidden marker line for a fingerprint.
+ */
+function buildFingerprintMarker(fingerprint: string): string {
+  return `<!-- ${FINGERPRINT_MARKER_PREFIX}${fingerprint} -->`
+}
+
+/**
+ * Build the hidden marker line for a live-state.
+ */
+function buildLiveStateMarker(liveState: string): string {
+  return `<!-- ${LIVE_STATE_MARKER_PREFIX}${liveState} -->`
+}
+
+// ---------------------------------------------------------------------------
+// Issue body / title builders
+// ---------------------------------------------------------------------------
+
+function buildProposalTitle(finding: PublicStatusTruthFinding): string {
+  return `Status truth: ${finding.kind} drift in ${finding.path}`
+}
+
+function buildProposalBody(finding: PublicStatusTruthFinding, generatedAt: string): string {
+  const liveStateMarker = finding.liveState === undefined ? '' : `\n${buildLiveStateMarker(finding.liveState)}`
+  const correctionLine =
+    finding.proposedCorrection === undefined ? '' : `\n**Proposed correction:** ${finding.proposedCorrection}`
+
+  return [
+    buildFingerprintMarker(finding.fingerprint),
+    liveStateMarker,
+    '',
+    `**Kind:** \`${finding.kind}\``,
+    `**Path:** \`${finding.path}\``,
+    `**Source reference:** ${finding.sourceRef}`,
+    `**Claimed state:** \`${finding.claimedState}\``,
+    finding.liveState === undefined ? '' : `**Live state:** \`${finding.liveState}\``,
+    correctionLine,
+    '',
+    `First detected at \`${generatedAt}\`.`,
+  ]
+    .filter(line => line !== '')
+    .join('\n')
+}
+
+function buildUpdateComment(finding: PublicStatusTruthFinding, generatedAt: string): string {
+  const liveStateLine = finding.liveState === undefined ? '' : `\n**Updated live state:** \`${finding.liveState}\``
+  const correctionLine =
+    finding.proposedCorrection === undefined ? '' : `\n**Proposed correction:** ${finding.proposedCorrection}`
+  return `Live-state details changed at \`${generatedAt}\`.${liveStateLine}${correctionLine}`
+}
+
+function buildRecurrenceComment(generatedAt: string): string {
+  return `Drift recurrence detected at \`${generatedAt}\`. This finding was previously resolved but has returned.`
+}
+
+function buildCloseComment(generatedAt: string): string {
+  return `Drift cleared at \`${generatedAt}\`. Closing as resolved.`
+}
+
+// ---------------------------------------------------------------------------
+// Type guard
+// ---------------------------------------------------------------------------
+
+function isPublicFinding(finding: StatusTruthFinding): finding is PublicStatusTruthFinding {
+  return finding.verdict !== 'unsafe'
+}
+
+// ---------------------------------------------------------------------------
+// Terminal label check
+// ---------------------------------------------------------------------------
+
+function hasTerminalLabel(labels: readonly string[]): boolean {
+  return labels.some(l => TERMINAL_LABELS.includes(l))
+}
+
+// ---------------------------------------------------------------------------
+// Pure lifecycle planner
+// ---------------------------------------------------------------------------
+
+/**
+ * Plan status-truth proposal lifecycle actions from a detect report and existing issues.
+ *
+ * Pure function: no I/O, no Octokit dependency. Deterministic from inputs.
+ *
+ * Processing order:
+ * 1. Reject unknown report versions immediately.
+ * 2. Build lookup maps from existing issues (open and closed by fingerprint).
+ * 3. Count malformed markers for operator attention.
+ * 4. For each proposal-eligible drifted finding:
+ *    a. Skip if in sameRunCreatedFingerprints (same-run dedup).
+ *    b. Check for terminal suppression (false-positive / rejected closed issue).
+ *    c. Check for matching open issue → no-action or update-comment.
+ *    d. Check for matching non-terminal closed issue → reopen.
+ *    e. Otherwise → open new proposal (after privacy gate).
+ * 5. Close-on-clear: only when scan is complete and not execution-failure.
+ */
+export function planStatusTruthProposalActions(
+  input: PlanStatusTruthProposalActionsInput,
+): PlanStatusTruthProposalActionsResult {
+  const {report, existingIssues, publicOutputTokens, sameRunCreatedFingerprints} = input
+
+  // 1. Reject unknown report versions
+  if (report.schema_version !== KNOWN_SCHEMA_VERSION || report.fingerprint_version !== KNOWN_FINGERPRINT_VERSION) {
+    return {
+      actions: [],
+      counts: {
+        opened: 0,
+        updated: 0,
+        reopened: 0,
+        closed: 0,
+        suppressed: 0,
+        blocked: 0,
+        noAction: 0,
+        sameRunDeduplicated: 0,
+        malformedMarkers: 0,
+        versionRejected: 1,
+      },
+    }
+  }
+
+  // 2. Build lookup maps from existing issues
+  const openByFingerprint = new Map<string, ExistingProposalIssue>()
+  const closedByFingerprint = new Map<string, ExistingProposalIssue>()
+  let malformedMarkers = 0
+
+  for (const issue of existingIssues) {
+    const fp = extractProposalFingerprint(issue.body)
+    if (fp === null) {
+      // Issue has no valid fingerprint marker — count as malformed if it has the proposal label
+      if (issue.labels.includes(PROPOSAL_LABEL)) {
+        malformedMarkers++
+      }
+      continue
+    }
+
+    if (issue.state === 'open') {
+      openByFingerprint.set(fp, issue)
+    } else {
+      // Closed: keep the most recently seen (map will hold last one; caller should sort by updated desc)
+      closedByFingerprint.set(fp, issue)
+    }
+  }
+
+  const actions: ProposalAction[] = []
+  let opened = 0
+  let updated = 0
+  let reopened = 0
+  let suppressed = 0
+  let blocked = 0
+  let noAction = 0
+  let sameRunDeduplicated = 0
+
+  // Track which fingerprints are active in this report (for close-on-clear)
+  const activeFingerprintsInReport = new Set<string>()
+
+  // 3. Process proposal-eligible findings
+  for (const finding of report.findings) {
+    // Skip unsafe findings — they have no identity-bearing fields and are never proposal-eligible
+    if (!isPublicFinding(finding)) continue
+
+    // Skip non-proposal-eligible findings (unresolved, current)
+    if (!finding.proposalEligible) continue
+
+    const {fingerprint} = finding
+    activeFingerprintsInReport.add(fingerprint)
+
+    // a. Same-run dedup: skip if already created this run
+    if (sameRunCreatedFingerprints.has(fingerprint)) {
+      sameRunDeduplicated++
+      continue
+    }
+
+    // b. Check for terminal suppression
+    const closedIssue = closedByFingerprint.get(fingerprint)
+    if (closedIssue !== undefined && hasTerminalLabel(closedIssue.labels)) {
+      actions.push({
+        type: 'suppress',
+        fingerprint,
+        reason: 'terminal outcome label on closed proposal',
+      })
+      suppressed++
+      continue
+    }
+
+    // c. Check for matching open issue
+    const openIssue = openByFingerprint.get(fingerprint)
+    if (openIssue !== undefined) {
+      // Compare recorded live-state to current live-state
+      const recordedLiveState = extractRecordedLiveState(openIssue.body)
+      const currentLiveState = finding.liveState
+
+      if (recordedLiveState !== null && currentLiveState !== undefined && recordedLiveState !== currentLiveState) {
+        // Live-state details changed — plan one update comment
+        const comment = buildUpdateComment(finding, report.generated_at)
+        const gateResult = applyPublicOutputGate({
+          surface: 'proposal-comment',
+          content: comment,
+          tokens: publicOutputTokens,
+          fingerprint,
+        })
+        if (!gateResult.allowed) {
+          blocked++
+          continue
+        }
+        actions.push({
+          type: 'update-comment',
+          issueNumber: openIssue.number,
+          comment: gateResult.sanitizedContent,
+        })
+        updated++
+      } else {
+        // Drift unchanged — no action to avoid comment spam
+        noAction++
+      }
+      continue
+    }
+
+    // d. Check for matching non-terminal closed issue → reopen
+    if (closedIssue !== undefined && !hasTerminalLabel(closedIssue.labels)) {
+      const comment = buildRecurrenceComment(report.generated_at)
+      const gateResult = applyPublicOutputGate({
+        surface: 'recurrence-comment',
+        content: comment,
+        tokens: publicOutputTokens,
+        fingerprint,
+      })
+      if (!gateResult.allowed) {
+        blocked++
+        continue
+      }
+      const removeLabels = closedIssue.labels.filter(l => RESOLVING_LABELS.includes(l))
+      actions.push({
+        type: 'reopen',
+        issueNumber: closedIssue.number,
+        comment: gateResult.sanitizedContent,
+        removeLabels,
+        addLabels: [OUTCOME_LABELS.recurring],
+      })
+      reopened++
+      continue
+    }
+
+    // e. New finding — open a proposal after privacy gating
+    const title = buildProposalTitle(finding)
+    const body = buildProposalBody(finding, report.generated_at)
+
+    const titleGate = applyPublicOutputGate({
+      surface: 'proposal-title',
+      content: title,
+      tokens: publicOutputTokens,
+      fingerprint,
+    })
+    if (!titleGate.allowed) {
+      blocked++
+      continue
+    }
+
+    const bodyGate = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: body,
+      tokens: publicOutputTokens,
+      fingerprint,
+    })
+    if (!bodyGate.allowed) {
+      blocked++
+      continue
+    }
+
+    actions.push({
+      type: 'open',
+      fingerprint,
+      title: titleGate.sanitizedContent,
+      body: bodyGate.sanitizedContent,
+      labels: [PROPOSAL_LABEL],
+    })
+    opened++
+  }
+
+  // 4. Close-on-clear: only when scan is complete and not execution-failure
+  const canClose = report.status !== 'execution-failure' && report.scan_complete
+  let closed = 0
+
+  if (canClose) {
+    for (const [fp, openIssue] of openByFingerprint) {
+      if (!activeFingerprintsInReport.has(fp)) {
+        const comment = buildCloseComment(report.generated_at)
+        const gateResult = applyPublicOutputGate({
+          surface: 'proposal-comment',
+          content: comment,
+          tokens: publicOutputTokens,
+          fingerprint: fp,
+        })
+        if (!gateResult.allowed) {
+          blocked++
+          continue
+        }
+        actions.push({
+          type: 'close',
+          issueNumber: openIssue.number,
+          labels: [OUTCOME_LABELS.resolved],
+          comment: gateResult.sanitizedContent,
+        })
+        closed++
+      }
+    }
+  }
+
+  return {
+    actions,
+    counts: {
+      opened,
+      updated,
+      reopened,
+      closed,
+      suppressed,
+      blocked,
+      noAction,
+      sameRunDeduplicated,
+      malformedMarkers,
+      versionRejected: 0,
+    },
+  }
+}

--- a/scripts/status-truth-proposals.ts
+++ b/scripts/status-truth-proposals.ts
@@ -1,11 +1,17 @@
 /**
- * Proposal lifecycle planner for the status-truth maintenance loop (Unit 3).
+ * Proposal lifecycle planner and I/O executor for the status-truth maintenance loop.
  *
+ * Unit 3 — Pure lifecycle planner:
  * Converts drifted, privacy-safe status claims into deterministic GitHub issue
  * lifecycle actions without touching GitHub.
  *
+ * Unit 4 — I/O executor:
+ * Executes planned proposal actions against GitHub via an injected Octokit-like
+ * client. Supports dry-run mode (counts only, no mutations), label gating
+ * (fail-closed if required labels cannot be confirmed), and same-run dedup.
+ *
  * Design invariants:
- * - Pure function: no I/O, no Octokit dependency.
+ * - Pure planner: no I/O, no Octokit dependency.
  * - One fingerprint → one proposal issue. Multiple drifted claims in the same
  *   file remain separate issues so outcomes can differ per claim.
  * - Terminal labels (false-positive, rejected) suppress future matching findings
@@ -16,13 +22,21 @@
  * - Same-run created-key set prevents duplicate proposals from GitHub list lag.
  * - All proposal content passes through the public-output privacy gate.
  * - Unknown report schema/fingerprint versions are rejected before any planning.
+ * - Executor fails closed on label gate failure; no proposals open without labels.
+ * - Dry-run mode reports counts only; zero GitHub mutations.
+ * - stdout/stderr carry counts only; no raw claim text, fingerprints, or tokens.
  *
  * Strip-only safe: no parameter properties, enums, or namespaces.
  */
 
 import type {PublicStatusTruthFinding, StatusTruthFinding, StatusTruthJsonReport} from './status-truth-detect.ts'
-import {KNOWN_FINGERPRINT_VERSION, KNOWN_SCHEMA_VERSION} from './status-truth-detect.ts'
-import {applyPublicOutputGate, type PublicOutputTokens} from './status-truth-public-output.ts'
+import {readFile, writeFile} from 'node:fs/promises'
+import process from 'node:process'
+
+import {Octokit} from '@octokit/rest'
+import {loadPrivateTokensFromDisk} from './capture-learnings-privacy.ts'
+import {KNOWN_FINGERPRINT_VERSION, KNOWN_SCHEMA_VERSION, validateStatusTruthArtifact} from './status-truth-detect.ts'
+import {applyPublicOutputGate, makePublicOutputTokens, type PublicOutputTokens} from './status-truth-public-output.ts'
 
 // ---------------------------------------------------------------------------
 // Label constants
@@ -516,4 +530,707 @@ export function planStatusTruthProposalActions(
       versionRejected: 0,
     },
   }
+}
+
+// ---------------------------------------------------------------------------
+// Unit 4: I/O executor types
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape of a single issue returned by listForRepo.
+ * Minimal fields needed for proposal lifecycle management.
+ */
+export interface IssueListItem {
+  readonly number: number
+  readonly state: string
+  readonly title: string
+  readonly body: string | null | undefined
+  readonly labels: readonly {readonly name?: string | null | undefined}[]
+}
+
+/**
+ * Minimal Octokit-like client interface for proposal issue mutations.
+ * Injected for testability; production code uses @octokit/rest Octokit.
+ * Uses function property style (not method shorthand) per lint rules.
+ */
+export interface StatusTruthOctokitClient {
+  readonly rest: {
+    readonly issues: {
+      readonly getLabel: (params: {owner: string; repo: string; name: string}) => Promise<{data: {name: string}}>
+      readonly createLabel: (params: {
+        owner: string
+        repo: string
+        name: string
+        color: string
+        description: string
+      }) => Promise<{data: {name: string}}>
+      readonly create: (params: {
+        owner: string
+        repo: string
+        title: string
+        body: string
+        labels: string[]
+      }) => Promise<{data: {number: number}}>
+      readonly createComment: (params: {
+        owner: string
+        repo: string
+        issue_number: number
+        body: string
+      }) => Promise<{data: {id: number}}>
+      readonly update: (params: {
+        owner: string
+        repo: string
+        issue_number: number
+        state?: 'open' | 'closed'
+        labels?: string[]
+      }) => Promise<{data: {number: number}}>
+      readonly removeLabel: (params: {
+        owner: string
+        repo: string
+        issue_number: number
+        name: string
+      }) => Promise<{data: unknown[]}>
+      readonly addLabels: (params: {
+        owner: string
+        repo: string
+        issue_number: number
+        labels: string[]
+      }) => Promise<{data: unknown[]}>
+      readonly listForRepo: (params: {
+        owner: string
+        repo: string
+        labels: string
+        state: 'open' | 'closed' | 'all'
+        per_page: number
+        page: number
+      }) => Promise<{data: IssueListItem[]}>
+    }
+  }
+}
+
+/**
+ * Fetch existing status-truth proposal issues from GitHub.
+ *
+ * Fetches open issues and recent closed issues (last 2 pages) labeled with
+ * PROPOSAL_LABEL. Filters to only issues that have the proposal label.
+ * Returns them as ExistingProposalIssue[] for the lifecycle planner.
+ *
+ * Fail-closed in live mode: any API error is re-thrown so the caller can
+ * abort before planning/executing mutations. In dry-run the caller may
+ * choose to swallow the error and fall back to an empty list.
+ *
+ * Exported for testability.
+ */
+export async function fetchExistingProposalIssues(params: {
+  octokit: StatusTruthOctokitClient
+  owner: string
+  repo: string
+}): Promise<ExistingProposalIssue[]> {
+  const {octokit, owner, repo} = params
+  const issues: ExistingProposalIssue[] = []
+
+  // Fetch open issues with the proposal label.
+  // Any error is propagated to the caller (fail-closed in live mode).
+  const openResponse = await octokit.rest.issues.listForRepo({
+    owner,
+    repo,
+    labels: PROPOSAL_LABEL,
+    state: 'open',
+    per_page: 100,
+    page: 1,
+  })
+  for (const issue of openResponse.data) {
+    const labelNames = issue.labels.map(l => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean)
+    if (!labelNames.includes(PROPOSAL_LABEL)) continue
+    issues.push({
+      number: issue.number,
+      state: 'open',
+      labels: labelNames,
+      title: issue.title,
+      body: issue.body,
+    })
+  }
+
+  // Fetch recent closed issues with the proposal label (2 pages).
+  // Any error on the first page is propagated; subsequent pages are best-effort.
+  for (const page of [1, 2]) {
+    let closedResponse: {data: IssueListItem[]}
+    try {
+      closedResponse = await octokit.rest.issues.listForRepo({
+        owner,
+        repo,
+        labels: PROPOSAL_LABEL,
+        state: 'closed',
+        per_page: 50,
+        page,
+      })
+    } catch (error: unknown) {
+      if (page === 1) {
+        // First closed page failure is fatal — propagate to caller
+        throw error
+      }
+      // Subsequent pages: best-effort; stop pagination
+      break
+    }
+    if (closedResponse.data.length === 0) break
+    for (const issue of closedResponse.data) {
+      const labelNames = issue.labels.map(l => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean)
+      if (!labelNames.includes(PROPOSAL_LABEL)) continue
+      issues.push({
+        number: issue.number,
+        state: 'closed',
+        labels: labelNames,
+        title: issue.title,
+        body: issue.body,
+      })
+    }
+  }
+
+  return issues
+}
+
+/** Label descriptor for runtime label creation. */
+export interface StatusTruthLabelDescriptor {
+  readonly name: string
+  readonly color: string
+  readonly description: string
+}
+
+/**
+ * All labels required by the status-truth loop.
+ * Must be confirmed before any proposal issue is opened.
+ * Fail-closed: if any required label cannot be confirmed, no proposals open.
+ */
+export const REQUIRED_LABELS: readonly StatusTruthLabelDescriptor[] = [
+  {
+    name: PROPOSAL_LABEL,
+    color: '0075ca',
+    description: 'Status-truth drift proposal requiring operator review',
+  },
+  {
+    name: OUTCOME_LABELS.accepted,
+    color: '0e8a16',
+    description: 'Status-truth proposal accepted as valid drift',
+  },
+  {
+    name: OUTCOME_LABELS.rejected,
+    color: 'e4e669',
+    description: 'Status-truth proposal rejected (claim was correct)',
+  },
+  {
+    name: OUTCOME_LABELS.falsePositive,
+    color: 'e4e669',
+    description: 'Status-truth proposal marked as false positive',
+  },
+  {
+    name: OUTCOME_LABELS.superseded,
+    color: 'cfd3d7',
+    description: 'Status-truth proposal superseded by a newer finding',
+  },
+  {
+    name: OUTCOME_LABELS.manuallyFixed,
+    color: '0e8a16',
+    description: 'Status-truth drift manually corrected',
+  },
+  {
+    name: OUTCOME_LABELS.resolved,
+    color: '0e8a16',
+    description: 'Status-truth drift resolved (auto-closed on clear)',
+  },
+  {
+    name: OUTCOME_LABELS.recurring,
+    color: 'd93f0b',
+    description: 'Status-truth drift recurred after previous resolution',
+  },
+]
+
+/** Input to the I/O executor. */
+export interface ExecuteStatusTruthProposalActionsInput {
+  /** Injected Octokit-like client for GitHub API calls. */
+  readonly octokit: StatusTruthOctokitClient
+  readonly owner: string
+  readonly repo: string
+  /** Planned actions from the pure lifecycle planner. */
+  readonly actions: readonly ProposalAction[]
+  /**
+   * When true: count actions but perform zero GitHub mutations.
+   * Summary clearly marks dry-run status.
+   */
+  readonly dryRun: boolean
+  /**
+   * Fingerprints already created in this run (same-run dedup guard).
+   * Prevents duplicate proposals when GitHub issue listing lags same-run writes.
+   */
+  readonly sameRunCreatedFingerprints: ReadonlySet<string>
+}
+
+/** Counts returned by the executor. */
+export interface ExecuteStatusTruthProposalActionsCounts {
+  readonly opened: number
+  readonly updated: number
+  readonly reopened: number
+  readonly closed: number
+  readonly suppressed: number
+  readonly failed: number
+  readonly sameRunDeduplicated: number
+}
+
+/** Result of the I/O executor. */
+export interface ExecuteStatusTruthProposalActionsResult {
+  readonly dryRun: boolean
+  /** True when required labels could not be confirmed; no proposals were opened. */
+  readonly labelGateFailed: boolean
+  readonly counts: ExecuteStatusTruthProposalActionsCounts
+}
+
+// ---------------------------------------------------------------------------
+// Unit 4: Label preflight helper
+// ---------------------------------------------------------------------------
+
+function isApiStatus(error: unknown, status: number): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    !Array.isArray(error) &&
+    typeof (error as Record<string, unknown>).status === 'number' &&
+    (error as Record<string, unknown>).status === status
+  )
+}
+
+/**
+ * Ensure all required labels exist in the repo.
+ *
+ * For each label:
+ * - If getLabel succeeds: confirmed.
+ * - If 404: attempt createLabel.
+ *   - createLabel succeeds or 422 (race): confirmed.
+ *   - createLabel other failure: excluded.
+ * - getLabel non-404 failure: excluded.
+ *
+ * Returns a Set<string> of confirmed label names.
+ * Caller must check that all required labels are in the set before proceeding.
+ */
+async function ensureStatusTruthLabels(
+  octokit: StatusTruthOctokitClient,
+  owner: string,
+  repo: string,
+  labels: readonly StatusTruthLabelDescriptor[],
+): Promise<Set<string>> {
+  const confirmed = new Set<string>()
+
+  for (const {name, color, description} of labels) {
+    try {
+      await octokit.rest.issues.getLabel({owner, repo, name})
+      confirmed.add(name)
+      continue
+    } catch (getError: unknown) {
+      if (!isApiStatus(getError, 404)) {
+        // Non-404 failure: cannot confirm this label
+        continue
+      }
+    }
+
+    // Label not found (404) — create it
+    try {
+      await octokit.rest.issues.createLabel({owner, repo, name, color, description})
+      confirmed.add(name)
+    } catch (createError: unknown) {
+      if (isApiStatus(createError, 422)) {
+        // Race with another writer — label now exists
+        confirmed.add(name)
+      }
+      // Other failure: label not confirmed
+    }
+  }
+
+  return confirmed
+}
+
+// ---------------------------------------------------------------------------
+// Unit 4: I/O executor
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute planned status-truth proposal lifecycle actions against GitHub.
+ *
+ * Processing order:
+ * 1. Label preflight: confirm all REQUIRED_LABELS exist (create if missing).
+ *    Fail closed if the primary proposal label cannot be confirmed.
+ * 2. For each action:
+ *    - dry-run: count only, no mutations.
+ *    - open: same-run dedup check, then issues.create.
+ *    - update-comment: issues.createComment.
+ *    - reopen: issues.update(state=open) + remove resolving labels + add recurring.
+ *    - close: issues.createComment + issues.update(state=closed) + add resolved label.
+ *    - suppress: count only, no API call.
+ * 3. One action failure does not abort remaining actions.
+ * 4. stdout/stderr carry counts only; no raw claim text, fingerprints, or tokens.
+ */
+export async function executeStatusTruthProposalActions(
+  input: ExecuteStatusTruthProposalActionsInput,
+): Promise<ExecuteStatusTruthProposalActionsResult> {
+  const {octokit, owner, repo, actions, dryRun, sameRunCreatedFingerprints} = input
+
+  // In dry-run mode: count actions but perform zero mutations.
+  // Label preflight is skipped in dry-run (no API calls at all).
+  if (dryRun) {
+    let opened = 0
+    let updated = 0
+    let reopened = 0
+    let closed = 0
+    let suppressed = 0
+    let sameRunDeduplicated = 0
+
+    for (const action of actions) {
+      if (action.type === 'open') {
+        if (sameRunCreatedFingerprints.has(action.fingerprint)) {
+          sameRunDeduplicated++
+        } else {
+          opened++
+        }
+      } else if (action.type === 'update-comment') {
+        updated++
+      } else if (action.type === 'reopen') {
+        reopened++
+      } else if (action.type === 'close') {
+        closed++
+      } else if (action.type === 'suppress') {
+        suppressed++
+      }
+    }
+
+    return {
+      dryRun: true,
+      labelGateFailed: false,
+      counts: {opened, updated, reopened, closed, suppressed, failed: 0, sameRunDeduplicated},
+    }
+  }
+
+  // Label preflight: confirm all required labels exist.
+  const confirmedLabels = await ensureStatusTruthLabels(octokit, owner, repo, REQUIRED_LABELS)
+
+  // Fail closed if ANY required label cannot be confirmed.
+  // Without all required labels, proposals would be opened without outcome labels,
+  // breaking the lifecycle state machine (terminal suppression, reopen, close-on-clear).
+  const missingRequired = REQUIRED_LABELS.filter(l => !confirmedLabels.has(l.name))
+  if (missingRequired.length > 0) {
+    return {
+      dryRun: false,
+      labelGateFailed: true,
+      counts: {opened: 0, updated: 0, reopened: 0, closed: 0, suppressed: 0, failed: 0, sameRunDeduplicated: 0},
+    }
+  }
+
+  // Same-run in-memory set (guards eventual-consistency race)
+  const createdThisRun = new Set<string>(sameRunCreatedFingerprints)
+
+  let opened = 0
+  let updated = 0
+  let reopened = 0
+  let closed = 0
+  let suppressed = 0
+  let failed = 0
+  let sameRunDeduplicated = 0
+
+  for (const action of actions) {
+    if (action.type === 'open') {
+      // Same-run dedup: skip if already created this run
+      if (createdThisRun.has(action.fingerprint)) {
+        sameRunDeduplicated++
+        continue
+      }
+
+      try {
+        await octokit.rest.issues.create({
+          owner,
+          repo,
+          title: action.title,
+          body: action.body,
+          labels: action.labels.filter(l => confirmedLabels.has(l)),
+        })
+        createdThisRun.add(action.fingerprint)
+        opened++
+      } catch {
+        failed++
+      }
+    } else if (action.type === 'update-comment') {
+      try {
+        await octokit.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number: action.issueNumber,
+          body: action.comment,
+        })
+        updated++
+      } catch {
+        failed++
+      }
+    } else if (action.type === 'reopen') {
+      try {
+        // Remove resolving labels first
+        for (const label of action.removeLabels) {
+          try {
+            await octokit.rest.issues.removeLabel({owner, repo, issue_number: action.issueNumber, name: label})
+          } catch {
+            // Label may not exist; continue
+          }
+        }
+        // Add recurring label
+        if (action.addLabels.length > 0) {
+          try {
+            await octokit.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: action.issueNumber,
+              labels: action.addLabels.filter(l => confirmedLabels.has(l)),
+            })
+          } catch {
+            // Non-fatal: label add failure does not block reopen
+          }
+        }
+        // Reopen the issue
+        await octokit.rest.issues.update({owner, repo, issue_number: action.issueNumber, state: 'open'})
+        // Add recurrence comment
+        await octokit.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number: action.issueNumber,
+          body: action.comment,
+        })
+        reopened++
+      } catch {
+        failed++
+      }
+    } else if (action.type === 'close') {
+      try {
+        // Add resolved label and close
+        await octokit.rest.issues.addLabels({
+          owner,
+          repo,
+          issue_number: action.issueNumber,
+          labels: action.labels.filter(l => confirmedLabels.has(l)),
+        })
+        await octokit.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number: action.issueNumber,
+          body: action.comment,
+        })
+        await octokit.rest.issues.update({owner, repo, issue_number: action.issueNumber, state: 'closed'})
+        closed++
+      } catch {
+        failed++
+      }
+    } else if (action.type === 'suppress') {
+      // Suppress: count only, no API call
+      suppressed++
+    }
+  }
+
+  return {
+    dryRun: false,
+    labelGateFailed: false,
+    counts: {opened, updated, reopened, closed, suppressed, failed, sameRunDeduplicated},
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Unit 4: CLI shell for the open/proposals step
+// ---------------------------------------------------------------------------
+
+type OctokitConstructor = new (params: {auth: string}) => StatusTruthOctokitClient
+
+async function loadOctokitConstructor(): Promise<OctokitConstructor> {
+  if (typeof Octokit !== 'function') {
+    throw new TypeError('Failed to load @octokit/rest Octokit constructor')
+  }
+  return Octokit as unknown as OctokitConstructor
+}
+
+async function createOctokitFromEnv(): Promise<StatusTruthOctokitClient> {
+  const token = process.env.GITHUB_TOKEN
+  if (token === undefined || token === '') {
+    throw new Error('status-truth-proposals: GITHUB_TOKEN is required in the environment')
+  }
+  const LoadedOctokit = await loadOctokitConstructor()
+  return new LoadedOctokit({auth: token})
+}
+
+/** Counts-only result written to stdout and STATUS_TRUTH_OPEN_RESULT_PATH. */
+interface OpenResult {
+  dryRun: boolean
+  labelGateFailed: boolean
+  counts: ExecuteStatusTruthProposalActionsCounts
+}
+
+/**
+ * CLI entry point for the status-truth open/proposals step.
+ *
+ * Environment variables:
+ * - STATUS_TRUTH_REPORT_PATH: path to the JSON report artifact from the detect step (required)
+ * - STATUS_TRUTH_OPEN_RESULT_PATH: path to write the counts-only result JSON (optional)
+ * - STATUS_TRUTH_DRY_RUN: set to 'true' for dry-run mode (optional)
+ * - GITHUB_TOKEN: write-scoped app token for issue mutations (required unless dry-run)
+ *
+ * Behavior:
+ * - Reads and validates the report artifact (schema/fingerprint version, required fields,
+ *   prohibited fields, count consistency). Fails closed on any validation error.
+ * - Loads privacy tokens from metadata/repos.yaml (fail-closed).
+ * - Plans proposal lifecycle actions (pure planner).
+ * - Executes actions (or counts only in dry-run mode).
+ * - Writes counts-only result to stdout and optionally to STATUS_TRUTH_OPEN_RESULT_PATH.
+ * - stdout/stderr carry counts only; no raw claim text, source paths, fingerprints, or tokens.
+ *
+ * Strip-only safe: no parameter properties, enums, or namespaces.
+ */
+async function runOpen(): Promise<void> {
+  const reportPath = process.env.STATUS_TRUTH_REPORT_PATH
+  const resultPath = process.env.STATUS_TRUTH_OPEN_RESULT_PATH
+  const dryRun = process.env.STATUS_TRUTH_DRY_RUN === 'true'
+
+  if (reportPath === undefined || reportPath === '') {
+    process.stderr.write('status-truth-proposals: STATUS_TRUTH_REPORT_PATH is required\n')
+    process.exit(1)
+  }
+
+  // Read and parse the report artifact
+  let rawJson: string
+  try {
+    rawJson = await readFile(reportPath, 'utf8')
+  } catch {
+    process.stderr.write('status-truth-proposals: could not read report artifact: error-class=read-failure\n')
+    process.exit(1)
+  }
+
+  let rawParsed: unknown
+  try {
+    rawParsed = JSON.parse(rawJson)
+  } catch {
+    process.stderr.write('status-truth-proposals: could not parse report artifact: error-class=parse-failure\n')
+    process.exit(1)
+  }
+
+  // Validate the artifact before any write planning
+  const validation = validateStatusTruthArtifact(rawParsed)
+  if (!validation.valid) {
+    process.stderr.write('status-truth-proposals: artifact validation failed: error-class=validation-failure\n')
+    process.exit(1)
+  }
+
+  const report = validation.report
+
+  // Load privacy tokens (fail-closed)
+  let publicOutputTokens: ReturnType<typeof makePublicOutputTokens>
+  try {
+    const privateTokens = await loadPrivateTokensFromDisk()
+    publicOutputTokens = makePublicOutputTokens({
+      privateTokens,
+      redactedCanonicalIds: new Set<string>(),
+    })
+  } catch {
+    process.stderr.write('status-truth-proposals: privacy token load failed: error-class=token-load-failure\n')
+    process.exit(1)
+  }
+
+  // Determine owner/repo from environment
+  const githubRepository = process.env.GITHUB_REPOSITORY ?? 'fro-bot/.github'
+  const slashIndex = githubRepository.indexOf('/')
+  const owner = slashIndex === -1 ? githubRepository : githubRepository.slice(0, slashIndex)
+  const repo = slashIndex === -1 ? '' : githubRepository.slice(slashIndex + 1)
+
+  // Fetch existing proposal issues from GitHub before planning.
+  // In dry-run mode we attempt a read-only fetch (best-effort) so the planner can
+  // no-op/update/reopen correctly rather than always opening duplicates.
+  // If the token is absent or the fetch fails in dry-run, fall back to empty list
+  // (no mutations happen anyway, so over-counting planned opens is acceptable).
+  //
+  // In live mode the fetch is fail-closed: if it fails we exit before planning or
+  // executing any mutations. Proceeding with an empty list in live mode would cause
+  // duplicate proposals to be opened for every existing finding.
+  let existingIssues: ExistingProposalIssue[] = []
+  // In live mode, a single Octokit instance is created for both the fetch and execute
+  // steps to avoid constructing it twice (and re-reading the token twice).
+  let liveOctokit: StatusTruthOctokitClient | undefined
+
+  if (dryRun) {
+    // Dry-run: attempt read-only fetch if token is available; fall back to empty list
+    const dryRunToken = process.env.GITHUB_TOKEN
+    if (dryRunToken !== undefined && dryRunToken !== '' && owner !== '' && repo !== '') {
+      try {
+        const LoadedOctokit = await loadOctokitConstructor()
+        const dryRunOctokit = new LoadedOctokit({auth: dryRunToken})
+        existingIssues = await fetchExistingProposalIssues({octokit: dryRunOctokit, owner, repo})
+      } catch {
+        // Non-fatal in dry-run: proceed with empty list (counts may over-estimate opens)
+      }
+    }
+  } else {
+    // Live mode: create a single Octokit instance for both the issue fetch and
+    // the execute step. Fail closed: if the fetch fails, exit before planning
+    // or executing mutations. Proceeding with an empty list would open duplicate
+    // proposals for all findings.
+    liveOctokit = await createOctokitFromEnv()
+    try {
+      existingIssues = await fetchExistingProposalIssues({octokit: liveOctokit, owner, repo})
+    } catch {
+      process.stderr.write('status-truth-proposals: existing issue fetch failed: error-class=fetch-failure\n')
+      process.exit(1)
+    }
+  }
+
+  // Plan proposal lifecycle actions (pure, no I/O)
+  const planResult = planStatusTruthProposalActions({
+    report,
+    existingIssues,
+    publicOutputTokens,
+    sameRunCreatedFingerprints: new Set<string>(),
+  })
+
+  // Execute actions (or count only in dry-run)
+  let executeResult: ExecuteStatusTruthProposalActionsResult
+
+  if (dryRun) {
+    executeResult = await executeStatusTruthProposalActions({
+      octokit: {} as StatusTruthOctokitClient, // not used in dry-run
+      owner: owner || 'fro-bot',
+      repo: repo || '.github',
+      actions: planResult.actions,
+      dryRun: true,
+      sameRunCreatedFingerprints: new Set<string>(),
+    })
+  } else {
+    // Reuse the single Octokit instance created for the fetch step above.
+    // liveOctokit is always defined here because dryRun is false.
+    executeResult = await executeStatusTruthProposalActions({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      octokit: liveOctokit!,
+      owner: owner || 'fro-bot',
+      repo: repo || '.github',
+      actions: planResult.actions,
+      dryRun: false,
+      sameRunCreatedFingerprints: new Set<string>(),
+    })
+  }
+
+  // Counts-only result — no raw claim text, source paths, fingerprints, or tokens
+  const result: OpenResult = {
+    dryRun: executeResult.dryRun,
+    labelGateFailed: executeResult.labelGateFailed,
+    counts: executeResult.counts,
+  }
+
+  const resultJson = `${JSON.stringify(result)}\n`
+  process.stdout.write(resultJson)
+
+  if (resultPath !== undefined && resultPath !== '') {
+    try {
+      await writeFile(resultPath, resultJson, {flag: 'w'})
+    } catch {
+      process.stderr.write('status-truth-proposals: could not write result: error-class=write-failure\n')
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await runOpen()
 }

--- a/scripts/status-truth-prs.test.ts
+++ b/scripts/status-truth-prs.test.ts
@@ -1,0 +1,705 @@
+/**
+ * Tests for the status-truth PR graduation gate planner.
+ *
+ * All tests are pure — no Octokit, no disk I/O.
+ *
+ * Design invariants under test:
+ * - PR pathway is disabled by default (enabled=false → proposal-only).
+ * - One PR action per run maximum (overflow → proposal-only).
+ * - Path authorization runs before diff rendering; forbidden paths → proposal-only.
+ * - Branch/title metadata is opaque (no source text, path, or fingerprint in names).
+ * - Opaque digest is a separate one-way hash; branch/title cannot prefix-match the fingerprint.
+ * - Existing PR rediscovery requires opaque metadata match + bot ownership + main target.
+ * - No action type can merge, approve, automerge, force-push, or retarget non-main.
+ * - Non-eligible/ambiguous candidates downgrade to proposal-only; no throws.
+ */
+
+import type {StatusTruthJsonReport} from './status-truth-detect.ts'
+import type {ExistingStatusTruthPr, PlanStatusTruthPrActionsInput, StatusTruthPrAction} from './status-truth-prs.ts'
+import type {PublicOutputTokens} from './status-truth-public-output.ts'
+import {createHash} from 'node:crypto'
+import {describe, expect, it} from 'vitest'
+import {GRADUATED_CLAIM_KINDS, planStatusTruthPrActions, PR_BRANCH_PREFIX, PR_TITLE_PREFIX} from './status-truth-prs.ts'
+
+// Mirrors the production digest derivation so tests stay in sync without
+// importing the private helper.
+function testDeriveOpaqueDigest(fingerprint: string): string {
+  return createHash('sha256').update(`status-truth-pr:${fingerprint}`).digest('hex').slice(0, 16)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeReport(overrides: Partial<StatusTruthJsonReport> = {}): StatusTruthJsonReport {
+  return {
+    schema_version: 1,
+    fingerprint_version: 1,
+    status: 'findings',
+    scan_complete: true,
+    generated_at: '2026-06-28T00:00:00Z',
+    failure_class: null,
+    repair_eligible: true,
+    findings: [],
+    counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+    ...overrides,
+  }
+}
+
+function makeDriftedFinding(
+  overrides: {
+    fingerprint?: string
+    kind?: 'pr-state' | 'issue-state' | 'release-tag-state' | 'plan-status' | 'rollout-tracker-status'
+    path?: string
+    sourceRef?: string
+    claimedState?: string
+    liveState?: string
+    proposedCorrection?: string
+  } = {},
+) {
+  return {
+    kind: overrides.kind ?? ('pr-state' as const),
+    path: overrides.path ?? 'docs/plans/example.md',
+    sourceRef: overrides.sourceRef ?? '#42',
+    verdict: 'drifted' as const,
+    fingerprint: overrides.fingerprint ?? 'abc123def456abcd',
+    claimedState: overrides.claimedState ?? 'open',
+    liveState: overrides.liveState ?? 'closed',
+    proposalEligible: true,
+    proposedCorrection: overrides.proposedCorrection ?? 'pr #42 is closed',
+  }
+}
+
+function makeLoadedTokens(): PublicOutputTokens {
+  return {
+    loaded: true,
+    privateTokens: new Set<string>(),
+    redactedCanonicalIds: new Set<string>(),
+  }
+}
+
+function makeBlockingTokens(): PublicOutputTokens {
+  return {
+    loaded: true,
+    privateTokens: new Set(['private-repo-name']),
+    redactedCanonicalIds: new Set<string>(),
+  }
+}
+
+function makeInput(overrides: Partial<PlanStatusTruthPrActionsInput> = {}): PlanStatusTruthPrActionsInput {
+  return {
+    report: makeReport(),
+    graduatedClaimKinds: new Set<string>(),
+    existingPrs: [],
+    publicOutputTokens: makeLoadedTokens(),
+    maxPrsPerRun: 1,
+    enabled: false,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: Disabled default — planner disabled path produces proposal-only/no PR counts
+// ---------------------------------------------------------------------------
+
+describe('disabled default', () => {
+  it('returns zero PR actions and all proposal-only when enabled=false', () => {
+    const finding = makeDriftedFinding()
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['pr-state']),
+        enabled: false,
+      }),
+    )
+
+    expect(result.counts.prActionsPlanned).toBe(0)
+    expect(result.counts.downgradedToProposalOnly).toBe(1)
+    expect(result.actions.every(a => a.type === 'downgrade-to-proposal')).toBe(true)
+  })
+
+  it('returns zero PR actions when no claim kinds are graduated even if enabled=true', () => {
+    const finding = makeDriftedFinding()
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set<string>(),
+        enabled: true,
+      }),
+    )
+
+    expect(result.counts.prActionsPlanned).toBe(0)
+    expect(result.counts.downgradedToProposalOnly).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Test 1: Happy path — graduated claim kind produces one correction PR action
+// ---------------------------------------------------------------------------
+
+describe('happy path: graduated claim kind', () => {
+  it('produces one open-pr action with opaque branch/title metadata', () => {
+    const finding = makeDriftedFinding({fingerprint: 'abc123def456abcd', kind: 'pr-state'})
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['pr-state']),
+        enabled: true,
+      }),
+    )
+
+    expect(result.counts.prActionsPlanned).toBe(1)
+    expect(result.counts.downgradedToProposalOnly).toBe(0)
+
+    const action = result.actions[0]
+    expect(action).toBeDefined()
+    expect(action?.type).toBe('open-pr')
+
+    if (action?.type === 'open-pr') {
+      // Branch name must start with the opaque prefix and not contain raw source text
+      expect(action.opaqueBranchName).toMatch(new RegExp(`^${PR_BRANCH_PREFIX}`))
+      // Branch name must not contain the fingerprint verbatim
+      expect(action.opaqueBranchName).not.toContain('abc123def456abcd')
+      // Branch name must not contain the path
+      expect(action.opaqueBranchName).not.toContain('docs/plans/example.md')
+      // Branch name must not contain the sourceRef
+      expect(action.opaqueBranchName).not.toContain('#42')
+
+      // Title must start with the opaque prefix (escape regex special chars)
+      const escapedTitlePrefix = PR_TITLE_PREFIX.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`)
+      expect(action.opaqueTitle).toMatch(new RegExp(`^${escapedTitlePrefix}`))
+      // Title must not contain raw claim text
+      expect(action.opaqueTitle).not.toContain('pr #42 is closed')
+      // Title must not contain the path
+      expect(action.opaqueTitle).not.toContain('docs/plans/example.md')
+
+      // Base branch must be main
+      expect(action.baseBranch).toBe('main')
+
+      // Opaque digest must be exactly 16 hex chars and equal sha256('status-truth-pr:${fingerprint}').slice(0, 16).
+      const expectedDigest = createHash('sha256').update('status-truth-pr:abc123def456abcd').digest('hex').slice(0, 16)
+      expect(action.opaqueDigest).toHaveLength(16)
+      expect(action.opaqueDigest).toBe(expectedDigest)
+
+      // Opaque digest must NOT be the fingerprint or its first 8 hex chars.
+      // The digest is a separate one-way hash; a prefix-match would leak the fingerprint.
+      expect(action.opaqueDigest).not.toBe('abc123def456abcd')
+      expect(action.opaqueDigest).not.toBe('abc123de') // first 8 chars of fingerprint
+      expect(action.opaqueBranchName).not.toContain('abc123de')
+      expect(action.opaqueTitle).not.toContain('abc123de')
+    }
+  })
+
+  it('GRADUATED_CLAIM_KINDS export is a readonly set (intentionally empty in Phase 1)', () => {
+    expect(GRADUATED_CLAIM_KINDS).toBeDefined()
+    expect(typeof GRADUATED_CLAIM_KINDS).toBe('object')
+    // Phase 1: no claim kinds are graduated yet; set is empty by design.
+    // To graduate a kind, add it via a reviewed repo change after Phase 1 signal.
+    expect(GRADUATED_CLAIM_KINDS.size).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Test 2: Edge case — two PR-eligible findings; one PR action, rest downgrade
+// ---------------------------------------------------------------------------
+
+describe('edge case: overflow to proposal-only', () => {
+  it('plans one PR action and downgrades the rest when two eligible findings appear', () => {
+    const finding1 = makeDriftedFinding({fingerprint: 'aaaa1111bbbb2222', kind: 'pr-state'})
+    const finding2 = makeDriftedFinding({
+      fingerprint: 'cccc3333dddd4444',
+      kind: 'pr-state',
+      sourceRef: '#99',
+      proposedCorrection: 'pr #99 is closed',
+    })
+    const report = makeReport({
+      findings: [finding1, finding2],
+      counts: {total: 2, current: 0, drifted: 2, unresolved: 0, unsafe: 0, proposal_eligible: 2},
+    })
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['pr-state']),
+        enabled: true,
+        maxPrsPerRun: 1,
+      }),
+    )
+
+    expect(result.counts.prActionsPlanned).toBe(1)
+    expect(result.counts.downgradedToProposalOnly).toBe(1)
+
+    const prActions = result.actions.filter(a => a.type === 'open-pr')
+    const downgradeActions = result.actions.filter(a => a.type === 'downgrade-to-proposal')
+    expect(prActions).toHaveLength(1)
+    expect(downgradeActions).toHaveLength(1)
+  })
+
+  it('respects maxPrsPerRun=0 by downgrading all', () => {
+    const finding = makeDriftedFinding({kind: 'pr-state'})
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['pr-state']),
+        enabled: true,
+        maxPrsPerRun: 0,
+      }),
+    )
+
+    expect(result.counts.prActionsPlanned).toBe(0)
+    expect(result.counts.downgradedToProposalOnly).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Test 3: Forbidden path — no PR action, proposal-only, diff not rendered
+// ---------------------------------------------------------------------------
+
+describe('forbidden path: path authorization', () => {
+  it('downgrades to proposal-only for authority-sensitive paths without rendering diff', () => {
+    const finding = makeDriftedFinding({
+      kind: 'pr-state',
+      path: '.github/workflows/main.yaml', // forbidden: workflow path
+    })
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['pr-state']),
+        enabled: true,
+      }),
+    )
+
+    expect(result.counts.prActionsPlanned).toBe(0)
+    expect(result.counts.pathForbidden).toBe(1)
+    expect(result.counts.downgradedToProposalOnly).toBe(1)
+
+    // No open-pr action
+    expect(result.actions.every(a => a.type !== 'open-pr')).toBe(true)
+
+    // Downgrade action must not contain correction text or path
+    const downgrade = result.actions.find(a => a.type === 'downgrade-to-proposal')
+    expect(downgrade).toBeDefined()
+    if (downgrade?.type === 'downgrade-to-proposal') {
+      // The action must not expose the forbidden path or correction text
+      expect(JSON.stringify(downgrade)).not.toContain('.github/workflows/main.yaml')
+      expect(JSON.stringify(downgrade)).not.toContain('pr #42 is closed')
+    }
+  })
+
+  it('downgrades to proposal-only for metadata/ paths', () => {
+    const finding = makeDriftedFinding({
+      kind: 'pr-state',
+      path: 'metadata/repos.yaml',
+    })
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['pr-state']),
+        enabled: true,
+      }),
+    )
+
+    expect(result.counts.pathForbidden).toBe(1)
+    expect(result.counts.prActionsPlanned).toBe(0)
+  })
+
+  it('downgrades to proposal-only for path traversal segments', () => {
+    const finding = makeDriftedFinding({
+      kind: 'pr-state',
+      path: 'docs/../.github/workflows/evil.yaml',
+    })
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['pr-state']),
+        enabled: true,
+      }),
+    )
+
+    expect(result.counts.pathForbidden).toBe(1)
+    expect(result.counts.prActionsPlanned).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Test 4: Branch/title candidate fails privacy gate — no PR action
+// ---------------------------------------------------------------------------
+
+describe('privacy gate: branch/title candidate blocked', () => {
+  it('downgrades to proposal-only when public output tokens block the PR metadata', () => {
+    // The finding's proposedCorrection contains a private token
+    const finding = makeDriftedFinding({
+      kind: 'pr-state',
+      proposedCorrection: 'pr #42 is closed (private-repo-name)',
+    })
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['pr-state']),
+        enabled: true,
+        publicOutputTokens: makeBlockingTokens(),
+      }),
+    )
+
+    expect(result.counts.prActionsPlanned).toBe(0)
+    expect(result.counts.privacyGateBlocked).toBe(1)
+    expect(result.counts.downgradedToProposalOnly).toBe(1)
+    expect(result.actions.every(a => a.type !== 'open-pr')).toBe(true)
+  })
+
+  it('downgrades to proposal-only when token load fails', () => {
+    const finding = makeDriftedFinding({kind: 'pr-state'})
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['pr-state']),
+        enabled: true,
+        publicOutputTokens: {loaded: false, error: 'token load failed'},
+      }),
+    )
+
+    expect(result.counts.prActionsPlanned).toBe(0)
+    expect(result.counts.privacyGateBlocked).toBe(1)
+    expect(result.counts.downgradedToProposalOnly).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Test 5: Existing branch/PR metadata mismatch — do not mutate
+// ---------------------------------------------------------------------------
+
+describe('existing PR: metadata mismatch', () => {
+  it('leaves finding as proposal-only when existing PR opaque metadata does not match', () => {
+    const finding = makeDriftedFinding({fingerprint: 'abc123def456abcd', kind: 'pr-state'})
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    // Existing PR with a different opaque digest (mismatch)
+    const existingPr: ExistingStatusTruthPr = {
+      number: 99,
+      state: 'open',
+      headBranch: `${PR_BRANCH_PREFIX}differentdigest`,
+      baseBranch: 'main',
+      opaqueDigest: 'differentdigest', // does not match the finding's fingerprint digest
+      botOwned: true,
+    }
+
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['pr-state']),
+        enabled: true,
+        existingPrs: [existingPr],
+      }),
+    )
+
+    // Should not produce a rediscover-pr action for the mismatched PR
+    expect(result.actions.every(a => a.type !== 'rediscover-pr')).toBe(true)
+    // The finding should either open a new PR or downgrade (not mutate the existing one)
+    // Since there's no match, it should plan a new open-pr (or downgrade if other gates fail)
+    // The key invariant: no mutation of the mismatched existing PR
+    const rediscoverActions = result.actions.filter(a => a.type === 'rediscover-pr')
+    expect(rediscoverActions).toHaveLength(0)
+  })
+
+  it('leaves finding as proposal-only when existing PR is not bot-owned', () => {
+    const finding = makeDriftedFinding({fingerprint: 'abc123def456abcd', kind: 'pr-state'})
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    // Use the correct derived digest but mark botOwned=false to test that gate.
+    const opaqueDigest = testDeriveOpaqueDigest('abc123def456abcd')
+    const existingPr: ExistingStatusTruthPr = {
+      number: 99,
+      state: 'open',
+      headBranch: `${PR_BRANCH_PREFIX}${opaqueDigest}`,
+      baseBranch: 'main',
+      opaqueDigest,
+      botOwned: false, // not bot-owned
+    }
+
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['pr-state']),
+        enabled: true,
+        existingPrs: [existingPr],
+      }),
+    )
+
+    // Must not rediscover a non-bot-owned PR
+    expect(result.actions.every(a => a.type !== 'rediscover-pr')).toBe(true)
+  })
+
+  it('leaves finding as proposal-only when existing PR targets non-main branch', () => {
+    const finding = makeDriftedFinding({fingerprint: 'abc123def456abcd', kind: 'pr-state'})
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const opaqueDigest = testDeriveOpaqueDigest('abc123def456abcd')
+    const existingPr: ExistingStatusTruthPr = {
+      number: 99,
+      state: 'open',
+      headBranch: `${PR_BRANCH_PREFIX}${opaqueDigest}`,
+      baseBranch: 'develop', // not main
+      opaqueDigest,
+      botOwned: true,
+    }
+
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['pr-state']),
+        enabled: true,
+        existingPrs: [existingPr],
+      }),
+    )
+
+    // Must not rediscover a PR targeting non-main
+    expect(result.actions.every(a => a.type !== 'rediscover-pr')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Test 6: Existing open status-truth PR rediscovered instead of creating duplicate
+// ---------------------------------------------------------------------------
+
+describe('existing PR: rediscovery', () => {
+  it('produces a rediscover-pr action when all matching criteria are met', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding({fingerprint, kind: 'pr-state'})
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    // Derive the opaque digest the same way the planner does (sha256 one-way hash).
+    const opaqueDigest = testDeriveOpaqueDigest(fingerprint)
+    const existingPr: ExistingStatusTruthPr = {
+      number: 77,
+      state: 'open',
+      headBranch: `${PR_BRANCH_PREFIX}${opaqueDigest}`,
+      baseBranch: 'main',
+      opaqueDigest,
+      botOwned: true,
+    }
+
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['pr-state']),
+        enabled: true,
+        existingPrs: [existingPr],
+      }),
+    )
+
+    expect(result.counts.prActionsPlanned).toBe(1)
+    const rediscoverAction = result.actions.find(a => a.type === 'rediscover-pr')
+    expect(rediscoverAction).toBeDefined()
+    if (rediscoverAction?.type === 'rediscover-pr') {
+      expect(rediscoverAction.existingPrNumber).toBe(77)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Test 7: Verification invariant — no forbidden action types
+// ---------------------------------------------------------------------------
+
+describe('verification invariant: no forbidden actions', () => {
+  it('no action type can be merge, approve, automerge, force-push, or retarget', () => {
+    const finding = makeDriftedFinding({kind: 'pr-state'})
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['pr-state']),
+        enabled: true,
+      }),
+    )
+
+    const forbiddenTypes = new Set(['merge', 'approve', 'automerge', 'force-push', 'retarget'])
+    for (const action of result.actions) {
+      expect(forbiddenTypes.has(action.type)).toBe(false)
+    }
+  })
+
+  it('the StatusTruthPrAction type union does not include forbidden action types', () => {
+    // This is a compile-time check enforced by the type system.
+    // At runtime, we verify that the allowed action types are only the safe ones.
+    const allowedTypes: StatusTruthPrAction['type'][] = ['open-pr', 'rediscover-pr', 'downgrade-to-proposal']
+    // If a forbidden type were added to the union, this array would need updating,
+    // and the test above would catch it at runtime.
+    expect(allowedTypes).not.toContain('merge')
+    expect(allowedTypes).not.toContain('approve')
+    expect(allowedTypes).not.toContain('automerge')
+    expect(allowedTypes).not.toContain('force-push')
+    expect(allowedTypes).not.toContain('retarget')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Additional invariants
+// ---------------------------------------------------------------------------
+
+describe('additional invariants', () => {
+  it('non-proposal-eligible findings are ignored', () => {
+    const finding = {
+      kind: 'pr-state' as const,
+      path: 'docs/plans/example.md',
+      sourceRef: '#42',
+      verdict: 'unresolved' as const,
+      fingerprint: 'abc123def456abcd',
+      claimedState: 'open',
+      proposalEligible: false,
+    }
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 0, unresolved: 1, unsafe: 0, proposal_eligible: 0},
+    })
+
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['pr-state']),
+        enabled: true,
+      }),
+    )
+
+    expect(result.counts.prActionsPlanned).toBe(0)
+    expect(result.counts.downgradedToProposalOnly).toBe(0)
+    expect(result.actions).toHaveLength(0)
+  })
+
+  it('unsafe findings are ignored', () => {
+    const finding = {
+      kind: 'pr-state' as const,
+      verdict: 'unsafe' as const,
+      proposalEligible: false as const,
+    }
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 0, unresolved: 0, unsafe: 1, proposal_eligible: 0},
+    })
+
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['pr-state']),
+        enabled: true,
+      }),
+    )
+
+    expect(result.counts.prActionsPlanned).toBe(0)
+    expect(result.actions).toHaveLength(0)
+  })
+
+  it('version-rejected report produces zero actions', () => {
+    const report = makeReport({
+      schema_version: 99,
+      fingerprint_version: 99,
+    })
+
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['pr-state']),
+        enabled: true,
+      }),
+    )
+
+    expect(result.counts.prActionsPlanned).toBe(0)
+    expect(result.counts.versionRejected).toBe(1)
+    expect(result.actions).toHaveLength(0)
+  })
+
+  it('allowed doc paths pass path authorization', () => {
+    const finding = makeDriftedFinding({
+      kind: 'pr-state',
+      path: 'docs/plans/example.md', // allowed path
+    })
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['pr-state']),
+        enabled: true,
+      }),
+    )
+
+    // docs/plans/ is an allowed path — should not be forbidden
+    expect(result.counts.pathForbidden).toBe(0)
+    expect(result.counts.prActionsPlanned).toBe(1)
+  })
+
+  it('README.md passes path authorization', () => {
+    const finding = makeDriftedFinding({
+      kind: 'pr-state',
+      path: 'README.md',
+    })
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['pr-state']),
+        enabled: true,
+      }),
+    )
+
+    expect(result.counts.pathForbidden).toBe(0)
+    expect(result.counts.prActionsPlanned).toBe(1)
+  })
+})

--- a/scripts/status-truth-prs.ts
+++ b/scripts/status-truth-prs.ts
@@ -1,0 +1,541 @@
+/**
+ * PR graduation gate planner for the status-truth maintenance loop.
+ *
+ * Pure PR planner: plans bounded correction PR actions for claim kinds that have
+ * graduated (demonstrated accuracy signal via accepted/rejected proposal outcomes).
+ *
+ * Design invariants:
+ * - Pure planner: no I/O, no Octokit dependency.
+ * - Disabled by default: `enabled=false` → all candidates downgrade to proposal-only.
+ * - One PR per run maximum (configurable via maxPrsPerRun; overflow → proposal-only).
+ * - Path authorization runs before diff rendering; forbidden paths → proposal-only
+ *   without extracting correction text or rendering PR metadata.
+ * - Opaque branch names and titles: no source text, path, or fingerprint in names.
+ *   Uses a short one-way digest (sha256 of a namespaced fingerprint) that cannot
+ *   reconstruct the source or the fingerprint.
+ * - Existing PR rediscovery requires: opaque digest match + bot ownership + main target.
+ * - No action type can merge, approve, automerge, force-push, or retarget non-main.
+ * - Non-eligible/ambiguous candidates downgrade to proposal-only; no throws.
+ * - All public output passes through the public-output privacy gate.
+ * - Unknown report schema/fingerprint versions are rejected before any planning.
+ *
+ * Strip-only safe: no parameter properties, enums, or namespaces.
+ */
+
+import type {PublicStatusTruthFinding, StatusTruthFinding, StatusTruthJsonReport} from './status-truth-detect.ts'
+import type {PublicOutputTokens} from './status-truth-public-output.ts'
+import {createHash} from 'node:crypto'
+import {KNOWN_FINGERPRINT_VERSION, KNOWN_SCHEMA_VERSION} from './status-truth-detect.ts'
+import {applyPublicOutputGate} from './status-truth-public-output.ts'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Opaque prefix for all status-truth correction PR branch names.
+ * Branch names must not contain source text, paths, or fingerprints.
+ */
+export const PR_BRANCH_PREFIX = 'status-truth/correction-'
+
+/**
+ * Opaque prefix for all status-truth correction PR titles.
+ * Titles must not contain source text, paths, or fingerprints.
+ */
+export const PR_TITLE_PREFIX = 'chore(status-truth): correction '
+
+/**
+ * The base branch all correction PRs must target.
+ * Retargeting to any other branch is forbidden.
+ */
+const BASE_BRANCH = 'main'
+
+/**
+ * Length of the opaque digest (hex chars) used in branch names and PR titles.
+ * Short enough to be opaque; long enough to be collision-resistant for this use.
+ */
+const OPAQUE_DIGEST_LENGTH = 16
+
+/**
+ * Namespace prefix for the one-way digest input.
+ * Prevents cross-context digest collisions.
+ */
+const OPAQUE_DIGEST_NAMESPACE = 'status-truth-pr'
+
+/**
+ * Claim kinds that have graduated to PR-eligible status.
+ *
+ * A claim kind graduates when it has demonstrated sufficient accuracy signal
+ * (accepted/rejected outcomes from proposal issues). This set is intentionally
+ * empty in Phase 1 — no claim kinds are graduated until Phase 1 produces signal.
+ *
+ * To graduate a claim kind: add it to this set in a reviewed repo change after
+ * Phase 1 accuracy data supports it.
+ */
+export const GRADUATED_CLAIM_KINDS: ReadonlySet<string> = new Set<string>()
+
+// ---------------------------------------------------------------------------
+// Path authorization
+// ---------------------------------------------------------------------------
+
+/**
+ * Authority-sensitive path prefixes that are always forbidden for correction PRs.
+ *
+ * These paths touch security-sensitive, configuration-sensitive, or authority-sensitive
+ * surfaces that must never be autonomously modified by the status-truth loop.
+ */
+const FORBIDDEN_PATH_PREFIXES: readonly string[] = [
+  '.github/workflows/',
+  '.github/hooks/',
+  '.github/settings',
+  '.github/actions/',
+  'metadata/',
+  'knowledge/',
+  'persona/',
+  'assets/',
+  'branding/',
+  'node_modules/',
+]
+
+/**
+ * Allowed path prefixes for correction PRs.
+ * Only paths under these prefixes may be targeted by a correction PR.
+ * All other paths are forbidden by default (allowlist, not denylist).
+ */
+const ALLOWED_PATH_PREFIXES: readonly string[] = ['docs/', 'README.md', 'SECURITY.md']
+
+/**
+ * Check whether a path contains traversal segments (e.g. `..`).
+ * Traversal segments are always forbidden regardless of the resolved path.
+ */
+function hasPathTraversal(filePath: string): boolean {
+  // Detect `..` segments in any position
+  return /(?:^|[/\\])\.\.(?:[/\\]|$)/u.test(filePath)
+}
+
+/**
+ * Authorize a file path for correction PR eligibility.
+ *
+ * Returns `true` when the path is allowed; `false` when forbidden.
+ *
+ * Authorization rules (in order):
+ * 1. Path traversal segments → forbidden.
+ * 2. Authority-sensitive prefix match → forbidden.
+ * 3. Allowed prefix match → allowed.
+ * 4. Default → forbidden (allowlist semantics).
+ */
+function isPathAuthorized(filePath: string): boolean {
+  // 1. Traversal check
+  if (hasPathTraversal(filePath)) return false
+
+  // 2. Forbidden prefix check
+  for (const prefix of FORBIDDEN_PATH_PREFIXES) {
+    if (filePath.startsWith(prefix)) return false
+  }
+
+  // 3. Allowed prefix check
+  for (const prefix of ALLOWED_PATH_PREFIXES) {
+    if (filePath === prefix || filePath.startsWith(prefix)) return true
+  }
+
+  // 4. Default: forbidden
+  return false
+}
+
+// ---------------------------------------------------------------------------
+// Opaque metadata generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive an opaque digest from a fingerprint.
+ *
+ * Computes sha256(`${OPAQUE_DIGEST_NAMESPACE}:${fingerprint}`) and takes the
+ * first OPAQUE_DIGEST_LENGTH hex characters. This is a separate one-way hash,
+ * so the digest cannot be used to reconstruct or prefix-match the fingerprint.
+ *
+ * Safety: branch names and PR titles contain only this derived digest, never
+ * the fingerprint itself or any prefix of it.
+ */
+function deriveOpaqueDigest(fingerprint: string): string {
+  return createHash('sha256')
+    .update(`${OPAQUE_DIGEST_NAMESPACE}:${fingerprint}`)
+    .digest('hex')
+    .slice(0, OPAQUE_DIGEST_LENGTH)
+}
+
+/**
+ * Build an opaque branch name for a correction PR.
+ * Format: `{PR_BRANCH_PREFIX}{opaqueDigest}`
+ * Must not contain source text, path, sourceRef, or fingerprint verbatim.
+ */
+function buildOpaqueBranchName(fingerprint: string): string {
+  return `${PR_BRANCH_PREFIX}${deriveOpaqueDigest(fingerprint)}`
+}
+
+/**
+ * Build an opaque PR title for a correction PR.
+ * Format: `{PR_TITLE_PREFIX}{opaqueDigest}`
+ * Must not contain source text, path, sourceRef, or claim text.
+ */
+function buildOpaqueTitle(fingerprint: string): string {
+  return `${PR_TITLE_PREFIX}${deriveOpaqueDigest(fingerprint)}`
+}
+
+// ---------------------------------------------------------------------------
+// Action types
+// ---------------------------------------------------------------------------
+
+/**
+ * Plan to open a new correction PR for a graduated finding.
+ *
+ * All metadata is opaque: branch name and title use a short digest,
+ * never source text, path, or fingerprint verbatim.
+ */
+export interface OpenPrAction {
+  readonly type: 'open-pr'
+  /** Opaque branch name derived from fingerprint digest. */
+  readonly opaqueBranchName: string
+  /** Opaque PR title derived from fingerprint digest. */
+  readonly opaqueTitle: string
+  /** Base branch — always 'main'. */
+  readonly baseBranch: 'main'
+  /** Opaque digest used for rediscovery matching. */
+  readonly opaqueDigest: string
+}
+
+/**
+ * Rediscover an existing open correction PR instead of creating a duplicate.
+ *
+ * Only produced when all matching criteria are met:
+ * - Opaque digest matches the finding's fingerprint digest.
+ * - PR is bot-owned.
+ * - PR targets main.
+ */
+export interface RediscoverPrAction {
+  readonly type: 'rediscover-pr'
+  /** The existing PR number to rediscover. */
+  readonly existingPrNumber: number
+  /** Opaque digest used for matching. */
+  readonly opaqueDigest: string
+}
+
+/**
+ * Downgrade a finding to proposal-only (no PR action).
+ *
+ * Used when:
+ * - Planner is disabled.
+ * - Claim kind is not graduated.
+ * - Path is forbidden.
+ * - Privacy gate blocks the PR metadata.
+ * - Overflow (maxPrsPerRun exceeded).
+ *
+ * The action carries only a downgrade reason code — no source text, path,
+ * fingerprint, or correction text.
+ */
+export interface DowngradeToProposalAction {
+  readonly type: 'downgrade-to-proposal'
+  /** Reason code for the downgrade (no source text or paths). */
+  readonly reason: 'disabled' | 'not-graduated' | 'path-forbidden' | 'privacy-gate-blocked' | 'overflow'
+}
+
+/**
+ * Discriminated union of all PR planner action types.
+ *
+ * Forbidden action types (merge, approve, automerge, force-push, retarget)
+ * are intentionally absent from this union.
+ */
+export type StatusTruthPrAction = OpenPrAction | RediscoverPrAction | DowngradeToProposalAction
+
+// ---------------------------------------------------------------------------
+// Input/output types
+// ---------------------------------------------------------------------------
+
+/**
+ * Simplified shape of an existing status-truth correction PR.
+ * Caller fetches from GitHub and passes in; planner is pure.
+ */
+export interface ExistingStatusTruthPr {
+  readonly number: number
+  readonly state: 'open' | 'closed'
+  /** Head branch name (must start with PR_BRANCH_PREFIX for rediscovery). */
+  readonly headBranch: string
+  /** Base branch name (must be 'main' for rediscovery). */
+  readonly baseBranch: string
+  /** Opaque digest extracted from the head branch name. */
+  readonly opaqueDigest: string
+  /** Whether the PR was created by the bot (required for rediscovery). */
+  readonly botOwned: boolean
+}
+
+/** Input to the pure PR planner. */
+export interface PlanStatusTruthPrActionsInput {
+  /** The status-truth report from the detect step. */
+  readonly report: StatusTruthJsonReport
+  /**
+   * Claim kinds that have graduated to PR-eligible status.
+   * Empty set → all candidates downgrade to proposal-only.
+   */
+  readonly graduatedClaimKinds: ReadonlySet<string>
+  /** Existing open status-truth correction PRs fetched from GitHub. */
+  readonly existingPrs: readonly ExistingStatusTruthPr[]
+  /** Loaded public-output token sets for privacy gating. */
+  readonly publicOutputTokens: PublicOutputTokens
+  /**
+   * Maximum number of PR actions to plan per run.
+   * Overflow candidates downgrade to proposal-only.
+   * Default: 1.
+   */
+  readonly maxPrsPerRun: number
+  /**
+   * Whether the PR pathway is enabled.
+   * When false: all candidates downgrade to proposal-only (no PR actions).
+   * Default: false (disabled until graduation criteria are met).
+   */
+  readonly enabled: boolean
+}
+
+/** Aggregate counts returned by the PR planner. */
+export interface PlanStatusTruthPrActionsCounts {
+  /** Number of PR actions planned (open-pr + rediscover-pr). */
+  readonly prActionsPlanned: number
+  /** Number of findings downgraded to proposal-only. */
+  readonly downgradedToProposalOnly: number
+  /** Number of findings blocked by path authorization. */
+  readonly pathForbidden: number
+  /** Number of findings blocked by the privacy gate. */
+  readonly privacyGateBlocked: number
+  /** Number of findings that overflowed the maxPrsPerRun limit. */
+  readonly overflow: number
+  /** 1 when the report version was rejected; 0 otherwise. */
+  readonly versionRejected: number
+}
+
+/** Result of the pure PR planner. */
+export interface PlanStatusTruthPrActionsResult {
+  readonly actions: readonly StatusTruthPrAction[]
+  readonly counts: PlanStatusTruthPrActionsCounts
+}
+
+// ---------------------------------------------------------------------------
+// Type guard
+// ---------------------------------------------------------------------------
+
+function isPublicFinding(finding: StatusTruthFinding): finding is PublicStatusTruthFinding {
+  return finding.verdict !== 'unsafe'
+}
+
+// ---------------------------------------------------------------------------
+// Existing PR rediscovery
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempt to rediscover an existing open correction PR for a finding.
+ *
+ * Rediscovery criteria (all must match):
+ * 1. PR is open.
+ * 2. PR is bot-owned.
+ * 3. PR targets main.
+ * 4. PR's opaque digest matches the finding's fingerprint digest.
+ *
+ * Returns the matching PR or null if no match.
+ */
+function findMatchingExistingPr(
+  fingerprint: string,
+  existingPrs: readonly ExistingStatusTruthPr[],
+): ExistingStatusTruthPr | null {
+  const digest = deriveOpaqueDigest(fingerprint)
+
+  for (const pr of existingPrs) {
+    if (
+      pr.state === 'open' &&
+      pr.botOwned &&
+      pr.baseBranch === BASE_BRANCH &&
+      pr.opaqueDigest === digest &&
+      pr.headBranch.startsWith(PR_BRANCH_PREFIX)
+    ) {
+      return pr
+    }
+  }
+
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Pure PR planner
+// ---------------------------------------------------------------------------
+
+/**
+ * Plan status-truth correction PR actions from a detect report.
+ *
+ * Pure function: no I/O, no Octokit dependency. Deterministic from inputs.
+ *
+ * Processing order:
+ * 1. Reject unknown report versions immediately.
+ * 2. If disabled: downgrade all proposal-eligible findings to proposal-only.
+ * 3. For each proposal-eligible drifted finding:
+ *    a. Skip if claim kind is not graduated → downgrade-to-proposal.
+ *    b. Run path authorization → downgrade-to-proposal if forbidden.
+ *    c. Check for existing PR rediscovery (all criteria must match).
+ *    d. Check overflow (maxPrsPerRun) → downgrade-to-proposal if exceeded.
+ *    e. Run privacy gate on opaque PR metadata → downgrade-to-proposal if blocked.
+ *    f. Plan open-pr action with opaque branch/title.
+ */
+export function planStatusTruthPrActions(input: PlanStatusTruthPrActionsInput): PlanStatusTruthPrActionsResult {
+  const {report, graduatedClaimKinds, existingPrs, publicOutputTokens, maxPrsPerRun, enabled} = input
+
+  // 1. Reject unknown report versions
+  if (report.schema_version !== KNOWN_SCHEMA_VERSION || report.fingerprint_version !== KNOWN_FINGERPRINT_VERSION) {
+    return {
+      actions: [],
+      counts: {
+        prActionsPlanned: 0,
+        downgradedToProposalOnly: 0,
+        pathForbidden: 0,
+        privacyGateBlocked: 0,
+        overflow: 0,
+        versionRejected: 1,
+      },
+    }
+  }
+
+  const actions: StatusTruthPrAction[] = []
+  let prActionsPlanned = 0
+  let downgradedToProposalOnly = 0
+  let pathForbidden = 0
+  let privacyGateBlocked = 0
+  let overflow = 0
+
+  // 2. If disabled: downgrade all proposal-eligible findings
+  if (!enabled) {
+    for (const finding of report.findings) {
+      if (!isPublicFinding(finding)) continue
+      if (!finding.proposalEligible) continue
+
+      actions.push({type: 'downgrade-to-proposal', reason: 'disabled'})
+      downgradedToProposalOnly++
+    }
+
+    return {
+      actions,
+      counts: {
+        prActionsPlanned,
+        downgradedToProposalOnly,
+        pathForbidden,
+        privacyGateBlocked,
+        overflow,
+        versionRejected: 0,
+      },
+    }
+  }
+
+  // 3. Process proposal-eligible findings
+  for (const finding of report.findings) {
+    // Skip unsafe findings
+    if (!isPublicFinding(finding)) continue
+
+    // Skip non-proposal-eligible findings
+    if (!finding.proposalEligible) continue
+
+    const {fingerprint, kind} = finding
+
+    // a. Check claim kind graduation
+    if (!graduatedClaimKinds.has(kind)) {
+      actions.push({type: 'downgrade-to-proposal', reason: 'not-graduated'})
+      downgradedToProposalOnly++
+      continue
+    }
+
+    // b. Path authorization (runs before any diff rendering)
+    if (!isPathAuthorized(finding.path)) {
+      actions.push({type: 'downgrade-to-proposal', reason: 'path-forbidden'})
+      downgradedToProposalOnly++
+      pathForbidden++
+      continue
+    }
+
+    // c. Check for existing PR rediscovery
+    const existingPr = findMatchingExistingPr(fingerprint, existingPrs)
+    if (existingPr !== null) {
+      // Rediscovery counts as a PR action (uses the slot)
+      if (prActionsPlanned >= maxPrsPerRun) {
+        actions.push({type: 'downgrade-to-proposal', reason: 'overflow'})
+        downgradedToProposalOnly++
+        overflow++
+        continue
+      }
+
+      actions.push({
+        type: 'rediscover-pr',
+        existingPrNumber: existingPr.number,
+        opaqueDigest: existingPr.opaqueDigest,
+      })
+      prActionsPlanned++
+      continue
+    }
+
+    // d. Check overflow
+    if (prActionsPlanned >= maxPrsPerRun) {
+      actions.push({type: 'downgrade-to-proposal', reason: 'overflow'})
+      downgradedToProposalOnly++
+      overflow++
+      continue
+    }
+
+    // e. Privacy gate on opaque PR metadata
+    // Gate the opaque title (does not contain source text, but must pass the gate)
+    const opaqueTitle = buildOpaqueTitle(fingerprint)
+    const titleGate = applyPublicOutputGate({
+      surface: 'pr-title',
+      content: opaqueTitle,
+      tokens: publicOutputTokens,
+      fingerprint,
+    })
+    if (!titleGate.allowed) {
+      actions.push({type: 'downgrade-to-proposal', reason: 'privacy-gate-blocked'})
+      downgradedToProposalOnly++
+      privacyGateBlocked++
+      continue
+    }
+
+    // Also gate the proposed correction content if present (for body/diff safety)
+    if (finding.proposedCorrection !== undefined) {
+      const correctionGate = applyPublicOutputGate({
+        surface: 'pr-body',
+        content: finding.proposedCorrection,
+        tokens: publicOutputTokens,
+        fingerprint,
+      })
+      if (!correctionGate.allowed) {
+        actions.push({type: 'downgrade-to-proposal', reason: 'privacy-gate-blocked'})
+        downgradedToProposalOnly++
+        privacyGateBlocked++
+        continue
+      }
+    }
+
+    // f. Plan open-pr action with opaque branch/title
+    const opaqueBranchName = buildOpaqueBranchName(fingerprint)
+    const opaqueDigest = deriveOpaqueDigest(fingerprint)
+
+    actions.push({
+      type: 'open-pr',
+      opaqueBranchName,
+      opaqueTitle: titleGate.sanitizedContent,
+      baseBranch: BASE_BRANCH,
+      opaqueDigest,
+    })
+    prActionsPlanned++
+  }
+
+  return {
+    actions,
+    counts: {
+      prActionsPlanned,
+      downgradedToProposalOnly,
+      pathForbidden,
+      privacyGateBlocked,
+      overflow,
+      versionRejected: 0,
+    },
+  }
+}

--- a/scripts/status-truth-public-output.test.ts
+++ b/scripts/status-truth-public-output.test.ts
@@ -462,6 +462,47 @@ describe('applyPublicOutputGate — integration: all surfaces use one gate', () 
 })
 
 // ---------------------------------------------------------------------------
+// Fix #8: MUTATION PROOF — gate adapter is load-bearing for private-token content
+// ---------------------------------------------------------------------------
+
+describe('MUTATION PROOF — applyPublicOutputGate blocks private-token content', () => {
+  it('content with a private token would be allowed absent the gate but applyPublicOutputGate blocks it', () => {
+    // MUTATION PROOF: if applyPublicOutputGate were replaced with an identity passthrough,
+    // this test would fail because the private token would leak into the output.
+    const privateToken = 'acme/secret-internal-repo'
+    const tokens = makePrivateTokens([privateToken])
+    const contentWithPrivateToken = `Status drift: PR #42 in ${privateToken} is closed (was open).`
+
+    // Without the gate (identity passthrough), this content would be returned as-is.
+    // The gate must block it.
+    const result = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: contentWithPrivateToken,
+      tokens,
+      fingerprint: 'abcdef0123456789',
+    })
+
+    // Gate blocks the content — private token must not appear in any output field
+    expect(result.allowed).toBe(false)
+    if (!result.allowed) {
+      expect(result.blockedCount).toBe(1)
+      // No sanitizedContent or blockedContent fields (private token must not leak)
+      expect('sanitizedContent' in result).toBe(false)
+      expect('blockedContent' in result).toBe(false)
+    }
+
+    // Verify the raw privacy check confirms the content is private
+    // (proving the gate wraps the correct underlying check)
+    // learningBodyHasPrivateLeak is already imported at the top of this file
+    const rawCheck = learningBodyHasPrivateLeak(
+      contentWithPrivateToken,
+      tokens.loaded ? tokens.privateTokens : new Set(),
+    )
+    expect(rawCheck).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Type contract: SafePublicOutput discriminated union
 // ---------------------------------------------------------------------------
 

--- a/scripts/status-truth-public-output.test.ts
+++ b/scripts/status-truth-public-output.test.ts
@@ -1,0 +1,500 @@
+/**
+ * Tests for the public-output privacy gate adapter.
+ *
+ * Key invariants under test:
+ * - One shared gate function covers every public surface kind.
+ * - Private-token or secret-like content blocks output; only counters are returned.
+ * - Token-load failure blocks all output (fail-closed).
+ * - Fingerprints never appear in counts-only surfaces (workflow-summary-row,
+ *   workflow-run-display-name, workflow-step-summary).
+ * - Phase 2 PR surfaces are gated in Phase 1.
+ * - Mutation guard: replacing the gate with an identity passthrough fails a private-identity test.
+ */
+
+import type {PublicOutputSurface, PublicOutputTokens} from './status-truth-public-output.ts'
+
+import {describe, expect, it} from 'vitest'
+import {learningBodyHasPrivateLeak} from './capture-learnings-privacy.ts'
+import {
+  applyPublicOutputGate,
+  COUNTS_ONLY_SURFACES,
+  isCountsOnlySurface,
+  isPublicOutputTokensLoaded,
+  makePublicOutputTokens,
+  PHASE2_RESERVED_SURFACES,
+} from './status-truth-public-output.ts'
+import {buildPrivateTokenSet} from './wiki-slug.ts'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal loaded token set with no private tokens and no redacted IDs. */
+function makeEmptyTokens(): PublicOutputTokens & {loaded: true} {
+  return makePublicOutputTokens({
+    privateTokens: new Set<string>(),
+    redactedCanonicalIds: new Set<string>(),
+  })
+}
+
+/** Build a loaded token set with a known private token. */
+function makePrivateTokens(privateNames: string[]): PublicOutputTokens & {loaded: true} {
+  return makePublicOutputTokens({
+    privateTokens: buildPrivateTokenSet(privateNames),
+    redactedCanonicalIds: new Set<string>(),
+  })
+}
+
+/** Build a loaded token set with a known redacted canonical ID. */
+function makeRedactedIdTokens(ids: string[]): PublicOutputTokens & {loaded: true} {
+  return makePublicOutputTokens({
+    privateTokens: new Set<string>(),
+    redactedCanonicalIds: new Set<string>(ids),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Token loading model
+// ---------------------------------------------------------------------------
+
+describe('makePublicOutputTokens / isPublicOutputTokensLoaded', () => {
+  it('loaded tokens have loaded:true and expose the token sets', () => {
+    const tokens = makePublicOutputTokens({
+      privateTokens: new Set(['acme/private-repo']),
+      redactedCanonicalIds: new Set(['R_kgDOABC123']),
+    })
+    expect(tokens.loaded).toBe(true)
+    if (tokens.loaded) {
+      expect(tokens.privateTokens.has('acme/private-repo')).toBe(true)
+      expect(tokens.redactedCanonicalIds.has('R_kgDOABC123')).toBe(true)
+    }
+  })
+
+  it('failed tokens have loaded:false and isPublicOutputTokensLoaded returns false', () => {
+    const tokens: PublicOutputTokens = {loaded: false, error: 'could not read metadata/repos.yaml'}
+    expect(tokens.loaded).toBe(false)
+    expect(isPublicOutputTokensLoaded(tokens)).toBe(false)
+  })
+
+  it('isPublicOutputTokensLoaded narrows to loaded variant', () => {
+    const tokens = makeEmptyTokens()
+    expect(isPublicOutputTokensLoaded(tokens)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Surface constants
+// ---------------------------------------------------------------------------
+
+describe('surface constants', () => {
+  it('COUNTS_ONLY_SURFACES contains workflow-summary-row, workflow-run-display-name, workflow-step-summary', () => {
+    expect(COUNTS_ONLY_SURFACES).toContain('workflow-summary-row')
+    expect(COUNTS_ONLY_SURFACES).toContain('workflow-run-display-name')
+    expect(COUNTS_ONLY_SURFACES).toContain('workflow-step-summary')
+  })
+
+  it('isCountsOnlySurface returns true for counts-only surfaces and false for others', () => {
+    expect(isCountsOnlySurface('workflow-summary-row')).toBe(true)
+    expect(isCountsOnlySurface('workflow-run-display-name')).toBe(true)
+    expect(isCountsOnlySurface('workflow-step-summary')).toBe(true)
+    expect(isCountsOnlySurface('proposal-body')).toBe(false)
+    expect(isCountsOnlySurface('pr-title')).toBe(false)
+  })
+
+  it('PHASE2_RESERVED_SURFACES contains pr-title, pr-body, pr-commit-message, pr-branch-name, pr-label', () => {
+    expect(PHASE2_RESERVED_SURFACES).toContain('pr-title')
+    expect(PHASE2_RESERVED_SURFACES).toContain('pr-body')
+    expect(PHASE2_RESERVED_SURFACES).toContain('pr-commit-message')
+    expect(PHASE2_RESERVED_SURFACES).toContain('pr-branch-name')
+    expect(PHASE2_RESERVED_SURFACES).toContain('pr-label')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Happy path: known-public content passes
+// ---------------------------------------------------------------------------
+
+describe('applyPublicOutputGate — happy path', () => {
+  it('known-public proposal title passes and returns sanitized content', () => {
+    const tokens = makeEmptyTokens()
+    const result = applyPublicOutputGate({
+      surface: 'proposal-title',
+      content: 'Status drift: PR #42 is closed (was open)',
+      tokens,
+      fingerprint: 'abcdef0123456789',
+    })
+    expect(result.allowed).toBe(true)
+    if (result.allowed) {
+      expect(result.sanitizedContent).toBe('Status drift: PR #42 is closed (was open)')
+    }
+  })
+
+  it('proposal body with fingerprint in content passes (fingerprint allowed in proposal surfaces)', () => {
+    const tokens = makeEmptyTokens()
+    const fingerprint = 'abcdef0123456789'
+    const result = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: `<!-- status-truth:fingerprint:${fingerprint} -->\n\nDrift detected.`,
+      tokens,
+      fingerprint,
+    })
+    expect(result.allowed).toBe(true)
+    if (result.allowed) {
+      expect(result.sanitizedContent).toContain('Drift detected.')
+    }
+  })
+
+  it('workflow-summary-row passes with counts-only content (no fingerprint parameter)', () => {
+    const tokens = makeEmptyTokens()
+    const result = applyPublicOutputGate({
+      surface: 'workflow-summary-row',
+      content: '| pr-state | 3 | 1 | 2 |',
+      tokens,
+      fingerprint: undefined,
+    })
+    expect(result.allowed).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Private token and redacted ID blocks
+// ---------------------------------------------------------------------------
+
+describe('applyPublicOutputGate — private token block', () => {
+  it('private repo token in proposal body blocks output and returns only counter', () => {
+    const tokens = makePrivateTokens(['acme/private-repo'])
+    const result = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: 'The claim references acme/private-repo which is private.',
+      tokens,
+      fingerprint: 'abcdef0123456789',
+    })
+    expect(result.allowed).toBe(false)
+    if (!result.allowed) {
+      expect(result.blockedCount).toBe(1)
+      // Blocked text must not be returned
+      expect('sanitizedContent' in result).toBe(false)
+      expect('blockedContent' in result).toBe(false)
+    }
+  })
+
+  it('private token in wiki-slug form (owner--repo) is also blocked', () => {
+    const tokens = makePrivateTokens(['acme/private-repo'])
+    const result = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: 'See acme--private-repo for details.',
+      tokens,
+      fingerprint: 'abcdef0123456789',
+    })
+    expect(result.allowed).toBe(false)
+  })
+
+  it('content referencing a redacted canonical ID is blocked', () => {
+    const tokens = makeRedactedIdTokens(['R_kgDOABC123'])
+    const result = applyPublicOutputGate({
+      surface: 'proposal-title',
+      content: 'Drift in R_kgDOABC123 repository',
+      tokens,
+      fingerprint: 'abcdef0123456789',
+    })
+    expect(result.allowed).toBe(false)
+    if (!result.allowed) {
+      expect(result.blockedCount).toBe(1)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Secret-like content blocks output
+// ---------------------------------------------------------------------------
+
+describe('applyPublicOutputGate — secret-like content', () => {
+  it('GitHub PAT in proposed correction blocks output', () => {
+    const tokens = makeEmptyTokens()
+    const result = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: 'Correction: use token ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      tokens,
+      fingerprint: 'abcdef0123456789',
+    })
+    expect(result.allowed).toBe(false)
+    if (!result.allowed) {
+      expect(result.blockedCount).toBe(1)
+    }
+  })
+
+  it('AWS access key in proposal body blocks output', () => {
+    const tokens = makeEmptyTokens()
+    const result = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: 'Key: AKIAIOSFODNN7EXAMPLE is referenced',
+      tokens,
+      fingerprint: 'abcdef0123456789',
+    })
+    expect(result.allowed).toBe(false)
+  })
+
+  it('private key block in recurrence comment blocks output', () => {
+    const tokens = makeEmptyTokens()
+    const result = applyPublicOutputGate({
+      surface: 'recurrence-comment',
+      content: '-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA...',
+      tokens,
+      fingerprint: 'abcdef0123456789',
+    })
+    expect(result.allowed).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Token loading failure blocks all output
+// ---------------------------------------------------------------------------
+
+describe('applyPublicOutputGate — token loading failure', () => {
+  it('failed token load blocks output and reports load failure reason', () => {
+    const failedTokens: PublicOutputTokens = {
+      loaded: false,
+      error: 'could not read metadata/repos.yaml',
+    }
+    const result = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: 'Drift detected: PR #42 is closed.',
+      tokens: failedTokens,
+      fingerprint: 'abcdef0123456789',
+    })
+    expect(result.allowed).toBe(false)
+    if (!result.allowed) {
+      expect(result.blockedCount).toBe(1)
+      expect(result.blockReason).toMatch(/token.*load|load.*fail/i)
+    }
+  })
+
+  it('failed token load blocks workflow summary output', () => {
+    const failedTokens: PublicOutputTokens = {loaded: false, error: 'parse error'}
+    const result = applyPublicOutputGate({
+      surface: 'workflow-summary-row',
+      content: '| pr-state | 3 | 1 | 2 |',
+      tokens: failedTokens,
+      fingerprint: undefined,
+    })
+    expect(result.allowed).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fingerprint surface rules
+// ---------------------------------------------------------------------------
+
+describe('applyPublicOutputGate — fingerprint surface rules', () => {
+  it('fingerprint parameter on workflow-summary-row is blocked (counts-only surface)', () => {
+    const tokens = makeEmptyTokens()
+    const fingerprint = 'abcdef0123456789'
+    const result = applyPublicOutputGate({
+      surface: 'workflow-summary-row',
+      content: '| pr-state | 3 | 1 |',
+      tokens,
+      fingerprint,
+    })
+    expect(result.allowed).toBe(false)
+    if (!result.allowed) {
+      expect(result.blockReason).toMatch(/fingerprint|counts.only/i)
+    }
+  })
+
+  it('fingerprint parameter on workflow-run-display-name is blocked (counts-only surface)', () => {
+    const tokens = makeEmptyTokens()
+    const result = applyPublicOutputGate({
+      surface: 'workflow-run-display-name',
+      content: 'Status truth: 3 findings',
+      tokens,
+      fingerprint: 'abcdef0123456789',
+    })
+    expect(result.allowed).toBe(false)
+    if (!result.allowed) {
+      expect(result.blockReason).toMatch(/fingerprint|counts.only/i)
+    }
+  })
+
+  it('fingerprint parameter on workflow-step-summary is blocked (counts-only surface)', () => {
+    const tokens = makeEmptyTokens()
+    const result = applyPublicOutputGate({
+      surface: 'workflow-step-summary',
+      content: 'Step completed.',
+      tokens,
+      fingerprint: 'abcdef0123456789',
+    })
+    expect(result.allowed).toBe(false)
+    if (!result.allowed) {
+      expect(result.blockReason).toMatch(/fingerprint|counts.only/i)
+    }
+  })
+
+  it('counts-only surface with no fingerprint parameter passes', () => {
+    const tokens = makeEmptyTokens()
+    const result = applyPublicOutputGate({
+      surface: 'workflow-run-display-name',
+      content: 'Status truth: 3 findings, 1 proposal',
+      tokens,
+      fingerprint: undefined,
+    })
+    expect(result.allowed).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Mutation guard: gate is load-bearing
+// ---------------------------------------------------------------------------
+
+describe('mutation guard — gate is load-bearing', () => {
+  it('private identity in proposal body is blocked by the gate (not passed through)', () => {
+    // If the gate were replaced with an identity passthrough, this would return allowed:true
+    // and the private name would leak.
+    const tokens = makePrivateTokens(['acme/private-repo'])
+    const privateContent = 'This proposal references acme/private-repo directly.'
+
+    const result = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: privateContent,
+      tokens,
+      fingerprint: 'abcdef0123456789',
+    })
+
+    expect(result.allowed).toBe(false)
+
+    // Verify the raw privacy check catches it (proving the gate wraps the right function)
+    const rawCheck = learningBodyHasPrivateLeak(privateContent, tokens.loaded ? tokens.privateTokens : new Set())
+    expect(rawCheck).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Integration: all 12 surfaces use the same gate
+// ---------------------------------------------------------------------------
+
+describe('applyPublicOutputGate — integration: all surfaces use one gate', () => {
+  const surfaces: PublicOutputSurface[] = [
+    'proposal-title',
+    'proposal-body',
+    'proposal-comment',
+    'recurrence-comment',
+    'workflow-summary-row',
+    'workflow-step-summary',
+    'workflow-run-display-name',
+    'pr-title',
+    'pr-body',
+    'pr-commit-message',
+    'pr-branch-name',
+    'pr-label',
+  ]
+
+  it('all 12 surface kinds are recognized by the gate (no unknown-surface error)', () => {
+    const tokens = makeEmptyTokens()
+    for (const surface of surfaces) {
+      const countsOnly = isCountsOnlySurface(surface)
+      const content = countsOnly ? '| pr-state | 1 | 0 | 1 |' : 'Safe public content for testing.'
+      const fingerprint = countsOnly ? undefined : 'abcdef0123456789'
+
+      const result = applyPublicOutputGate({surface, content, tokens, fingerprint})
+      expect(typeof result.allowed).toBe('boolean')
+    }
+  })
+
+  it('private token blocks ALL surface kinds', () => {
+    const tokens = makePrivateTokens(['acme/private-repo'])
+    const privateContent = 'acme/private-repo is referenced here'
+
+    for (const surface of surfaces) {
+      const countsOnly = isCountsOnlySurface(surface)
+      const content = countsOnly ? `| acme/private-repo | 1 |` : privateContent
+      const fingerprint = countsOnly ? undefined : 'abcdef0123456789'
+
+      const result = applyPublicOutputGate({surface, content, tokens, fingerprint})
+      expect(result.allowed).toBe(false)
+    }
+  })
+
+  it('secret blocks ALL surface kinds', () => {
+    const tokens = makeEmptyTokens()
+    const secretContent = 'ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+
+    for (const surface of surfaces) {
+      const countsOnly = isCountsOnlySurface(surface)
+      const content = countsOnly ? `| ${secretContent} |` : secretContent
+      const fingerprint = countsOnly ? undefined : 'abcdef0123456789'
+
+      const result = applyPublicOutputGate({surface, content, tokens, fingerprint})
+      expect(result.allowed).toBe(false)
+    }
+  })
+
+  it('proposal surfaces (title, body, comment, recurrence-comment) all pass with clean public content', () => {
+    const tokens = makeEmptyTokens()
+    const proposalSurfaces: PublicOutputSurface[] = [
+      'proposal-title',
+      'proposal-body',
+      'proposal-comment',
+      'recurrence-comment',
+    ]
+    for (const surface of proposalSurfaces) {
+      const result = applyPublicOutputGate({
+        surface,
+        content: 'Status drift: PR #42 is closed (was open).',
+        tokens,
+        fingerprint: 'abcdef0123456789',
+      })
+      expect(result.allowed).toBe(true)
+    }
+  })
+
+  it('Phase 2 PR surfaces are gated and pass with clean content', () => {
+    const tokens = makeEmptyTokens()
+    const prSurfaces: PublicOutputSurface[] = ['pr-title', 'pr-body', 'pr-commit-message', 'pr-branch-name', 'pr-label']
+    for (const surface of prSurfaces) {
+      const result = applyPublicOutputGate({
+        surface,
+        content: 'fix: correct PR #42 state in docs/plans/example.md',
+        tokens,
+        fingerprint: 'abcdef0123456789',
+      })
+      expect(result.allowed).toBe(true)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Type contract: SafePublicOutput discriminated union
+// ---------------------------------------------------------------------------
+
+describe('SafePublicOutput type contract', () => {
+  it('allowed result has sanitizedContent and no blockedCount', () => {
+    const tokens = makeEmptyTokens()
+    const result = applyPublicOutputGate({
+      surface: 'proposal-title',
+      content: 'Safe title',
+      tokens,
+      fingerprint: 'abcdef0123456789',
+    })
+    expect(result.allowed).toBe(true)
+    if (result.allowed) {
+      expect(typeof result.sanitizedContent).toBe('string')
+      expect('blockedCount' in result).toBe(false)
+    }
+  })
+
+  it('blocked result has blockedCount and blockReason, no sanitizedContent or blockedContent', () => {
+    const tokens: PublicOutputTokens = {loaded: false, error: 'test error'}
+    const result = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: 'Some content',
+      tokens,
+      fingerprint: 'abcdef0123456789',
+    })
+    expect(result.allowed).toBe(false)
+    if (!result.allowed) {
+      expect(result.blockedCount).toBe(1)
+      expect(typeof result.blockReason).toBe('string')
+      expect('sanitizedContent' in result).toBe(false)
+      expect('blockedContent' in result).toBe(false)
+    }
+  })
+})

--- a/scripts/status-truth-public-output.ts
+++ b/scripts/status-truth-public-output.ts
@@ -1,0 +1,242 @@
+/**
+ * Public-output privacy gate adapter for the status-truth maintenance loop.
+ *
+ * One exported function — `applyPublicOutputGate` — covers all surface kinds so
+ * no public-render helper can bypass the shared gate.
+ *
+ * Design invariants:
+ * - Wraps `capture-learnings-privacy.ts` helpers; does not fork privacy logic.
+ * - Token-load failure blocks ALL output (fail-closed).
+ * - Private-token or secret-like content blocks output; only counters are returned.
+ * - Fingerprints are excluded from counts-only surfaces (workflow-summary-row,
+ *   workflow-run-display-name, workflow-step-summary): providing a fingerprint
+ *   parameter for those surfaces causes the gate to block.
+ * - Phase 2 PR surfaces are reserved in the Phase 1 schema so they cannot bypass
+ *   the gate when PR support is enabled later.
+ *
+ * Strip-only safe: no parameter properties, enums, or namespaces.
+ */
+
+import {learningBodyHasPrivateLeak, logDiffHasSecret} from './capture-learnings-privacy.ts'
+
+// ---------------------------------------------------------------------------
+// Surface kinds
+// ---------------------------------------------------------------------------
+
+/**
+ * All public output surface kinds covered by the gate.
+ *
+ * Phase 1: proposal-title, proposal-body, proposal-comment, recurrence-comment,
+ *   workflow-summary-row, workflow-step-summary, workflow-run-display-name.
+ *
+ * Phase 2 reserved: pr-title, pr-body, pr-commit-message, pr-branch-name, pr-label.
+ *   Reserved in the Phase 1 schema so future PR metadata cannot bypass the gate.
+ */
+export type PublicOutputSurface =
+  | 'proposal-title'
+  | 'proposal-body'
+  | 'proposal-comment'
+  | 'recurrence-comment'
+  | 'workflow-summary-row'
+  | 'workflow-step-summary'
+  | 'workflow-run-display-name'
+  | 'pr-title'
+  | 'pr-body'
+  | 'pr-commit-message'
+  | 'pr-branch-name'
+  | 'pr-label'
+
+/**
+ * Surfaces that carry aggregate counters only — fingerprints must never appear.
+ * Providing a fingerprint parameter for these surfaces causes the gate to block.
+ */
+export const COUNTS_ONLY_SURFACES: readonly PublicOutputSurface[] = [
+  'workflow-summary-row',
+  'workflow-step-summary',
+  'workflow-run-display-name',
+]
+
+/** Returns true when `surface` is a counts-only surface (fingerprint parameter must be undefined). */
+export function isCountsOnlySurface(surface: PublicOutputSurface): boolean {
+  return COUNTS_ONLY_SURFACES.includes(surface)
+}
+
+/**
+ * Phase 2 reserved surfaces. Gated in Phase 1 so future PR metadata cannot bypass the gate.
+ */
+export const PHASE2_RESERVED_SURFACES: readonly PublicOutputSurface[] = [
+  'pr-title',
+  'pr-body',
+  'pr-commit-message',
+  'pr-branch-name',
+  'pr-label',
+]
+
+// ---------------------------------------------------------------------------
+// Token loading model
+// ---------------------------------------------------------------------------
+
+/**
+ * Loaded public-output token set.
+ *
+ * Both sets must be loaded before the gate can operate. An empty set is valid
+ * (no private repos configured); a failed load must use the `loaded:false` variant.
+ */
+export interface PublicOutputTokensLoaded {
+  readonly loaded: true
+  readonly privateTokens: Set<string>
+  readonly redactedCanonicalIds: Set<string>
+}
+
+/**
+ * Failed public-output token load.
+ *
+ * The gate treats this as a hard block: no output is emitted when tokens
+ * could not be loaded. Never use an empty set as a proxy for a failed load.
+ */
+export interface PublicOutputTokensFailed {
+  readonly loaded: false
+  readonly error: string
+}
+
+/** Discriminated union for the token loading result. */
+export type PublicOutputTokens = PublicOutputTokensLoaded | PublicOutputTokensFailed
+
+/** Type guard: narrows `PublicOutputTokens` to the loaded variant. */
+export function isPublicOutputTokensLoaded(tokens: PublicOutputTokens): tokens is PublicOutputTokensLoaded {
+  return tokens.loaded === true
+}
+
+/**
+ * Construct a loaded `PublicOutputTokens` from pre-built token sets.
+ * Both sets may be empty (no private repos / no redacted IDs configured).
+ */
+export function makePublicOutputTokens(params: {
+  privateTokens: Set<string>
+  redactedCanonicalIds: Set<string>
+}): PublicOutputTokensLoaded {
+  return {
+    loaded: true,
+    privateTokens: params.privateTokens,
+    redactedCanonicalIds: params.redactedCanonicalIds,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Gate output types
+// ---------------------------------------------------------------------------
+
+/** Allowed output: content passed all gate checks. */
+export interface SafePublicOutputAllowed {
+  readonly allowed: true
+  readonly sanitizedContent: string
+}
+
+/**
+ * Blocked output: content failed at least one gate check.
+ * Blocked text is intentionally absent — never returned.
+ */
+export interface SafePublicOutputBlocked {
+  readonly allowed: false
+  readonly blockedCount: 1
+  readonly blockReason: string
+}
+
+/** Discriminated union for the gate result. */
+export type SafePublicOutput = SafePublicOutputAllowed | SafePublicOutputBlocked
+
+// ---------------------------------------------------------------------------
+// Gate input
+// ---------------------------------------------------------------------------
+
+export interface PublicOutputGateInput {
+  /** The surface kind being gated. */
+  readonly surface: PublicOutputSurface
+  /** The rendered content to gate. Must be the final rendered string, not raw claim data. */
+  readonly content: string
+  /** Token sets for privacy scanning. Must be loaded; failed load blocks immediately. */
+  readonly tokens: PublicOutputTokens
+  /**
+   * The claim fingerprint, if applicable.
+   * Must be `undefined` for counts-only surfaces (workflow-summary-row, etc.).
+   * Providing a fingerprint for a counts-only surface causes the gate to block.
+   */
+  readonly fingerprint: string | undefined
+}
+
+// ---------------------------------------------------------------------------
+// Gate implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply the public-output privacy gate to a single rendered surface.
+ *
+ * Gate checks (in order):
+ * 1. Token load failure → block immediately (fail-closed).
+ * 2. Counts-only surface with fingerprint present → block.
+ * 3. Secret-like content (GitHub PAT, AWS key, private key, etc.) → block.
+ * 4. Private-token match (private repo name in any form) → block.
+ * 5. Redacted canonical ID match → block.
+ *
+ * On block: returns `{ allowed: false, blockedCount: 1, blockReason }`.
+ * On pass: returns `{ allowed: true, sanitizedContent: content }`.
+ * Blocked text is never returned.
+ */
+export function applyPublicOutputGate(input: PublicOutputGateInput): SafePublicOutput {
+  const {surface, content, tokens, fingerprint} = input
+
+  // 1. Token load failure → fail closed immediately
+  if (!tokens.loaded) {
+    return {
+      allowed: false,
+      blockedCount: 1,
+      blockReason: 'token load failure: privacy gate cannot operate without loaded token sets',
+    }
+  }
+
+  // 2. Counts-only surface: fingerprint parameter must not be provided
+  if (isCountsOnlySurface(surface) && fingerprint !== undefined) {
+    return {
+      allowed: false,
+      blockedCount: 1,
+      blockReason: `fingerprint excluded from counts-only surface: ${surface}`,
+    }
+  }
+
+  // 3. Secret-like content → block
+  if (logDiffHasSecret(content)) {
+    return {
+      allowed: false,
+      blockedCount: 1,
+      blockReason: 'secret-like content detected in rendered output',
+    }
+  }
+
+  // 4. Private-token match → block
+  if (learningBodyHasPrivateLeak(content, tokens.privateTokens)) {
+    return {
+      allowed: false,
+      blockedCount: 1,
+      blockReason: 'private identifier token detected in rendered output',
+    }
+  }
+
+  // 5. Redacted canonical ID match → block
+  if (tokens.redactedCanonicalIds.size > 0) {
+    const lowerContent = content.toLowerCase()
+    for (const id of tokens.redactedCanonicalIds) {
+      if (lowerContent.includes(id.toLowerCase())) {
+        return {
+          allowed: false,
+          blockedCount: 1,
+          blockReason: 'redacted canonical identifier detected in rendered output',
+        }
+      }
+    }
+  }
+
+  return {
+    allowed: true,
+    sanitizedContent: content,
+  }
+}


### PR DESCRIPTION
## Summary

- Add a status-truth detector for documented PR, issue, release, plan, and rollout status claims, with typed JSON reports and fail-closed handling for unsupported or incomplete scans.
- Add proposal issue lifecycle planning/opening with privacy gating, label preflight, existing-issue dedupe, outcome labels, and counts-only workflow summaries.
- Add a disabled PR-graduation planner scaffold for future bounded correction PRs after claim kinds prove reliable through proposal signal.

## Safety

- Scheduled runs default to dry-run; live proposal writes require manual dispatch with `dry_run=false` and a scoped app token.
- Incomplete scans and execution failures do not create, update, reopen, or close proposal issues.
- Cross-repo references are not resolved as current-repo claims.
- PR correction automation remains disabled by default and cannot merge, approve, enable automerge, force-push, or retarget branches.

## Verification

- `pnpm bootstrap && pnpm check-types && pnpm lint && pnpm test`