### PR TITLE
feat: calibrate status-truth signal

### DIFF
--- a/docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md
+++ b/docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md
@@ -20,6 +20,18 @@ Bounded PRs stay in this plan as a second phase: once proposal outcomes show a c
 reliable, Fro Bot can open small human-reviewed correction PRs under strict privacy, branch, path,
 and diff gates.
 
+## Implementation Status
+
+Phase 1 now provides the status-truth foundation: deterministic claim extraction, read-only live
+state resolution for current-repo and confirmed-public cross-repo issue/PR/release references,
+privacy-gated proposal planning, outcome labels for usefulness signal, and a dry-run-first workflow.
+
+The loop intentionally excludes unsupported `plan-status` claims from default scans until a real
+file-parse resolver exists. Bounded correction PRs remain disabled until proposal outcomes establish
+per-kind accuracy thresholds. The next dependency for downstream A2 features is collecting accepted,
+rejected, and false-positive proposal signal against representative tracker/coordination claims before
+graduating any claim kind to correction PRs.
+
 ## Problem Frame
 
 Recent rollout work around #3512, #48, #907, #1033, release-versus-deploy state, and live

--- a/scripts/status-truth-detect.test.ts
+++ b/scripts/status-truth-detect.test.ts
@@ -4,6 +4,9 @@ import type {
   DetectOctokitClient,
   FileLister,
   FileReader,
+  IssueCommentFetcher,
+  IssueLister,
+  IssueListItem,
   PublicStatusTruthFinding,
   ResolverResult,
   ResolverType,
@@ -15,6 +18,7 @@ import type {
 import {describe, expect, it} from 'vitest'
 
 import {
+  buildDetectOctokitOptions,
   buildStatusTruthReport,
   CLAIM_KIND_DEFINITIONS,
   computeClaimFingerprint,
@@ -23,11 +27,14 @@ import {
   isKnownReportVersion,
   KNOWN_FINGERPRINT_VERSION,
   KNOWN_SCHEMA_VERSION,
+  listCurrentRepoIssueComments,
+  listCurrentRepoIssues,
   normalizeClaimText,
   resolveAllClaims,
   resolveClaimLiveState,
+  scanIssueStatusTruthClaims,
   scanStatusTruthClaims,
-  selectFailureClass,
+  selectDetectFailureClass,
   validateStatusTruthArtifact,
 } from './status-truth-detect.ts'
 
@@ -1189,6 +1196,7 @@ function makeMockDetectOctokit(
   } = {},
 ): DetectOctokitClient {
   return {
+    paginate: async () => [],
     rest: {
       pulls: {
         get: async () => {
@@ -1201,12 +1209,15 @@ function makeMockDetectOctokit(
           if (overrides.issueThrows === true) throw new Error('API error')
           return {data: {state: overrides.issueState ?? 'open'}}
         },
+        listForRepo: async () => ({data: []}),
+        listComments: async () => ({data: []}),
       },
       repos: {
         getReleaseByTag: async () => {
           if (overrides.releaseThrows === true) throw new Error('API error')
           return {data: {draft: overrides.releaseDraft ?? false, prerelease: false}}
         },
+        get: async () => ({data: {private: false}}),
       },
     },
   }
@@ -1447,6 +1458,7 @@ describe('Unit 4: extract → resolve → detect pipeline', () => {
   it('resolveAllClaims deduplicates by kind:sourceRef to avoid redundant API calls', async () => {
     let callCount = 0
     const octokit: DetectOctokitClient = {
+      paginate: async () => [],
       rest: {
         pulls: {
           get: async () => {
@@ -1454,8 +1466,15 @@ describe('Unit 4: extract → resolve → detect pipeline', () => {
             return {data: {state: 'open', merged: false}}
           },
         },
-        issues: {get: async () => ({data: {state: 'open'}})},
-        repos: {getReleaseByTag: async () => ({data: {draft: false, prerelease: false}})},
+        issues: {
+          get: async () => ({data: {state: 'open'}}),
+          listForRepo: async () => ({data: []}),
+          listComments: async () => ({data: []}),
+        },
+        repos: {
+          getReleaseByTag: async () => ({data: {draft: false, prerelease: false}}),
+          get: async () => ({data: {private: false}}),
+        },
       },
     }
 
@@ -1521,21 +1540,7 @@ describe('buildProposedCorrection: $ token safety via detectStatusTruthClaims', 
   })
 })
 
-describe('runDetect failure-class selection logic', () => {
-  it('returns file-parse-error when scanErrors > 0 regardless of resolveErrors', () => {
-    expect(selectFailureClass(1, 0)).toBe('file-parse-error')
-    expect(selectFailureClass(3, 2)).toBe('file-parse-error')
-  })
-
-  it('returns api-unavailable when scanErrors === 0 and resolveErrors > 0', () => {
-    expect(selectFailureClass(0, 1)).toBe('api-unavailable')
-    expect(selectFailureClass(0, 5)).toBe('api-unavailable')
-  })
-
-  it('returns null when both scanErrors and resolveErrors are 0', () => {
-    expect(selectFailureClass(0, 0)).toBeNull()
-  })
-
+describe('buildStatusTruthReport failure-class integration', () => {
   it('buildStatusTruthReport with file-parse-error failureClass produces execution-failure status', () => {
     const report = buildStatusTruthReport({
       findings: [],
@@ -1558,5 +1563,1353 @@ describe('runDetect failure-class selection logic', () => {
     })
     expect(report.status).toBe('execution-failure')
     expect(report.failure_class).toBe('api-unavailable')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// selectDetectFailureClass: issue/comment API failures must map to api-unavailable
+// ---------------------------------------------------------------------------
+
+describe('selectDetectFailureClass', () => {
+  it('returns null when all error counts are zero', () => {
+    expect(selectDetectFailureClass({fileScanErrors: 0, issueScanErrors: 0, resolveErrors: 0})).toBeNull()
+  })
+
+  it('returns file-parse-error when fileScanErrors > 0 and no other errors', () => {
+    expect(selectDetectFailureClass({fileScanErrors: 1, issueScanErrors: 0, resolveErrors: 0})).toBe('file-parse-error')
+    expect(selectDetectFailureClass({fileScanErrors: 3, issueScanErrors: 0, resolveErrors: 0})).toBe('file-parse-error')
+  })
+
+  it('returns api-unavailable when issueScanErrors > 0 and fileScanErrors === 0', () => {
+    // Issue list/comment fetch failures are API failures, not file-parse errors
+    expect(selectDetectFailureClass({fileScanErrors: 0, issueScanErrors: 1, resolveErrors: 0})).toBe('api-unavailable')
+    expect(selectDetectFailureClass({fileScanErrors: 0, issueScanErrors: 5, resolveErrors: 0})).toBe('api-unavailable')
+  })
+
+  it('returns api-unavailable when resolveErrors > 0 and fileScanErrors === 0', () => {
+    expect(selectDetectFailureClass({fileScanErrors: 0, issueScanErrors: 0, resolveErrors: 1})).toBe('api-unavailable')
+    expect(selectDetectFailureClass({fileScanErrors: 0, issueScanErrors: 0, resolveErrors: 4})).toBe('api-unavailable')
+  })
+
+  it('returns api-unavailable when both issueScanErrors and resolveErrors > 0 and fileScanErrors === 0', () => {
+    expect(selectDetectFailureClass({fileScanErrors: 0, issueScanErrors: 2, resolveErrors: 3})).toBe('api-unavailable')
+  })
+
+  it('returns file-parse-error when fileScanErrors > 0 even if issueScanErrors and resolveErrors are also > 0', () => {
+    // file-parse-error takes precedence when file scanning itself failed
+    expect(selectDetectFailureClass({fileScanErrors: 1, issueScanErrors: 1, resolveErrors: 1})).toBe('file-parse-error')
+    expect(selectDetectFailureClass({fileScanErrors: 2, issueScanErrors: 3, resolveErrors: 0})).toBe('file-parse-error')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// CALIBRATION: plan-status exclusion from production scans
+// ---------------------------------------------------------------------------
+
+describe('scanStatusTruthClaims: plan-status exclusion (calibration)', () => {
+  it('production scan (default) excludes plan-status claims so dry-run produces zero unresolved plan-status noise', async () => {
+    // A plan doc with frontmatter status: active — production scan must NOT emit plan-status claims
+    const fileLister: FileLister = async () => ['docs/plans/my-plan.md']
+    const fileReader: FileReader = async () => '---\nstatus: active\ntitle: My Plan\n---\n\nContent.'
+
+    const {claims} = await scanStatusTruthClaims({fileLister, fileReader})
+    // Default production scan must exclude plan-status
+    const planStatusClaims = claims.filter(c => c.kind === 'plan-status')
+    expect(planStatusClaims).toHaveLength(0)
+  })
+
+  it('pure extractor still extracts plan-status when all kinds are enabled', () => {
+    // extractStatusTruthClaimsFromText is a pure function and always extracts all kinds
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/my-plan.md',
+      text: '---\nstatus: active\ntitle: My Plan\n---\n\nContent.',
+    })
+    const planStatusClaims = claims.filter(c => c.kind === 'plan-status')
+    expect(planStatusClaims).toHaveLength(1)
+  })
+
+  it('production scan with explicit enabledKinds including plan-status does emit plan-status claims', async () => {
+    // When caller explicitly opts in, plan-status is included
+    const fileLister: FileLister = async () => ['docs/plans/my-plan.md']
+    const fileReader: FileReader = async () => '---\nstatus: active\ntitle: My Plan\n---\n\nContent.'
+
+    const {claims} = await scanStatusTruthClaims({
+      fileLister,
+      fileReader,
+      enabledKinds: ['pr-state', 'issue-state', 'release-tag-state', 'plan-status', 'rollout-tracker-status'],
+    })
+    const planStatusClaims = claims.filter(c => c.kind === 'plan-status')
+    expect(planStatusClaims).toHaveLength(1)
+  })
+
+  it('production scan default still emits pr-state and issue-state claims', async () => {
+    const fileLister: FileLister = async () => ['README.md']
+    const fileReader: FileReader = async () => 'PR #42 is open and issue #10 is closed.'
+
+    const {claims} = await scanStatusTruthClaims({fileLister, fileReader})
+    expect(claims.filter(c => c.kind === 'pr-state')).toHaveLength(1)
+    expect(claims.filter(c => c.kind === 'issue-state')).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// CALIBRATION: GitHub issue body/comment scanning
+// ---------------------------------------------------------------------------
+
+describe('scanIssueStatusTruthClaims: issue body/comment scanning (calibration)', () => {
+  it('issue body containing "PR #42 is open" yields a pr-state claim with synthetic issue body path', async () => {
+    const issues: IssueListItem[] = [{number: 3512, title: 'Rollout tracker', body: 'PR #42 is open', labels: []}]
+    const issueLister: IssueLister = async () => issues
+    const commentFetcher: IssueCommentFetcher = async () => []
+
+    const {claims} = await scanIssueStatusTruthClaims({
+      owner: 'fro-bot',
+      repo: '.github',
+      issueLister,
+      commentFetcher,
+    })
+
+    expect(claims).toHaveLength(1)
+    const claim = claims[0]
+    expect(claim?.kind).toBe('pr-state')
+    expect(claim?.sourceRef).toBe('#42')
+    expect(claim?.path).toBe('github-issue://current/issues/3512#body')
+  })
+
+  it('resolver saying PR is closed yields a drifted finding for issue body claim', async () => {
+    const issues: IssueListItem[] = [{number: 3512, title: 'Rollout tracker', body: 'PR #42 is open', labels: []}]
+    const issueLister: IssueLister = async () => issues
+    const commentFetcher: IssueCommentFetcher = async () => []
+
+    const {claims} = await scanIssueStatusTruthClaims({
+      owner: 'fro-bot',
+      repo: '.github',
+      issueLister,
+      commentFetcher,
+    })
+
+    const resolverResults = makeResolverResults([
+      {kind: 'pr-state', sourceRef: '#42', result: {status: 'resolved', state: 'closed'}},
+    ])
+
+    const findings = detectStatusTruthClaims(claims, resolverResults)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.verdict).toBe('drifted')
+  })
+
+  it('issue comments are scanned and can produce claims', async () => {
+    const issues: IssueListItem[] = [{number: 100, title: 'Some issue', body: null, labels: []}]
+    const issueLister: IssueLister = async () => issues
+    const commentFetcher: IssueCommentFetcher = async () => [{id: 9001, body: 'issue #55 is closed'}]
+
+    const {claims} = await scanIssueStatusTruthClaims({
+      owner: 'fro-bot',
+      repo: '.github',
+      issueLister,
+      commentFetcher,
+    })
+
+    expect(claims).toHaveLength(1)
+    const claim = claims[0]
+    expect(claim?.kind).toBe('issue-state')
+    expect(claim?.path).toBe('github-issue://current/issues/100#comment-9001')
+  })
+
+  it('issues labeled "status-truth" are skipped', async () => {
+    const issues: IssueListItem[] = [
+      {number: 200, title: 'Status truth proposal', body: 'PR #42 is open', labels: [{name: 'status-truth'}]},
+    ]
+    const issueLister: IssueLister = async () => issues
+    const commentFetcher: IssueCommentFetcher = async () => []
+
+    const {claims} = await scanIssueStatusTruthClaims({
+      owner: 'fro-bot',
+      repo: '.github',
+      issueLister,
+      commentFetcher,
+    })
+
+    expect(claims).toHaveLength(0)
+  })
+
+  it('issues containing the proposal marker in title are skipped', async () => {
+    const issues: IssueListItem[] = [
+      {number: 201, title: '[status-truth-proposal] Fix PR #42', body: 'PR #42 is open', labels: []},
+    ]
+    const issueLister: IssueLister = async () => issues
+    const commentFetcher: IssueCommentFetcher = async () => []
+
+    const {claims} = await scanIssueStatusTruthClaims({
+      owner: 'fro-bot',
+      repo: '.github',
+      issueLister,
+      commentFetcher,
+    })
+
+    expect(claims).toHaveLength(0)
+  })
+
+  it('issue list fetch failure produces non-clean failure class (api-unavailable)', async () => {
+    const issueLister: IssueLister = async () => {
+      throw new Error('API rate limit')
+    }
+    const commentFetcher: IssueCommentFetcher = async () => []
+
+    const result = await scanIssueStatusTruthClaims({
+      owner: 'fro-bot',
+      repo: '.github',
+      issueLister,
+      commentFetcher,
+    })
+
+    // Must not fake clean — must report failure
+    expect(result.scanErrors).toBeGreaterThan(0)
+    expect(result.claims).toHaveLength(0)
+  })
+
+  it('per-issue comment fetch failure counts as scan error and does not silently hide as clean', async () => {
+    const issues: IssueListItem[] = [{number: 300, title: 'Some issue', body: 'PR #42 is open', labels: []}]
+    const issueLister: IssueLister = async () => issues
+    const commentFetcher: IssueCommentFetcher = async () => {
+      throw new Error('comment fetch failed')
+    }
+
+    const result = await scanIssueStatusTruthClaims({
+      owner: 'fro-bot',
+      repo: '.github',
+      issueLister,
+      commentFetcher,
+    })
+
+    // Body claims still extracted; comment fetch failure counted
+    expect(result.scanErrors).toBeGreaterThan(0)
+    // Body claim from issue 300 should still be present (path uses `current`)
+    expect(result.claims.filter(c => c.path === 'github-issue://current/issues/300#body')).toHaveLength(1)
+  })
+
+  it('synthetic issue paths use current scheme and do not contain owner/repo identity', () => {
+    // Structural test: synthetic paths use `current` (not owner/repo) so generic
+    // code does not leak identity before explicit publicness proof.
+    const syntheticBodyPath = 'github-issue://current/issues/3512#body'
+    const syntheticCommentPath = 'github-issue://current/issues/3512#comment-9001'
+
+    // These paths use the `current` scheme
+    expect(syntheticBodyPath).toMatch(/^github-issue:\/\/current\/issues\/\d+#body$/)
+    expect(syntheticCommentPath).toMatch(/^github-issue:\/\/current\/issues\/\d+#comment-\d+$/)
+
+    // The path scheme must not contain raw body text or private identifiers
+    expect(syntheticBodyPath).not.toContain('PR #42 is open')
+    expect(syntheticCommentPath).not.toContain('issue #55 is closed')
+
+    // Must not contain owner/repo identity
+    expect(syntheticBodyPath).not.toContain('fro-bot')
+    expect(syntheticBodyPath).not.toContain('.github')
+  })
+
+  it('issue body with null body produces no claims (graceful null handling)', async () => {
+    const issues: IssueListItem[] = [{number: 400, title: 'Empty body issue', body: null, labels: []}]
+    const issueLister: IssueLister = async () => issues
+    const commentFetcher: IssueCommentFetcher = async () => []
+
+    const {claims, scanErrors} = await scanIssueStatusTruthClaims({
+      owner: 'fro-bot',
+      repo: '.github',
+      issueLister,
+      commentFetcher,
+    })
+
+    expect(claims).toHaveLength(0)
+    expect(scanErrors).toBe(0)
+  })
+
+  it('comment with null body produces no claims (graceful null handling)', async () => {
+    const issues: IssueListItem[] = [{number: 500, title: 'Issue with null comment', body: null, labels: []}]
+    const issueLister: IssueLister = async () => issues
+    const commentFetcher: IssueCommentFetcher = async () => [{id: 9002, body: null}]
+
+    const {claims, scanErrors} = await scanIssueStatusTruthClaims({
+      owner: 'fro-bot',
+      repo: '.github',
+      issueLister,
+      commentFetcher,
+    })
+
+    expect(claims).toHaveLength(0)
+    expect(scanErrors).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Blocker 1: Synthetic issue paths must use `current`, not owner/repo
+// ---------------------------------------------------------------------------
+
+describe('synthetic issue paths use current, not owner/repo', () => {
+  it('issue body path uses github-issue://current/issues/<n>#body, not owner/repo', async () => {
+    const issues: IssueListItem[] = [{number: 3512, title: 'Rollout tracker', body: 'PR #42 is open', labels: []}]
+    const issueLister: IssueLister = async () => issues
+    const commentFetcher: IssueCommentFetcher = async () => []
+
+    const {claims} = await scanIssueStatusTruthClaims({
+      owner: 'fro-bot',
+      repo: '.github',
+      issueLister,
+      commentFetcher,
+    })
+
+    expect(claims).toHaveLength(1)
+    const claim = claims[0]
+    // Must use `current`, not owner/repo
+    expect(claim?.path).toBe('github-issue://current/issues/3512#body')
+    expect(claim?.path).not.toContain('fro-bot')
+    expect(claim?.path).not.toContain('.github')
+  })
+
+  it('issue comment path uses github-issue://current/issues/<n>#comment-<id>, not owner/repo', async () => {
+    const issues: IssueListItem[] = [{number: 100, title: 'Some issue', body: null, labels: []}]
+    const issueLister: IssueLister = async () => issues
+    const commentFetcher: IssueCommentFetcher = async () => [{id: 9001, body: 'issue #55 is closed'}]
+
+    const {claims} = await scanIssueStatusTruthClaims({
+      owner: 'fro-bot',
+      repo: '.github',
+      issueLister,
+      commentFetcher,
+    })
+
+    expect(claims).toHaveLength(1)
+    const claim = claims[0]
+    // Must use `current`, not owner/repo
+    expect(claim?.path).toBe('github-issue://current/issues/100#comment-9001')
+    expect(claim?.path).not.toContain('fro-bot')
+    expect(claim?.path).not.toContain('.github')
+  })
+
+  it('scanner output for issue body uses current path regardless of owner/repo passed in', async () => {
+    // Even with a different owner/repo, the path must always use `current`
+    const issues: IssueListItem[] = [{number: 7, title: 'Test', body: 'issue #1 is open', labels: []}]
+    const issueLister: IssueLister = async () => issues
+    const commentFetcher: IssueCommentFetcher = async () => []
+
+    const {claims} = await scanIssueStatusTruthClaims({
+      owner: 'some-other-org',
+      repo: 'some-other-repo',
+      issueLister,
+      commentFetcher,
+    })
+
+    expect(claims).toHaveLength(1)
+    expect(claims[0]?.path).toBe('github-issue://current/issues/7#body')
+    expect(claims[0]?.path).not.toContain('some-other-org')
+    expect(claims[0]?.path).not.toContain('some-other-repo')
+  })
+
+  it('scanner output for issue comment uses current path regardless of owner/repo passed in', async () => {
+    const issues: IssueListItem[] = [{number: 8, title: 'Test', body: null, labels: []}]
+    const issueLister: IssueLister = async () => issues
+    const commentFetcher: IssueCommentFetcher = async () => [{id: 42, body: 'PR #5 is open'}]
+
+    const {claims} = await scanIssueStatusTruthClaims({
+      owner: 'some-other-org',
+      repo: 'some-other-repo',
+      issueLister,
+      commentFetcher,
+    })
+
+    expect(claims).toHaveLength(1)
+    expect(claims[0]?.path).toBe('github-issue://current/issues/8#comment-42')
+    expect(claims[0]?.path).not.toContain('some-other-org')
+    expect(claims[0]?.path).not.toContain('some-other-repo')
+  })
+
+  it('no public finding path or sourceRef test regresses: public finding path is still present', async () => {
+    // Regression guard: public findings still have path and sourceRef fields
+    const issues: IssueListItem[] = [{number: 3512, title: 'Rollout tracker', body: 'PR #42 is open', labels: []}]
+    const issueLister: IssueLister = async () => issues
+    const commentFetcher: IssueCommentFetcher = async () => []
+
+    const {claims} = await scanIssueStatusTruthClaims({
+      owner: 'fro-bot',
+      repo: '.github',
+      issueLister,
+      commentFetcher,
+    })
+
+    const resolverResults = makeResolverResults([
+      {kind: 'pr-state', sourceRef: '#42', result: {status: 'resolved', state: 'closed'}},
+    ])
+
+    const findings = detectStatusTruthClaims(claims, resolverResults)
+    expect(findings).toHaveLength(1)
+    const finding = findings[0]
+    expect(finding?.verdict).toBe('drifted')
+    // Public finding must still have path and sourceRef
+    if (finding?.verdict === 'drifted') {
+      expect(finding.path).toBe('github-issue://current/issues/3512#body')
+      expect(finding.sourceRef).toBe('#42')
+      expect(typeof finding.fingerprint).toBe('string')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Blocker 2: Production issue/comment fetchers must paginate
+// ---------------------------------------------------------------------------
+
+describe('listCurrentRepoIssues: pagination helper fetches all pages', () => {
+  it('fetches multiple pages until exhausted', async () => {
+    // Simulate two pages: page 1 has 2 items, page 2 has 1 item, page 3 is empty
+    const page1 = [
+      {number: 1, title: 'Issue 1', body: 'body1', labels: [] as {name?: string}[]},
+      {number: 2, title: 'Issue 2', body: 'body2', labels: [] as {name?: string}[]},
+    ]
+    const page2 = [{number: 3, title: 'Issue 3', body: 'body3', labels: [] as {name?: string}[]}]
+
+    let callCount = 0
+    const mockPaginate = async (_fn: unknown, _params: unknown) => {
+      callCount++
+      // paginate returns all items flattened
+      return [...page1, ...page2]
+    }
+
+    const octokit = {
+      paginate: mockPaginate,
+      rest: {
+        pulls: {get: async () => ({data: {state: 'open', merged: false}})},
+        issues: {
+          get: async () => ({data: {state: 'open'}}),
+          listForRepo: async () => ({data: []}),
+          listComments: async () => ({data: []}),
+        },
+        repos: {getReleaseByTag: async () => ({data: {draft: false, prerelease: false}})},
+      },
+    } as unknown as DetectOctokitClient
+
+    const result = await listCurrentRepoIssues(octokit, 'fro-bot', '.github')
+    expect(callCount).toBe(1)
+    expect(result).toHaveLength(3)
+    expect(result[0]?.number).toBe(1)
+    expect(result[2]?.number).toBe(3)
+  })
+
+  it('maps labels correctly, defaulting missing name to empty string', async () => {
+    const rawIssues = [
+      {
+        number: 10,
+        title: 'Labeled issue',
+        body: 'body',
+        labels: [{name: 'bug'}, {name: undefined}] as {name?: string}[],
+      },
+    ]
+
+    const octokit = {
+      paginate: async () => rawIssues,
+      rest: {
+        pulls: {get: async () => ({data: {state: 'open', merged: false}})},
+        issues: {
+          get: async () => ({data: {state: 'open'}}),
+          listForRepo: async () => ({data: []}),
+          listComments: async () => ({data: []}),
+        },
+        repos: {getReleaseByTag: async () => ({data: {draft: false, prerelease: false}})},
+      },
+    } as unknown as DetectOctokitClient
+
+    const result = await listCurrentRepoIssues(octokit, 'fro-bot', '.github')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.labels).toEqual([{name: 'bug'}, {name: ''}])
+  })
+})
+
+describe('listCurrentRepoIssueComments: pagination helper fetches all pages', () => {
+  it('fetches multiple pages of comments until exhausted', async () => {
+    const allComments = [
+      {id: 1, body: 'comment 1'},
+      {id: 2, body: 'comment 2'},
+      {id: 3, body: 'comment 3'},
+    ]
+
+    let callCount = 0
+    const octokit = {
+      paginate: async () => {
+        callCount++
+        return allComments
+      },
+      rest: {
+        pulls: {get: async () => ({data: {state: 'open', merged: false}})},
+        issues: {
+          get: async () => ({data: {state: 'open'}}),
+          listForRepo: async () => ({data: []}),
+          listComments: async () => ({data: []}),
+        },
+        repos: {getReleaseByTag: async () => ({data: {draft: false, prerelease: false}})},
+      },
+    } as unknown as DetectOctokitClient
+
+    const result = await listCurrentRepoIssueComments(octokit, 'fro-bot', '.github', 42)
+    expect(callCount).toBe(1)
+    expect(result).toHaveLength(3)
+    expect(result[0]?.id).toBe(1)
+  })
+
+  it('maps comment body correctly, defaulting undefined body to null', async () => {
+    const rawComments = [
+      {id: 5, body: undefined},
+      {id: 6, body: 'hello'},
+    ]
+
+    const octokit = {
+      paginate: async () => rawComments,
+      rest: {
+        pulls: {get: async () => ({data: {state: 'open', merged: false}})},
+        issues: {
+          get: async () => ({data: {state: 'open'}}),
+          listForRepo: async () => ({data: []}),
+          listComments: async () => ({data: []}),
+        },
+        repos: {getReleaseByTag: async () => ({data: {draft: false, prerelease: false}})},
+      },
+    } as unknown as DetectOctokitClient
+
+    const result = await listCurrentRepoIssueComments(octokit, 'fro-bot', '.github', 42)
+    expect(result).toHaveLength(2)
+    expect(result[0]?.body).toBeNull()
+    expect(result[1]?.body).toBe('hello')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cross-repo status-truth signal: grammar, publicness proof, privacy gates
+// ---------------------------------------------------------------------------
+
+// Helper: build a mock DetectOctokitClient that supports repos.get for publicness
+function makeCrossRepoOctokit(
+  overrides: {
+    repoPublic?: boolean
+    repoThrows?: boolean
+    repoThrowsStatus?: number
+    prState?: string
+    prMerged?: boolean
+    issueState?: string
+    releaseDraft?: boolean
+    prThrows?: boolean
+    issueThrows?: boolean
+    releaseThrows?: boolean
+  } = {},
+): DetectOctokitClient {
+  return {
+    paginate: async () => [],
+    rest: {
+      pulls: {
+        get: async () => {
+          if (overrides.prThrows === true) throw new Error('API error')
+          return {data: {state: overrides.prState ?? 'open', merged: overrides.prMerged ?? false}}
+        },
+      },
+      issues: {
+        get: async () => {
+          if (overrides.issueThrows === true) throw new Error('API error')
+          return {data: {state: overrides.issueState ?? 'open'}}
+        },
+        listForRepo: async () => ({data: []}),
+        listComments: async () => ({data: []}),
+      },
+      repos: {
+        getReleaseByTag: async () => {
+          if (overrides.releaseThrows === true) throw new Error('API error')
+          return {data: {draft: overrides.releaseDraft ?? false, prerelease: false}}
+        },
+        get: async () => {
+          if (overrides.repoThrows === true) {
+            const err = Object.assign(new Error('Not Found'), {status: overrides.repoThrowsStatus ?? 404})
+            throw err
+          }
+          return {data: {private: !(overrides.repoPublic ?? true)}}
+        },
+      },
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cross-repo claim grammar: extractStatusTruthClaimsFromText
+// ---------------------------------------------------------------------------
+
+describe('cross-repo claim grammar: extractStatusTruthClaimsFromText', () => {
+  // PR forms
+  it('parses "fro-bot/agent#1033 is merged" as a cross-repo pr-state claim', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/example.md',
+      text: 'fro-bot/agent#1033 is merged',
+    })
+    const crossRepoPr = claims.filter(c => c.kind === 'pr-state' && 'targetOwner' in c)
+    expect(crossRepoPr).toHaveLength(1)
+    const claim = crossRepoPr[0] as StatusTruthClaim & {targetOwner: string; targetRepo: string}
+    expect(claim.targetOwner).toBe('fro-bot')
+    expect(claim.targetRepo).toBe('agent')
+    expect(claim.claimedState).toBe('merged')
+    expect(claim.sourceRef).toMatch(/^fro-bot\/agent#1033/)
+  })
+
+  it('parses "fro-bot/agent#1033 is open" as a cross-repo pr-state claim', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/example.md',
+      text: 'fro-bot/agent#1033 is open',
+    })
+    const crossRepoPr = claims.filter(c => c.kind === 'pr-state' && 'targetOwner' in c)
+    expect(crossRepoPr).toHaveLength(1)
+    const claim = crossRepoPr[0] as StatusTruthClaim & {targetOwner: string; targetRepo: string}
+    expect(claim.claimedState).toBe('open')
+  })
+
+  it('parses "fro-bot/agent#1033 is closed" as a cross-repo pr-state claim', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/example.md',
+      text: 'fro-bot/agent#1033 is closed',
+    })
+    const crossRepoPr = claims.filter(c => c.kind === 'pr-state' && 'targetOwner' in c)
+    expect(crossRepoPr).toHaveLength(1)
+    const claim = crossRepoPr[0] as StatusTruthClaim & {targetOwner: string; targetRepo: string}
+    expect(claim.claimedState).toBe('closed')
+  })
+
+  // Issue forms
+  it('parses "issue fro-bot/dashboard#48 is open" as a cross-repo issue-state claim', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/example.md',
+      text: 'issue fro-bot/dashboard#48 is open',
+    })
+    const crossRepoIssue = claims.filter(c => c.kind === 'issue-state' && 'targetOwner' in c)
+    expect(crossRepoIssue).toHaveLength(1)
+    const claim = crossRepoIssue[0] as StatusTruthClaim & {targetOwner: string; targetRepo: string}
+    expect(claim.targetOwner).toBe('fro-bot')
+    expect(claim.targetRepo).toBe('dashboard')
+    expect(claim.claimedState).toBe('open')
+    expect(claim.sourceRef).toMatch(/^fro-bot\/dashboard#48/)
+  })
+
+  it('parses "fro-bot/dashboard#48 is closed" as a cross-repo claim (pr-state or issue-state)', () => {
+    // Without an explicit "issue" prefix, "closed" is ambiguous (PR or issue).
+    // The extractor emits a pr-state claim (default for ambiguous open/closed).
+    // Use "issue fro-bot/dashboard#48 is closed" for unambiguous issue-state.
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/example.md',
+      text: 'fro-bot/dashboard#48 is closed',
+    })
+    const crossRepoClaims = claims.filter(
+      c => (c.kind === 'issue-state' || c.kind === 'pr-state') && 'targetOwner' in c,
+    )
+    expect(crossRepoClaims.length).toBeGreaterThan(0)
+    const claim = crossRepoClaims[0] as StatusTruthClaim & {targetOwner: string; targetRepo: string}
+    expect(claim.claimedState).toBe('closed')
+    expect(claim.targetOwner).toBe('fro-bot')
+    expect(claim.targetRepo).toBe('dashboard')
+  })
+
+  // Release forms
+  it('parses "release fro-bot/agent@v0.78.0 is published" as a cross-repo release-tag-state claim', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/example.md',
+      text: 'release fro-bot/agent@v0.78.0 is published',
+    })
+    const crossRepoRelease = claims.filter(c => c.kind === 'release-tag-state' && 'targetOwner' in c)
+    expect(crossRepoRelease).toHaveLength(1)
+    const claim = crossRepoRelease[0] as StatusTruthClaim & {targetOwner: string; targetRepo: string}
+    expect(claim.targetOwner).toBe('fro-bot')
+    expect(claim.targetRepo).toBe('agent')
+    expect(claim.claimedState).toBe('published')
+    expect(claim.sourceRef).toMatch(/^fro-bot\/agent@v0\.78\.0/)
+  })
+
+  it('parses "release fro-bot/agent@v0.78.0 is draft" as a cross-repo release-tag-state claim', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/example.md',
+      text: 'release fro-bot/agent@v0.78.0 is draft',
+    })
+    const crossRepoRelease = claims.filter(c => c.kind === 'release-tag-state' && 'targetOwner' in c)
+    expect(crossRepoRelease).toHaveLength(1)
+    const claim = crossRepoRelease[0] as StatusTruthClaim & {targetOwner: string; targetRepo: string}
+    expect(claim.claimedState).toBe('draft')
+  })
+
+  // Bare #N near cross-repo ref must not be extracted as current-repo
+  it('bare #N near cross-repo ref is not extracted as current-repo (existing guard)', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/example.md',
+      text: 'fro-bot/agent#1033 is merged and PR #1033 is open',
+    })
+    // No bare #1033 current-repo claim
+    expect(claims.filter(c => c.sourceRef === '#1033')).toHaveLength(0)
+    // Cross-repo claim may be present
+    const crossRepoClaims = claims.filter(c => 'targetOwner' in c)
+    expect(crossRepoClaims.length).toBeGreaterThanOrEqual(1)
+  })
+
+  // Cross-repo claim sourceRef must include owner/repo identity
+  it('cross-repo claim sourceRef includes owner/repo identity (not bare #N)', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/example.md',
+      text: 'fro-bot/agent#1033 is merged',
+    })
+    const crossRepoClaims = claims.filter(c => 'targetOwner' in c)
+    for (const claim of crossRepoClaims) {
+      expect(claim.sourceRef).not.toMatch(/^#\d+$/)
+      expect(claim.sourceRef).toContain('fro-bot/agent')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cross-repo publicness proof and resolver
+// ---------------------------------------------------------------------------
+
+describe('resolveClaimLiveState: cross-repo publicness proof', () => {
+  it('cross-repo PR claim resolves to merged when repo is public and PR is merged', async () => {
+    const octokit = makeCrossRepoOctokit({repoPublic: true, prState: 'closed', prMerged: true})
+    const claim: StatusTruthClaim & {targetOwner: string; targetRepo: string} = {
+      kind: 'pr-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'fro-bot/agent#1033',
+      claimedState: 'merged',
+      normalizedText: 'fro-bot/agent#1033 is merged',
+      targetOwner: 'fro-bot',
+      targetRepo: 'agent',
+    }
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') expect(result.state).toBe('merged')
+  })
+
+  it('cross-repo PR claim resolves to open when repo is public and PR is open', async () => {
+    const octokit = makeCrossRepoOctokit({repoPublic: true, prState: 'open', prMerged: false})
+    const claim: StatusTruthClaim & {targetOwner: string; targetRepo: string} = {
+      kind: 'pr-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'fro-bot/agent#1033',
+      claimedState: 'open',
+      normalizedText: 'fro-bot/agent#1033 is open',
+      targetOwner: 'fro-bot',
+      targetRepo: 'agent',
+    }
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') expect(result.state).toBe('open')
+  })
+
+  it('cross-repo issue claim resolves to closed when repo is public and issue is closed', async () => {
+    const octokit = makeCrossRepoOctokit({repoPublic: true, issueState: 'closed'})
+    const claim: StatusTruthClaim & {targetOwner: string; targetRepo: string} = {
+      kind: 'issue-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'fro-bot/dashboard#48',
+      claimedState: 'open',
+      normalizedText: 'issue fro-bot/dashboard#48 is open',
+      targetOwner: 'fro-bot',
+      targetRepo: 'dashboard',
+    }
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') expect(result.state).toBe('closed')
+  })
+
+  it('cross-repo release claim resolves to published when repo is public and release is published', async () => {
+    const octokit = makeCrossRepoOctokit({repoPublic: true, releaseDraft: false})
+    const claim: StatusTruthClaim & {targetOwner: string; targetRepo: string} = {
+      kind: 'release-tag-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'fro-bot/agent@v0.78.0',
+      claimedState: 'published',
+      normalizedText: 'release fro-bot/agent@v0.78.0 is published',
+      targetOwner: 'fro-bot',
+      targetRepo: 'agent',
+    }
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') expect(result.state).toBe('published')
+  })
+
+  it('cross-repo PR claim returns private when repo is private (repos.get returns private:true)', async () => {
+    const octokit = makeCrossRepoOctokit({repoPublic: false})
+    const claim: StatusTruthClaim & {targetOwner: string; targetRepo: string} = {
+      kind: 'pr-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'private-org/private-repo#99',
+      claimedState: 'open',
+      normalizedText: 'private-org/private-repo#99 is open',
+      targetOwner: 'private-org',
+      targetRepo: 'private-repo',
+    }
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('private')
+  })
+
+  it('cross-repo PR claim returns private when repos.get throws 404 (repo not found / private)', async () => {
+    const octokit = makeCrossRepoOctokit({repoThrows: true, repoThrowsStatus: 404})
+    const claim: StatusTruthClaim & {targetOwner: string; targetRepo: string} = {
+      kind: 'pr-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'unknown-org/unknown-repo#1',
+      claimedState: 'open',
+      normalizedText: 'unknown-org/unknown-repo#1 is open',
+      targetOwner: 'unknown-org',
+      targetRepo: 'unknown-repo',
+    }
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('private')
+  })
+
+  it('cross-repo PR claim returns private when repos.get throws 403 (forbidden)', async () => {
+    const octokit = makeCrossRepoOctokit({repoThrows: true, repoThrowsStatus: 403})
+    const claim: StatusTruthClaim & {targetOwner: string; targetRepo: string} = {
+      kind: 'pr-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'forbidden-org/forbidden-repo#1',
+      claimedState: 'open',
+      normalizedText: 'forbidden-org/forbidden-repo#1 is open',
+      targetOwner: 'forbidden-org',
+      targetRepo: 'forbidden-repo',
+    }
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('private')
+  })
+
+  it('cross-repo PR claim returns unavailable (not private) when repo is public but PR API fails after proof', async () => {
+    // Publicness is proven (repo is public), but the PR fetch itself fails.
+    // Identity is already proven public, so result is unavailable (not private).
+    const octokit = makeCrossRepoOctokit({repoPublic: true, prThrows: true})
+    const claim: StatusTruthClaim & {targetOwner: string; targetRepo: string} = {
+      kind: 'pr-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'fro-bot/agent#1033',
+      claimedState: 'open',
+      normalizedText: 'fro-bot/agent#1033 is open',
+      targetOwner: 'fro-bot',
+      targetRepo: 'agent',
+    }
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    // After publicness proof, API failure is unavailable (not private)
+    expect(result.status).toBe('unavailable')
+  })
+
+  it('cross-repo issue claim returns private when repos.get throws 404', async () => {
+    const octokit = makeCrossRepoOctokit({repoThrows: true, repoThrowsStatus: 404})
+    const claim: StatusTruthClaim & {targetOwner: string; targetRepo: string} = {
+      kind: 'issue-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'unknown-org/unknown-repo#48',
+      claimedState: 'open',
+      normalizedText: 'issue unknown-org/unknown-repo#48 is open',
+      targetOwner: 'unknown-org',
+      targetRepo: 'unknown-repo',
+    }
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('private')
+  })
+
+  it('cross-repo release claim returns private when repos.get throws 403', async () => {
+    const octokit = makeCrossRepoOctokit({repoThrows: true, repoThrowsStatus: 403})
+    const claim: StatusTruthClaim & {targetOwner: string; targetRepo: string} = {
+      kind: 'release-tag-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'forbidden-org/forbidden-repo@v1.0.0',
+      claimedState: 'published',
+      normalizedText: 'release forbidden-org/forbidden-repo@v1.0.0 is published',
+      targetOwner: 'forbidden-org',
+      targetRepo: 'forbidden-repo',
+    }
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('private')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Privacy gate: unsafe finding must not expose identity fields
+// ---------------------------------------------------------------------------
+
+describe('cross-repo privacy gate: unsafe finding omits identity fields', () => {
+  it('private cross-repo PR claim produces unsafe finding with no path/sourceRef/claimedState/fingerprint', () => {
+    const claim: StatusTruthClaim & {targetOwner: string; targetRepo: string} = {
+      kind: 'pr-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'private-org/private-repo#99',
+      claimedState: 'open',
+      normalizedText: 'private-org/private-repo#99 is open',
+      targetOwner: 'private-org',
+      targetRepo: 'private-repo',
+    }
+    const resolverResults = makeResolverResults([
+      {kind: 'pr-state', sourceRef: 'private-org/private-repo#99', result: {status: 'private'}},
+    ])
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+    expect(findings).toHaveLength(1)
+    const finding = findings[0]
+    expect(finding?.verdict).toBe('unsafe')
+    expect(finding?.proposalEligible).toBe(false)
+    expect('path' in (finding ?? {})).toBe(false)
+    expect('sourceRef' in (finding ?? {})).toBe(false)
+    expect('claimedState' in (finding ?? {})).toBe(false)
+    expect('fingerprint' in (finding ?? {})).toBe(false)
+    expect('proposedCorrection' in (finding ?? {})).toBe(false)
+    expect('liveState' in (finding ?? {})).toBe(false)
+    // targetOwner/targetRepo must not appear in the finding
+    expect('targetOwner' in (finding ?? {})).toBe(false)
+    expect('targetRepo' in (finding ?? {})).toBe(false)
+  })
+
+  it('public cross-repo PR claim produces public finding with sourceRef including owner/repo identity', () => {
+    const claim: StatusTruthClaim & {targetOwner: string; targetRepo: string} = {
+      kind: 'pr-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'fro-bot/agent#1033',
+      claimedState: 'merged',
+      normalizedText: 'fro-bot/agent#1033 is merged',
+      targetOwner: 'fro-bot',
+      targetRepo: 'agent',
+    }
+    const resolverResults = makeResolverResults([
+      {kind: 'pr-state', sourceRef: 'fro-bot/agent#1033', result: {status: 'resolved', state: 'merged'}},
+    ])
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+    expect(findings).toHaveLength(1)
+    const finding = findings[0]
+    expect(finding?.verdict).toBe('current')
+    if (finding?.verdict === 'current') {
+      // Public finding includes sourceRef with owner/repo identity (proven public)
+      expect(finding.sourceRef).toContain('fro-bot/agent')
+      expect(finding.path).toBe('docs/plans/example.md')
+      expect(typeof finding.fingerprint).toBe('string')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #3512-style coordination signal: end-to-end cross-repo fixture
+// ---------------------------------------------------------------------------
+
+describe('#3512-style cross-repo coordination signal (synthetic public-safe fixtures)', () => {
+  // Inspired by real coordination patterns in issue #3512 (rollout tracker).
+  // All fixtures are synthetic and use public repos only.
+
+  it('synthetic #3512-style: cross-repo closed PR claim becomes drifted when live state is merged', async () => {
+    // Fixture: a coordination comment says "fro-bot/agent#1033 is closed"
+    // but the live PR is actually merged. This is a real drift signal.
+    const text = 'Coordination: fro-bot/agent#1033 is closed'
+    const claims = extractStatusTruthClaimsFromText({path: 'docs/plans/rollout.md', text})
+    const crossRepoClaims = claims.filter(c => 'targetOwner' in c && c.kind === 'pr-state')
+    expect(crossRepoClaims.length).toBeGreaterThan(0)
+
+    const octokit = makeCrossRepoOctokit({repoPublic: true, prState: 'closed', prMerged: true})
+    const {resolverResults} = await resolveAllClaims({
+      claims: crossRepoClaims,
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+    })
+
+    const findings = detectStatusTruthClaims(crossRepoClaims, resolverResults)
+    // At least one finding must be drifted (closed claimed, merged live)
+    const drifted = findings.filter(f => f.verdict === 'drifted')
+    expect(drifted.length).toBeGreaterThan(0)
+    if (drifted[0]?.verdict === 'drifted') {
+      expect(drifted[0].claimedState).toBe('closed')
+      expect(drifted[0].liveState).toBe('merged')
+    }
+  })
+
+  it('synthetic #3512-style: cross-repo open issue claim becomes current when live state is open', async () => {
+    const text = 'Tracking: issue fro-bot/dashboard#48 is open'
+    const claims = extractStatusTruthClaimsFromText({path: 'docs/plans/rollout.md', text})
+    const crossRepoClaims = claims.filter(c => 'targetOwner' in c && c.kind === 'issue-state')
+    expect(crossRepoClaims.length).toBeGreaterThan(0)
+
+    const octokit = makeCrossRepoOctokit({repoPublic: true, issueState: 'open'})
+    const {resolverResults} = await resolveAllClaims({
+      claims: crossRepoClaims,
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+    })
+
+    const findings = detectStatusTruthClaims(crossRepoClaims, resolverResults)
+    const current = findings.filter(f => f.verdict === 'current')
+    expect(current.length).toBeGreaterThan(0)
+  })
+
+  it('synthetic #3512-style: cross-repo merged PR claim is current when live state is merged', async () => {
+    const text = 'Merged: fro-bot/agent#1033 is merged'
+    const claims = extractStatusTruthClaimsFromText({path: 'docs/plans/rollout.md', text})
+    const crossRepoClaims = claims.filter(c => 'targetOwner' in c && c.kind === 'pr-state')
+    expect(crossRepoClaims.length).toBeGreaterThan(0)
+
+    const octokit = makeCrossRepoOctokit({repoPublic: true, prState: 'closed', prMerged: true})
+    const {resolverResults} = await resolveAllClaims({
+      claims: crossRepoClaims,
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+    })
+
+    const findings = detectStatusTruthClaims(crossRepoClaims, resolverResults)
+    const current = findings.filter(f => f.verdict === 'current')
+    expect(current.length).toBeGreaterThan(0)
+  })
+
+  it('synthetic #3512-style: private cross-repo claim produces unsafe finding (zero identity fields)', async () => {
+    const text = 'Blocked by: private-org/private-repo#99 is open'
+    const claims = extractStatusTruthClaimsFromText({path: 'docs/plans/rollout.md', text})
+    const crossRepoClaims = claims.filter(c => 'targetOwner' in c && c.kind === 'pr-state')
+    expect(crossRepoClaims.length).toBeGreaterThan(0)
+
+    const octokit = makeCrossRepoOctokit({repoPublic: false})
+    const {resolverResults} = await resolveAllClaims({
+      claims: crossRepoClaims,
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+    })
+
+    const findings = detectStatusTruthClaims(crossRepoClaims, resolverResults)
+    const unsafe = findings.filter(f => f.verdict === 'unsafe')
+    expect(unsafe.length).toBeGreaterThan(0)
+    for (const finding of unsafe) {
+      expect('path' in finding).toBe(false)
+      expect('sourceRef' in finding).toBe(false)
+      expect('targetOwner' in finding).toBe(false)
+      expect('targetRepo' in finding).toBe(false)
+    }
+  })
+
+  it('plan-status default exclusion is intact: cross-repo scan does not break plan-status exclusion', async () => {
+    // Regression guard: adding cross-repo support must not re-enable plan-status in default scan
+    const fileLister: FileLister = async () => ['docs/plans/my-plan.md']
+    const fileReader: FileReader = async () =>
+      '---\nstatus: active\ntitle: My Plan\n---\n\nfro-bot/agent#1033 is merged'
+
+    const {claims} = await scanStatusTruthClaims({fileLister, fileReader})
+    const planStatusClaims = claims.filter(c => c.kind === 'plan-status')
+    expect(planStatusClaims).toHaveLength(0)
+    // Cross-repo claim should still be extracted (if in DEFAULT_ENABLED_KINDS)
+    const crossRepoClaims = claims.filter(c => 'targetOwner' in c)
+    // Cross-repo pr-state is in DEFAULT_ENABLED_KINDS, so it should be present
+    expect(crossRepoClaims.length).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Ambiguous cross-repo open/closed: PR-first with issue fallback
+// ---------------------------------------------------------------------------
+
+describe('ambiguous cross-repo open/closed: PR-first with issue fallback', () => {
+  // Problem: "marcusrbrown/infra#579 is closed" defaults to pr-state.
+  // When PR lookup 404s but issue lookup succeeds, the finding must be
+  // issue-state (current), not pr-state (unresolved).
+
+  it('RED: ambiguous public owner/repo#N is closed — PR 404, issue closed → issue-state current finding', async () => {
+    // Claim extracted as ambiguous (open/closed without explicit issue prefix)
+    // PR lookup 404s, issue lookup returns closed → must produce issue-state current finding
+    const octokit = makeCrossRepoOctokit({
+      repoPublic: true,
+      prThrows: true, // PR 404
+      issueState: 'closed',
+    })
+    const claim: StatusTruthClaim = {
+      kind: 'pr-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'marcusrbrown/infra#579',
+      claimedState: 'closed',
+      normalizedText: 'marcusrbrown/infra#579 is closed',
+      targetOwner: 'marcusrbrown',
+      targetRepo: 'infra',
+      targetNumberKind: 'ambiguous',
+    }
+
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    // Must resolve as issue-state, not be unavailable
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') {
+      expect(result.state).toBe('closed')
+      // resolvedKind must indicate this resolved as an issue
+      expect(result.resolvedKind).toBe('issue-state')
+    }
+  })
+
+  it('RED: ambiguous public owner/repo#N is open — PR lookup succeeds → pr-state current finding', async () => {
+    // When PR lookup succeeds, kind stays pr-state
+    const octokit = makeCrossRepoOctokit({
+      repoPublic: true,
+      prState: 'open',
+      prMerged: false,
+    })
+    const claim: StatusTruthClaim = {
+      kind: 'pr-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'fro-bot/agent#123',
+      claimedState: 'open',
+      normalizedText: 'fro-bot/agent#123 is open',
+      targetOwner: 'fro-bot',
+      targetRepo: 'agent',
+      targetNumberKind: 'ambiguous',
+    }
+
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') {
+      expect(result.state).toBe('open')
+      // resolvedKind must be pr-state (PR lookup succeeded)
+      expect(result.resolvedKind).toBe('pr-state')
+    }
+  })
+
+  it('RED: ambiguous claim — publicness check still happens before PR/issue lookup', async () => {
+    // repos.get throws 404 → private, no PR or issue lookup attempted
+    const octokit = makeCrossRepoOctokit({repoThrows: true, repoThrowsStatus: 404})
+    const claim: StatusTruthClaim = {
+      kind: 'pr-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'private-org/private-repo#579',
+      claimedState: 'closed',
+      normalizedText: 'private-org/private-repo#579 is closed',
+      targetOwner: 'private-org',
+      targetRepo: 'private-repo',
+      targetNumberKind: 'ambiguous',
+    }
+
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('private')
+  })
+
+  it('RED: ambiguous claim — private repo (private:true) still produces unsafe/no identity fields', async () => {
+    const octokit = makeCrossRepoOctokit({repoPublic: false})
+    const claim: StatusTruthClaim = {
+      kind: 'pr-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'private-org/private-repo#579',
+      claimedState: 'closed',
+      normalizedText: 'private-org/private-repo#579 is closed',
+      targetOwner: 'private-org',
+      targetRepo: 'private-repo',
+      targetNumberKind: 'ambiguous',
+    }
+
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('private')
+  })
+
+  it('RED: ambiguous claim — PR 404 and issue 404 → unresolved (both unavailable after publicness proof)', async () => {
+    const octokit = makeCrossRepoOctokit({
+      repoPublic: true,
+      prThrows: true,
+      issueThrows: true,
+    })
+    const claim: StatusTruthClaim = {
+      kind: 'pr-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'fro-bot/agent#999',
+      claimedState: 'closed',
+      normalizedText: 'fro-bot/agent#999 is closed',
+      targetOwner: 'fro-bot',
+      targetRepo: 'agent',
+      targetNumberKind: 'ambiguous',
+    }
+
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    expect(result.status).toBe('unavailable')
+  })
+
+  it('RED: detectStatusTruthClaims uses resolvedKind to emit issue-state finding for ambiguous claim resolved as issue', () => {
+    // When resolver returns resolvedKind: 'issue-state', the finding kind must be issue-state
+    const claim: StatusTruthClaim = {
+      kind: 'pr-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'marcusrbrown/infra#579',
+      claimedState: 'closed',
+      normalizedText: 'marcusrbrown/infra#579 is closed',
+      targetOwner: 'marcusrbrown',
+      targetRepo: 'infra',
+      targetNumberKind: 'ambiguous',
+    }
+
+    const resolverResults: Record<string, ResolverResult> = {
+      'pr-state:marcusrbrown/infra#579': {
+        status: 'resolved',
+        state: 'closed',
+        resolvedKind: 'issue-state',
+      },
+    }
+
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+    expect(findings).toHaveLength(1)
+    const finding = findings[0]
+    // Finding kind must be issue-state (not pr-state)
+    expect(finding?.kind).toBe('issue-state')
+    expect(finding?.verdict).toBe('current')
+  })
+
+  it('RED: extractStatusTruthClaimsFromText marks ambiguous open/closed cross-repo refs with targetNumberKind=ambiguous', () => {
+    // "marcusrbrown/infra#579 is closed" — no explicit issue prefix, not merged → ambiguous
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/example.md',
+      text: 'marcusrbrown/infra#579 is closed',
+    })
+    const crossRepoClaims = claims.filter(c => 'targetOwner' in c)
+    expect(crossRepoClaims.length).toBeGreaterThan(0)
+    const claim = crossRepoClaims[0]
+    expect(claim?.targetNumberKind).toBe('ambiguous')
+  })
+
+  it('RED: explicit "issue" prefix sets targetNumberKind=issue (not ambiguous)', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/example.md',
+      text: 'issue fro-bot/dashboard#48 is closed',
+    })
+    const crossRepoClaims = claims.filter(c => 'targetOwner' in c && c.kind === 'issue-state')
+    expect(crossRepoClaims.length).toBeGreaterThan(0)
+    const claim = crossRepoClaims[0]
+    // Explicit issue prefix → not ambiguous
+    expect(claim?.targetNumberKind).not.toBe('ambiguous')
+  })
+
+  it('RED: "merged" state sets targetNumberKind=pr (not ambiguous)', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/example.md',
+      text: 'fro-bot/agent#1033 is merged',
+    })
+    const crossRepoClaims = claims.filter(c => 'targetOwner' in c && c.kind === 'pr-state')
+    expect(crossRepoClaims.length).toBeGreaterThan(0)
+    const claim = crossRepoClaims[0]
+    // merged is unambiguously PR
+    expect(claim?.targetNumberKind).toBe('pr')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Blocker 1: Fingerprint stability for ambiguous cross-repo claims
+// ---------------------------------------------------------------------------
+
+describe('fingerprint stability: ambiguous cross-repo claim resolved as pr-state vs issue-state', () => {
+  it('same claim/path/sourceRef/normalizedText produces identical fingerprint regardless of resolvedKind', () => {
+    // The fingerprint must be computed from the extracted claim kind (claim.kind),
+    // not the effective kind (resolvedKind). This prevents fingerprint churn when
+    // the same ambiguous claim resolves differently across runs.
+    const claim: StatusTruthClaim = {
+      kind: 'pr-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'marcusrbrown/infra#579',
+      claimedState: 'closed',
+      normalizedText: 'marcusrbrown/infra#579 is closed',
+      targetOwner: 'marcusrbrown',
+      targetRepo: 'infra',
+      targetNumberKind: 'ambiguous',
+    }
+
+    // Resolver result 1: resolves as pr-state
+    const resolverResultsPr: Record<string, ResolverResult> = {
+      'pr-state:marcusrbrown/infra#579': {
+        status: 'resolved',
+        state: 'closed',
+        resolvedKind: 'pr-state',
+      },
+    }
+
+    // Resolver result 2: resolves as issue-state (PR 404, issue fallback)
+    const resolverResultsIssue: Record<string, ResolverResult> = {
+      'pr-state:marcusrbrown/infra#579': {
+        status: 'resolved',
+        state: 'closed',
+        resolvedKind: 'issue-state',
+      },
+    }
+
+    const findingsPr = detectStatusTruthClaims([claim], resolverResultsPr)
+    const findingsIssue = detectStatusTruthClaims([claim], resolverResultsIssue)
+
+    expect(findingsPr).toHaveLength(1)
+    expect(findingsIssue).toHaveLength(1)
+
+    const fpPr = findingsPr[0]
+    const fpIssue = findingsIssue[0]
+
+    // Both must be public findings (current verdict)
+    expect(fpPr?.verdict).toBe('current')
+    expect(fpIssue?.verdict).toBe('current')
+
+    // Fingerprints must be identical — stable identity regardless of resolution path
+    if (fpPr?.verdict !== 'unsafe' && fpIssue?.verdict !== 'unsafe') {
+      expect(fpPr?.fingerprint).toBe(fpIssue?.fingerprint)
+    }
+
+    // The emitted kind may differ (pr-state vs issue-state) — that's fine
+    expect(fpPr?.kind).toBe('pr-state')
+    expect(fpIssue?.kind).toBe('issue-state')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Blocker 2: proveRepoPublic must be explicit (private === false)
+// ---------------------------------------------------------------------------
+
+describe('proveRepoPublic: explicit private === false check', () => {
+  it('repos.get returning private:undefined is treated as private (not public)', async () => {
+    // When the API returns an unknown/unexpected shape (private: undefined),
+    // the resolver must treat it as private/unsafe — not public.
+    const octokit: DetectOctokitClient = {
+      paginate: async () => [],
+      rest: {
+        pulls: {get: async () => ({data: {state: 'open', merged: false}})},
+        issues: {
+          get: async () => ({data: {state: 'open'}}),
+          listForRepo: async () => ({data: []}),
+          listComments: async () => ({data: []}),
+        },
+        repos: {
+          getReleaseByTag: async () => ({data: {draft: false, prerelease: false}}),
+          // Returns private: undefined — unknown shape
+          get: async () => ({data: {private: undefined as unknown as boolean}}),
+        },
+      },
+    }
+
+    const claim: StatusTruthClaim = {
+      kind: 'pr-state',
+      path: 'docs/plans/example.md',
+      sourceRef: 'some-org/some-repo#1',
+      claimedState: 'open',
+      normalizedText: 'some-org/some-repo#1 is open',
+      targetOwner: 'some-org',
+      targetRepo: 'some-repo',
+      targetNumberKind: 'ambiguous',
+    }
+
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+    // private: undefined must NOT be treated as public — must be private/unsafe
+    expect(result.status).toBe('private')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Detect Octokit construction: no-op log handlers suppress request URL leaks
+// ---------------------------------------------------------------------------
+
+describe('detect Octokit options: log suppression', () => {
+  it('RED: buildDetectOctokitOptions returns options with no-op log handlers', () => {
+    // The detect Octokit must not log request URLs to stderr.
+    // buildDetectOctokitOptions must export options with a log object
+    // whose methods are no-ops (do not write to stderr).
+    const options = buildDetectOctokitOptions('test-token')
+    expect(options).toHaveProperty('log')
+    const log = options.log as Record<string, unknown>
+    expect(typeof log.debug).toBe('function')
+    expect(typeof log.info).toBe('function')
+    expect(typeof log.warn).toBe('function')
+    expect(typeof log.error).toBe('function')
+    // No-op: calling them must not throw and must not write to stderr
+    ;(log.debug as (msg: string) => void)('GET /repos/marcusrbrown/infra/pulls/579 - 404')
+    ;(log.info as (msg: string) => void)('test')
+    ;(log.warn as (msg: string) => void)('test')
+    ;(log.error as (msg: string) => void)('test')
+  })
+
+  it('RED: buildDetectOctokitOptions includes auth token', () => {
+    const options = buildDetectOctokitOptions('my-secret-token')
+    expect(options.auth).toBe('my-secret-token')
   })
 })

--- a/scripts/status-truth-detect.ts
+++ b/scripts/status-truth-detect.ts
@@ -15,6 +15,8 @@ export type FailureClass = 'api-unavailable' | 'file-parse-error' | 'sub-resolve
  *
  * - `resolved`: live state was successfully fetched; `state` holds the value.
  *   Compound resolvers may include `subResolverResults` for required sub-resolvers.
+ *   `resolvedKind` is set when the resolver determined a different kind than the
+ *   claim's declared kind (e.g., ambiguous open/closed resolved as issue-state).
  * - `unavailable`: the source could not be reached (API down, file missing, etc.).
  * - `private`: the source exists but identity is private/unknown — must not be
  *   exposed in findings.
@@ -23,6 +25,7 @@ export type ResolverResult =
   | {
       readonly status: 'resolved'
       readonly state: string
+      readonly resolvedKind?: ClaimKind
       readonly subResolverResults?: Readonly<Record<string, ResolverResult>>
     }
   | {readonly status: 'unavailable'}
@@ -96,6 +99,18 @@ export interface StatusTruthClaim {
   readonly sourceRef: string
   readonly claimedState: string
   readonly normalizedText: string
+  /** Present only for cross-repo claims. Proven public before any identity is emitted. */
+  readonly targetOwner?: string
+  /** Present only for cross-repo claims. Proven public before any identity is emitted. */
+  readonly targetRepo?: string
+  /**
+   * Disambiguation hint for cross-repo open/closed claims.
+   * - `'pr'`: explicitly a PR (e.g., state is 'merged', or explicit PR grammar)
+   * - `'issue'`: explicitly an issue (e.g., 'issue owner/repo#N is ...' prefix)
+   * - `'ambiguous'`: open/closed without explicit prefix — try PR first, then issue
+   * - `undefined`: not a cross-repo claim, or kind is unambiguous
+   */
+  readonly targetNumberKind?: 'pr' | 'issue' | 'ambiguous'
 }
 
 /**
@@ -167,9 +182,28 @@ export function normalizeClaimText(text: string): string {
   return text.trim().toLowerCase().replaceAll(/\s+/gu, ' ')
 }
 
-export function selectFailureClass(scanErrors: number, resolveErrors: number): FailureClass | null {
-  if (scanErrors > 0) return 'file-parse-error'
-  if (resolveErrors > 0) return 'api-unavailable'
+/**
+ * Select the failure class for the detect step, distinguishing file-system scan
+ * errors from GitHub API/issue errors.
+ *
+ * Precedence:
+ * - `file-parse-error`: per-file read/parse errors during file-system scanning
+ * - `api-unavailable`: issue list/comment fetch failures or resolver API errors
+ * - `null`: no errors
+ *
+ * Issue scan errors (issueScanErrors) are API failures — the GitHub issue list
+ * or comment endpoints were unreachable — and must not be reported as
+ * `file-parse-error`. Only `fileScanErrors` (local file read failures) map to
+ * `file-parse-error`.
+ */
+export function selectDetectFailureClass(params: {
+  fileScanErrors: number
+  issueScanErrors: number
+  resolveErrors: number
+}): FailureClass | null {
+  const {fileScanErrors, issueScanErrors, resolveErrors} = params
+  if (fileScanErrors > 0) return 'file-parse-error'
+  if (issueScanErrors > 0 || resolveErrors > 0) return 'api-unavailable'
   return null
 }
 
@@ -239,11 +273,20 @@ function compoundSubResolversAllResolved(
  * - Compound: any required sub-resolver not resolved → unresolved
  * - Live state matches claimed state → current
  * - Live state differs from claimed state → drifted
+ *
+ * When the resolver returns `resolvedKind`, the effective kind for the finding
+ * is `resolvedKind` (e.g., ambiguous open/closed resolved as issue-state).
  */
 function classifyClaim(
   claim: StatusTruthClaim,
   result: ResolverResult | undefined,
-): {verdict: ClaimVerdict; proposalEligible: boolean; proposedCorrection?: string; liveState?: string} {
+): {
+  verdict: ClaimVerdict
+  proposalEligible: boolean
+  proposedCorrection?: string
+  liveState?: string
+  effectiveKind?: ClaimKind
+} {
   if (!result) {
     return {verdict: 'unresolved', proposalEligible: false}
   }
@@ -256,19 +299,20 @@ function classifyClaim(
     return {verdict: 'unresolved', proposalEligible: false}
   }
 
-  const {state: liveState, subResolverResults} = result
+  const {state: liveState, subResolverResults, resolvedKind} = result
+  const effectiveKind = resolvedKind ?? claim.kind
 
-  const def = CLAIM_KIND_DEFINITIONS.find(d => d.kind === claim.kind)
-  if (def?.resolverType === 'compound' && !compoundSubResolversAllResolved(claim.kind, subResolverResults)) {
+  const def = CLAIM_KIND_DEFINITIONS.find(d => d.kind === effectiveKind)
+  if (def?.resolverType === 'compound' && !compoundSubResolversAllResolved(effectiveKind, subResolverResults)) {
     return {verdict: 'unresolved', proposalEligible: false}
   }
 
   if (liveState === claim.claimedState) {
-    return {verdict: 'current', proposalEligible: false, liveState}
+    return {verdict: 'current', proposalEligible: false, liveState, effectiveKind}
   }
 
   const proposedCorrection = buildProposedCorrection(claim, liveState)
-  return {verdict: 'drifted', proposalEligible: true, proposedCorrection, liveState}
+  return {verdict: 'drifted', proposalEligible: true, proposedCorrection, liveState, effectiveKind}
 }
 
 /** Resolver type processing order: file-parse → api → compound. */
@@ -299,19 +343,24 @@ export function detectStatusTruthClaims(
   for (const claim of sorted) {
     const resultKey = `${claim.kind}:${claim.sourceRef}`
     const result = resolverResults[resultKey]
-    const {verdict, proposalEligible, proposedCorrection, liveState} = classifyClaim(claim, result)
+    const {verdict, proposalEligible, proposedCorrection, liveState, effectiveKind} = classifyClaim(claim, result)
+    // Use effectiveKind when the resolver determined a different kind (e.g., ambiguous → issue-state)
+    const findingKind = effectiveKind ?? claim.kind
 
     if (verdict === 'unsafe') {
       const finding: UnsafeStatusTruthFinding = {
-        kind: claim.kind,
+        kind: findingKind,
         verdict: 'unsafe',
         proposalEligible: false,
       }
       findings.push(finding)
     } else {
+      // Fingerprint uses the extracted claim kind (claim.kind), not the effective kind.
+      // This keeps proposal identity stable even when ambiguous claims resolve differently
+      // across runs (e.g., pr-state vs issue-state fallback for open/closed cross-repo refs).
       const fingerprint = computeClaimFingerprint(claim.kind, claim.path, claim.sourceRef, claim.normalizedText)
       const finding: PublicStatusTruthFinding = {
-        kind: claim.kind,
+        kind: findingKind,
         path: claim.path,
         sourceRef: claim.sourceRef,
         verdict,
@@ -422,6 +471,27 @@ function isExcludedPath(filePath: string): boolean {
 const CROSS_REPO_REF_PATTERN = /\b[\w.-]+\/[\w.-]+#(\d+)\b/gu
 
 /**
+ * Cross-repo PR/issue claim grammar patterns.
+ *
+ * Matches:
+ *   - `owner/repo#N is merged|open|closed`  (PR or issue — disambiguated by state)
+ *   - `issue owner/repo#N is open|closed`   (explicit issue prefix)
+ *   - `release owner/repo@tag is published|draft|unpublished`
+ *
+ * Groups: [owner, repo, number, state]
+ */
+const CROSS_REPO_PR_ISSUE_PATTERN = /\b(?:(issue)\s+)?([\w.-]+)\/([\w.-]+)#(\d+)\s+is\s+(merged|open|closed)\b/giu
+
+/**
+ * Cross-repo release/tag claim grammar pattern.
+ *
+ * Matches: `release owner/repo@tag is published|draft|unpublished`
+ * Groups: [owner, repo, tag, state]
+ */
+const CROSS_REPO_RELEASE_PATTERN =
+  /\brelease\s+([\w.-]+)\/([\w.-]+)@([\w.-]+)\s+is\s+(published|draft|unpublished)\b/giu
+
+/**
  * Build a set of issue/PR numbers that appear in cross-repo references
  * within the given text. These numbers must not be extracted as bare #N
  * current-repo references.
@@ -509,6 +579,76 @@ export function extractStatusTruthClaimsFromText(params: {path: string; text: st
     }
   }
 
+  // ---------------------------------------------------------------------------
+  // Cross-repo claim extraction
+  // ---------------------------------------------------------------------------
+
+  // Extract cross-repo PR/issue claims: `[issue] owner/repo#N is merged|open|closed`
+  for (const match of text.matchAll(CROSS_REPO_PR_ISSUE_PATTERN)) {
+    const issuePrefix = match[1] // 'issue' or undefined
+    const owner = match[2]
+    const repo = match[3]
+    const number = match[4]
+    const state = match[5]
+    if (owner === undefined || repo === undefined || number === undefined || state === undefined) continue
+
+    const fullMatch = match[0]
+    const normalizedText = normalizeClaimText(fullMatch)
+    const claimedState = state.toLowerCase()
+
+    // Disambiguate: if state is 'merged', it's a PR. If 'issue' prefix, it's an issue.
+    // Otherwise 'open'/'closed' could be either — mark as ambiguous for PR-first resolution.
+    let kind: ClaimKind
+    let targetNumberKind: 'pr' | 'issue' | 'ambiguous'
+    if (issuePrefix !== undefined) {
+      kind = 'issue-state'
+      targetNumberKind = 'issue'
+    } else if (claimedState === 'merged') {
+      kind = 'pr-state'
+      targetNumberKind = 'pr'
+    } else {
+      // 'open' or 'closed' without 'issue' prefix — ambiguous (PR or issue)
+      kind = 'pr-state'
+      targetNumberKind = 'ambiguous'
+    }
+
+    const sourceRef = `${owner}/${repo}#${number}`
+    claims.push({
+      kind,
+      path,
+      sourceRef,
+      claimedState,
+      normalizedText,
+      targetOwner: owner,
+      targetRepo: repo,
+      targetNumberKind,
+    })
+  }
+
+  // Extract cross-repo release claims: `release owner/repo@tag is published|draft|unpublished`
+  for (const match of text.matchAll(CROSS_REPO_RELEASE_PATTERN)) {
+    const owner = match[1]
+    const repo = match[2]
+    const tag = match[3]
+    const state = match[4]
+    if (owner === undefined || repo === undefined || tag === undefined || state === undefined) continue
+
+    const fullMatch = match[0]
+    const normalizedText = normalizeClaimText(fullMatch)
+    const claimedState = state.toLowerCase()
+    const sourceRef = `${owner}/${repo}@${tag}`
+
+    claims.push({
+      kind: 'release-tag-state',
+      path,
+      sourceRef,
+      claimedState,
+      normalizedText,
+      targetOwner: owner,
+      targetRepo: repo,
+    })
+  }
+
   return claims
 }
 
@@ -525,11 +665,30 @@ export type FileReader = (filePath: string) => Promise<string>
 export type FileLister = () => Promise<string[]>
 
 /**
+ * Claim kinds enabled by default in production scans.
+ *
+ * `plan-status` is intentionally excluded from the default set because
+ * `resolveClaimLiveState` returns `unavailable` for it (no file-parse resolver
+ * exists yet). Including it would produce 100% unresolved findings with zero
+ * signal — pure noise in dry-run output.
+ *
+ * Callers may opt in by passing `enabledKinds` explicitly.
+ */
+export const DEFAULT_ENABLED_KINDS: readonly ClaimKind[] = [
+  'pr-state',
+  'issue-state',
+  'release-tag-state',
+  'rollout-tracker-status',
+]
+
+/**
  * Scan a bounded set of public docs paths for status-truth claims.
  *
  * @param params - Scan parameters.
  * @param params.fileLister - Injected function that returns the list of paths to scan.
  * @param params.fileReader - Injected function that reads a file's text content.
+ * @param params.enabledKinds - Claim kinds to include. Defaults to DEFAULT_ENABLED_KINDS
+ *   (excludes plan-status until a real file-parse resolver exists).
  * @returns All extracted claims from all scanned files.
  *
  * Scan failures for individual files are counted but do not abort the scan.
@@ -538,8 +697,9 @@ export type FileLister = () => Promise<string[]>
 export async function scanStatusTruthClaims(params: {
   fileLister: FileLister
   fileReader: FileReader
+  enabledKinds?: readonly ClaimKind[]
 }): Promise<{claims: StatusTruthClaim[]; scanErrors: number}> {
-  const {fileLister, fileReader} = params
+  const {fileLister, fileReader, enabledKinds = DEFAULT_ENABLED_KINDS} = params
   const paths = await fileLister()
   const claims: StatusTruthClaim[] = []
   let scanErrors = 0
@@ -548,10 +708,163 @@ export async function scanStatusTruthClaims(params: {
     if (isExcludedPath(filePath)) continue
     try {
       const text = await fileReader(filePath)
-      const fileClaims = extractStatusTruthClaimsFromText({path: filePath, text})
+      const fileClaims = extractStatusTruthClaimsFromText({path: filePath, text}).filter(c =>
+        enabledKinds.includes(c.kind),
+      )
       claims.push(...fileClaims)
     } catch {
       // Count per-file read errors; do not abort the scan
+      scanErrors++
+    }
+  }
+
+  return {claims, scanErrors}
+}
+
+// ---------------------------------------------------------------------------
+// Unit 4: GitHub issue body/comment scanning
+// ---------------------------------------------------------------------------
+
+/**
+ * A minimal issue list item returned by the issue lister.
+ * Injected for testability; production uses Octokit list response.
+ */
+export interface IssueListItem {
+  readonly number: number
+  readonly title: string
+  readonly body: string | null
+  readonly labels: readonly {readonly name: string}[]
+}
+
+/**
+ * A minimal issue comment returned by the comment fetcher.
+ * Injected for testability; production uses Octokit list response.
+ */
+export interface IssueComment {
+  readonly id: number
+  readonly body: string | null
+}
+
+/**
+ * Injected issue lister type for testability.
+ * Production: calls Octokit issues.listForRepo. Tests: returns fixture data.
+ */
+export type IssueLister = (params: {owner: string; repo: string}) => Promise<IssueListItem[]>
+
+/**
+ * Injected issue comment fetcher type for testability.
+ * Production: calls Octokit issues.listComments. Tests: returns fixture data.
+ */
+export type IssueCommentFetcher = (params: {
+  owner: string
+  repo: string
+  issueNumber: number
+}) => Promise<IssueComment[]>
+
+/**
+ * Labels and title markers that identify status-truth proposal issues.
+ * Issues matching any of these are excluded from scanning to prevent
+ * the loop from scanning its own proposal state.
+ */
+const STATUS_TRUTH_PROPOSAL_LABELS: readonly string[] = ['status-truth']
+const STATUS_TRUTH_PROPOSAL_TITLE_MARKER = '[status-truth-proposal]'
+
+/**
+ * Check whether an issue is a status-truth proposal issue that should be excluded.
+ * Matches by label name or title prefix/marker.
+ */
+function isStatusTruthProposalIssue(issue: IssueListItem): boolean {
+  for (const label of issue.labels) {
+    if (STATUS_TRUTH_PROPOSAL_LABELS.includes(label.name)) return true
+  }
+  return issue.title.toLowerCase().includes(STATUS_TRUTH_PROPOSAL_TITLE_MARKER)
+}
+
+/**
+ * Build a synthetic public-safe path for an issue body source.
+ * Format: `github-issue://current/issues/<number>#body`
+ *
+ * Uses `current` instead of `owner/repo` so that generic code does not
+ * embed identity before explicit publicness proof. The resolver already
+ * knows the owner/repo from its own context.
+ */
+function issueBodyPath(issueNumber: number): string {
+  return `github-issue://current/issues/${issueNumber}#body`
+}
+
+/**
+ * Build a synthetic public-safe path for an issue comment source.
+ * Format: `github-issue://current/issues/<number>#comment-<id>`
+ *
+ * Uses `current` instead of `owner/repo` for the same reason as issueBodyPath.
+ */
+function issueCommentPath(issueNumber: number, commentId: number): string {
+  return `github-issue://current/issues/${issueNumber}#comment-${commentId}`
+}
+
+/**
+ * Scan current-repo GitHub issue bodies and comments for status-truth claims.
+ *
+ * @param params - Scan parameters.
+ * @param params.owner - Repository owner.
+ * @param params.repo - Repository name.
+ * @param params.issueLister - Injected function that returns open issues.
+ * @param params.commentFetcher - Injected function that returns comments for an issue.
+ * @param params.enabledKinds - Claim kinds to include. Defaults to DEFAULT_ENABLED_KINDS.
+ * @returns Extracted claims and scan error count.
+ *
+ * Failure behavior:
+ * - If the issue list fetch fails, returns scanErrors > 0 and empty claims (non-clean).
+ * - Per-issue comment fetch failures count as scan errors but do not abort body scanning.
+ * - Issues labeled `status-truth` or containing the proposal marker are skipped.
+ * - Null bodies/comments are silently skipped (no error).
+ */
+export async function scanIssueStatusTruthClaims(params: {
+  owner: string
+  repo: string
+  issueLister: IssueLister
+  commentFetcher: IssueCommentFetcher
+  enabledKinds?: readonly ClaimKind[]
+}): Promise<{claims: StatusTruthClaim[]; scanErrors: number}> {
+  const {owner, repo, issueLister, commentFetcher, enabledKinds = DEFAULT_ENABLED_KINDS} = params
+  const claims: StatusTruthClaim[] = []
+  let scanErrors = 0
+
+  let issues: IssueListItem[]
+  try {
+    issues = await issueLister({owner, repo})
+  } catch {
+    // Issue list fetch failure — non-clean, report as scan error
+    scanErrors++
+    return {claims, scanErrors}
+  }
+
+  for (const issue of issues) {
+    // Skip status-truth proposal issues to prevent self-scanning
+    if (isStatusTruthProposalIssue(issue)) continue
+
+    // Scan issue body
+    if (issue.body !== null && issue.body !== '') {
+      const bodyPath = issueBodyPath(issue.number)
+      const bodyClaims = extractStatusTruthClaimsFromText({path: bodyPath, text: issue.body}).filter(c =>
+        enabledKinds.includes(c.kind),
+      )
+      claims.push(...bodyClaims)
+    }
+
+    // Scan issue comments
+    try {
+      const comments = await commentFetcher({owner, repo, issueNumber: issue.number})
+      for (const comment of comments) {
+        if (comment.body === null || comment.body === '') continue
+        const commentPath = issueCommentPath(issue.number, comment.id)
+        const commentClaims = extractStatusTruthClaimsFromText({path: commentPath, text: comment.body}).filter(c =>
+          enabledKinds.includes(c.kind),
+        )
+        claims.push(...commentClaims)
+      }
+    } catch {
+      // Per-issue comment fetch failure — count as scan error, continue with other issues
       scanErrors++
     }
   }
@@ -566,8 +879,13 @@ export async function scanStatusTruthClaims(params: {
 /**
  * Minimal Octokit-like client for the detect step (read-only).
  * Injected for testability; production code uses @octokit/rest Octokit.
+ *
+ * `paginate` mirrors the Octokit paginate API: given a REST endpoint function
+ * and its params, it fetches all pages and returns the flattened data array.
+ * This is the only supported pagination mechanism for issue/comment listing.
  */
 export interface DetectOctokitClient {
+  readonly paginate: <T>(fn: unknown, params: unknown) => Promise<T[]>
   readonly rest: {
     readonly pulls: {
       readonly get: (params: {owner: string; repo: string; pull_number: number}) => Promise<{
@@ -578,13 +896,87 @@ export interface DetectOctokitClient {
       readonly get: (params: {owner: string; repo: string; issue_number: number}) => Promise<{
         data: {state: string}
       }>
+      readonly listForRepo: (params: {
+        owner: string
+        repo: string
+        state: 'open' | 'closed' | 'all'
+        per_page: number
+      }) => Promise<{
+        data: {
+          number: number
+          title: string
+          body: string | null
+          labels: {name?: string | undefined}[]
+        }[]
+      }>
+      readonly listComments: (params: {
+        owner: string
+        repo: string
+        issue_number: number
+        per_page: number
+      }) => Promise<{
+        data: {id: number; body?: string | null | undefined}[]
+      }>
     }
     readonly repos: {
       readonly getReleaseByTag: (params: {owner: string; repo: string; tag: string}) => Promise<{
         data: {draft: boolean; prerelease: boolean}
       }>
+      /**
+       * Used for cross-repo publicness proof.
+       * Returns `{data: {private: boolean}}`.
+       * Throws with `.status` 403 or 404 when the repo is inaccessible/private.
+       */
+      readonly get: (params: {owner: string; repo: string}) => Promise<{
+        data: {private: boolean}
+      }>
     }
   }
+}
+
+/**
+ * Fetch all open issues for the current repo using Octokit pagination.
+ *
+ * Uses `octokit.paginate` to fetch every page, so "clean" cannot mean
+ * "nothing in the first 100 results". Exported for unit-testability.
+ */
+export async function listCurrentRepoIssues(
+  octokit: DetectOctokitClient,
+  owner: string,
+  repo: string,
+): Promise<IssueListItem[]> {
+  const raw = await octokit.paginate<{
+    number: number
+    title: string
+    body: string | null
+    labels: {name?: string | undefined}[]
+  }>(octokit.rest.issues.listForRepo, {owner, repo, state: 'open', per_page: 100})
+  return raw.map(issue => ({
+    number: issue.number,
+    title: issue.title,
+    body: issue.body,
+    labels: issue.labels.map(l => ({name: l.name ?? ''})),
+  }))
+}
+
+/**
+ * Fetch all comments for a single issue using Octokit pagination.
+ *
+ * Uses `octokit.paginate` to fetch every page. Exported for unit-testability.
+ */
+export async function listCurrentRepoIssueComments(
+  octokit: DetectOctokitClient,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): Promise<IssueComment[]> {
+  const raw = await octokit.paginate<{id: number; body?: string | null | undefined}>(octokit.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: issueNumber,
+    per_page: 100,
+  })
+  return raw.map(c => ({id: c.id, body: c.body ?? null}))
 }
 
 /**
@@ -599,6 +991,25 @@ export interface DetectOctokitClient {
  * Plan-status: resolved via file-parse (not this function)
  * Rollout-tracker: compound — returns unavailable (Phase 1 scope cut)
  */
+/**
+ * Prove that a target repo is public using `repos.get`.
+ *
+ * Returns `true` if the repo is confirmed public.
+ * Returns `false` if the repo is private (`data.private === true`).
+ * Throws with `{status: 'private'}` sentinel if the API throws 403/404 or any
+ * other error before publicness is confirmed — callers must treat this as private.
+ *
+ * This is the ONLY gate before cross-repo identity is exposed in findings.
+ */
+async function proveRepoPublic(
+  octokit: DetectOctokitClient,
+  targetOwner: string,
+  targetRepo: string,
+): Promise<boolean> {
+  const {data} = await octokit.rest.repos.get({owner: targetOwner, repo: targetRepo})
+  return data.private === false
+}
+
 export async function resolveClaimLiveState(params: {
   claim: StatusTruthClaim
   octokit: DetectOctokitClient
@@ -606,6 +1017,92 @@ export async function resolveClaimLiveState(params: {
   repo: string
 }): Promise<ResolverResult> {
   const {claim, octokit, owner, repo} = params
+
+  // ---------------------------------------------------------------------------
+  // Cross-repo resolution: publicness proof required before any identity exposure
+  // ---------------------------------------------------------------------------
+  if (claim.targetOwner !== undefined && claim.targetRepo !== undefined) {
+    const targetOwner = claim.targetOwner
+    const targetRepo = claim.targetRepo
+
+    // Step 1: Prove publicness. Any failure before proof → private.
+    let isPublic: boolean
+    try {
+      isPublic = await proveRepoPublic(octokit, targetOwner, targetRepo)
+    } catch {
+      // 403, 404, or any other error before proof → treat as private
+      return {status: 'private'}
+    }
+
+    if (!isPublic) {
+      return {status: 'private'}
+    }
+
+    // Step 2: Publicness proven. Resolve against target repo.
+    // API failure AFTER proof → unavailable (identity already proven public).
+    if (claim.kind === 'pr-state') {
+      const match = /^[\w.-]+\/[\w.-]+#(\d+)$/u.exec(claim.sourceRef)
+      if (match === null || match[1] === undefined) return {status: 'unavailable'}
+      const prNumber = Number.parseInt(match[1], 10)
+
+      // Ambiguous open/closed: try PR first, fall back to issue if PR lookup fails
+      if (claim.targetNumberKind === 'ambiguous') {
+        try {
+          const {data} = await octokit.rest.pulls.get({owner: targetOwner, repo: targetRepo, pull_number: prNumber})
+          if (data.merged) return {status: 'resolved', state: 'merged', resolvedKind: 'pr-state'}
+          return {status: 'resolved', state: data.state === 'open' ? 'open' : 'closed', resolvedKind: 'pr-state'}
+        } catch {
+          // PR lookup failed — try issue fallback
+        }
+        try {
+          const {data} = await octokit.rest.issues.get({
+            owner: targetOwner,
+            repo: targetRepo,
+            issue_number: prNumber,
+          })
+          return {status: 'resolved', state: data.state === 'open' ? 'open' : 'closed', resolvedKind: 'issue-state'}
+        } catch {
+          return {status: 'unavailable'}
+        }
+      }
+
+      // Explicit PR (merged, or targetNumberKind === 'pr')
+      try {
+        const {data} = await octokit.rest.pulls.get({owner: targetOwner, repo: targetRepo, pull_number: prNumber})
+        if (data.merged) return {status: 'resolved', state: 'merged'}
+        return {status: 'resolved', state: data.state === 'open' ? 'open' : 'closed'}
+      } catch {
+        return {status: 'unavailable'}
+      }
+    }
+
+    if (claim.kind === 'issue-state') {
+      const match = /^[\w.-]+\/[\w.-]+#(\d+)$/u.exec(claim.sourceRef)
+      if (match === null || match[1] === undefined) return {status: 'unavailable'}
+      const issueNumber = Number.parseInt(match[1], 10)
+      try {
+        const {data} = await octokit.rest.issues.get({owner: targetOwner, repo: targetRepo, issue_number: issueNumber})
+        return {status: 'resolved', state: data.state === 'open' ? 'open' : 'closed'}
+      } catch {
+        return {status: 'unavailable'}
+      }
+    }
+
+    if (claim.kind === 'release-tag-state') {
+      const match = /^[\w.-]+\/[\w.-]+@(.+)$/u.exec(claim.sourceRef)
+      if (match === null || match[1] === undefined) return {status: 'unavailable'}
+      const tag = match[1]
+      try {
+        const {data} = await octokit.rest.repos.getReleaseByTag({owner: targetOwner, repo: targetRepo, tag})
+        return {status: 'resolved', state: data.draft ? 'draft' : 'published'}
+      } catch {
+        return {status: 'unavailable'}
+      }
+    }
+
+    // Unsupported cross-repo claim kind
+    return {status: 'unavailable'}
+  }
 
   if (claim.kind === 'plan-status') {
     // plan-status requires cross-file comparison to detect drift, which is out of
@@ -796,6 +1293,47 @@ export function validateStatusTruthArtifact(
 }
 
 // ---------------------------------------------------------------------------
+// Unit 4: Octokit construction helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * No-op logger that satisfies the Octokit log interface without writing to stderr.
+ *
+ * The default Octokit logger writes request URLs and error details to stderr,
+ * which leaks raw source refs (e.g., `GET /repos/owner/repo/pulls/579 - 404`)
+ * from caught errors. This no-op logger suppresses all output while still
+ * satisfying the interface contract.
+ */
+const NOOP_LOGGER = {
+  debug: (_msg: string) => undefined,
+  info: (_msg: string) => undefined,
+  warn: (_msg: string) => undefined,
+  error: (_msg: string) => undefined,
+}
+
+/**
+ * Build Octokit constructor options for the detect step.
+ *
+ * Includes:
+ * - `auth`: the GitHub token
+ * - `request.timeout`: 10 second timeout
+ * - `log`: no-op logger to suppress request URL leaks to stderr
+ *
+ * Exported for testability — callers can verify the log handlers are no-ops.
+ */
+export function buildDetectOctokitOptions(token: string): {
+  auth: string
+  request: {timeout: number}
+  log: typeof NOOP_LOGGER
+} {
+  return {
+    auth: token,
+    request: {timeout: 10_000},
+    log: NOOP_LOGGER,
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Unit 4: CLI shell
 // ---------------------------------------------------------------------------
 
@@ -861,35 +1399,51 @@ async function runDetect(): Promise<void> {
   let report: StatusTruthJsonReport
 
   try {
-    // Step 1: Scan for claims
-    const {claims, scanErrors} = await scanStatusTruthClaims({fileLister, fileReader})
+    // Step 1: Scan file-system docs for claims (plan-status excluded by default)
+    const {claims: fileClaims, scanErrors: fileScanErrors} = await scanStatusTruthClaims({fileLister, fileReader})
 
-    // Step 2: Resolve live state
-    // Build Octokit client if token is available; otherwise all claims become unavailable
+    // Step 2: Resolve live state and scan GitHub issues (if token available)
     const token = process.env.GITHUB_TOKEN
     let resolverResults: Record<string, ResolverResult> = {}
     let resolveErrors = 0
+    let issueScanErrors = 0
+    let issueClaims: StatusTruthClaim[] = []
 
     if (token !== undefined && token !== '') {
       const {Octokit} = await import('@octokit/rest')
-      const octokit = new Octokit({auth: token, request: {timeout: 10_000}}) as unknown as DetectOctokitClient
-      const resolved = await resolveAllClaims({claims, octokit, owner, repo})
+      const octokit = new Octokit(buildDetectOctokitOptions(token)) as unknown as DetectOctokitClient
+
+      // Build injected issue lister/comment fetcher using paginated helpers
+      // (avoids the per_page:100 truncation bug — fetches all pages)
+      const issueLister: IssueLister = async ({owner: o, repo: r}) => listCurrentRepoIssues(octokit, o, r)
+
+      const commentFetcher: IssueCommentFetcher = async ({owner: o, repo: r, issueNumber}) =>
+        listCurrentRepoIssueComments(octokit, o, r, issueNumber)
+
+      // Scan GitHub issue bodies and comments
+      const issueResult = await scanIssueStatusTruthClaims({owner, repo, issueLister, commentFetcher})
+      issueClaims = issueResult.claims
+      issueScanErrors = issueResult.scanErrors
+
+      // Resolve all claims (file + issue) against live state
+      const allClaims = [...fileClaims, ...issueClaims]
+      const resolved = await resolveAllClaims({claims: allClaims, octokit, owner, repo})
       resolverResults = resolved.resolverResults
       resolveErrors = resolved.resolveErrors
     }
     // If no token: all API claims remain unresolved (resolverResults stays empty)
 
-    // Step 3: Classify claims into findings
-    const findings = detectStatusTruthClaims(claims, resolverResults)
+    // Step 3: Classify all claims into findings
+    const allClaims = [...fileClaims, ...issueClaims]
+    const findings = detectStatusTruthClaims(allClaims, resolverResults)
 
-    // Scan is complete if no per-file or resolve errors occurred.
+    // Scan is complete if no per-file, issue-scan, or resolve errors occurred.
     // Failure class distinguishes the error source:
-    // - file-parse-error: per-file read/parse errors during scanning
-    // - api-unavailable: resolver/API errors after scanning succeeded
-    const totalErrors = scanErrors + resolveErrors
-    const scanComplete = totalErrors === 0
+    // - file-parse-error: per-file read/parse errors during file-system scanning
+    // - api-unavailable: issue list/comment fetch failures or resolver API errors
+    const scanComplete = fileScanErrors === 0 && issueScanErrors === 0 && resolveErrors === 0
 
-    const failureClass = selectFailureClass(scanErrors, resolveErrors)
+    const failureClass = selectDetectFailureClass({fileScanErrors, issueScanErrors, resolveErrors})
 
     report = buildStatusTruthReport({
       findings,

--- a/scripts/status-truth-proposals.test.ts
+++ b/scripts/status-truth-proposals.test.ts
@@ -19,12 +19,16 @@ import {describe, expect, it} from 'vitest'
 import {
   executeStatusTruthProposalActions,
   extractProposalFingerprint,
+  extractRedactedCanonicalIds,
   fetchExistingProposalIssues,
+  loadRedactedCanonicalIdsFromDisk,
+  NOOP_LOG,
   OUTCOME_LABELS,
   planStatusTruthProposalActions,
   PROPOSAL_LABEL,
   REQUIRED_LABELS,
 } from './status-truth-proposals.ts'
+import {applyPublicOutputGate, makePublicOutputTokens} from './status-truth-public-output.ts'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1448,6 +1452,306 @@ describe('fetchExistingProposalIssues', () => {
 })
 
 // ---------------------------------------------------------------------------
+// extractRedactedCanonicalIds — pure helper
+// ---------------------------------------------------------------------------
+
+describe('extractRedactedCanonicalIds', () => {
+  it('extracts node_id from private entries', () => {
+    const repos = [
+      {
+        owner: '[REDACTED]',
+        name: 'R_kgDOFIXTURE001',
+        private: true,
+        node_id: 'R_kgDOFIXTURE001',
+        added: '2026-01-01',
+        onboarding_status: 'onboarded' as const,
+        last_survey_at: null,
+        last_survey_status: null,
+        has_fro_bot_workflow: false,
+        has_renovate: false,
+      },
+    ]
+    const ids = extractRedactedCanonicalIds(repos)
+    expect(ids.has('R_kgDOFIXTURE001')).toBe(true)
+  })
+
+  it('extracts database_id as string from private entries', () => {
+    const repos = [
+      {
+        owner: '[REDACTED]',
+        name: 'R_kgDOFIXTURE002',
+        private: true,
+        node_id: 'R_kgDOFIXTURE002',
+        database_id: 987654321,
+        added: '2026-01-01',
+        onboarding_status: 'onboarded' as const,
+        last_survey_at: null,
+        last_survey_status: null,
+        has_fro_bot_workflow: false,
+        has_renovate: false,
+      },
+    ]
+    const ids = extractRedactedCanonicalIds(repos)
+    expect(ids.has('987654321')).toBe(true)
+  })
+
+  it('does NOT include node_id or database_id from public (non-private) entries', () => {
+    const repos = [
+      {
+        owner: 'fro-bot',
+        name: 'public-repo',
+        private: false,
+        node_id: 'R_kgDOPUBLIC001',
+        database_id: 111111111,
+        added: '2026-01-01',
+        onboarding_status: 'onboarded' as const,
+        last_survey_at: null,
+        last_survey_status: null,
+        has_fro_bot_workflow: false,
+        has_renovate: false,
+      },
+    ]
+    const ids = extractRedactedCanonicalIds(repos)
+    expect(ids.has('R_kgDOPUBLIC001')).toBe(false)
+    expect(ids.has('111111111')).toBe(false)
+  })
+
+  it('does NOT include IDs from entries where private is undefined (treat-as-private fail-safe: excluded from redactedCanonicalIds)', () => {
+    // Entries with private===undefined have no confirmed canonical IDs to redact
+    // (they have no node_id in practice). They are excluded from redactedCanonicalIds.
+    const repos = [
+      {
+        owner: 'fro-bot',
+        name: 'legacy-repo',
+        added: '2026-01-01',
+        onboarding_status: 'onboarded' as const,
+        last_survey_at: null,
+        last_survey_status: null,
+        has_fro_bot_workflow: false,
+        has_renovate: false,
+      },
+    ]
+    const ids = extractRedactedCanonicalIds(repos)
+    expect(ids.size).toBe(0)
+  })
+
+  it('returns empty set for empty repos array', () => {
+    const ids = extractRedactedCanonicalIds([])
+    expect(ids.size).toBe(0)
+  })
+
+  it('includes both node_id and database_id when both are present on a private entry', () => {
+    const repos = [
+      {
+        owner: '[REDACTED]',
+        name: 'R_kgDOFIXTURE003',
+        private: true,
+        node_id: 'R_kgDOFIXTURE003',
+        database_id: 123456789,
+        added: '2026-01-01',
+        onboarding_status: 'onboarded' as const,
+        last_survey_at: null,
+        last_survey_status: null,
+        has_fro_bot_workflow: false,
+        has_renovate: false,
+      },
+    ]
+    const ids = extractRedactedCanonicalIds(repos)
+    expect(ids.has('R_kgDOFIXTURE003')).toBe(true)
+    expect(ids.has('123456789')).toBe(true)
+    expect(ids.size).toBe(2)
+  })
+
+  it('handles private entry with no node_id or database_id gracefully (empty contribution)', () => {
+    const repos = [
+      {
+        owner: '[REDACTED]',
+        name: '[REDACTED]',
+        private: true,
+        added: '2026-01-01',
+        onboarding_status: 'onboarded' as const,
+        last_survey_at: null,
+        last_survey_status: null,
+        has_fro_bot_workflow: false,
+        has_renovate: false,
+      },
+    ]
+    const ids = extractRedactedCanonicalIds(repos)
+    expect(ids.size).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// loadRedactedCanonicalIdsFromDisk — disk loader
+// ---------------------------------------------------------------------------
+
+describe('loadRedactedCanonicalIdsFromDisk', () => {
+  it('loads node_id and database_id from private entries in a fixture YAML', async () => {
+    const fixtureYaml = `
+version: 1
+repos:
+  - owner: "[REDACTED]"
+    name: "R_kgDOFIXTURE001"
+    private: true
+    node_id: "R_kgDOFIXTURE001"
+    database_id: 987654321
+    added: "2026-01-01"
+    onboarding_status: onboarded
+    last_survey_at: null
+    last_survey_status: null
+    has_fro_bot_workflow: false
+    has_renovate: false
+`
+    const readFileFn = async (_path: string, _enc: BufferEncoding) => fixtureYaml
+    const ids = await loadRedactedCanonicalIdsFromDisk(readFileFn)
+    expect(ids.has('R_kgDOFIXTURE001')).toBe(true)
+    expect(ids.has('987654321')).toBe(true)
+  })
+
+  it('returns empty set when no private entries exist', async () => {
+    const fixtureYaml = `
+version: 1
+repos:
+  - owner: "fro-bot"
+    name: "public-repo"
+    private: false
+    node_id: "R_kgDOPUBLIC001"
+    database_id: 111111111
+    added: "2026-01-01"
+    onboarding_status: onboarded
+    last_survey_at: null
+    last_survey_status: null
+    has_fro_bot_workflow: false
+    has_renovate: false
+`
+    const readFileFn = async (_path: string, _enc: BufferEncoding) => fixtureYaml
+    const ids = await loadRedactedCanonicalIdsFromDisk(readFileFn)
+    expect(ids.size).toBe(0)
+  })
+
+  it('throws when the file cannot be read (fail-closed)', async () => {
+    const readFileFn = async (_path: string, _enc: BufferEncoding): Promise<string> => {
+      throw new Error('ENOENT: no such file or directory')
+    }
+    await expect(loadRedactedCanonicalIdsFromDisk(readFileFn)).rejects.toThrow()
+  })
+
+  it('throws when the YAML is malformed (fail-closed)', async () => {
+    const readFileFn = async (_path: string, _enc: BufferEncoding) => '{ invalid yaml: ['
+    await expect(loadRedactedCanonicalIdsFromDisk(readFileFn)).rejects.toThrow()
+  })
+
+  it('throws when the YAML has wrong schema (fail-closed)', async () => {
+    const readFileFn = async (_path: string, _enc: BufferEncoding) => 'version: 2\nrepos: []'
+    await expect(loadRedactedCanonicalIdsFromDisk(readFileFn)).rejects.toThrow()
+  })
+
+  it('does not include public repo IDs even when node_id is present', async () => {
+    const fixtureYaml = `
+version: 1
+repos:
+  - owner: "fro-bot"
+    name: "public-repo"
+    private: false
+    node_id: "R_kgDOPUBLIC999"
+    database_id: 999999999
+    added: "2026-01-01"
+    onboarding_status: onboarded
+    last_survey_at: null
+    last_survey_status: null
+    has_fro_bot_workflow: false
+    has_renovate: false
+  - owner: "[REDACTED]"
+    name: "R_kgDOFIXTURE004"
+    private: true
+    node_id: "R_kgDOFIXTURE004"
+    database_id: 444444444
+    added: "2026-01-01"
+    onboarding_status: onboarded
+    last_survey_at: null
+    last_survey_status: null
+    has_fro_bot_workflow: false
+    has_renovate: false
+`
+    const readFileFn = async (_path: string, _enc: BufferEncoding) => fixtureYaml
+    const ids = await loadRedactedCanonicalIdsFromDisk(readFileFn)
+    // Private entry IDs present
+    expect(ids.has('R_kgDOFIXTURE004')).toBe(true)
+    expect(ids.has('444444444')).toBe(true)
+    // Public entry IDs absent
+    expect(ids.has('R_kgDOPUBLIC999')).toBe(false)
+    expect(ids.has('999999999')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Mutation test: redactedCanonicalIds blocks private node_id in proposal body
+// ---------------------------------------------------------------------------
+
+describe('redactedCanonicalIds mutation test — private node_id blocks proposal body', () => {
+  it('proposal body containing a fixture private node_id is blocked when loaded via extractRedactedCanonicalIds', () => {
+    const privateNodeId = 'R_kgDOFIXTURE001'
+    const privateDatabaseId = 987654321
+
+    const repos = [
+      {
+        owner: '[REDACTED]',
+        name: privateNodeId,
+        private: true,
+        node_id: privateNodeId,
+        database_id: privateDatabaseId,
+        added: '2026-01-01',
+        onboarding_status: 'onboarded' as const,
+        last_survey_at: null,
+        last_survey_status: null,
+        has_fro_bot_workflow: false,
+        has_renovate: false,
+      },
+    ]
+
+    const redactedCanonicalIds = extractRedactedCanonicalIds(repos)
+    const tokens = makePublicOutputTokens({
+      privateTokens: new Set<string>(),
+      redactedCanonicalIds,
+    })
+
+    // Body containing the private node_id must be blocked
+    const bodyWithNodeId = `<!-- status-truth:fingerprint=abc123 -->\n\nRepo node_id: ${privateNodeId}`
+    const nodeIdResult = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: bodyWithNodeId,
+      tokens,
+      fingerprint: 'abc123',
+    })
+    expect(nodeIdResult.allowed).toBe(false)
+    if (!nodeIdResult.allowed) {
+      expect(nodeIdResult.blockedCount).toBe(1)
+      expect('sanitizedContent' in nodeIdResult).toBe(false)
+    }
+
+    // Body containing the private database_id (as string) must be blocked
+    const bodyWithDatabaseId = `<!-- status-truth:fingerprint=abc123 -->\n\nRepo database_id: ${privateDatabaseId}`
+    const databaseIdResult = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: bodyWithDatabaseId,
+      tokens,
+      fingerprint: 'abc123',
+    })
+    expect(databaseIdResult.allowed).toBe(false)
+
+    // Body with no private IDs must pass
+    const safeBody = `<!-- status-truth:fingerprint=abc123 -->\n\nSafe public content.`
+    const safeResult = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: safeBody,
+      tokens,
+      fingerprint: 'abc123',
+    })
+    expect(safeResult.allowed).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Unit 4 hardening: label gate must block on ANY missing required label
 // ---------------------------------------------------------------------------
 
@@ -2318,5 +2622,360 @@ describe('Fix #9: same-run duplicate proposal deduplication', () => {
     // Second occurrence is deduplicated
     expect(counts.sameRunDeduplicated).toBe(1)
     expect(counts.opened).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Security fix #1: Octokit no-op log handlers
+// ---------------------------------------------------------------------------
+
+describe('NOOP_LOG — Octokit default logger suppression', () => {
+  it('NOOP_LOG is exported and has all four required log handler methods', () => {
+    expect(typeof NOOP_LOG).toBe('object')
+    expect(typeof NOOP_LOG.debug).toBe('function')
+    expect(typeof NOOP_LOG.info).toBe('function')
+    expect(typeof NOOP_LOG.warn).toBe('function')
+    expect(typeof NOOP_LOG.error).toBe('function')
+  })
+
+  it('NOOP_LOG handlers are callable and return undefined (no-op)', () => {
+    // Calling them must not throw and must not produce output
+    expect(NOOP_LOG.debug()).toBeUndefined()
+    expect(NOOP_LOG.info()).toBeUndefined()
+    expect(NOOP_LOG.warn()).toBeUndefined()
+    expect(NOOP_LOG.error()).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Security fix #2: case-sensitive canonical ID matching
+// ---------------------------------------------------------------------------
+
+describe('redactedCanonicalIds — case-sensitive substring matching', () => {
+  it('proposal body containing the exact fixture node_id as a substring is blocked', () => {
+    // Use fixture IDs only — no real private values
+    const fixtureNodeId = 'R_kgDOFIXTURE001'
+    const repos = [
+      {
+        owner: '[REDACTED]',
+        name: fixtureNodeId,
+        private: true as const,
+        node_id: fixtureNodeId,
+        added: '2026-01-01',
+        onboarding_status: 'onboarded' as const,
+        last_survey_at: null,
+        last_survey_status: null,
+        has_fro_bot_workflow: false,
+        has_renovate: false,
+      },
+    ]
+    const redactedCanonicalIds = extractRedactedCanonicalIds(repos)
+    const tokens = makePublicOutputTokens({
+      privateTokens: new Set<string>(),
+      redactedCanonicalIds,
+    })
+
+    // Body containing the exact node_id as a substring must be blocked
+    const bodyWithId = `<!-- status-truth:fingerprint=abc123 -->\n\nRepo: ${fixtureNodeId} is referenced here.`
+    const result = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: bodyWithId,
+      tokens,
+      fingerprint: 'abc123',
+    })
+    expect(result.allowed).toBe(false)
+    if (!result.allowed) {
+      expect(result.blockedCount).toBe(1)
+      expect('sanitizedContent' in result).toBe(false)
+    }
+  })
+
+  it('proposal body containing a different-case variant of the fixture node_id is NOT blocked (case-sensitive)', () => {
+    // The canonical ID has a specific casing; a different-case variant is a different string
+    const fixtureNodeId = 'R_kgDOFIXTURE001'
+    const repos = [
+      {
+        owner: '[REDACTED]',
+        name: fixtureNodeId,
+        private: true as const,
+        node_id: fixtureNodeId,
+        added: '2026-01-01',
+        onboarding_status: 'onboarded' as const,
+        last_survey_at: null,
+        last_survey_status: null,
+        has_fro_bot_workflow: false,
+        has_renovate: false,
+      },
+    ]
+    const redactedCanonicalIds = extractRedactedCanonicalIds(repos)
+    const tokens = makePublicOutputTokens({
+      privateTokens: new Set<string>(),
+      redactedCanonicalIds,
+    })
+
+    // Different-case variant — must NOT be treated as the same canonical ID
+    const differentCaseId = fixtureNodeId.toLowerCase() // 'r_kgdofixture001'
+    const bodyWithDifferentCase = `<!-- status-truth:fingerprint=abc123 -->\n\nRef: ${differentCaseId}`
+    const result = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: bodyWithDifferentCase,
+      tokens,
+      fingerprint: 'abc123',
+    })
+    // Case-sensitive: different-case variant must pass (it's a different string)
+    expect(result.allowed).toBe(true)
+  })
+
+  it('proposal body containing the exact fixture database_id as a substring is blocked', () => {
+    const fixtureDatabaseId = 987654321
+    const repos = [
+      {
+        owner: '[REDACTED]',
+        name: 'R_kgDOFIXTURE002',
+        private: true as const,
+        node_id: 'R_kgDOFIXTURE002',
+        database_id: fixtureDatabaseId,
+        added: '2026-01-01',
+        onboarding_status: 'onboarded' as const,
+        last_survey_at: null,
+        last_survey_status: null,
+        has_fro_bot_workflow: false,
+        has_renovate: false,
+      },
+    ]
+    const redactedCanonicalIds = extractRedactedCanonicalIds(repos)
+    const tokens = makePublicOutputTokens({
+      privateTokens: new Set<string>(),
+      redactedCanonicalIds,
+    })
+
+    // Body containing the database_id as a substring must be blocked
+    const bodyWithDbId = `<!-- status-truth:fingerprint=abc123 -->\n\nDatabase ID: ${fixtureDatabaseId}`
+    const result = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: bodyWithDbId,
+      tokens,
+      fingerprint: 'abc123',
+    })
+    expect(result.allowed).toBe(false)
+    if (!result.allowed) {
+      expect(result.blockedCount).toBe(1)
+    }
+  })
+
+  it('safe body with no canonical IDs passes when redactedCanonicalIds are loaded', () => {
+    const fixtureNodeId = 'R_kgDOFIXTURE001'
+    const repos = [
+      {
+        owner: '[REDACTED]',
+        name: fixtureNodeId,
+        private: true as const,
+        node_id: fixtureNodeId,
+        added: '2026-01-01',
+        onboarding_status: 'onboarded' as const,
+        last_survey_at: null,
+        last_survey_status: null,
+        has_fro_bot_workflow: false,
+        has_renovate: false,
+      },
+    ]
+    const redactedCanonicalIds = extractRedactedCanonicalIds(repos)
+    const tokens = makePublicOutputTokens({
+      privateTokens: new Set<string>(),
+      redactedCanonicalIds,
+    })
+
+    const safeBody = `<!-- status-truth:fingerprint=abc123 -->\n\nSafe public content with no private IDs.`
+    const result = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: safeBody,
+      tokens,
+      fingerprint: 'abc123',
+    })
+    expect(result.allowed).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Security fix #3: production-loaded redactedCanonicalIds block rendered content
+// ---------------------------------------------------------------------------
+
+describe('production-loaded redactedCanonicalIds — block rendered proposal body/comment without leaking IDs', () => {
+  it('loadRedactedCanonicalIdsFromDisk + applyPublicOutputGate blocks proposal body containing fixture node_id', async () => {
+    // Simulate production load path: loadRedactedCanonicalIdsFromDisk → makePublicOutputTokens → applyPublicOutputGate
+    const fixtureNodeId = 'R_kgDOFIXTURE001'
+    const fixtureYaml = `
+version: 1
+repos:
+  - owner: "[REDACTED]"
+    name: "${fixtureNodeId}"
+    private: true
+    node_id: "${fixtureNodeId}"
+    database_id: 987654321
+    added: "2026-01-01"
+    onboarding_status: onboarded
+    last_survey_at: null
+    last_survey_status: null
+    has_fro_bot_workflow: false
+    has_renovate: false
+`
+    const readFileFn = async (_path: string, _enc: BufferEncoding) => fixtureYaml
+    const redactedCanonicalIds = await loadRedactedCanonicalIdsFromDisk(readFileFn)
+    const tokens = makePublicOutputTokens({
+      privateTokens: new Set<string>(),
+      redactedCanonicalIds,
+    })
+
+    // Proposal body containing the fixture node_id must be blocked
+    const bodyWithId = `<!-- status-truth:fingerprint=abc123 -->\n\nRepo node_id: ${fixtureNodeId} is referenced.`
+    const result = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: bodyWithId,
+      tokens,
+      fingerprint: 'abc123',
+    })
+
+    // Must be blocked — no ID leaks to sanitizedContent
+    expect(result.allowed).toBe(false)
+    if (!result.allowed) {
+      expect(result.blockedCount).toBe(1)
+      // Blocked text must not appear in any output field
+      expect('sanitizedContent' in result).toBe(false)
+      expect('blockedContent' in result).toBe(false)
+    }
+  })
+
+  it('loadRedactedCanonicalIdsFromDisk + applyPublicOutputGate blocks comment containing fixture database_id', async () => {
+    const fixtureDatabaseId = 987654321
+    const fixtureYaml = `
+version: 1
+repos:
+  - owner: "[REDACTED]"
+    name: "R_kgDOFIXTURE002"
+    private: true
+    node_id: "R_kgDOFIXTURE002"
+    database_id: ${fixtureDatabaseId}
+    added: "2026-01-01"
+    onboarding_status: onboarded
+    last_survey_at: null
+    last_survey_status: null
+    has_fro_bot_workflow: false
+    has_renovate: false
+`
+    const readFileFn = async (_path: string, _enc: BufferEncoding) => fixtureYaml
+    const redactedCanonicalIds = await loadRedactedCanonicalIdsFromDisk(readFileFn)
+    const tokens = makePublicOutputTokens({
+      privateTokens: new Set<string>(),
+      redactedCanonicalIds,
+    })
+
+    // Comment containing the fixture database_id must be blocked
+    const commentWithDbId = `Drift recurrence detected. Database ID: ${fixtureDatabaseId} is referenced.`
+    const result = applyPublicOutputGate({
+      surface: 'recurrence-comment',
+      content: commentWithDbId,
+      tokens,
+      fingerprint: 'abc123',
+    })
+
+    expect(result.allowed).toBe(false)
+    if (!result.allowed) {
+      expect(result.blockedCount).toBe(1)
+      expect('sanitizedContent' in result).toBe(false)
+    }
+  })
+
+  it('production-loaded tokens do not block safe content (no false positives)', async () => {
+    const fixtureNodeId = 'R_kgDOFIXTURE001'
+    const fixtureYaml = `
+version: 1
+repos:
+  - owner: "[REDACTED]"
+    name: "${fixtureNodeId}"
+    private: true
+    node_id: "${fixtureNodeId}"
+    database_id: 987654321
+    added: "2026-01-01"
+    onboarding_status: onboarded
+    last_survey_at: null
+    last_survey_status: null
+    has_fro_bot_workflow: false
+    has_renovate: false
+`
+    const readFileFn = async (_path: string, _enc: BufferEncoding) => fixtureYaml
+    const redactedCanonicalIds = await loadRedactedCanonicalIdsFromDisk(readFileFn)
+    const tokens = makePublicOutputTokens({
+      privateTokens: new Set<string>(),
+      redactedCanonicalIds,
+    })
+
+    // Safe content with no private IDs must pass
+    const safeBody = `<!-- status-truth:fingerprint=abc123 -->\n\nDrift detected in docs/plans/example.md. PR #42 is closed.`
+    const result = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: safeBody,
+      tokens,
+      fingerprint: 'abc123',
+    })
+
+    expect(result.allowed).toBe(true)
+    if (result.allowed) {
+      expect(result.sanitizedContent).toBe(safeBody)
+    }
+  })
+
+  it('planStatusTruthProposalActions with production-loaded tokens blocks proposal body containing fixture node_id', async () => {
+    // End-to-end: load tokens from fixture YAML, run planner, verify blocked count and no open actions
+    const fixtureNodeId = 'R_kgDOFIXTURE001'
+    const fixtureYaml = `
+version: 1
+repos:
+  - owner: "[REDACTED]"
+    name: "${fixtureNodeId}"
+    private: true
+    node_id: "${fixtureNodeId}"
+    database_id: 987654321
+    added: "2026-01-01"
+    onboarding_status: onboarded
+    last_survey_at: null
+    last_survey_status: null
+    has_fro_bot_workflow: false
+    has_renovate: false
+`
+    const readFileFn = async (_path: string, _enc: BufferEncoding) => fixtureYaml
+    const redactedCanonicalIds = await loadRedactedCanonicalIdsFromDisk(readFileFn)
+    const tokens = makePublicOutputTokens({
+      privateTokens: new Set<string>(),
+      redactedCanonicalIds,
+    })
+
+    // Finding whose proposedCorrection contains the fixture node_id
+    const finding = {
+      ...makeDriftedFinding('abc123def456abcd'),
+      proposedCorrection: `Repo node_id is ${fixtureNodeId}`,
+    }
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const {actions, counts} = planStatusTruthProposalActions(
+      makePlanInput({report, existingIssues: [], publicOutputTokens: tokens}),
+    )
+
+    // No open actions — body was blocked by the canonical ID gate
+    expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+    expect(counts.blocked).toBeGreaterThanOrEqual(1)
+
+    // Verify no action contains the fixture node_id (no leakage)
+    for (const action of actions) {
+      if (action.type === 'open') {
+        expect(action.body).not.toContain(fixtureNodeId)
+        expect(action.title).not.toContain(fixtureNodeId)
+      }
+      if (action.type === 'update-comment' || action.type === 'reopen' || action.type === 'close') {
+        expect(action.comment).not.toContain(fixtureNodeId)
+      }
+    }
   })
 })

--- a/scripts/status-truth-proposals.ts
+++ b/scripts/status-truth-proposals.ts
@@ -29,14 +29,91 @@
  * Strip-only safe: no parameter properties, enums, or namespaces.
  */
 
+import type {RepoEntry} from './schemas.ts'
 import type {PublicStatusTruthFinding, StatusTruthFinding, StatusTruthJsonReport} from './status-truth-detect.ts'
 import {readFile, writeFile} from 'node:fs/promises'
 import process from 'node:process'
 
 import {Octokit} from '@octokit/rest'
-import {loadPrivateTokensFromDisk} from './capture-learnings-privacy.ts'
+import {parse} from 'yaml'
+import {isRecord, loadPrivateTokensFromDisk} from './capture-learnings-privacy.ts'
+import {assertReposFile} from './schemas.ts'
 import {KNOWN_FINGERPRINT_VERSION, KNOWN_SCHEMA_VERSION, validateStatusTruthArtifact} from './status-truth-detect.ts'
 import {applyPublicOutputGate, makePublicOutputTokens, type PublicOutputTokens} from './status-truth-public-output.ts'
+
+// ---------------------------------------------------------------------------
+// Redacted canonical ID helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract redacted canonical IDs (node_id and database_id as string) from private repo entries.
+ *
+ * Only entries with `private === true` contribute IDs. Public entries and entries with
+ * `private` absent are excluded. This is the secondary denylist guard: node_id and
+ * database_id values must never appear in any public output surface.
+ *
+ * Pure function: no I/O, no side effects.
+ */
+export function extractRedactedCanonicalIds(repos: readonly RepoEntry[]): Set<string> {
+  const ids = new Set<string>()
+  for (const entry of repos) {
+    if (entry.private !== true) continue
+    if (entry.node_id !== undefined && entry.node_id !== '') {
+      ids.add(entry.node_id)
+    }
+    if (entry.database_id !== undefined) {
+      ids.add(String(entry.database_id))
+    }
+  }
+  return ids
+}
+
+/**
+ * Load redacted canonical IDs from `metadata/repos.yaml`.
+ *
+ * Reads and validates the repos file, then delegates to `extractRedactedCanonicalIds`.
+ *
+ * Fail-closed contract:
+ * - If the file cannot be read, parsed, or validated, this function THROWS.
+ * - The caller MUST NOT emit any public output when this throws.
+ * - Never use an empty set as a proxy for a failed load.
+ *
+ * @param readFileFn - Injectable readFile for testing (defaults to node:fs/promises readFile).
+ */
+export async function loadRedactedCanonicalIdsFromDisk(
+  readFileFn: (path: string, encoding: BufferEncoding) => Promise<string> = readFile,
+): Promise<Set<string>> {
+  let reposYaml: string
+  try {
+    reposYaml = await readFileFn('metadata/repos.yaml', 'utf8')
+  } catch (error: unknown) {
+    throw new Error(
+      'status-truth-proposals: could not read metadata/repos.yaml — redacted canonical ID gate cannot operate',
+      {cause: error},
+    )
+  }
+
+  let parsed: unknown
+  try {
+    parsed = parse(reposYaml)
+  } catch (error: unknown) {
+    throw new Error(
+      'status-truth-proposals: could not parse metadata/repos.yaml — redacted canonical ID gate cannot operate',
+      {cause: error},
+    )
+  }
+
+  if (!isRecord(parsed)) {
+    throw new TypeError(
+      'status-truth-proposals: metadata/repos.yaml has unexpected shape — redacted canonical ID gate cannot operate',
+    )
+  }
+
+  // Validate schema — throws SchemaValidationError on invalid shape
+  assertReposFile(parsed, 'repos')
+
+  return extractRedactedCanonicalIds(parsed.repos)
+}
 
 // ---------------------------------------------------------------------------
 // Label constants
@@ -1231,7 +1308,19 @@ export async function executeStatusTruthProposalActions(
 // Unit 4: CLI shell for the open/proposals step
 // ---------------------------------------------------------------------------
 
-type OctokitConstructor = new (params: {auth: string; request?: {timeout?: number}}) => StatusTruthOctokitClient
+/** No-op log handler object — suppresses all Octokit default logger output. */
+export const NOOP_LOG = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+}
+
+type OctokitConstructor = new (params: {
+  auth: string
+  request?: {timeout?: number}
+  log?: {debug: () => void; info: () => void; warn: () => void; error: () => void}
+}) => StatusTruthOctokitClient
 
 async function loadOctokitConstructor(): Promise<OctokitConstructor> {
   if (typeof Octokit !== 'function') {
@@ -1246,7 +1335,7 @@ async function createOctokitFromEnv(): Promise<StatusTruthOctokitClient> {
     throw new Error('status-truth-proposals: GITHUB_TOKEN is required in the environment')
   }
   const LoadedOctokit = await loadOctokitConstructor()
-  return new LoadedOctokit({auth: token, request: {timeout: 10_000}})
+  return new LoadedOctokit({auth: token, request: {timeout: 10_000}, log: NOOP_LOG})
 }
 
 /** Counts-only result written to stdout and STATUS_TRUTH_OPEN_RESULT_PATH. */
@@ -1327,10 +1416,13 @@ async function runOpen(): Promise<void> {
   // Load privacy tokens (fail-closed)
   let publicOutputTokens: ReturnType<typeof makePublicOutputTokens>
   try {
-    const privateTokens = await loadPrivateTokensFromDisk()
+    const [privateTokens, redactedCanonicalIds] = await Promise.all([
+      loadPrivateTokensFromDisk(),
+      loadRedactedCanonicalIdsFromDisk(),
+    ])
     publicOutputTokens = makePublicOutputTokens({
       privateTokens,
-      redactedCanonicalIds: new Set<string>(),
+      redactedCanonicalIds,
     })
   } catch {
     process.stderr.write('status-truth-proposals: privacy token load failed: error-class=token-load-failure\n')
@@ -1363,7 +1455,7 @@ async function runOpen(): Promise<void> {
     if (dryRunToken !== undefined && dryRunToken !== '' && owner !== '' && repo !== '') {
       try {
         const LoadedOctokit = await loadOctokitConstructor()
-        const dryRunOctokit = new LoadedOctokit({auth: dryRunToken, request: {timeout: 10_000}})
+        const dryRunOctokit = new LoadedOctokit({auth: dryRunToken, request: {timeout: 10_000}, log: NOOP_LOG})
         existingIssues = await fetchExistingProposalIssues({octokit: dryRunOctokit, owner, repo})
       } catch {
         // Non-fatal in dry-run: proceed with empty list (counts may over-estimate opens)

--- a/scripts/status-truth-public-output.test.ts
+++ b/scripts/status-truth-public-output.test.ts
@@ -202,6 +202,53 @@ describe('applyPublicOutputGate — private token block', () => {
       expect(result.blockedCount).toBe(1)
     }
   })
+
+  it('canonical ID match is case-sensitive: exact fixture node_id as substring is blocked', () => {
+    // The canonical ID 'R_kgDOFIXTURE001' must block content containing it as a substring
+    const fixtureId = 'R_kgDOFIXTURE001'
+    const tokens = makeRedactedIdTokens([fixtureId])
+    const result = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: `Repo node_id: ${fixtureId} is referenced here.`,
+      tokens,
+      fingerprint: 'abcdef0123456789',
+    })
+    expect(result.allowed).toBe(false)
+    if (!result.allowed) {
+      expect(result.blockedCount).toBe(1)
+    }
+  })
+
+  it('canonical ID match is case-sensitive: different-case variant of fixture node_id is NOT blocked', () => {
+    // node_id values have fixed casing; a different-case variant is a different string
+    const fixtureId = 'R_kgDOFIXTURE001'
+    const tokens = makeRedactedIdTokens([fixtureId])
+    // Lowercase variant — must NOT be treated as the same canonical ID
+    const differentCase = fixtureId.toLowerCase() // 'r_kgdofixture001'
+    const result = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: `Ref: ${differentCase} is safe.`,
+      tokens,
+      fingerprint: 'abcdef0123456789',
+    })
+    // Case-sensitive: different-case variant must pass
+    expect(result.allowed).toBe(true)
+  })
+
+  it('canonical ID match is case-sensitive: uppercase variant of lowercase fixture ID is NOT blocked', () => {
+    // Fixture ID is lowercase; uppercase variant must not be blocked
+    const fixtureId = 'fixture_id_lowercase_001'
+    const tokens = makeRedactedIdTokens([fixtureId])
+    const upperCase = fixtureId.toUpperCase() // 'FIXTURE_ID_LOWERCASE_001'
+    const result = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: `Ref: ${upperCase} is safe.`,
+      tokens,
+      fingerprint: 'abcdef0123456789',
+    })
+    // Case-sensitive: uppercase variant must pass
+    expect(result.allowed).toBe(true)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/scripts/status-truth-public-output.ts
+++ b/scripts/status-truth-public-output.ts
@@ -221,11 +221,12 @@ export function applyPublicOutputGate(input: PublicOutputGateInput): SafePublicO
     }
   }
 
-  // 5. Redacted canonical ID match → block
+  // 5. Redacted canonical ID match → block (case-sensitive substring match)
+  // node_id and database_id values are opaque identifiers with fixed casing;
+  // case-folding would allow a different-case variant to bypass the gate.
   if (tokens.redactedCanonicalIds.size > 0) {
-    const lowerContent = content.toLowerCase()
     for (const id of tokens.redactedCanonicalIds) {
-      if (lowerContent.includes(id.toLowerCase())) {
+      if (content.includes(id)) {
         return {
           allowed: false,
           blockedCount: 1,


### PR DESCRIPTION
## Summary

Calibrates the Status Truth loop so dry-runs produce useful public coordination signal instead of unresolved plan-status noise.

## Changes

- Excludes unsupported `plan-status` claims from default production scans until a real resolver exists.
- Scans current-repo issue bodies and comments with paginated read-only GitHub API calls.
- Resolves confirmed-public cross-repo issue, PR, and release references after proving the target repository is public.
- Treats private, unknown, or ambiguous cross-repo targets as unsafe findings with identity-bearing fields stripped.
- Loads redacted canonical IDs from repository metadata into the public-output gate.
- Suppresses Octokit request logging in Status Truth detect/proposal paths.
- Documents the current Phase 1 boundary and remaining graduation path in the plan.

## Verification

- `pnpm bootstrap && pnpm check-types && pnpm lint && pnpm test`
- Local Status Truth detect/open dry-run against current issue surfaces
- Privacy check: added diff does not contain real private canonical IDs
