### PR TITLE
feat: complete status-truth signal generation

### DIFF
--- a/.github/workflows/status-truth.yaml
+++ b/.github/workflows/status-truth.yaml
@@ -243,6 +243,24 @@ jobs:
               echo "| Blocked | $(jq '(.plannedCounts.blocked // 0)' "$result") |"
               echo "| Overflowed | $(jq '(.plannedCounts.overflowed // 0)' "$result") |"
 
+              # Outcome counts (read-model: current state of all proposal issues)
+              if jq -e '.outcomeCounts' "$result" >/dev/null 2>&1; then
+                echo ""
+                echo "### Proposal outcome counts"
+                echo ""
+                echo "| Outcome | Count |"
+                echo "| --- | --- |"
+                echo "| Proposed pending | $(jq '.outcomeCounts.proposedPending // 0' "$result") |"
+                echo "| Accepted | $(jq '.outcomeCounts.explicitAccepted // 0' "$result") |"
+                echo "| Rejected | $(jq '.outcomeCounts.explicitRejected // 0' "$result") |"
+                echo "| False positive | $(jq '.outcomeCounts.falsePositive // 0' "$result") |"
+                echo "| Resolved positive | $(jq '.outcomeCounts.resolvedPositive // 0' "$result") |"
+                echo "| Superseded | $(jq '.outcomeCounts.superseded // 0' "$result") |"
+                echo "| Needs outcome | $(jq '.outcomeCounts.needsOutcome // 0' "$result") |"
+                echo "| Conflicting labels | $(jq '.outcomeCounts.conflictingLabels // 0' "$result") |"
+                echo "| Malformed outcome | $(jq '.outcomeCounts.malformedOutcome // 0' "$result") |"
+              fi
+
               # Planned per-kind counts (from planner; counts-only, no paths or fingerprints)
               kind_count=$(jq '.plannedCountsByKind | length' "$result" 2>/dev/null || echo 0)
               if [[ "$kind_count" -gt 0 ]]; then

--- a/.github/workflows/status-truth.yaml
+++ b/.github/workflows/status-truth.yaml
@@ -35,9 +35,12 @@ jobs:
     name: Detect status-truth drift
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Detect job uses only the default read-only permissions.
+    # Detect job needs read access to contents, issues, and pull-requests for
+    # API-backed claim resolution (PR/issue/release state lookups).
     permissions:
       contents: read
+      issues: read
+      pull-requests: read
 
     steps:
       - name: ⤵ Checkout Branch

--- a/.github/workflows/status-truth.yaml
+++ b/.github/workflows/status-truth.yaml
@@ -245,6 +245,7 @@ jobs:
               echo "| Version rejected | $(jq '.plannedCounts.versionRejected // 0' "$result") |"
               echo "| Blocked | $(jq '(.plannedCounts.blocked // 0)' "$result") |"
               echo "| Overflowed | $(jq '(.plannedCounts.overflowed // 0)' "$result") |"
+              echo "| Needs outcome cooldown | $(jq '(.plannedCounts.needsOutcomeCooldown // 0)' "$result") |"
 
               # Outcome counts (read-model: current state of all proposal issues)
               if jq -e '.outcomeCounts' "$result" >/dev/null 2>&1; then

--- a/.github/workflows/status-truth.yaml
+++ b/.github/workflows/status-truth.yaml
@@ -238,9 +238,10 @@ jobs:
               echo "| Closed | $(jq '.counts.closed // 0' "$result") |"
               echo "| Suppressed | $(jq '.counts.suppressed // 0' "$result") |"
               echo "| Failed | $(jq '.counts.failed // 0' "$result") |"
-              echo "| Same-run deduplicated | $(jq '.counts.sameRunDeduplicated // 0' "$result") |"
+              echo "| Same-run deduplicated | $(jq '.plannedCounts.sameRunDeduplicated // 0' "$result") |"
               echo "| Version rejected | $(jq '.plannedCounts.versionRejected // 0' "$result") |"
               echo "| Blocked | $(jq '(.plannedCounts.blocked // 0)' "$result") |"
+              echo "| Overflowed | $(jq '(.plannedCounts.overflowed // 0)' "$result") |"
 
               # Planned per-kind counts (from planner; counts-only, no paths or fingerprints)
               kind_count=$(jq '.plannedCountsByKind | length' "$result" 2>/dev/null || echo 0)

--- a/.github/workflows/status-truth.yaml
+++ b/.github/workflows/status-truth.yaml
@@ -60,6 +60,30 @@ jobs:
             echo "data branch not yet established; skipping metadata overlay."
           fi
 
+      # Best-effort rollout snapshot for rollout-tracker-status resolution.
+      # Raw snapshot output is streamed directly into jq and never echoed to logs.
+      - name: 📸 Load rollout snapshot (best-effort)
+        id: rollout-snapshot
+        env:
+          # Same credential class as gateway-rollout-tracker; scoped to this read-only snapshot step.
+          GH_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+          ROLLOUT_TRACKER_SNAPSHOT_PATH: ${{ runner.temp }}/rollout-snapshot.json
+        run: |
+          set -euo pipefail
+          snapshot_path="$ROLLOUT_TRACKER_SNAPSHOT_PATH"
+          tmp_snapshot="${snapshot_path}.tmp"
+          snapshot_error="${RUNNER_TEMP}/rollout-snapshot-error.log"
+          trap 'rm -f "$tmp_snapshot" "$snapshot_error"' EXIT
+
+          if node scripts/rollout-tracker-snapshot.ts 2>"$snapshot_error" | jq -e '.snapshot' > "$tmp_snapshot"; then
+            mv "$tmp_snapshot" "$snapshot_path"
+            item_count=$(jq '.items | length' "$snapshot_path" 2>/dev/null || echo 0)
+            echo "rollout-snapshot: loaded snapshot with ${item_count} item(s)"
+            echo "snapshot_path=${snapshot_path}" >> "$GITHUB_OUTPUT"
+          else
+            echo "rollout-snapshot: snapshot command unavailable; rollout-tracker claims will be unresolved"
+          fi
+
       - name: 🔍 Detect status-truth drift
         id: detect
         env:
@@ -69,6 +93,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           STATUS_TRUTH_REPORT_PATH: ${{ runner.temp }}/status-truth-report.json
+          # Snapshot path from the pre-detect step (empty string if unavailable).
+          # loadRolloutSnapshot in the script treats empty string as absent.
+          STATUS_TRUTH_ROLLOUT_SNAPSHOT_PATH: ${{ steps.rollout-snapshot.outputs.snapshot_path || '' }}
           # Scheduled runs default to dry-run=true; only workflow_dispatch can set false.
           STATUS_TRUTH_DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
         run: node scripts/status-truth-detect.ts

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Fro Bot control plane:
 | **Update Metadata** | Refresh `metadata/renovate.yaml` from the fro-bot org scan | Daily 04:30 UTC, dispatch |
 | **Dispatch Renovate** | Dispatch Renovate runs across repos tracked in `metadata/renovate.yaml` | Every 4 hours at `:30`, dispatch |
 | **Gateway Rollout Tracker** | Track and report on gateway rollout status across managed repos | Schedule, dispatch |
-| **Status Truth** | Detect drift in typed public coordination claims and manage proposal issues with counts-only summaries | Sunday 19:00 UTC, dispatch |
+| **Status Truth** | Detect drift in typed public coordination claims and manage proposal issues with counts-only summaries | Sunday 21:00 UTC, dispatch |
 | **Reset Survey Status** | Manually clear stale survey state for one or more tracked repos on `data` | Manual dispatch |
 | **Wiki Lint** | Lint the authoritative wiki snapshot restored from `origin/data` | Sunday 20:00 UTC, dispatch |
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ This repository provides shared configurations and automation for the Fro Bot ec
 ### Prerequisites
 
 - **Node.js** 24 (pinned in [`mise.toml`](mise.toml); native TypeScript execution, no build step)
-- **pnpm** 11.8.0 (pinned in `packageManager`)
+- **pnpm** 11.9.0 (pinned in `packageManager`)
 - **Git** for version control
 - Optional: [`mise`](https://mise.jdx.dev/) to auto-install the pinned toolchain
 
@@ -150,7 +150,7 @@ This repository provides shared configurations and automation for the Fro Bot ec
 ├── .github/                # GitHub-specific configurations
 │   ├── actions/setup/      # Composite bootstrap action
 │   ├── hooks/              # Copilot governance hooks
-│   ├── workflows/          # 23 GitHub Actions workflows (see Automation)
+│   ├── workflows/          # 24 GitHub Actions workflows (see Automation)
 │   ├── copilot-instructions.md  # Canonical AI-assistant guidance
 │   ├── renovate.json5      # Dependency management config
 │   └── settings.yml        # Repository settings via Probot
@@ -217,6 +217,7 @@ Fro Bot control plane:
 | **Update Metadata** | Refresh `metadata/renovate.yaml` from the fro-bot org scan | Daily 04:30 UTC, dispatch |
 | **Dispatch Renovate** | Dispatch Renovate runs across repos tracked in `metadata/renovate.yaml` | Every 4 hours at `:30`, dispatch |
 | **Gateway Rollout Tracker** | Track and report on gateway rollout status across managed repos | Schedule, dispatch |
+| **Status Truth** | Detect drift in typed public coordination claims and manage proposal issues with counts-only summaries | Sunday 19:00 UTC, dispatch |
 | **Reset Survey Status** | Manually clear stale survey state for one or more tracked repos on `data` | Manual dispatch |
 | **Wiki Lint** | Lint the authoritative wiki snapshot restored from `origin/data` | Sunday 20:00 UTC, dispatch |
 

--- a/docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md
+++ b/docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md
@@ -22,14 +22,14 @@ and diff gates.
 
 ## Implementation Status
 
-Phase 1 now provides the status-truth foundation: deterministic claim extraction, read-only live
+Phase 1 now provides the status-truth signal foundation: deterministic claim extraction, read-only live
 state resolution for current-repo and confirmed-public cross-repo issue/PR/release references,
-privacy-gated proposal planning, outcome labels for usefulness signal, and a dry-run-first workflow.
+file-backed `plan-status` resolution, rollout snapshot resolution, privacy-gated proposal planning,
+proposal caps, outcome counts, seven-day manual-closure cooldowns, and a dry-run-first workflow.
 
-The loop intentionally excludes unsupported `plan-status` claims from default scans until a real
-file-parse resolver exists. Bounded correction PRs remain disabled until proposal outcomes establish
-per-kind accuracy thresholds. The next dependency for downstream A2 features is collecting accepted,
-rejected, and false-positive proposal signal against representative tracker/coordination claims before
+Bounded correction PRs remain disabled until proposal outcomes establish per-kind accuracy thresholds.
+The next dependency for downstream A2 features is collecting accepted, rejected, false-positive,
+resolved, and needs-outcome proposal signal against representative tracker/coordination claims before
 graduating any claim kind to correction PRs.
 
 ## Problem Frame

--- a/docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md
+++ b/docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md
@@ -449,6 +449,8 @@ changes.
 
 ### U5. Manual closure cooldown and recurrence behavior
 
+Status: complete.
+
 **Goal:** Prevent bot-versus-operator loops while preserving recurrence handling for unresolved drift.
 
 **Requirements:** R7, R8

--- a/docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md
+++ b/docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md
@@ -404,6 +404,8 @@ findings.
 
 ### U4. Outcome classification and accuracy math
 
+Status: complete.
+
 **Goal:** Classify proposal outcomes into a stable usefulness signal without mutating issue state.
 
 **Requirements:** R7, R8

--- a/docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md
+++ b/docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md
@@ -168,9 +168,11 @@ first useful drift run from becoming noisy issue spam.
   fingerprint drift after the cooldown may reopen with a recurrence/needs-outcome comment.
 - **Schedules stay conservative:** Scheduled runs remain safe and low-noise. Any first live proposal
   run should be manually dispatched after dry-run counts are reviewed.
-- **Credential split is explicit:** Snapshot/detect paths run read-only. Proposal mutation paths mint
-  issue-write credentials only for non-dry-run proposal writes. This slice never mints contents-write
-  or pull-request-write credentials.
+- **Credential split is explicit:** The rollout snapshot path uses the existing tracker credential only
+  inside the snapshot step because the default `GITHUB_TOKEN` cannot read the Fro Bot Project. Proposal
+  mutation paths still mint issue-write credentials only for non-dry-run proposal writes. This slice
+  never mints contents-write or pull-request-write credentials; a dedicated Project-read credential is
+  a future hardening improvement.
 
 ### Outcome State Contract
 
@@ -303,6 +305,8 @@ claims.
   existing API-backed findings.
 
 ### U2. Rollout-tracker compound resolver
+
+Status: complete.
 
 **Goal:** Resolve rollout-tracker claims through the existing tracker snapshot rather than treating
 them as permanently unavailable.

--- a/docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md
+++ b/docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md
@@ -1,0 +1,585 @@
+---
+title: 'feat: Complete status-truth signal generation'
+type: feat
+status: active
+date: 2026-06-30
+origin: docs/brainstorms/2026-06-26-a2-self-maintenance-portfolio-requirements.md
+---
+
+# feat: Complete status-truth signal generation
+
+## Overview
+
+Complete the next A2 status-truth slice by turning the merged foundation from a safe advisory loop
+into a proposal-signal producer. The work finishes the missing status resolvers, keeps proposal
+volume bounded, and makes operator outcomes measurable enough to decide whether any claim kind can
+later graduate to bounded correction PRs.
+
+Bounded PR execution remains out of scope. The current foundation has not collected accepted,
+rejected, or false-positive proposal history, so opening correction PRs now would skip the safety
+gate that the origin requirements and prior plan both depend on.
+
+---
+
+## Problem Frame
+
+The merged status-truth workflow now scans public docs and issue surfaces, verifies current-repo and
+confirmed-public cross-repo issue/PR/release claims, and can plan privacy-gated proposal issues. A
+manual dry-run on `main` proved the loop is operational and counts-only, but it produced one current
+cross-repo issue finding and no drift or proposals.
+
+That is the right safety posture for a foundation, but it is not yet enough for dependent A2 work.
+The A2 arc needs durable proposal outcomes by claim kind before bounded correction PRs can be
+enabled. The immediate gap is therefore signal generation: finish the resolver types that were
+intentionally deferred, exercise them against representative coordination claims, and prevent the
+first useful drift run from becoming noisy issue spam.
+
+---
+
+## Requirements Trace
+
+- R1. Finish status-truth claim kinds that affect the next operator action without adding broad prose
+  auditing.
+- R2. Resolve plan-status claims from authoritative plan metadata rather than narrative text.
+- R3. Resolve rollout-tracker claims from the existing tracker snapshot contract rather than
+  re-deriving Project truth in prompts.
+- R4. Classify unavailable snapshot, missing file, malformed metadata, private identity, and API
+  failures as unresolved or blocked, never as drift.
+- R5. Keep workflow summaries and logs counts-only; proposal details appear only after public-output
+  gating.
+- R6. Cap issue mutations per run and preserve overflow as counts so a high-drift run cannot spam the
+  issue tracker.
+- R7. Treat operator outcomes as the decision log: accepted, resolved, manually-fixed, rejected,
+  false-positive, superseded, recurring, and unlabeled manual closure must have explicit semantics.
+- R8. Preserve the Phase 1 proposal-only boundary; no PR execution, no automerge, no branch-protection
+  bypass, and no new authority writes.
+- R9. Use identity-safe fixtures and public artifacts: examples, tests, reports, logs, summaries, and
+  docs may contain only synthetic, redacted, or already-public non-sensitive identifiers.
+
+---
+
+## Success Criteria
+
+- A manual dry-run on `main` can produce useful current/drifted/unresolved signal for the completed
+  resolver kinds without emitting raw claim text, fingerprints, private identity, or tracker payloads
+  in workflow-visible output.
+- When proposal-eligible drift exists, a manual live run can open or update a reviewable, privacy-safe
+  bounded set of proposal issues instead of creating unbounded issue noise.
+- A high-drift fixture run cannot exceed five mutating proposal actions and reports every overflowed
+  action as blocked counts.
+- Operator outcomes produce per-kind accuracy signal that distinguishes explicit acceptance, resolved
+  positives, rejection, false positives, malformed/conflicting labels, and unresolved closure states.
+- A closed-without-outcome proposal remains closed for seven days, then reopens only if the same drift
+  persists and no terminal/resolution label was added.
+- The slice reduces future manual reconciliation work by moving stale coordination claims into a
+  durable proposal queue; it does not require PR execution to prove that value.
+
+---
+
+## Scope Boundaries
+
+- In scope: `plan-status` file parsing, `rollout-tracker-status` compound resolution, proposal caps,
+  overflow reporting, outcome-signal accuracy math, and a capped set of identity-safe fixtures from
+  current status-truth plan prose and prior rollout-style coordination prose.
+- In scope: manual dry-run and optional manual live proposal runs after implementation, with schedule
+  remaining conservative.
+- Out of scope: bounded correction PR execution, PR branch cleanup, new required checks, Project board
+  writes, dashboard UI, org-wide scanning, private repo claims, broad docs linting, and dependency
+  hygiene.
+- Out of scope: any new PR creation/update/merge logic, branch mutation, branch-protection changes,
+  contents-write scope, pull-request-write scope, or transition code for PR execution.
+
+### Deferred to Separate Tasks
+
+- Bounded correction PR execution: separate plan after proposal outcomes prove at least one claim kind
+  is reliable.
+- Additional claim kinds beyond status truth: separate A2 expansion after this slice produces useful
+  signal.
+- Refreshing stale older solution docs: separate compound-refresh pass if those docs block future work.
+- `docs/solutions/` capture: conditional on this slice surfacing a reusable implementation lesson;
+  otherwise update only operator-facing and plan-status docs.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/status-truth-detect.ts`: typed claim definitions, source-publicity gates, resolver
+  typology, report contract, and scan shell.
+- `scripts/status-truth-proposals.ts`: proposal lifecycle planner, outcome labels, same-run dedupe,
+  label preflight, and write shell.
+- `scripts/status-truth-public-output.ts`: shared public-output gate for proposal and summary surfaces.
+- `scripts/status-truth-prs.ts`: pure PR planner only; useful for later graduation boundaries, not
+  execution in this slice.
+- `scripts/rollout-tracker-snapshot.ts`: existing tracker snapshot and hash contract to reuse as the
+  compound source of truth.
+- `.github/workflows/status-truth.yaml`: dry-run-first detect/open workflow and disabled PR placeholder.
+- `scripts/wiki-lint.ts` and `scripts/wiki-lint-issues.ts`: pure report construction, issue lifecycle
+  markers, and same-run created-key discipline.
+- `scripts/capture-learnings-open.ts`: proposal issue creation, runtime label preflight, and issue cap
+  precedent.
+- `scripts/capture-learnings-privacy.ts`: private-token and secret gate primitives.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/github-issues-api-same-run-eventual-consistency-2026-05-20.md`:
+  carry an in-memory created-key set so same-run issue listing lag cannot duplicate proposals.
+- `docs/solutions/best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md`: fail closed
+  on ambiguous identity and keep public-output gates at trusted chokepoints.
+- `docs/solutions/best-practices/pure-core-privacy-gates-shared-module-2026-06-22.md`: keep privacy
+  gate load failures in the I/O shell and mutation-test the chokepoint.
+- `docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md`: verify every public
+  surface before claiming no private identity can leak.
+- `docs/solutions/best-practices/credential-mint-time-permission-scoping-2026-06-22.md`: privilege is
+  constrained by mint-time permissions, not by having a second token.
+- `docs/solutions/integration-issues/wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md`:
+  snapshot unavailability should still produce a durable report artifact.
+
+---
+
+## Key Technical Decisions
+
+- **Complete signal before PR autonomy:** This slice targets proposal-quality signal, not correction
+  PR execution. Graduation still requires observed outcomes.
+- **Plan metadata is authoritative for plan status:** A claim about a plan's status resolves against
+  current plan frontmatter. The claim must identify its target by explicit repo-relative plan path or
+  unique plan title; ambiguous self-references, missing files, malformed frontmatter, or unsupported
+  status values are unresolved rather than drifted.
+- **Tracker snapshot is the rollout source of truth:** Rollout-tracker claims resolve through a fixed
+  claim-to-snapshot field map. The map is code-reviewed and tested; arbitrary snapshot fields do not
+  become claim sources by accident. Snapshot access failure, malformed snapshot data, stale snapshot
+  schema, or source disagreement blocks proposal output.
+- **Snapshot output is untrusted input:** The resolver validates snapshot schema before use and never
+  echoes raw snapshot payloads, Project field values, issue titles, or tracker internals into public
+  workflow output.
+- **Overflow is a blocked outcome, not hidden work:** Once the per-run mutation cap is reached,
+  additional proposal actions remain counted and visible without creating issue noise. The initial cap
+  is five mutating proposal actions per run, evaluated after privacy blocking and same-run dedupe.
+- **Mutation priority is deterministic:** When the cap is exhausted, actions are budgeted in this
+  order: close cleared existing proposals, update existing proposals, reopen recurring proposals, then
+  open new proposals. Overflowed actions remain planned-but-blocked counts.
+- **Resolved drift is positive signal without impersonating human judgment:** Auto-close-on-clear can
+  count as a useful detection, but it should stay distinguishable from an explicit operator
+  `accepted` label.
+- **Manual closure without outcome label is not a command to fight the operator:** The next run should
+  not immediately reopen the issue. It should enter a seven-day needs-outcome cooldown from the issue
+  `closed_at` timestamp; terminal or resolution labels override the cooldown, and persistent same-
+  fingerprint drift after the cooldown may reopen with a recurrence/needs-outcome comment.
+- **Schedules stay conservative:** Scheduled runs remain safe and low-noise. Any first live proposal
+  run should be manually dispatched after dry-run counts are reviewed.
+- **Credential split is explicit:** Snapshot/detect paths run read-only. Proposal mutation paths mint
+  issue-write credentials only for non-dry-run proposal writes. This slice never mints contents-write
+  or pull-request-write credentials.
+
+### Outcome State Contract
+
+| Semantic state | Storage signal | Accuracy role | Lifecycle effect |
+| --- | --- | --- | --- |
+| Proposed | Open proposal with `status-truth` label and fingerprint marker | Pending | Remains open until drift clears or operator labels it. |
+| Explicit accepted | `status-truth:accepted` | Positive, human-confirmed | Eligible input for future graduation math. |
+| Resolved positive | `status-truth:resolved` or `status-truth:manually-fixed` after close-on-clear | Positive, bot-inferred | Counts separately from explicit accepted. |
+| Rejected | `status-truth:rejected` | Negative | Terminal suppression for same fingerprint. |
+| False positive | `status-truth:false-positive` | Negative | Terminal suppression for same fingerprint. |
+| Superseded | `status-truth:superseded` | Excluded from accuracy | Suppresses the old fingerprint until claim/source changes. |
+| Recurring | `status-truth:recurring` | Attention signal | Reopened non-terminal drift after cooldown/clearance rules. |
+| Needs outcome | Closed proposal with no recognized terminal/resolution label | Excluded from accuracy | Cooldown before any reopen; counted for operator attention. |
+| Conflicting labels | Mutually exclusive outcome labels present together | Excluded from accuracy | Counted for attention; no graduation input. |
+
+### Public Artifact Contract
+
+| Surface | Allowed content | Prohibited content |
+| --- | --- | --- |
+| Workflow summary and logs | Counts, claim kinds, failure classes, dry-run/live status | Raw claim text, snippets, fingerprints, file paths, repo paths, tracker payloads, issue titles, credentials |
+| Detect/open artifacts | Versioned machine fields, counts, safe source refs after identity proof | Private identity, raw API responses, node IDs, database IDs, secrets, ungated rendered bodies |
+| Proposal issue title/body/comments | Sanitized public location and checked public source after public-output gate | Private/unknown repo identity, secret-like values, tracker internals, workflow logs, credential data |
+| Tests and docs fixtures | Synthetic, redacted, or already-public non-sensitive examples | Handles, emails, private repo links, private canonical IDs, copied sensitive coordination text |
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should the next slice build PR execution?** No. PR execution is gated on proposal outcomes; adding
+  it now would violate the two-phase delivery decision.
+- **Should proposal-volume protection wait until drift appears?** No. The first useful resolver can
+  reveal multiple stale claims at once, so caps need to land with signal generation.
+- **Should unlabeled manual closures reopen immediately?** No. Immediate reopen creates a bot-versus-
+  operator loop. Treat unlabeled closure as a needs-outcome state with cooldown semantics.
+- **What cap applies to proposal mutations?** Start with five mutating proposal actions per run,
+  counted after privacy blocking and same-run dedupe using the deterministic mutation priority order.
+
+### Deferred to Implementation
+
+- Exact plan-status phrase grammar should be grounded from current plan prose while writing tests.
+- Exact tracker snapshot field names should be characterized from the live snapshot contract while
+  preserving the plan's fixed claim-to-field mapping requirement.
+- Exact cooldown copy can follow existing issue-lifecycle conventions, but start, end, and override
+  conditions are fixed here and must be explicit in tests: seven days from issue `closed_at`, terminal
+  or resolution label overrides, same-fingerprint drift after cooldown may reopen.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation
+> specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+  scan[Status-truth scan] --> kind{Claim kind}
+  kind --> plan[Plan-status resolver]
+  kind --> tracker[Rollout-tracker resolver]
+  kind --> existing[Existing API resolvers]
+
+  plan --> classify{Current, drifted, unresolved, unsafe}
+  tracker --> classify
+  existing --> classify
+
+  classify -->|current| counts[Counts-only signal]
+  classify -->|unresolved or unsafe| counts
+  classify -->|drifted and safe| proposalPlan[Proposal planner]
+
+  proposalPlan --> cap{Mutation cap available?}
+  cap -->|yes| issueAction[Open, update, reopen, or close proposal]
+  cap -->|no| overflow[Blocked overflow count]
+
+  issueAction --> outcomes[Outcome labels and clear-on-fix signal]
+  overflow --> counts
+  outcomes --> graduationGate[Future PR graduation gate]
+```
+
+---
+
+## Implementation Units
+
+### U1. Plan-status file resolver
+
+Status: complete.
+
+**Goal:** Resolve public claims about plan status against current plan metadata.
+
+**Requirements:** R1, R2, R4, R5
+
+**Dependencies:** Existing status-truth detect foundation.
+
+**Files:**
+- Modify: `scripts/status-truth-detect.ts`
+- Test: `scripts/status-truth-detect.test.ts`
+- Test fixtures: representative plan-status prose in existing status-truth tests
+
+**Approach:**
+- Add a file-parse resolver for plan-status claims using current plan frontmatter as the authoritative
+  state.
+- Normalize supported status vocabulary conservatively; unsupported or malformed values become
+  unresolved.
+- Keep raw claim text and source snippets out of artifacts, logs, and workflow summaries.
+- Use representative plan prose to prevent a grammar that only passes synthetic examples.
+- Limit fixtures to a small set of synthetic or redacted snippets derived from current plan and prior
+  rollout-style prose; do not sweep the repository for arbitrary examples.
+
+**Execution note:** Implement behavior test-first; this resolver is a correctness seam for future file
+claims.
+
+**Patterns to follow:**
+- `scripts/wiki-lint.ts` for pure local file analysis and structured report building.
+- Existing status-truth API resolver tests for current/drifted/unresolved classification shape.
+
+**Test scenarios:**
+- Happy path: a public plan-status claim matches frontmatter and is classified current.
+- Happy path: a public plan-status claim conflicts with frontmatter and becomes drifted.
+- Edge case: a plan-status claim has no explicit target path or unique title; classify unresolved.
+- Edge case: referenced plan file is missing; classify unresolved and emit no proposal-eligible
+  finding.
+- Edge case: frontmatter exists but status is missing or unsupported; classify unresolved.
+- Error path: file read failure increments the file-parse failure class and does not emit a clean
+  report.
+- Privacy path: artifacts and stdout omit raw claim text, source snippets, fingerprints, and private
+  identity tokens.
+
+**Verification:**
+- Plan-status findings participate in the same report contract and proposal eligibility rules as
+  existing API-backed findings.
+
+### U2. Rollout-tracker compound resolver
+
+**Goal:** Resolve rollout-tracker claims through the existing tracker snapshot rather than treating
+them as permanently unavailable.
+
+**Requirements:** R1, R3, R4, R5
+
+**Dependencies:** U1 only for shared test helpers; otherwise can proceed independently from the same
+foundation.
+
+**Files:**
+- Modify: `scripts/status-truth-detect.ts`
+- Modify: `scripts/rollout-tracker-snapshot.ts` if pure exports need a small extraction seam
+- Modify: `.github/workflows/status-truth.yaml`
+- Test: `scripts/status-truth-detect.test.ts`
+- Test: `scripts/rollout-tracker-snapshot.test.ts` if the extraction seam changes behavior
+
+**Approach:**
+- Treat the rollout snapshot as a compound sub-resolver source. Detection consumes a sanitized,
+  schema-validated snapshot result and compares claim state only against the fixed field map this unit
+  defines.
+- Keep Project access and snapshot failures as unresolved, not drifted, so incomplete source data does
+  not create public proposals.
+- Keep raw snapshot payloads private to the resolver boundary. Public artifacts may contain counts,
+  claim kind, and failure class only.
+- Preserve read/write credential separation. Snapshot access must not widen the proposal write token
+  or route Project credentials into public output.
+- Emit a durable report artifact even when the snapshot is unavailable, matching the existing
+  authoritative-snapshot failure pattern.
+
+**Execution note:** Characterize current snapshot output before changing imports or workflow plumbing.
+
+**Patterns to follow:**
+- `scripts/rollout-tracker-snapshot.ts` for tracker truth and digest semantics.
+- `docs/solutions/integration-issues/wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md`
+  for unavailable-snapshot reporting.
+
+**Test scenarios:**
+- Happy path: tracker claim matches snapshot state and is classified current.
+- Happy path: tracker claim conflicts with snapshot state and becomes drifted when all source data is
+  public and complete.
+- Edge case: snapshot source is unavailable; classify unresolved and do not close existing proposals.
+- Edge case: snapshot payload contains unexpected fields or schema version; classify unresolved or
+  execution-failure without echoing payload details.
+- Edge case: compound sub-resolver disagreement blocks proposal eligibility.
+- Error path: snapshot parsing fails; the run emits an execution-failure or unresolved report rather
+  than a fake clean report.
+- Integration: workflow dry-run consumes the snapshot path without minting write credentials.
+
+**Verification:**
+- Rollout-tracker claims produce current/drifted/unresolved counts from the snapshot contract without
+  adding Project writes or leaking tracker internals to public summaries.
+
+### U3. Proposal caps and overflow reporting
+
+**Goal:** Prevent a useful drift run from opening too many issues or comments at once.
+
+**Requirements:** R5, R6, R8
+
+**Dependencies:** Existing proposal planner; can be developed before U1/U2 and exercised with fixture
+findings.
+
+**Files:**
+- Modify: `scripts/status-truth-proposals.ts`
+- Test: `scripts/status-truth-proposals.test.ts`
+- Modify: `.github/workflows/status-truth.yaml`
+
+**Approach:**
+- Add a per-run cap for mutating proposal actions: open, update-comment, reopen, and close.
+- Preserve same-run dedupe before cap accounting so the cap measures real unique work.
+- Apply privacy blocking before cap accounting so blocked/unsafe findings do not consume mutation
+  budget.
+- Use the deterministic priority order from Key Technical Decisions: close, update, reopen, then open.
+- Represent overflow as blocked planned work in counts and summaries, without rendering claim text or
+  creating partial issue state.
+- Ensure dry-run exercises the same cap logic and reports what would be blocked.
+
+**Execution note:** Add planner tests before touching the Octokit shell.
+
+**Patterns to follow:**
+- `scripts/capture-learnings-open.ts` for maximum proposal discipline.
+- `scripts/status-truth-proposals.ts` existing same-run fingerprint dedupe.
+
+**Test scenarios:**
+- Happy path: fewer planned mutations than the cap execute normally.
+- Edge case: more drifted findings than the cap produce allowed actions plus overflow counts.
+- Edge case: close/update/reopen/open actions compete for the cap; the fixed priority order is honored.
+- Edge case: same-run duplicate fingerprints do not consume cap slots twice.
+- Error path: cap overflow never creates, comments, reopens, or closes issues beyond the limit.
+- Integration: workflow summary reports mutation and overflow counts only.
+
+**Verification:**
+- A synthetic high-drift report cannot create unbounded issue noise in dry-run or live mode.
+
+### U4. Outcome classification and accuracy math
+
+**Goal:** Classify proposal outcomes into a stable usefulness signal without mutating issue state.
+
+**Requirements:** R7, R8
+
+**Dependencies:** U3 for cap-aware lifecycle planning.
+
+**Files:**
+- Modify: `scripts/status-truth-proposals.ts`
+- Test: `scripts/status-truth-proposals.test.ts`
+- Modify: `README.md`
+
+**Approach:**
+- Treat explicit accepted, rejected, false-positive, superseded, recurring, resolved, and
+  manually-fixed states as distinct semantic outcomes using the Outcome State Contract.
+- Count clear-on-fix as positive usefulness without converting it into an explicit operator-accepted
+  label.
+- Handle conflicting outcome labels conservatively: exclude the issue from accuracy math and surface a
+  needs-attention count.
+- Treat manual closure without terminal outcome as `needs outcome`: excluded from accuracy math and
+  surfaced for attention, with no reopen behavior in this unit.
+- Keep workflow summaries aggregate-only; operator details stay in the proposal issue thread.
+
+**Execution note:** Start with label-set table tests; these states are easy to regress with label
+changes.
+
+**Patterns to follow:**
+- Existing status-truth proposal planner outcome labels.
+- `scripts/wiki-lint-issues.ts` recurrence comments and close-on-clear behavior.
+
+**Test scenarios:**
+- Happy path: explicit accepted and rejected labels contribute to per-kind usefulness counts.
+- Happy path: drift clears after a proposal and contributes a distinct resolved positive count.
+- Edge case: an issue has conflicting accepted/rejected labels; it is excluded from accuracy math and
+  counted for attention.
+- Edge case: closed-without-outcome contributes to needs-outcome counts but not usefulness math.
+- Error path: malformed outcome markers do not crash planning and do not inflate accuracy.
+- Integration: workflow summary reports aggregate usefulness and attention counts only.
+
+**Verification:**
+- Operator outcome labels can drive future graduation decisions without requiring workflow-log review.
+
+### U5. Manual closure cooldown and recurrence behavior
+
+**Goal:** Prevent bot-versus-operator loops while preserving recurrence handling for unresolved drift.
+
+**Requirements:** R7, R8
+
+**Dependencies:** U4.
+
+**Files:**
+- Modify: `scripts/status-truth-proposals.ts`
+- Test: `scripts/status-truth-proposals.test.ts`
+- Modify: `README.md`
+
+**Approach:**
+- Store manual closure without a terminal/resolution label as a derived planning condition, not a new
+  label.
+- Define cooldown as seven days from the proposal issue `closed_at` timestamp. During cooldown, keep the
+  issue closed, count it as needs-outcome, and do not open a duplicate proposal for the same
+  fingerprint.
+- After cooldown, if the same drift still exists and no terminal/resolution label was added, reopen the
+  issue with a concise recurrence/needs-outcome comment.
+- Terminal labels override cooldown. Resolved or manually-fixed labels clear cooldown and allow normal
+  close-on-clear behavior. Conflicting labels block mutation and surface needs-attention counts.
+- Reopen removes resolving labels only when the issue was previously non-terminal and the same drift
+  recurs after cooldown.
+
+**Execution note:** Implement as pure lifecycle planning before wiring Octokit mutation behavior.
+
+**Patterns to follow:**
+- `scripts/wiki-lint-issues.ts` recurrence comments and close-on-clear behavior.
+- Existing status-truth proposal planner reopen and close actions.
+
+**Test scenarios:**
+- Happy path: closed-without-outcome during cooldown is not reopened and does not create a duplicate.
+- Happy path: closed-without-outcome after cooldown reopens with a recurrence/needs-outcome comment.
+- Edge case: terminal rejected or false-positive label suppresses recurrence forever for the same
+  fingerprint.
+- Edge case: resolved or manually-fixed label prevents recurrence while the drift is clear, but a changed
+  claim/source fingerprint can create a new proposal.
+- Error path: missing `closed_at` on a closed issue is treated conservatively as needs-attention with
+  no mutation.
+- Integration: reopened issues remove stale resolving labels and add recurring state without leaking
+  claim text into workflow summaries.
+
+**Verification:**
+- Manual proposal closure cannot cause immediate bot aggression, and persistent recurrence still has a
+  documented path back to operator attention.
+
+### U6. Documentation and operational calibration
+
+**Goal:** Keep the plan, operator docs, and reusable learnings aligned with the completed signal slice.
+
+**Requirements:** R5, R6, R7, R8
+
+**Dependencies:** U1-U5.
+
+**Files:**
+- Modify: `docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md`
+- Modify: `README.md`
+- Create if warranted: `docs/solutions/best-practices/status-truth-resolver-typology-2026-06-30.md`
+
+**Approach:**
+- Update the existing status-truth plan implementation status without overstating PR graduation.
+- Document supported claim kinds, proposal caps, overflow, and operator outcome labels from the
+  operator perspective.
+- Capture the resolver typology learning only if implementation produces a reusable pattern worth
+  preserving: API, file-parse, compound, unavailable, unresolved, and why unresolved findings are
+  honest signal rather than failure.
+- After merge, manually run a dry-run on `main`; only run live proposal opening when dry-run counts are
+  reviewable and proposal-eligible drift exists.
+
+**Patterns to follow:**
+- Existing README Status-Truth Proposals section.
+- `docs/solutions/` frontmatter conventions for reusable best-practice learnings.
+
+**Test scenarios:**
+- Documentation expectation: README labels and operator flow match the label constants and workflow
+  behavior.
+- Documentation expectation: plan status update does not mark bounded PR execution complete.
+- Documentation expectation: any solution doc created contains no private identifiers, internal session
+  narration, or public-surface unsafe examples.
+
+**Verification:**
+- A future implementer can tell which claim kinds are active, which are deferred, how proposal caps
+  work, and why PR execution remains gated.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Status-truth detect reads repo docs/issues/comments and live public GitHub
+  state, optionally consumes tracker snapshot data, emits a safe report, then proposal planning may
+  mutate GitHub issues under caps.
+- **Error propagation:** Missing or inaccessible resolver state becomes unresolved/blocked signal and
+  prevents close-on-clear. Privacy module failures block public output before any proposal mutation.
+- **State lifecycle risks:** Proposal issues remain the decision log. Same-run dedupe, terminal labels,
+  cooldowns, and overflow counts must compose without creating duplicate or adversarial issue loops.
+- **API surface parity:** Future A2 workflows should invoke this status-truth loop instead of embedding
+  ad hoc status reconciliation in prompts.
+- **Integration coverage:** Tests must cover report-to-proposal handoff, snapshot unavailable state,
+  cap overflow, manual closure semantics, and output-gate boundaries.
+- **Unchanged invariants:** `main` branch protection, human merge, `data` branch authority, metadata
+  writes, wiki authority, workflow settings, hooks, secrets, and release config remain unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Resolver grammar creates false positives | Ground grammar in representative real coordination prose and keep unsupported forms unresolved. |
+| Snapshot access failure causes fake clean runs | Emit unresolved or execution-failure reports and never close proposals from incomplete scans. |
+| First useful run opens too many issues | Land mutation caps and overflow counts with resolver completion. |
+| Bot fights operator manual closures | Use cooldown/needs-outcome semantics instead of immediate reopen. |
+| Usefulness math overstates confidence | Keep explicit accepted, resolved positive, rejected, false-positive, malformed, and conflicting states separate. |
+| Private identity leaks through new resolver sources | Reuse public identity gates and rendered-output privacy gates; fail closed on unknown or ambiguous identity. |
+| PR execution sneaks in early | Keep workflow PR job disabled and do not add contents-write or pull-request-write execution in this plan. |
+
+---
+
+## Rollout / Verification Notes
+
+- Keep the scheduled workflow conservative while the resolver slice lands.
+- Require at least one manual dry-run on merged `main` before any live proposal run.
+- Run a live non-dry-run only when dry-run output shows reviewable proposal-eligible drift and no
+  blocker-class privacy or resolver failures.
+- Do not enable bounded correction PRs until proposal outcomes establish per-kind reliability.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-06-26-a2-self-maintenance-portfolio-requirements.md](../brainstorms/2026-06-26-a2-self-maintenance-portfolio-requirements.md)
+- Prior plan: [docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md](2026-06-26-001-feat-status-truth-maintenance-loop-plan.md)
+- Related scripts: `scripts/status-truth-detect.ts`, `scripts/status-truth-proposals.ts`,
+  `scripts/status-truth-public-output.ts`, `scripts/status-truth-prs.ts`,
+  `scripts/rollout-tracker-snapshot.ts`
+- Related workflow: `.github/workflows/status-truth.yaml`
+- Related learnings: `docs/solutions/best-practices/github-issues-api-same-run-eventual-consistency-2026-05-20.md`,
+  `docs/solutions/best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md`,
+  `docs/solutions/best-practices/pure-core-privacy-gates-shared-module-2026-06-22.md`,
+  `docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md`,
+  `docs/solutions/best-practices/credential-mint-time-permission-scoping-2026-06-22.md`,
+  `docs/solutions/integration-issues/wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md`

--- a/docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md
+++ b/docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md
@@ -499,6 +499,8 @@ Status: complete.
 
 ### U6. Documentation and operational calibration
 
+Status: complete.
+
 **Goal:** Keep the plan, operator docs, and reusable learnings aligned with the completed signal slice.
 
 **Requirements:** R5, R6, R7, R8

--- a/docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md
+++ b/docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md
@@ -361,6 +361,8 @@ foundation.
 
 ### U3. Proposal caps and overflow reporting
 
+Status: complete.
+
 **Goal:** Prevent a useful drift run from opening too many issues or comments at once.
 
 **Requirements:** R5, R6, R8

--- a/scripts/check-private-leak.test.ts
+++ b/scripts/check-private-leak.test.ts
@@ -2686,36 +2686,35 @@ describe('assertCompareNotTruncated — truncation detection (FIX 1, P1)', () =>
     expect(() => assertCompareNotTruncated(compareJson)).toThrow(/fail closed/i)
   })
 
-  // Scenario: a file is missing its patch field (individually too large) → fail closed
-  it('throws when any file entry is missing its patch field', () => {
-    // #given: two files, the second has no patch (API omits it for very large files)
+  // Scenario: a file is missing its patch field (JSON omits it for large files) → NOT a truncation signal
+  it('does not throw when a file entry is missing its patch field (JSON omission is not truncation)', () => {
+    // #given: two files, the second has no patch — GitHub omits `patch` in JSON for large files,
+    // but the raw diff media response always includes the full content and is the actual scan source.
     const compareJson = {
       total_commits: 1,
       files: [
         {filename: 'small-file.ts', status: 'modified', patch: '@@ -1 +1 @@\n-old\n+new'},
-        {filename: 'huge-file.ts', status: 'modified'}, // patch intentionally absent
+        {filename: 'huge-file.ts', status: 'modified'}, // patch absent in JSON — raw diff has it
       ],
     }
 
-    // #when / #then: throws because a file has no patch — and the filename is NOT echoed
-    // (a path could embed a private slug; the message stays redacted).
-    expect(() => assertCompareNotTruncated(compareJson)).toThrow(/file patch was omitted.*fail closed/i)
-    expect(() => assertCompareNotTruncated(compareJson)).not.toThrow(/huge-file\.ts/)
+    // #when / #then: does NOT throw — missing JSON patch is not a truncation signal.
+    // fetchDiffForSha will fetch the raw diff which includes the full patch content.
+    expect(() => assertCompareNotTruncated(compareJson)).not.toThrow()
   })
 
-  // Scenario: first file missing patch → fail closed (order doesn't matter)
-  it('throws when the first file entry is missing its patch field', () => {
+  // Scenario: first file missing patch → still not a truncation signal
+  it('does not throw when the first file entry is missing its patch field', () => {
     const compareJson = {
       total_commits: 1,
       files: [
-        {filename: 'huge-first.ts', status: 'added'}, // no patch
+        {filename: 'huge-first.ts', status: 'added'}, // no patch in JSON
         {filename: 'normal.ts', status: 'modified', patch: '@@ -1 +1 @@\n-old\n+new'},
       ],
     }
 
-    // Throws on the missing-patch signal without echoing the filename.
-    expect(() => assertCompareNotTruncated(compareJson)).toThrow(/file patch was omitted.*fail closed/i)
-    expect(() => assertCompareNotTruncated(compareJson)).not.toThrow(/huge-first\.ts/)
+    // Missing JSON patch is not fatal — raw diff fetch covers it.
+    expect(() => assertCompareNotTruncated(compareJson)).not.toThrow()
   })
 
   // Scenario: well-formed response under the cap → does NOT throw
@@ -2826,19 +2825,21 @@ describe('main() — FIX 1 (P1): truncation in compare JSON → fail closed', ()
     }
   })
 
-  it('fails closed (process.exit(1)) when compare JSON has a file with no patch field', async () => {
-    // #given: workflow_run payload; compare JSON has a file with no patch (too large)
+  it('proceeds and scans raw diff when compare JSON has a file with no patch field', async () => {
+    // #given: workflow_run payload; compare JSON has a file with no patch (JSON omits it for large files).
+    // The raw diff media response always includes the full content — it is the actual scan source.
+    // A missing JSON patch is NOT a truncation signal and must not cause a false failure.
     const eventJson = makeWorkflowRunEvent({headSha: 'sha-no-patch'})
     const prApiResolver = makePrApiResolver({
       prByNumber: makePrApiResponse({number: 42, headSha: 'sha-no-patch'}),
     })
 
-    // Compare JSON with one normal file and one file missing its patch
+    // Compare JSON: one file has no patch (JSON omission for large file), file count is under cap.
     const compareJsonWithMissingPatch = JSON.stringify({
       total_commits: 1,
       files: [
         {filename: 'normal.ts', status: 'modified', patch: '@@ -1 +1 @@\n-old\n+new'},
-        {filename: 'huge-binary.bin', status: 'modified'}, // no patch — too large
+        {filename: 'huge-binary.bin', status: 'modified'}, // patch absent in JSON — raw diff has it
       ],
     })
 
@@ -2847,8 +2848,53 @@ describe('main() — FIX 1 (P1): truncation in compare JSON → fail closed', ()
       .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
       .mockReturnValueOnce(makeYamlBase64(['R_no_patch'])) // fetchPrivateNodeIds
       .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'acme/private-repo'}}})) // resolver
+      .mockReturnValueOnce(compareJsonWithMissingPatch) // fetchDiffForSha: compare JSON (missing patch — not fatal)
+      .mockReturnValueOnce(makeDiff('docs/public.md', ['some public content'])) // fetchDiffForSha: raw diff (scanned)
+
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    process.env.GITHUB_EVENT_PATH = '/fake/event.json'
+    process.env.FRO_BOT_POLL_PAT = 'test-pat'
+    try {
+      // #when: main() runs with a compare response that has a file missing its JSON patch
+      await main(makeWorkflowRunReader(eventJson), prApiResolver)
+      // #then: no exit called — missing JSON patch is not fatal; raw diff was fetched and scanned
+      expect(exitSpy).not.toHaveBeenCalled()
+    } finally {
+      exitSpy.mockRestore()
+      vi.restoreAllMocks()
+      delete process.env.GITHUB_EVENT_PATH
+      delete process.env.FRO_BOT_POLL_PAT
+      mockExecFileSync.mockReset()
+    }
+  })
+
+  it('proceeds and detects private token in raw diff even when compare JSON patch is absent', async () => {
+    // #given: compare JSON has a file with no patch; raw diff contains a private token in added lines.
+    // This proves the raw diff is scanned (not the JSON patch) and the gate still catches leaks.
+    const eventJson = makeWorkflowRunEvent({headSha: 'sha-no-patch-leak'})
+    const prApiResolver = makePrApiResolver({
+      prByNumber: makePrApiResponse({number: 42, headSha: 'sha-no-patch-leak'}),
+    })
+
+    const compareJsonWithMissingPatch = JSON.stringify({
+      total_commits: 1,
+      files: [
+        {filename: 'docs/leak.md', status: 'modified'}, // patch absent in JSON
+      ],
+    })
+
+    mockExecFileSync.mockReset()
+    mockExecFileSync
+      .mockReturnValueOnce('fro-bot/.github') // gh repo view (fullName)
+      .mockReturnValueOnce(makeYamlBase64(['R_no_patch_leak'])) // fetchPrivateNodeIds
+      .mockReturnValueOnce(JSON.stringify({data: {node: {nameWithOwner: 'acme/private-repo'}}})) // resolver
       .mockReturnValueOnce(compareJsonWithMissingPatch) // fetchDiffForSha: compare JSON (missing patch)
-    // Note: the raw diff fetch is NOT reached — truncation throws before it
+      .mockReturnValueOnce(makeDiff('docs/leak.md', ['See acme/private-repo for details.'])) // raw diff has the leak
 
     const stderrOutput: string[] = []
     vi.spyOn(process.stderr, 'write').mockImplementation((msg: unknown) => {
@@ -2863,13 +2909,14 @@ describe('main() — FIX 1 (P1): truncation in compare JSON → fail closed', ()
     process.env.GITHUB_EVENT_PATH = '/fake/event.json'
     process.env.FRO_BOT_POLL_PAT = 'test-pat'
     try {
-      // #when: main() runs with a compare response that has a file missing its patch
+      // #when: main() runs — raw diff is scanned and the private token is detected
       await expect(main(makeWorkflowRunReader(eventJson), prApiResolver)).rejects.toThrow('process.exit called')
-      // #then: fail closed — process.exit(1) was called
+      // #then: fail closed because the raw diff contains a private token
       expect(exitSpy).toHaveBeenCalledWith(1)
-      // #then: stderr mentions the truncation
+      // #then: the matched file path appears in stderr (not the private name)
       const stderrText = stderrOutput.join('')
-      expect(stderrText).toMatch(/patch omitted|fail closed/i)
+      expect(stderrText).toContain('docs/leak.md')
+      expect(stderrText).not.toContain('acme/private-repo')
     } finally {
       exitSpy.mockRestore()
       vi.restoreAllMocks()

--- a/scripts/check-private-leak.ts
+++ b/scripts/check-private-leak.ts
@@ -571,13 +571,18 @@ function fetchPrivateNodeIds(
 const COMPARE_API_FILE_CAP = 300
 
 /**
- * Check the compare JSON response for truncation signals.
+ * Check the compare JSON response for file-list truncation.
  * Exported for unit testing.
  *
- * GitHub's compare API caps `files` at 300 per response. Two truncation signals:
- * 1. `files.length >= 300` — the cap was hit; additional files may be missing.
- * 2. Any file entry missing its `patch` field — the API omits `patch` for very large
- *    individual files; we cannot scan a file whose patch was dropped.
+ * GitHub's compare API caps `files` at 300 entries per response. When the cap is
+ * hit, additional changed files are silently omitted from the JSON — we cannot
+ * guarantee a complete scan, so we throw (fail closed).
+ *
+ * A missing per-file `patch` field is NOT a truncation signal. The JSON
+ * representation omits `patch` for individually large files, but the raw unified
+ * diff media response (fetched separately by `fetchDiffForSha`) always includes
+ * the full patch content. The raw diff is the actual scan source; the JSON check
+ * exists only to guard against file-list truncation.
  *
  * Throws with a redacted message if truncation is detected so the caller (main()'s
  * try/catch) exits non-zero — fail closed.
@@ -592,23 +597,14 @@ export function assertCompareNotTruncated(compareJson: unknown): void {
     throw new TypeError('check-private-leak: compare API response missing files array — fail closed')
   }
 
-  // Signal 1: file count at or above the API cap.
+  // File count at or above the API cap: additional files may be missing from the list.
+  // This is the only truncation signal we guard against here. A missing per-file `patch`
+  // field is not fatal — the raw diff fetch (Step 2 in fetchDiffForSha) always includes
+  // the full patch content and is the actual scan source.
   if (files.length >= COMPARE_API_FILE_CAP) {
     throw new Error(
       `check-private-leak: diff too large to scan completely (${files.length} files >= ${COMPARE_API_FILE_CAP}-file cap) — fail closed`,
     )
-  }
-
-  // Signal 2: any file missing its patch field (individually too large for the API to include).
-  // The filename is intentionally NOT echoed — a path under knowledge/wiki/repos/ could embed a
-  // private slug. Fail closed with a count-only message.
-  for (const file of files) {
-    if (!isRecord(file)) continue
-    if (!('patch' in file)) {
-      throw new Error(
-        'check-private-leak: a file patch was omitted by the compare API (file too large to diff) — fail closed',
-      )
-    }
   }
 }
 
@@ -620,30 +616,34 @@ export function assertCompareNotTruncated(compareJson: unknown): void {
  * force-push TOCTOU: the diff is for exactly the SHA the commit status is posted to,
  * regardless of any subsequent force-push to the PR branch.
  *
- * Truncation guard (fail-closed): before fetching the raw diff, queries the compare
- * endpoint as JSON (no diff media type) to check for truncation. GitHub caps the
- * `files` array at 300 entries and omits `patch` for individually-too-large files.
- * Either signal means we cannot guarantee a complete scan → throws so main()'s
- * try/catch exits non-zero (fail closed). The raw diff fetch is skipped on truncation.
+ * Two-step fetch:
+ * 1. JSON truncation check — queries the compare endpoint without a diff media type to
+ *    inspect `files.length`. If the file list is at or above the 300-entry cap, the
+ *    response is truncated and we cannot guarantee a complete scan → throws (fail closed).
+ *    A missing per-file `patch` in the JSON is NOT a truncation signal and does not throw.
+ * 2. Raw diff fetch — requests the same endpoint with `Accept: application/vnd.github.v3.diff`.
+ *    This always returns the full unified diff, including patches for large files that the
+ *    JSON representation omits. The raw diff is the actual scan source.
  *
  * Accepts an explicit env so FRO_BOT_POLL_PAT never reaches the gh subprocess
  * (mirrors the --promotion gitEnv isolation pattern). The PAT-stripped env is used
  * for BOTH the JSON truncation check and the raw diff fetch.
  */
 function fetchDiffForSha(headSha: string, env: NodeJS.ProcessEnv): string {
-  // Step 1: fetch the compare JSON to detect truncation before scanning.
-  // No diff media type — returns { total_commits, files: [...] } with per-file patch fields.
+  // Step 1: fetch the compare JSON to check for file-list truncation.
+  // No diff media type — returns { total_commits, files: [...] }.
+  // Throws if files.length >= 300 (file list truncated) — fail closed.
+  // A missing per-file `patch` in the JSON is not fatal; the raw diff (Step 2) is the scan source.
   const compareJsonRaw = execFileSync(
     'gh',
     ['api', `repos/{owner}/{repo}/compare/${EXPECTED_BASE_BRANCH}...${headSha}`],
     {encoding: 'utf8', env},
   )
   const compareJson: unknown = JSON.parse(compareJsonRaw)
-  // Throws if truncated — fail closed. main()'s try/catch maps this to process.exit(1).
   assertCompareNotTruncated(compareJson)
 
-  // Step 2: fetch the raw unified diff for the actual scan content.
-  // Only reached when the JSON check confirms the diff is complete.
+  // Step 2: fetch the raw unified diff — the actual scan source.
+  // The raw diff always includes full patch content, even for files whose JSON `patch` was omitted.
   return execFileSync(
     'gh',
     [

--- a/scripts/rollout-tracker-snapshot.test.ts
+++ b/scripts/rollout-tracker-snapshot.test.ts
@@ -271,7 +271,7 @@ describe('hashSnapshot', () => {
           content_repo: 'fro-bot/dashboard',
           status: 'Todo',
           readiness: 'ready now',
-          gate: 'Unit 3',
+          gate: 'Gateway stage 3',
           issue_state: 'open',
           issue_closed_at: null,
           issue_labels: [],
@@ -286,7 +286,7 @@ describe('hashSnapshot', () => {
           ...baseItem,
           status: 'In Progress',
           readiness: 'blocked',
-          gate: 'Unit 4',
+          gate: 'Gateway stage 4',
         },
       ],
     }
@@ -302,7 +302,7 @@ describe('hashSnapshot', () => {
           content_repo: 'fro-bot/dashboard',
           status: 'Todo',
           readiness: 'ready now',
-          gate: 'Unit 3',
+          gate: 'Gateway stage 3',
           issue_state: 'open',
           issue_closed_at: null,
           issue_labels: [],
@@ -514,7 +514,7 @@ describe('decideComment', () => {
 
 describe('rollout-tracker-snapshot CLI fixture path', () => {
   it('gates comments only on tracked identity or issue-state transitions', () => {
-    const items = [makeProjectItem({content_number: 24, content_repo: 'fro-bot/dashboard', gate: 'Unit 3'})]
+    const items = [makeProjectItem({content_number: 24, content_repo: 'fro-bot/dashboard', gate: 'Gateway stage 3'})]
     const issues = [makeIssueState({number: 24, repo: 'fro-bot/dashboard', state: 'open'})]
 
     const first = runCliFixture({items, issues})
@@ -713,6 +713,10 @@ describe('deriveTrackedIssueRefs', () => {
     expect(refs).not.toContain('#907')
     expect(refs).toContain('fro-bot/agent#929')
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('unsupported'))
+    // stderr must not contain repo names or item IDs
+    const written = stderrSpy.mock.calls.map(c => String(c[0])).join('')
+    expect(written).not.toContain('fro-bot/agent')
+    expect(written).not.toContain('907')
     stderrSpy.mockRestore()
   })
 
@@ -727,6 +731,9 @@ describe('deriveTrackedIssueRefs', () => {
     expect(refs).not.toContain('fro-bot/agent#0')
     expect(refs).toContain('fro-bot/agent#929')
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('unsupported'))
+    // stderr must not contain repo names or item IDs
+    const written = stderrSpy.mock.calls.map(c => String(c[0])).join('')
+    expect(written).not.toContain('fro-bot/agent')
     stderrSpy.mockRestore()
   })
 
@@ -789,6 +796,10 @@ describe('unsupported Project items excluded from snapshot', () => {
     expect(snapshot.items).toHaveLength(1)
     expect(snapshot.items[0]?.content_number).toBe(929)
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('unsupported'))
+    // stderr must not contain repo names or item IDs
+    const written = stderrSpy.mock.calls.map(c => String(c[0])).join('')
+    expect(written).not.toContain('fro-bot/agent')
+    expect(written).not.toContain('907')
     stderrSpy.mockRestore()
   })
 
@@ -804,6 +815,9 @@ describe('unsupported Project items excluded from snapshot', () => {
     expect(snapshot.items).toHaveLength(1)
     expect(snapshot.items[0]?.content_number).toBe(929)
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('unsupported'))
+    // stderr must not contain repo names or item IDs
+    const written = stderrSpy.mock.calls.map(c => String(c[0])).join('')
+    expect(written).not.toContain('fro-bot/agent')
     stderrSpy.mockRestore()
   })
 

--- a/scripts/rollout-tracker-snapshot.ts
+++ b/scripts/rollout-tracker-snapshot.ts
@@ -134,15 +134,20 @@ export function deriveTrackedIssueRefs(items: ProjectItem[]): string[] {
 }
 
 function filterSupportedProjectItems(items: ProjectItem[]): ProjectItem[] {
-  return items.filter(item => {
+  let skipped = 0
+  const supported = items.filter(item => {
     if (item.content_repo === '' || item.content_number === 0) {
-      process.stderr.write(
-        `rollout-tracker-snapshot: warning — skipping unsupported Project item (id=${item.id}, repo="${item.content_repo}", number=${item.content_number})\n`,
-      )
+      skipped++
       return false
     }
     return true
   })
+  if (skipped > 0) {
+    process.stderr.write(
+      `rollout-tracker-snapshot: warning — skipping ${skipped} unsupported Project item(s) (missing repo or number)\n`,
+    )
+  }
+  return supported
 }
 
 /**
@@ -354,6 +359,7 @@ async function main(): Promise<void> {
       const {execSync} = await import('node:child_process')
       rawItems = execSync(`gh project item-list ${projectNumber} --owner ${projectOwner} --format json --limit 100`, {
         encoding: 'utf8',
+        timeout: 60_000,
       })
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error)
@@ -399,7 +405,7 @@ async function main(): Promise<void> {
         const raw = execFileSync(
           'gh',
           ['issue', 'view', numStr, '--repo', repo, '--json', 'number,state,title,closedAt,labels'],
-          {encoding: 'utf8'},
+          {encoding: 'utf8', timeout: 30_000},
         )
         const parsed = JSON.parse(raw) as {
           number: number
@@ -416,11 +422,9 @@ async function main(): Promise<void> {
           closed_at: parsed.closedAt,
           labels: parsed.labels.map(l => l.name),
         })
-      } catch (error) {
-        const detail = error instanceof Error ? error.message : String(error)
-        process.stderr.write(`rollout-tracker-snapshot: FATAL — failed to fetch ${ref}: ${detail}\n`)
+      } catch {
         process.stderr.write(
-          'rollout-tracker-snapshot: refusing to treat tracked issue access failure as no-drift; exiting 1\n',
+          'rollout-tracker-snapshot: FATAL — failed to fetch a tracked issue; refusing to treat access failure as no-drift; exiting 1\n',
         )
         process.exit(1)
       }

--- a/scripts/status-truth-detect.test.ts
+++ b/scripts/status-truth-detect.test.ts
@@ -4376,3 +4376,80 @@ describe('loadRolloutSnapshot: snapshot file loading and validation', () => {
     expect(result).toBeNull()
   })
 })
+
+// ---------------------------------------------------------------------------
+// buildProposedCorrection — trailing-state-only replacement
+// When the claimed state word appears in the path/tag (e.g. active-plan.md,
+// v1.0-active), the correction must replace only the trailing state token,
+// not the first occurrence in the path.
+// ---------------------------------------------------------------------------
+
+describe('buildProposedCorrection: trailing-state replacement via detect pipeline', () => {
+  it('plan-status path containing claimed state word with hyphen: correction replaces only trailing state', async () => {
+    // normalizedText = "plan docs/plans/active-plan.md is active"
+    // claimedState   = "active"
+    // Bug: \bactive\b matches "active" in "active-plan.md" first → corrupts path
+    // Fix: replace only the trailing "active" (the last occurrence)
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'plan docs/plans/active-plan.md is active',
+    })
+    const claim = claims.find(c => c.kind === 'plan-status')
+    expect(claim).toBeDefined()
+    if (claim === undefined) return
+
+    // Verify the claim was extracted correctly
+    expect(claim.claimedState).toBe('active')
+    expect(claim.normalizedText).toBe('plan docs/plans/active-plan.md is active')
+
+    const resolverResults: Record<string, ResolverResult> = {
+      [`plan-status:${claim.sourceRef}`]: {status: 'resolved', state: 'complete'},
+    }
+
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+    expect(findings).toHaveLength(1)
+    const finding = findings[0]
+    expect(finding?.verdict).toBe('drifted')
+    if (finding?.verdict === 'drifted') {
+      expect(finding.proposedCorrection).toBeDefined()
+      // Must contain the live state
+      expect(finding.proposedCorrection).toContain('complete')
+      // Must NOT corrupt the path — "active-plan.md" must remain intact
+      expect(finding.proposedCorrection).toContain('active-plan.md')
+      // The trailing state must be replaced
+      expect(finding.proposedCorrection).not.toMatch(/\bactive\s*$/)
+    }
+  })
+
+  it('release-tag-state tag containing claimed state word with hyphen: correction replaces only trailing state', () => {
+    // normalizedText = "release v1.0-published is published"
+    // claimedState   = "published"
+    // Bug: \bpublished\b matches "published" in "v1.0-published" first → corrupts tag
+    // Fix: replace only the trailing "published" (the last occurrence)
+    const claim: StatusTruthClaim = {
+      kind: 'release-tag-state',
+      path: 'README.md',
+      sourceRef: '@v1.0-published',
+      claimedState: 'published',
+      normalizedText: 'release v1.0-published is published',
+    }
+
+    const resolverResults = makeResolverResults([
+      {kind: 'release-tag-state', sourceRef: '@v1.0-published', result: {status: 'resolved', state: 'draft'}},
+    ])
+
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+    expect(findings).toHaveLength(1)
+    const finding = findings[0]
+    expect(finding?.verdict).toBe('drifted')
+    if (finding?.verdict === 'drifted') {
+      expect(finding.proposedCorrection).toBeDefined()
+      // Must contain the live state
+      expect(finding.proposedCorrection).toContain('draft')
+      // Must NOT corrupt the tag — "v1.0-published" must remain intact
+      expect(finding.proposedCorrection).toContain('v1.0-published')
+      // The trailing state must be replaced
+      expect(finding.proposedCorrection).not.toMatch(/\bpublished\s*$/)
+    }
+  })
+})

--- a/scripts/status-truth-detect.test.ts
+++ b/scripts/status-truth-detect.test.ts
@@ -1,3 +1,4 @@
+import type {RolloutSnapshot, SnapshotItem} from './rollout-tracker-snapshot.ts'
 import type {
   ClaimKind,
   ClaimVerdict,
@@ -15,7 +16,9 @@ import type {
   StatusTruthJsonReport,
 } from './status-truth-detect.ts'
 
-import {describe, expect, it} from 'vitest'
+import process from 'node:process'
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {
   buildDetectOctokitOptions,
@@ -30,11 +33,13 @@ import {
   KNOWN_SCHEMA_VERSION,
   listCurrentRepoIssueComments,
   listCurrentRepoIssues,
+  loadRolloutSnapshot,
   normalizeClaimText,
   resolveAllClaims,
   resolveClaimLiveState,
   resolveFileParseClaims,
   resolvePlanStatusClaim,
+  resolveRolloutTrackerClaim,
   scanIssueStatusTruthClaims,
   scanStatusTruthClaims,
   selectDetectFailureClass,
@@ -3691,5 +3696,683 @@ describe('plan-status drift: proposedCorrection contains expected status replace
       // (it should have replaced 'active' with 'complete')
       expect(finding.proposedCorrection).not.toMatch(/\bactive\b/)
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// U2: Rollout-tracker compound resolver tests
+// ---------------------------------------------------------------------------
+
+/** Build a minimal SnapshotItem for test fixtures. */
+function makeSnapshotItem(overrides: Partial<SnapshotItem> = {}): SnapshotItem {
+  return {
+    content_number: 3512,
+    content_repo: 'fro-bot/.github',
+    status: 'In Progress',
+    readiness: null,
+    gate: null,
+    issue_state: 'open',
+    issue_closed_at: null,
+    issue_labels: [],
+    ...overrides,
+  }
+}
+
+/** Build a minimal RolloutSnapshot for test fixtures. */
+function makeRolloutSnapshot(items: SnapshotItem[] = [makeSnapshotItem()]): RolloutSnapshot {
+  return {items}
+}
+
+describe('resolveRolloutTrackerClaim', () => {
+  // ── Happy path: snapshot state matches claim ──────────────────────────────
+
+  it('happy path: snapshot issue_state matches claimed state => resolved with matching state', async () => {
+    const snapshot = makeRolloutSnapshot([makeSnapshotItem({content_number: 3512, issue_state: 'open'})])
+    const claim = makeClaim({
+      kind: 'rollout-tracker-status',
+      sourceRef: '#3512',
+      claimedState: 'open',
+      normalizedText: 'rollout tracker #3512 is open',
+    })
+
+    const result = await resolveRolloutTrackerClaim({claim, snapshot})
+
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') {
+      expect(result.state).toBe('open')
+    }
+  })
+
+  it('happy path: snapshot issue_state "closed" matches claimed "closed" => resolved current', async () => {
+    const snapshot = makeRolloutSnapshot([makeSnapshotItem({content_number: 3512, issue_state: 'closed'})])
+    const claim = makeClaim({
+      kind: 'rollout-tracker-status',
+      sourceRef: '#3512',
+      claimedState: 'closed',
+      normalizedText: 'rollout tracker #3512 is closed',
+    })
+
+    const result = await resolveRolloutTrackerClaim({claim, snapshot})
+
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') {
+      expect(result.state).toBe('closed')
+    }
+  })
+
+  // ── Happy path: snapshot state conflicts with claim => drifted ────────────
+
+  it('happy path: snapshot issue_state conflicts with claimed state => resolved with live state (drifted via detectStatusTruthClaims)', async () => {
+    const snapshot = makeRolloutSnapshot([makeSnapshotItem({content_number: 3512, issue_state: 'closed'})])
+    const claim = makeClaim({
+      kind: 'rollout-tracker-status',
+      sourceRef: '#3512',
+      claimedState: 'open',
+      normalizedText: 'rollout tracker #3512 is open',
+    })
+
+    const result = await resolveRolloutTrackerClaim({claim, snapshot})
+
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') {
+      // Live state is 'closed'; claim says 'open' → detectStatusTruthClaims will classify as drifted
+      expect(result.state).toBe('closed')
+    }
+  })
+
+  it('integration: drifted rollout-tracker claim produces drifted finding and is proposal-eligible', async () => {
+    const snapshot = makeRolloutSnapshot([makeSnapshotItem({content_number: 3512, issue_state: 'closed'})])
+    const claim = makeClaim({
+      kind: 'rollout-tracker-status',
+      sourceRef: '#3512',
+      claimedState: 'open',
+      normalizedText: 'rollout tracker #3512 is open',
+    })
+
+    const result = await resolveRolloutTrackerClaim({claim, snapshot})
+    const resolverResults = makeResolverResults([{kind: 'rollout-tracker-status', sourceRef: '#3512', result}])
+
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+
+    expect(findings).toHaveLength(1)
+    const finding = findings[0]
+    expect(finding?.verdict).toBe('drifted')
+    expect(finding?.proposalEligible).toBe(true)
+  })
+
+  // ── Edge case: snapshot unavailable => unresolved ─────────────────────────
+
+  it('edge: snapshot is null (unavailable) => unavailable, no proposal eligibility', async () => {
+    const claim = makeClaim({
+      kind: 'rollout-tracker-status',
+      sourceRef: '#3512',
+      claimedState: 'open',
+      normalizedText: 'rollout tracker #3512 is open',
+    })
+
+    const result = await resolveRolloutTrackerClaim({claim, snapshot: null})
+
+    expect(result.status).toBe('unavailable')
+  })
+
+  it('edge: snapshot unavailable => detectStatusTruthClaims classifies as unresolved, not drifted', async () => {
+    const claim = makeClaim({
+      kind: 'rollout-tracker-status',
+      sourceRef: '#3512',
+      claimedState: 'open',
+      normalizedText: 'rollout tracker #3512 is open',
+    })
+
+    const result = await resolveRolloutTrackerClaim({claim, snapshot: null})
+    const resolverResults = makeResolverResults([{kind: 'rollout-tracker-status', sourceRef: '#3512', result}])
+
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.verdict).toBe('unresolved')
+    expect(findings[0]?.proposalEligible).toBe(false)
+  })
+
+  it('edge: snapshot item not found for sourceRef => unavailable', async () => {
+    // Snapshot has item #9999 but claim references #3512
+    const snapshot = makeRolloutSnapshot([makeSnapshotItem({content_number: 9999, issue_state: 'open'})])
+    const claim = makeClaim({
+      kind: 'rollout-tracker-status',
+      sourceRef: '#3512',
+      claimedState: 'open',
+      normalizedText: 'rollout tracker #3512 is open',
+    })
+
+    const result = await resolveRolloutTrackerClaim({claim, snapshot})
+
+    expect(result.status).toBe('unavailable')
+  })
+
+  // ── Edge case: malformed/unexpected snapshot schema => unresolved ─────────
+
+  it('edge: snapshot with null issue_state for matched item => unavailable (incomplete data)', async () => {
+    const snapshot = makeRolloutSnapshot([makeSnapshotItem({content_number: 3512, issue_state: null})])
+    const claim = makeClaim({
+      kind: 'rollout-tracker-status',
+      sourceRef: '#3512',
+      claimedState: 'open',
+      normalizedText: 'rollout tracker #3512 is open',
+    })
+
+    const result = await resolveRolloutTrackerClaim({claim, snapshot})
+
+    // null issue_state means we cannot determine live state → unavailable
+    expect(result.status).toBe('unavailable')
+  })
+
+  it('edge: snapshot with empty items array => unavailable', async () => {
+    const snapshot = makeRolloutSnapshot([])
+    const claim = makeClaim({
+      kind: 'rollout-tracker-status',
+      sourceRef: '#3512',
+      claimedState: 'open',
+      normalizedText: 'rollout tracker #3512 is open',
+    })
+
+    const result = await resolveRolloutTrackerClaim({claim, snapshot})
+
+    expect(result.status).toBe('unavailable')
+  })
+
+  // ── Edge case: compound sub-resolver disagreement blocks proposal eligibility
+
+  it('edge: compound sub-resolver disagreement (issue-state unavailable) blocks proposal eligibility', async () => {
+    // The rollout-tracker-status resolver returns resolved, but sub-resolvers are unavailable.
+    // detectStatusTruthClaims must classify as unresolved when sub-resolvers are not all resolved.
+    const rolloutClaim = makeClaim({
+      kind: 'rollout-tracker-status',
+      path: 'docs/plans/rollout.md',
+      sourceRef: '#3512',
+      claimedState: 'open',
+      normalizedText: 'rollout tracker #3512 is open',
+    })
+
+    const resolverResults = makeResolverResults([
+      {
+        kind: 'rollout-tracker-status',
+        sourceRef: '#3512',
+        result: {
+          status: 'resolved',
+          state: 'closed', // conflicts with claim
+          subResolverResults: {
+            'issue-state': {status: 'unavailable'},
+            'pr-state': {status: 'unavailable'},
+          },
+        },
+      },
+    ])
+
+    const findings = detectStatusTruthClaims([rolloutClaim], resolverResults)
+
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.verdict).toBe('unresolved')
+    expect(findings[0]?.proposalEligible).toBe(false)
+  })
+
+  // ── Public output safety: no raw snapshot payload in resolver result ───────
+
+  it('safety: resolver result does not echo raw snapshot payload, issue titles, or tracker internals', async () => {
+    const snapshot = makeRolloutSnapshot([
+      makeSnapshotItem({
+        content_number: 3512,
+        issue_state: 'closed',
+        // These fields must not appear in the resolver result
+        status: 'SENSITIVE_PROJECT_STATUS',
+        readiness: 'SENSITIVE_READINESS',
+        gate: 'SENSITIVE_GATE',
+        issue_labels: ['SENSITIVE_LABEL'],
+      }),
+    ])
+    const claim = makeClaim({
+      kind: 'rollout-tracker-status',
+      sourceRef: '#3512',
+      claimedState: 'open',
+      normalizedText: 'rollout tracker #3512 is open',
+    })
+
+    const result = await resolveRolloutTrackerClaim({claim, snapshot})
+
+    // The result must only contain status and state — no raw snapshot fields
+    const resultJson = JSON.stringify(result)
+    expect(resultJson).not.toContain('SENSITIVE_PROJECT_STATUS')
+    expect(resultJson).not.toContain('SENSITIVE_READINESS')
+    expect(resultJson).not.toContain('SENSITIVE_GATE')
+    expect(resultJson).not.toContain('SENSITIVE_LABEL')
+    expect(resultJson).not.toContain('issue_labels')
+    expect(resultJson).not.toContain('issue_closed_at')
+  })
+
+  // ── resolveClaimLiveState integration: snapshot injection ─────────────────
+
+  it('integration: resolveClaimLiveState with snapshot resolves rollout-tracker-status claim', async () => {
+    const octokit = makeMockDetectOctokit()
+    const snapshot = makeRolloutSnapshot([makeSnapshotItem({content_number: 3512, issue_state: 'closed'})])
+    const claim = makeTestClaim({
+      kind: 'rollout-tracker-status',
+      sourceRef: '#3512',
+      claimedState: 'open',
+    })
+
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github', snapshot})
+
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') {
+      expect(result.state).toBe('closed')
+    }
+  })
+
+  it('integration: resolveClaimLiveState without snapshot returns unavailable for rollout-tracker-status', async () => {
+    const octokit = makeMockDetectOctokit()
+    const claim = makeTestClaim({
+      kind: 'rollout-tracker-status',
+      sourceRef: '#3512',
+      claimedState: 'open',
+    })
+
+    // No snapshot provided — should remain unavailable (Phase 1 behavior preserved)
+    const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
+
+    expect(result.status).toBe('unavailable')
+  })
+
+  // ── Dry-run path: no write credentials minted ─────────────────────────────
+
+  it('safety: resolveRolloutTrackerClaim is a pure read-only function (no Octokit, no write token)', async () => {
+    // The function signature must not require an Octokit client or any write credential.
+    // This test verifies the function can be called with only claim + snapshot.
+    const snapshot = makeRolloutSnapshot([makeSnapshotItem({content_number: 3512, issue_state: 'open'})])
+    const claim = makeClaim({
+      kind: 'rollout-tracker-status',
+      sourceRef: '#3512',
+      claimedState: 'open',
+      normalizedText: 'rollout tracker #3512 is open',
+    })
+
+    // Must not throw or require any additional credentials
+    const result = await resolveRolloutTrackerClaim({claim, snapshot})
+    expect(result.status).toBe('resolved')
+  })
+
+  // ── Durable report artifact even when snapshot unavailable ────────────────
+
+  it('integration: snapshot unavailable still produces a durable execution-failure report (not fake clean)', async () => {
+    const claim = makeClaim({
+      kind: 'rollout-tracker-status',
+      sourceRef: '#3512',
+      claimedState: 'open',
+      normalizedText: 'rollout tracker #3512 is open',
+    })
+
+    // Simulate snapshot unavailable
+    const result = await resolveRolloutTrackerClaim({claim, snapshot: null})
+    const resolverResults = makeResolverResults([{kind: 'rollout-tracker-status', sourceRef: '#3512', result}])
+
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+    const report = buildStatusTruthReport({
+      findings,
+      scanComplete: true,
+      generatedAt: '2026-06-30T00:00:00Z',
+      failureClass: 'sub-resolver-unavailable',
+    })
+
+    // Report must be execution-failure (not clean) when snapshot is unavailable
+    expect(report.status).toBe('execution-failure')
+    expect(report.failure_class).toBe('sub-resolver-unavailable')
+    expect(report.repair_eligible).toBe(false)
+    // The finding is still present as unresolved (not hidden)
+    expect(report.counts.unresolved).toBe(1)
+    expect(report.counts.proposal_eligible).toBe(0)
+  })
+
+  // ── Grammar tightening: unsupported claim forms => no claim extracted ──────
+
+  it('grammar: "rollout tracker #3512 is active" extracts a rollout-tracker-status claim', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/rollout.md',
+      text: 'The rollout tracker #3512 is active.',
+    })
+    const trackerClaims = claims.filter(c => c.kind === 'rollout-tracker-status')
+    expect(trackerClaims).toHaveLength(1)
+    expect(trackerClaims[0]?.sourceRef).toBe('#3512')
+    expect(trackerClaims[0]?.claimedState).toBe('active')
+  })
+
+  it('grammar: "rollout tracker #3512 is open" extracts a rollout-tracker-status claim', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/rollout.md',
+      text: 'rollout tracker #3512 is open',
+    })
+    const trackerClaims = claims.filter(c => c.kind === 'rollout-tracker-status')
+    expect(trackerClaims).toHaveLength(1)
+    expect(trackerClaims[0]?.claimedState).toBe('open')
+  })
+
+  it('grammar: "rollout tracker #3512 is closed" extracts a rollout-tracker-status claim', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/rollout.md',
+      text: 'rollout tracker #3512 is closed',
+    })
+    const trackerClaims = claims.filter(c => c.kind === 'rollout-tracker-status')
+    expect(trackerClaims).toHaveLength(1)
+    expect(trackerClaims[0]?.claimedState).toBe('closed')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveAllClaims snapshot wiring
+// ---------------------------------------------------------------------------
+
+describe('resolveAllClaims: snapshot wiring for rollout-tracker-status', () => {
+  it('resolveAllClaims with snapshot resolves rollout-tracker-status claim to current', async () => {
+    // When a snapshot is provided and the item matches, the claim resolves to current/drifted
+    // instead of unavailable. This test proves the snapshot flows through resolveAllClaims
+    // into resolveClaimLiveState.
+    const snapshot = makeRolloutSnapshot([makeSnapshotItem({content_number: 3512, issue_state: 'open'})])
+    const claim = makeTestClaim({
+      kind: 'rollout-tracker-status',
+      sourceRef: '#3512',
+      claimedState: 'open',
+      normalizedText: 'rollout tracker #3512 is open',
+    })
+    const octokit = makeMockDetectOctokit()
+
+    const {resolverResults} = await resolveAllClaims({
+      claims: [claim],
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      snapshot,
+    })
+
+    const result = resolverResults['rollout-tracker-status:#3512']
+    expect(result).toBeDefined()
+    expect(result?.status).toBe('resolved')
+    if (result?.status === 'resolved') {
+      expect(result.state).toBe('open')
+    }
+  })
+
+  it('resolveAllClaims with snapshot resolves rollout-tracker-status claim to drifted state', async () => {
+    // Snapshot says issue is closed; claim says open → drifted
+    const snapshot = makeRolloutSnapshot([makeSnapshotItem({content_number: 3512, issue_state: 'closed'})])
+    const claim = makeTestClaim({
+      kind: 'rollout-tracker-status',
+      sourceRef: '#3512',
+      claimedState: 'open',
+      normalizedText: 'rollout tracker #3512 is open',
+    })
+    const octokit = makeMockDetectOctokit()
+
+    const {resolverResults} = await resolveAllClaims({
+      claims: [claim],
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      snapshot,
+    })
+
+    const result = resolverResults['rollout-tracker-status:#3512']
+    expect(result?.status).toBe('resolved')
+    if (result?.status === 'resolved') {
+      expect(result.state).toBe('closed')
+    }
+
+    // Verify the full pipeline: drifted finding produced
+    // The snapshot satisfies both sub-resolvers (issue-state + pr-state), so the compound
+    // claim is fully resolved and proposal-eligible when drifted.
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.verdict).toBe('drifted')
+    expect(findings[0]?.proposalEligible).toBe(true) // compound: sub-resolvers satisfied by snapshot
+  })
+
+  it('resolveAllClaims without snapshot leaves rollout-tracker-status unavailable', async () => {
+    // No snapshot → rollout-tracker-status stays unavailable (not fake-resolved)
+    const claim = makeTestClaim({
+      kind: 'rollout-tracker-status',
+      sourceRef: '#3512',
+      claimedState: 'open',
+      normalizedText: 'rollout tracker #3512 is open',
+    })
+    const octokit = makeMockDetectOctokit()
+
+    const {resolverResults} = await resolveAllClaims({
+      claims: [claim],
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      // No snapshot param
+    })
+
+    const result = resolverResults['rollout-tracker-status:#3512']
+    expect(result?.status).toBe('unavailable')
+  })
+
+  it('resolveAllClaims with null snapshot leaves rollout-tracker-status unavailable', async () => {
+    // Explicit null snapshot → unavailable (snapshot was attempted but failed)
+    const claim = makeTestClaim({
+      kind: 'rollout-tracker-status',
+      sourceRef: '#3512',
+      claimedState: 'open',
+      normalizedText: 'rollout tracker #3512 is open',
+    })
+    const octokit = makeMockDetectOctokit()
+
+    const {resolverResults} = await resolveAllClaims({
+      claims: [claim],
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      snapshot: null,
+    })
+
+    const result = resolverResults['rollout-tracker-status:#3512']
+    expect(result?.status).toBe('unavailable')
+  })
+
+  it('resolveAllClaims snapshot does not affect non-rollout-tracker claims', async () => {
+    // Snapshot presence must not change resolution of pr-state or issue-state claims
+    const snapshot = makeRolloutSnapshot([makeSnapshotItem({content_number: 42, issue_state: 'closed'})])
+    const prClaim = makeTestClaim({kind: 'pr-state', sourceRef: '#42', claimedState: 'open'})
+    const octokit = makeMockDetectOctokit({prState: 'open'})
+
+    const {resolverResults} = await resolveAllClaims({
+      claims: [prClaim],
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      snapshot,
+    })
+
+    // PR claim must resolve via API, not snapshot
+    const result = resolverResults['pr-state:#42']
+    expect(result?.status).toBe('resolved')
+    if (result?.status === 'resolved') {
+      expect(result.state).toBe('open') // API says open, not snapshot's closed
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// loadRolloutSnapshot helper
+// ---------------------------------------------------------------------------
+
+describe('loadRolloutSnapshot: snapshot file loading and validation', () => {
+  beforeEach(() => {
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('loadRolloutSnapshot returns null when env var is not set', async () => {
+    // No STATUS_TRUTH_ROLLOUT_SNAPSHOT_PATH → null (no snapshot available)
+    const result = await loadRolloutSnapshot({snapshotPath: undefined})
+    expect(result).toBeNull()
+  })
+
+  it('loadRolloutSnapshot returns null when env var is empty string', async () => {
+    const result = await loadRolloutSnapshot({snapshotPath: ''})
+    expect(result).toBeNull()
+  })
+
+  it('loadRolloutSnapshot returns a valid RolloutSnapshot from a well-formed JSON file', async () => {
+    // Inject a file reader that returns valid snapshot JSON
+    const snapshot: RolloutSnapshot = {
+      items: [
+        {
+          content_number: 3512,
+          content_repo: 'fro-bot/.github',
+          status: 'In Progress',
+          readiness: null,
+          gate: null,
+          issue_state: 'open',
+          issue_closed_at: null,
+          issue_labels: [],
+        },
+      ],
+    }
+    const fileReader = async (_path: string) => JSON.stringify(snapshot)
+
+    const result = await loadRolloutSnapshot({snapshotPath: '/tmp/snapshot.json', fileReader})
+    expect(result).not.toBeNull()
+    expect(result?.items).toHaveLength(1)
+    expect(result?.items[0]?.content_number).toBe(3512)
+    expect(result?.items[0]?.issue_state).toBe('open')
+  })
+
+  it('loadRolloutSnapshot returns null for malformed JSON', async () => {
+    // Malformed JSON → null, no throw, no raw payload in output
+    const fileReader = async (_path: string) => 'not-valid-json{{{}'
+    const result = await loadRolloutSnapshot({snapshotPath: '/tmp/snapshot.json', fileReader})
+    expect(result).toBeNull()
+  })
+
+  it('loadRolloutSnapshot returns null when JSON is valid but missing items array', async () => {
+    // Valid JSON but wrong shape → null
+    const fileReader = async (_path: string) => JSON.stringify({notItems: []})
+    const result = await loadRolloutSnapshot({snapshotPath: '/tmp/snapshot.json', fileReader})
+    expect(result).toBeNull()
+  })
+
+  it('loadRolloutSnapshot returns null when items is not an array', async () => {
+    const fileReader = async (_path: string) => JSON.stringify({items: 'not-an-array'})
+    const result = await loadRolloutSnapshot({snapshotPath: '/tmp/snapshot.json', fileReader})
+    expect(result).toBeNull()
+  })
+
+  it('loadRolloutSnapshot returns null when file read fails', async () => {
+    // File read failure → null, no throw
+    const fileReader = async (_path: string) => {
+      throw new Error('ENOENT: no such file or directory')
+    }
+    const result = await loadRolloutSnapshot({snapshotPath: '/tmp/missing.json', fileReader})
+    expect(result).toBeNull()
+  })
+
+  it('loadRolloutSnapshot rejects items with non-number content_number', async () => {
+    // Item with string content_number → null (conservative validation)
+    const badSnapshot = {
+      items: [
+        {
+          content_number: 'not-a-number',
+          content_repo: 'fro-bot/.github',
+          status: null,
+          readiness: null,
+          gate: null,
+          issue_state: 'open',
+          issue_closed_at: null,
+          issue_labels: [],
+        },
+      ],
+    }
+    const fileReader = async (_path: string) => JSON.stringify(badSnapshot)
+    const result = await loadRolloutSnapshot({snapshotPath: '/tmp/snapshot.json', fileReader})
+    expect(result).toBeNull()
+  })
+
+  it('loadRolloutSnapshot rejects items with invalid issue_state value', async () => {
+    // issue_state must be "open" | "closed" | "merged" | null
+    const badSnapshot = {
+      items: [
+        {
+          content_number: 3512,
+          content_repo: 'fro-bot/.github',
+          status: null,
+          readiness: null,
+          gate: null,
+          issue_state: 'INVALID_STATE',
+          issue_closed_at: null,
+          issue_labels: [],
+        },
+      ],
+    }
+    const fileReader = async (_path: string) => JSON.stringify(badSnapshot)
+    const result = await loadRolloutSnapshot({snapshotPath: '/tmp/snapshot.json', fileReader})
+    expect(result).toBeNull()
+  })
+
+  it('loadRolloutSnapshot accepts items with null issue_state', async () => {
+    // null issue_state is valid (item exists but state not yet fetched)
+    const snapshot = {
+      items: [
+        {
+          content_number: 3512,
+          content_repo: 'fro-bot/.github',
+          status: null,
+          readiness: null,
+          gate: null,
+          issue_state: null,
+          issue_closed_at: null,
+          issue_labels: [],
+        },
+      ],
+    }
+    const fileReader = async (_path: string) => JSON.stringify(snapshot)
+    const result = await loadRolloutSnapshot({snapshotPath: '/tmp/snapshot.json', fileReader})
+    expect(result).not.toBeNull()
+    expect(result?.items[0]?.issue_state).toBeNull()
+  })
+
+  it('loadRolloutSnapshot accepts empty items array', async () => {
+    const fileReader = async (_path: string) => JSON.stringify({items: []})
+    const result = await loadRolloutSnapshot({snapshotPath: '/tmp/snapshot.json', fileReader})
+    expect(result).not.toBeNull()
+    expect(result?.items).toHaveLength(0)
+  })
+
+  it('loadRolloutSnapshot rejects items with non-array issue_labels', async () => {
+    const badSnapshot = {
+      items: [
+        {
+          content_number: 3512,
+          content_repo: 'fro-bot/.github',
+          status: null,
+          readiness: null,
+          gate: null,
+          issue_state: 'open',
+          issue_closed_at: null,
+          issue_labels: 'not-an-array',
+        },
+      ],
+    }
+    const fileReader = async (_path: string) => JSON.stringify(badSnapshot)
+    const result = await loadRolloutSnapshot({snapshotPath: '/tmp/snapshot.json', fileReader})
+    expect(result).toBeNull()
+  })
+
+  it('loadRolloutSnapshot does not leak raw payload in return value on malformed input', async () => {
+    // Even if the JSON is parseable but wrong shape, the return is null — not the raw object
+    const fileReader = async (_path: string) =>
+      JSON.stringify({items: [{content_number: 'SENSITIVE_VALUE', issue_state: 'SENSITIVE_STATE'}]})
+    const result = await loadRolloutSnapshot({snapshotPath: '/tmp/snapshot.json', fileReader})
+    // Must return null (validation failed), not the raw object
+    expect(result).toBeNull()
   })
 })

--- a/scripts/status-truth-detect.test.ts
+++ b/scripts/status-truth-detect.test.ts
@@ -22,6 +22,7 @@ import {
   buildStatusTruthReport,
   CLAIM_KIND_DEFINITIONS,
   computeClaimFingerprint,
+  DEFAULT_ENABLED_KINDS,
   detectStatusTruthClaims,
   extractStatusTruthClaimsFromText,
   isKnownReportVersion,
@@ -32,6 +33,8 @@ import {
   normalizeClaimText,
   resolveAllClaims,
   resolveClaimLiveState,
+  resolveFileParseClaims,
+  resolvePlanStatusClaim,
   scanIssueStatusTruthClaims,
   scanStatusTruthClaims,
   selectDetectFailureClass,
@@ -827,11 +830,8 @@ describe('validateStatusTruthArtifact', () => {
 // Unit 4: Artifact safety contract tests
 // ---------------------------------------------------------------------------
 
-describe('Unit 4: artifact safety contract', () => {
+describe('artifact safety contract', () => {
   it('detect output artifact contains safe machine fields and counters but no raw claim text or source snippets', () => {
-    // The report envelope must not expose raw claim text or source snippets.
-    // Findings carry typed fields (kind, path, sourceRef, verdict, fingerprint,
-    // claimedState, liveState) but NOT raw document text or API response bodies.
     const claim = makeClaim({
       kind: 'pr-state',
       path: 'docs/plans/example.md',
@@ -974,10 +974,6 @@ describe('Unit 4: artifact safety contract', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// Unit 4 corrections: extractStatusTruthClaimsFromText tests
-// ---------------------------------------------------------------------------
-
 describe('extractStatusTruthClaimsFromText', () => {
   it('extracts a pr-state claim from text containing "PR #42 is open"', () => {
     const claims = extractStatusTruthClaimsFromText({
@@ -1017,15 +1013,16 @@ describe('extractStatusTruthClaimsFromText', () => {
     expect(claim?.claimedState).toBe('published')
   })
 
-  it('extracts a plan-status claim from frontmatter "status: active"', () => {
+  it('extracts a plan-status claim from cross-file prose reference "docs/plans/my-plan.md is active"', () => {
     const claims = extractStatusTruthClaimsFromText({
-      path: 'docs/plans/my-plan.md',
-      text: '---\nstatus: active\ntitle: My Plan\n---\n\nContent.',
+      path: 'README.md',
+      text: 'The plan docs/plans/my-plan.md is active.',
     })
     expect(claims).toHaveLength(1)
     const claim = claims[0]
     expect(claim?.kind).toBe('plan-status')
-    expect(claim?.sourceRef).toBe('docs/plans/my-plan.md#status')
+    // sourceRef is the plan path itself (not path#status) for cross-file claims
+    expect(claim?.sourceRef).toBe('docs/plans/my-plan.md')
     expect(claim?.claimedState).toBe('active')
   })
 
@@ -1056,20 +1053,12 @@ describe('extractStatusTruthClaimsFromText', () => {
     expect(claims[0]?.normalizedText).toBe('pr #42 is open')
   })
 
-  // Fix #1: Cross-repo PR/issue references must not resolve as current-repo references.
-  // When text contains "fro-bot/agent#1033 PR #1033 is open", the extractor must NOT
-  // produce a bare #1033 sourceRef that the resolver would treat as current-repo.
   it('cross-repo PR reference: text with owner/repo prefix near claim does not produce bare #N sourceRef', () => {
-    // This text has a cross-repo context: "fro-bot/agent#1033" followed by "PR #1033 is open"
-    // The extractor currently produces bare #1033 which the resolver treats as current-repo.
-    // After fix: either the sourceRef is prefixed (fro-bot/agent#1033) or the claim is skipped.
     const claims = extractStatusTruthClaimsFromText({
       path: 'docs/plans/example.md',
       text: 'See fro-bot/agent#1033 PR #1033 is open for context.',
     })
-    // Assert directly: no bare #1033 sourceRef must be extracted
     expect(claims.filter(c => c.sourceRef === '#1033')).toHaveLength(0)
-    // If a claim is extracted, its sourceRef must NOT be bare #1033
     for (const claim of claims) {
       if (claim.kind === 'pr-state' && claim.claimedState === 'open') {
         expect(claim.sourceRef).not.toBe('#1033')
@@ -1078,12 +1067,10 @@ describe('extractStatusTruthClaimsFromText', () => {
   })
 
   it('cross-repo issue reference: text with owner/repo prefix near claim does not produce bare #N sourceRef', () => {
-    // "fro-bot/dashboard#48 issue #48 is open" — must not produce bare #48
     const claims = extractStatusTruthClaimsFromText({
       path: 'docs/plans/example.md',
       text: 'Tracked in fro-bot/dashboard#48 issue #48 is open.',
     })
-    // Assert directly: no bare #48 sourceRef must be extracted
     expect(claims.filter(c => c.sourceRef === '#48')).toHaveLength(0)
     for (const claim of claims) {
       if (claim.kind === 'issue-state' && claim.claimedState === 'open') {
@@ -1092,10 +1079,6 @@ describe('extractStatusTruthClaimsFromText', () => {
     }
   })
 })
-
-// ---------------------------------------------------------------------------
-// Unit 4 corrections: scanStatusTruthClaims tests
-// ---------------------------------------------------------------------------
 
 describe('scanStatusTruthClaims', () => {
   it('scans files returned by fileLister and extracts claims', async () => {
@@ -1179,10 +1162,6 @@ describe('scanStatusTruthClaims', () => {
     expect(scanErrors).toBe(0)
   })
 })
-
-// ---------------------------------------------------------------------------
-// Unit 4 corrections: resolveClaimLiveState tests
-// ---------------------------------------------------------------------------
 
 function makeMockDetectOctokit(
   overrides: {
@@ -1310,21 +1289,15 @@ describe('resolveClaimLiveState', () => {
     expect(result.status).toBe('unavailable')
   })
 
-  // Fix #3: plan-status resolver must not return claimedState as live state
-  it('plan-status returns unavailable (not resolved with claimedState as live state)', async () => {
+  it('plan-status without fileReader returns unavailable', async () => {
     const octokit = makeMockDetectOctokit()
-    const claim = makeTestClaim({kind: 'plan-status', sourceRef: 'docs/plans/foo.md#status', claimedState: 'active'})
+    const claim = makeTestClaim({kind: 'plan-status', sourceRef: 'docs/plans/foo.md', claimedState: 'active'})
     const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
-    // plan-status has no real file-parse resolver yet; must be unavailable, not resolved
     expect(result.status).toBe('unavailable')
   })
 })
 
-// ---------------------------------------------------------------------------
-// Unit 4 corrections: end-to-end extract → resolve → detect pipeline tests
-// ---------------------------------------------------------------------------
-
-describe('Unit 4: extract → resolve → detect pipeline', () => {
+describe('extract → resolve → detect pipeline', () => {
   it('text fixture "PR #42 is open" extracts pr-state claim; when resolver says closed, report contains one drifted finding', async () => {
     // Extract
     const claims = extractStatusTruthClaimsFromText({
@@ -1386,10 +1359,7 @@ describe('Unit 4: extract → resolve → detect pipeline', () => {
     expect(findings[0]?.proposalEligible).toBe(false)
   })
 
-  // Fix #1: cross-repo text that produces a bare #N must not classify as current-repo drifted
   it('cross-repo context text: extracted claim (if any) classifies as unresolved, not drifted', async () => {
-    // Text: "fro-bot/agent#1033 PR #1033 is open" — if extractor produces bare #1033,
-    // the resolver must return unavailable (not resolved), so detect classifies as unresolved.
     const claims = extractStatusTruthClaimsFromText({
       path: 'docs/plans/example.md',
       text: 'See fro-bot/agent#1033 PR #1033 is open for context.',
@@ -1404,11 +1374,8 @@ describe('Unit 4: extract → resolve → detect pipeline', () => {
     })
 
     const findings = detectStatusTruthClaims(claims, resolverResults)
-    // Any pr-state finding for #1033 must be unresolved (not drifted/current)
     for (const finding of findings) {
       if (finding.kind === 'pr-state' && finding.verdict !== 'unsafe') {
-        // If a bare #1033 was extracted and resolved as current-repo, it would be drifted.
-        // After fix: either no claim extracted, or sourceRef is non-bare and verdict is unresolved.
         expect(finding.verdict).not.toBe('drifted')
         expect(finding.verdict).not.toBe('current')
       }
@@ -1490,10 +1457,6 @@ describe('Unit 4: extract → resolve → detect pipeline', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// Unit 4 fix 1: buildProposedCorrection uses replacement function ($ safety)
-// ---------------------------------------------------------------------------
-
 describe('buildProposedCorrection: $ token safety via detectStatusTruthClaims', () => {
   it('live state containing $& is inserted literally, not expanded as a replacement token', () => {
     // If String.replace used a string replacement, '$&' would expand to the matched text.
@@ -1566,10 +1529,6 @@ describe('buildStatusTruthReport failure-class integration', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// selectDetectFailureClass: issue/comment API failures must map to api-unavailable
-// ---------------------------------------------------------------------------
-
 describe('selectDetectFailureClass', () => {
   it('returns null when all error counts are zero', () => {
     expect(selectDetectFailureClass({fileScanErrors: 0, issueScanErrors: 0, resolveErrors: 0})).toBeNull()
@@ -1602,42 +1561,40 @@ describe('selectDetectFailureClass', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// CALIBRATION: plan-status exclusion from production scans
-// ---------------------------------------------------------------------------
-
-describe('scanStatusTruthClaims: plan-status exclusion (calibration)', () => {
-  it('production scan (default) excludes plan-status claims so dry-run produces zero unresolved plan-status noise', async () => {
-    // A plan doc with frontmatter status: active — production scan must NOT emit plan-status claims
+describe('scanStatusTruthClaims: plan-status no-noise behavior', () => {
+  it('production scan (default): self-referential plan frontmatter does NOT produce plan-status claims', async () => {
     const fileLister: FileLister = async () => ['docs/plans/my-plan.md']
     const fileReader: FileReader = async () => '---\nstatus: active\ntitle: My Plan\n---\n\nContent.'
 
     const {claims} = await scanStatusTruthClaims({fileLister, fileReader})
-    // Default production scan must exclude plan-status
+    // Self-referential frontmatter must not produce plan-status claims
     const planStatusClaims = claims.filter(c => c.kind === 'plan-status')
     expect(planStatusClaims).toHaveLength(0)
   })
 
-  it('pure extractor still extracts plan-status when all kinds are enabled', () => {
-    // extractStatusTruthClaimsFromText is a pure function and always extracts all kinds
+  it('pure extractor: self-referential frontmatter does NOT produce plan-status claims', () => {
     const claims = extractStatusTruthClaimsFromText({
       path: 'docs/plans/my-plan.md',
       text: '---\nstatus: active\ntitle: My Plan\n---\n\nContent.',
     })
     const planStatusClaims = claims.filter(c => c.kind === 'plan-status')
+    expect(planStatusClaims).toHaveLength(0)
+  })
+
+  it('pure extractor: cross-file prose reference DOES produce plan-status claims', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'The plan docs/plans/my-plan.md is active.',
+    })
+    const planStatusClaims = claims.filter(c => c.kind === 'plan-status')
     expect(planStatusClaims).toHaveLength(1)
   })
 
-  it('production scan with explicit enabledKinds including plan-status does emit plan-status claims', async () => {
-    // When caller explicitly opts in, plan-status is included
-    const fileLister: FileLister = async () => ['docs/plans/my-plan.md']
-    const fileReader: FileReader = async () => '---\nstatus: active\ntitle: My Plan\n---\n\nContent.'
+  it('production scan with default kinds: cross-file prose reference emits plan-status claim', async () => {
+    const fileLister: FileLister = async () => ['README.md']
+    const fileReader: FileReader = async () => 'The plan docs/plans/my-plan.md is active.'
 
-    const {claims} = await scanStatusTruthClaims({
-      fileLister,
-      fileReader,
-      enabledKinds: ['pr-state', 'issue-state', 'release-tag-state', 'plan-status', 'rollout-tracker-status'],
-    })
+    const {claims} = await scanStatusTruthClaims({fileLister, fileReader})
     const planStatusClaims = claims.filter(c => c.kind === 'plan-status')
     expect(planStatusClaims).toHaveLength(1)
   })
@@ -1652,11 +1609,7 @@ describe('scanStatusTruthClaims: plan-status exclusion (calibration)', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// CALIBRATION: GitHub issue body/comment scanning
-// ---------------------------------------------------------------------------
-
-describe('scanIssueStatusTruthClaims: issue body/comment scanning (calibration)', () => {
+describe('scanIssueStatusTruthClaims: issue body/comment scanning', () => {
   it('issue body containing "PR #42 is open" yields a pr-state claim with synthetic issue body path', async () => {
     const issues: IssueListItem[] = [{number: 3512, title: 'Rollout tracker', body: 'PR #42 is open', labels: []}]
     const issueLister: IssueLister = async () => issues
@@ -1781,27 +1734,20 @@ describe('scanIssueStatusTruthClaims: issue body/comment scanning (calibration)'
       commentFetcher,
     })
 
-    // Body claims still extracted; comment fetch failure counted
     expect(result.scanErrors).toBeGreaterThan(0)
-    // Body claim from issue 300 should still be present (path uses `current`)
     expect(result.claims.filter(c => c.path === 'github-issue://current/issues/300#body')).toHaveLength(1)
   })
 
   it('synthetic issue paths use current scheme and do not contain owner/repo identity', () => {
-    // Structural test: synthetic paths use `current` (not owner/repo) so generic
-    // code does not leak identity before explicit publicness proof.
     const syntheticBodyPath = 'github-issue://current/issues/3512#body'
     const syntheticCommentPath = 'github-issue://current/issues/3512#comment-9001'
 
-    // These paths use the `current` scheme
     expect(syntheticBodyPath).toMatch(/^github-issue:\/\/current\/issues\/\d+#body$/)
     expect(syntheticCommentPath).toMatch(/^github-issue:\/\/current\/issues\/\d+#comment-\d+$/)
 
-    // The path scheme must not contain raw body text or private identifiers
     expect(syntheticBodyPath).not.toContain('PR #42 is open')
     expect(syntheticCommentPath).not.toContain('issue #55 is closed')
 
-    // Must not contain owner/repo identity
     expect(syntheticBodyPath).not.toContain('fro-bot')
     expect(syntheticBodyPath).not.toContain('.github')
   })
@@ -1839,10 +1785,6 @@ describe('scanIssueStatusTruthClaims: issue body/comment scanning (calibration)'
   })
 })
 
-// ---------------------------------------------------------------------------
-// Blocker 1: Synthetic issue paths must use `current`, not owner/repo
-// ---------------------------------------------------------------------------
-
 describe('synthetic issue paths use current, not owner/repo', () => {
   it('issue body path uses github-issue://current/issues/<n>#body, not owner/repo', async () => {
     const issues: IssueListItem[] = [{number: 3512, title: 'Rollout tracker', body: 'PR #42 is open', labels: []}]
@@ -1858,7 +1800,6 @@ describe('synthetic issue paths use current, not owner/repo', () => {
 
     expect(claims).toHaveLength(1)
     const claim = claims[0]
-    // Must use `current`, not owner/repo
     expect(claim?.path).toBe('github-issue://current/issues/3512#body')
     expect(claim?.path).not.toContain('fro-bot')
     expect(claim?.path).not.toContain('.github')
@@ -1878,14 +1819,12 @@ describe('synthetic issue paths use current, not owner/repo', () => {
 
     expect(claims).toHaveLength(1)
     const claim = claims[0]
-    // Must use `current`, not owner/repo
     expect(claim?.path).toBe('github-issue://current/issues/100#comment-9001')
     expect(claim?.path).not.toContain('fro-bot')
     expect(claim?.path).not.toContain('.github')
   })
 
   it('scanner output for issue body uses current path regardless of owner/repo passed in', async () => {
-    // Even with a different owner/repo, the path must always use `current`
     const issues: IssueListItem[] = [{number: 7, title: 'Test', body: 'issue #1 is open', labels: []}]
     const issueLister: IssueLister = async () => issues
     const commentFetcher: IssueCommentFetcher = async () => []
@@ -1921,8 +1860,7 @@ describe('synthetic issue paths use current, not owner/repo', () => {
     expect(claims[0]?.path).not.toContain('some-other-repo')
   })
 
-  it('no public finding path or sourceRef test regresses: public finding path is still present', async () => {
-    // Regression guard: public findings still have path and sourceRef fields
+  it('public finding path and sourceRef fields are still present after issue scan', async () => {
     const issues: IssueListItem[] = [{number: 3512, title: 'Rollout tracker', body: 'PR #42 is open', labels: []}]
     const issueLister: IssueLister = async () => issues
     const commentFetcher: IssueCommentFetcher = async () => []
@@ -1942,7 +1880,6 @@ describe('synthetic issue paths use current, not owner/repo', () => {
     expect(findings).toHaveLength(1)
     const finding = findings[0]
     expect(finding?.verdict).toBe('drifted')
-    // Public finding must still have path and sourceRef
     if (finding?.verdict === 'drifted') {
       expect(finding.path).toBe('github-issue://current/issues/3512#body')
       expect(finding.sourceRef).toBe('#42')
@@ -1951,13 +1888,8 @@ describe('synthetic issue paths use current, not owner/repo', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// Blocker 2: Production issue/comment fetchers must paginate
-// ---------------------------------------------------------------------------
-
 describe('listCurrentRepoIssues: pagination helper fetches all pages', () => {
   it('fetches multiple pages until exhausted', async () => {
-    // Simulate two pages: page 1 has 2 items, page 2 has 1 item, page 3 is empty
     const page1 = [
       {number: 1, title: 'Issue 1', body: 'body1', labels: [] as {name?: string}[]},
       {number: 2, title: 'Issue 2', body: 'body2', labels: [] as {name?: string}[]},
@@ -2077,11 +2009,6 @@ describe('listCurrentRepoIssueComments: pagination helper fetches all pages', ()
   })
 })
 
-// ---------------------------------------------------------------------------
-// Cross-repo status-truth signal: grammar, publicness proof, privacy gates
-// ---------------------------------------------------------------------------
-
-// Helper: build a mock DetectOctokitClient that supports repos.get for publicness
 function makeCrossRepoOctokit(
   overrides: {
     repoPublic?: boolean
@@ -2129,10 +2056,6 @@ function makeCrossRepoOctokit(
     },
   }
 }
-
-// ---------------------------------------------------------------------------
-// Cross-repo claim grammar: extractStatusTruthClaimsFromText
-// ---------------------------------------------------------------------------
 
 describe('cross-repo claim grammar: extractStatusTruthClaimsFromText', () => {
   // PR forms
@@ -2257,10 +2180,6 @@ describe('cross-repo claim grammar: extractStatusTruthClaimsFromText', () => {
     }
   })
 })
-
-// ---------------------------------------------------------------------------
-// Cross-repo publicness proof and resolver
-// ---------------------------------------------------------------------------
 
 describe('resolveClaimLiveState: cross-repo publicness proof', () => {
   it('cross-repo PR claim resolves to merged when repo is public and PR is merged', async () => {
@@ -2421,10 +2340,6 @@ describe('resolveClaimLiveState: cross-repo publicness proof', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// Privacy gate: unsafe finding must not expose identity fields
-// ---------------------------------------------------------------------------
-
 describe('cross-repo privacy gate: unsafe finding omits identity fields', () => {
   it('private cross-repo PR claim produces unsafe finding with no path/sourceRef/claimedState/fingerprint', () => {
     const claim: StatusTruthClaim & {targetOwner: string; targetRepo: string} = {
@@ -2481,17 +2396,8 @@ describe('cross-repo privacy gate: unsafe finding omits identity fields', () => 
   })
 })
 
-// ---------------------------------------------------------------------------
-// #3512-style coordination signal: end-to-end cross-repo fixture
-// ---------------------------------------------------------------------------
-
-describe('#3512-style cross-repo coordination signal (synthetic public-safe fixtures)', () => {
-  // Inspired by real coordination patterns in issue #3512 (rollout tracker).
-  // All fixtures are synthetic and use public repos only.
-
-  it('synthetic #3512-style: cross-repo closed PR claim becomes drifted when live state is merged', async () => {
-    // Fixture: a coordination comment says "fro-bot/agent#1033 is closed"
-    // but the live PR is actually merged. This is a real drift signal.
+describe('cross-repo coordination signal (synthetic public-safe fixtures)', () => {
+  it('cross-repo closed PR claim becomes drifted when live state is merged', async () => {
     const text = 'Coordination: fro-bot/agent#1033 is closed'
     const claims = extractStatusTruthClaimsFromText({path: 'docs/plans/rollout.md', text})
     const crossRepoClaims = claims.filter(c => 'targetOwner' in c && c.kind === 'pr-state')
@@ -2515,7 +2421,7 @@ describe('#3512-style cross-repo coordination signal (synthetic public-safe fixt
     }
   })
 
-  it('synthetic #3512-style: cross-repo open issue claim becomes current when live state is open', async () => {
+  it('cross-repo open issue claim becomes current when live state is open', async () => {
     const text = 'Tracking: issue fro-bot/dashboard#48 is open'
     const claims = extractStatusTruthClaimsFromText({path: 'docs/plans/rollout.md', text})
     const crossRepoClaims = claims.filter(c => 'targetOwner' in c && c.kind === 'issue-state')
@@ -2534,7 +2440,7 @@ describe('#3512-style cross-repo coordination signal (synthetic public-safe fixt
     expect(current.length).toBeGreaterThan(0)
   })
 
-  it('synthetic #3512-style: cross-repo merged PR claim is current when live state is merged', async () => {
+  it('cross-repo merged PR claim is current when live state is merged', async () => {
     const text = 'Merged: fro-bot/agent#1033 is merged'
     const claims = extractStatusTruthClaimsFromText({path: 'docs/plans/rollout.md', text})
     const crossRepoClaims = claims.filter(c => 'targetOwner' in c && c.kind === 'pr-state')
@@ -2553,7 +2459,7 @@ describe('#3512-style cross-repo coordination signal (synthetic public-safe fixt
     expect(current.length).toBeGreaterThan(0)
   })
 
-  it('synthetic #3512-style: private cross-repo claim produces unsafe finding (zero identity fields)', async () => {
+  it('private cross-repo claim produces unsafe finding (zero identity fields)', async () => {
     const text = 'Blocked by: private-org/private-repo#99 is open'
     const claims = extractStatusTruthClaimsFromText({path: 'docs/plans/rollout.md', text})
     const crossRepoClaims = claims.filter(c => 'targetOwner' in c && c.kind === 'pr-state')
@@ -2578,8 +2484,7 @@ describe('#3512-style cross-repo coordination signal (synthetic public-safe fixt
     }
   })
 
-  it('plan-status default exclusion is intact: cross-repo scan does not break plan-status exclusion', async () => {
-    // Regression guard: adding cross-repo support must not re-enable plan-status in default scan
+  it('cross-repo scan does not break plan-status no-noise behavior', async () => {
     const fileLister: FileLister = async () => ['docs/plans/my-plan.md']
     const fileReader: FileReader = async () =>
       '---\nstatus: active\ntitle: My Plan\n---\n\nfro-bot/agent#1033 is merged'
@@ -2587,25 +2492,13 @@ describe('#3512-style cross-repo coordination signal (synthetic public-safe fixt
     const {claims} = await scanStatusTruthClaims({fileLister, fileReader})
     const planStatusClaims = claims.filter(c => c.kind === 'plan-status')
     expect(planStatusClaims).toHaveLength(0)
-    // Cross-repo claim should still be extracted (if in DEFAULT_ENABLED_KINDS)
     const crossRepoClaims = claims.filter(c => 'targetOwner' in c)
-    // Cross-repo pr-state is in DEFAULT_ENABLED_KINDS, so it should be present
     expect(crossRepoClaims.length).toBeGreaterThan(0)
   })
 })
 
-// ---------------------------------------------------------------------------
-// Ambiguous cross-repo open/closed: PR-first with issue fallback
-// ---------------------------------------------------------------------------
-
 describe('ambiguous cross-repo open/closed: PR-first with issue fallback', () => {
-  // Problem: "marcusrbrown/infra#579 is closed" defaults to pr-state.
-  // When PR lookup 404s but issue lookup succeeds, the finding must be
-  // issue-state (current), not pr-state (unresolved).
-
-  it('RED: ambiguous public owner/repo#N is closed — PR 404, issue closed → issue-state current finding', async () => {
-    // Claim extracted as ambiguous (open/closed without explicit issue prefix)
-    // PR lookup 404s, issue lookup returns closed → must produce issue-state current finding
+  it('ambiguous public owner/repo#N is closed — PR 404, issue closed → issue-state current finding', async () => {
     const octokit = makeCrossRepoOctokit({
       repoPublic: true,
       prThrows: true, // PR 404
@@ -2614,11 +2507,11 @@ describe('ambiguous cross-repo open/closed: PR-first with issue fallback', () =>
     const claim: StatusTruthClaim = {
       kind: 'pr-state',
       path: 'docs/plans/example.md',
-      sourceRef: 'marcusrbrown/infra#579',
+      sourceRef: 'example-org/example-repo#579',
       claimedState: 'closed',
-      normalizedText: 'marcusrbrown/infra#579 is closed',
-      targetOwner: 'marcusrbrown',
-      targetRepo: 'infra',
+      normalizedText: 'example-org/example-repo#579 is closed',
+      targetOwner: 'example-org',
+      targetRepo: 'example-repo',
       targetNumberKind: 'ambiguous',
     }
 
@@ -2632,8 +2525,7 @@ describe('ambiguous cross-repo open/closed: PR-first with issue fallback', () =>
     }
   })
 
-  it('RED: ambiguous public owner/repo#N is open — PR lookup succeeds → pr-state current finding', async () => {
-    // When PR lookup succeeds, kind stays pr-state
+  it('ambiguous public owner/repo#N is open — PR lookup succeeds → pr-state current finding', async () => {
     const octokit = makeCrossRepoOctokit({
       repoPublic: true,
       prState: 'open',
@@ -2659,8 +2551,7 @@ describe('ambiguous cross-repo open/closed: PR-first with issue fallback', () =>
     }
   })
 
-  it('RED: ambiguous claim — publicness check still happens before PR/issue lookup', async () => {
-    // repos.get throws 404 → private, no PR or issue lookup attempted
+  it('ambiguous claim — publicness check still happens before PR/issue lookup', async () => {
     const octokit = makeCrossRepoOctokit({repoThrows: true, repoThrowsStatus: 404})
     const claim: StatusTruthClaim = {
       kind: 'pr-state',
@@ -2677,7 +2568,7 @@ describe('ambiguous cross-repo open/closed: PR-first with issue fallback', () =>
     expect(result.status).toBe('private')
   })
 
-  it('RED: ambiguous claim — private repo (private:true) still produces unsafe/no identity fields', async () => {
+  it('ambiguous claim — private repo (private:true) still produces unsafe/no identity fields', async () => {
     const octokit = makeCrossRepoOctokit({repoPublic: false})
     const claim: StatusTruthClaim = {
       kind: 'pr-state',
@@ -2694,7 +2585,7 @@ describe('ambiguous cross-repo open/closed: PR-first with issue fallback', () =>
     expect(result.status).toBe('private')
   })
 
-  it('RED: ambiguous claim — PR 404 and issue 404 → unresolved (both unavailable after publicness proof)', async () => {
+  it('ambiguous claim — PR 404 and issue 404 → unresolved (both unavailable after publicness proof)', async () => {
     const octokit = makeCrossRepoOctokit({
       repoPublic: true,
       prThrows: true,
@@ -2715,21 +2606,21 @@ describe('ambiguous cross-repo open/closed: PR-first with issue fallback', () =>
     expect(result.status).toBe('unavailable')
   })
 
-  it('RED: detectStatusTruthClaims uses resolvedKind to emit issue-state finding for ambiguous claim resolved as issue', () => {
+  it('detectStatusTruthClaims uses resolvedKind to emit issue-state finding for ambiguous claim resolved as issue', () => {
     // When resolver returns resolvedKind: 'issue-state', the finding kind must be issue-state
     const claim: StatusTruthClaim = {
       kind: 'pr-state',
       path: 'docs/plans/example.md',
-      sourceRef: 'marcusrbrown/infra#579',
+      sourceRef: 'example-org/example-repo#579',
       claimedState: 'closed',
-      normalizedText: 'marcusrbrown/infra#579 is closed',
-      targetOwner: 'marcusrbrown',
-      targetRepo: 'infra',
+      normalizedText: 'example-org/example-repo#579 is closed',
+      targetOwner: 'example-org',
+      targetRepo: 'example-repo',
       targetNumberKind: 'ambiguous',
     }
 
     const resolverResults: Record<string, ResolverResult> = {
-      'pr-state:marcusrbrown/infra#579': {
+      'pr-state:example-org/example-repo#579': {
         status: 'resolved',
         state: 'closed',
         resolvedKind: 'issue-state',
@@ -2744,11 +2635,11 @@ describe('ambiguous cross-repo open/closed: PR-first with issue fallback', () =>
     expect(finding?.verdict).toBe('current')
   })
 
-  it('RED: extractStatusTruthClaimsFromText marks ambiguous open/closed cross-repo refs with targetNumberKind=ambiguous', () => {
-    // "marcusrbrown/infra#579 is closed" — no explicit issue prefix, not merged → ambiguous
+  it('extractStatusTruthClaimsFromText marks ambiguous open/closed cross-repo refs with targetNumberKind=ambiguous', () => {
+    // "example-org/example-repo#579 is closed" — no explicit issue prefix, not merged → ambiguous
     const claims = extractStatusTruthClaimsFromText({
       path: 'docs/plans/example.md',
-      text: 'marcusrbrown/infra#579 is closed',
+      text: 'example-org/example-repo#579 is closed',
     })
     const crossRepoClaims = claims.filter(c => 'targetOwner' in c)
     expect(crossRepoClaims.length).toBeGreaterThan(0)
@@ -2756,7 +2647,7 @@ describe('ambiguous cross-repo open/closed: PR-first with issue fallback', () =>
     expect(claim?.targetNumberKind).toBe('ambiguous')
   })
 
-  it('RED: explicit "issue" prefix sets targetNumberKind=issue (not ambiguous)', () => {
+  it('explicit "issue" prefix sets targetNumberKind=issue (not ambiguous)', () => {
     const claims = extractStatusTruthClaimsFromText({
       path: 'docs/plans/example.md',
       text: 'issue fro-bot/dashboard#48 is closed',
@@ -2768,7 +2659,7 @@ describe('ambiguous cross-repo open/closed: PR-first with issue fallback', () =>
     expect(claim?.targetNumberKind).not.toBe('ambiguous')
   })
 
-  it('RED: "merged" state sets targetNumberKind=pr (not ambiguous)', () => {
+  it('"merged" state sets targetNumberKind=pr (not ambiguous)', () => {
     const claims = extractStatusTruthClaimsFromText({
       path: 'docs/plans/example.md',
       text: 'fro-bot/agent#1033 is merged',
@@ -2781,38 +2672,147 @@ describe('ambiguous cross-repo open/closed: PR-first with issue fallback', () =>
   })
 })
 
-// ---------------------------------------------------------------------------
-// Blocker 1: Fingerprint stability for ambiguous cross-repo claims
-// ---------------------------------------------------------------------------
+describe('runDetect-equivalent: plan-status resolves without GITHUB_TOKEN', () => {
+  // These tests exercise the exact logic that runDetect() must perform in the no-token path.
+  // They use resolveFileParseClaims (the exported helper that runDetect calls) to prove
+  // that plan-status claims are resolved via file-parse even when no Octokit client exists.
+
+  it('file-parse plan-status claim resolves to current without Octokit when target frontmatter matches', async () => {
+    // Simulates the no-token path in runDetect:
+    // scan → resolveFileParseClaims → detect
+    // The claim is in a scanning file; the target plan file has matching frontmatter.
+    const scanningFileContent = 'docs/plans/example.md is active'
+    const planFileContent = '---\nstatus: active\ntitle: Example Plan\n---\n\nContent.'
+
+    const fileReader: FileReader = async (filePath: string) => {
+      if (filePath === 'docs/plans/example.md') return planFileContent
+      return ''
+    }
+
+    const fileLister: FileLister = async () => ['README.md']
+    const scanFileReader: FileReader = async () => scanningFileContent
+
+    const {claims} = await scanStatusTruthClaims({fileLister, fileReader: scanFileReader})
+    const planStatusClaims = claims.filter(c => c.kind === 'plan-status')
+    expect(planStatusClaims).toHaveLength(1)
+
+    // No-token path: resolve only file-parse claims using the exported helper
+    const resolverResults = await resolveFileParseClaims({claims, fileReader})
+
+    // Detect: plan-status claim must be current, not unresolved
+    const findings = detectStatusTruthClaims(claims, resolverResults)
+    expect(findings).toHaveLength(1)
+    const finding = findings[0]
+    expect(finding?.verdict).toBe('current')
+    expect(finding?.proposalEligible).toBe(false)
+    if (finding?.verdict === 'current') {
+      expect(finding.liveState).toBe('active')
+      expect(finding.kind).toBe('plan-status')
+    }
+  })
+
+  it('file-parse plan-status claim resolves to drifted without Octokit when frontmatter differs', async () => {
+    // Claim says "active" but plan file says "complete"
+    const planFileContent = '---\nstatus: complete\ntitle: Example Plan\n---\n\nContent.'
+
+    const fileReader: FileReader = async (filePath: string) => {
+      if (filePath === 'docs/plans/example.md') return planFileContent
+      return ''
+    }
+
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'docs/plans/example.md is active',
+    })
+    const planStatusClaims = claims.filter(c => c.kind === 'plan-status')
+    expect(planStatusClaims).toHaveLength(1)
+
+    const resolverResults = await resolveFileParseClaims({claims: planStatusClaims, fileReader})
+
+    const findings = detectStatusTruthClaims(planStatusClaims, resolverResults)
+    expect(findings).toHaveLength(1)
+    const finding = findings[0]
+    expect(finding?.verdict).toBe('drifted')
+    expect(finding?.proposalEligible).toBe(true)
+    if (finding?.verdict === 'drifted') {
+      expect(finding.liveState).toBe('complete')
+      expect(finding.claimedState).toBe('active')
+    }
+  })
+
+  it('API-backed claims (pr-state) remain unresolved without token in the no-token path', async () => {
+    // resolveFileParseClaims only resolves file-parse kinds; API claims get no entry.
+    const claims = extractStatusTruthClaimsFromText({path: 'README.md', text: 'PR #42 is open'})
+    const prClaims = claims.filter(c => c.kind === 'pr-state')
+    expect(prClaims).toHaveLength(1)
+
+    const fileReader: FileReader = async () => ''
+    const resolverResults = await resolveFileParseClaims({claims: prClaims, fileReader})
+
+    // pr-state is API-backed; resolveFileParseClaims must not add an entry for it
+    expect(Object.keys(resolverResults)).toHaveLength(0)
+
+    const findings = detectStatusTruthClaims(prClaims, resolverResults)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.verdict).toBe('unresolved')
+    expect(findings[0]?.proposalEligible).toBe(false)
+  })
+
+  it('mixed scan: plan-status resolves via file-parse, pr-state stays unresolved, without token', async () => {
+    // Simulates the full no-token runDetect flow with both claim kinds present.
+    const planFileContent = '---\nstatus: active\ntitle: Example Plan\n---\n\nContent.'
+
+    const fileReader: FileReader = async (filePath: string) => {
+      if (filePath === 'docs/plans/example.md') return planFileContent
+      return ''
+    }
+
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'docs/plans/example.md is active and PR #42 is open',
+    })
+    const planStatusClaims = claims.filter(c => c.kind === 'plan-status')
+    const prClaims = claims.filter(c => c.kind === 'pr-state')
+    expect(planStatusClaims).toHaveLength(1)
+    expect(prClaims).toHaveLength(1)
+
+    // No-token path: resolveFileParseClaims resolves plan-status; API claims get no entry
+    const resolverResults = await resolveFileParseClaims({claims, fileReader})
+
+    const findings = detectStatusTruthClaims(claims, resolverResults)
+    expect(findings).toHaveLength(2)
+
+    const planFinding = findings.find(f => f.kind === 'plan-status')
+    const prFinding = findings.find(f => f.kind === 'pr-state')
+
+    expect(planFinding?.verdict).toBe('current')
+    expect(prFinding?.verdict).toBe('unresolved')
+  })
+})
 
 describe('fingerprint stability: ambiguous cross-repo claim resolved as pr-state vs issue-state', () => {
   it('same claim/path/sourceRef/normalizedText produces identical fingerprint regardless of resolvedKind', () => {
-    // The fingerprint must be computed from the extracted claim kind (claim.kind),
-    // not the effective kind (resolvedKind). This prevents fingerprint churn when
-    // the same ambiguous claim resolves differently across runs.
     const claim: StatusTruthClaim = {
       kind: 'pr-state',
       path: 'docs/plans/example.md',
-      sourceRef: 'marcusrbrown/infra#579',
+      sourceRef: 'example-org/example-repo#579',
       claimedState: 'closed',
-      normalizedText: 'marcusrbrown/infra#579 is closed',
-      targetOwner: 'marcusrbrown',
-      targetRepo: 'infra',
+      normalizedText: 'example-org/example-repo#579 is closed',
+      targetOwner: 'example-org',
+      targetRepo: 'example-repo',
       targetNumberKind: 'ambiguous',
     }
 
-    // Resolver result 1: resolves as pr-state
     const resolverResultsPr: Record<string, ResolverResult> = {
-      'pr-state:marcusrbrown/infra#579': {
+      'pr-state:example-org/example-repo#579': {
         status: 'resolved',
         state: 'closed',
         resolvedKind: 'pr-state',
       },
     }
 
-    // Resolver result 2: resolves as issue-state (PR 404, issue fallback)
     const resolverResultsIssue: Record<string, ResolverResult> = {
-      'pr-state:marcusrbrown/infra#579': {
+      'pr-state:example-org/example-repo#579': {
         status: 'resolved',
         state: 'closed',
         resolvedKind: 'issue-state',
@@ -2828,29 +2828,20 @@ describe('fingerprint stability: ambiguous cross-repo claim resolved as pr-state
     const fpPr = findingsPr[0]
     const fpIssue = findingsIssue[0]
 
-    // Both must be public findings (current verdict)
     expect(fpPr?.verdict).toBe('current')
     expect(fpIssue?.verdict).toBe('current')
 
-    // Fingerprints must be identical — stable identity regardless of resolution path
     if (fpPr?.verdict !== 'unsafe' && fpIssue?.verdict !== 'unsafe') {
       expect(fpPr?.fingerprint).toBe(fpIssue?.fingerprint)
     }
 
-    // The emitted kind may differ (pr-state vs issue-state) — that's fine
     expect(fpPr?.kind).toBe('pr-state')
     expect(fpIssue?.kind).toBe('issue-state')
   })
 })
 
-// ---------------------------------------------------------------------------
-// Blocker 2: proveRepoPublic must be explicit (private === false)
-// ---------------------------------------------------------------------------
-
 describe('proveRepoPublic: explicit private === false check', () => {
   it('repos.get returning private:undefined is treated as private (not public)', async () => {
-    // When the API returns an unknown/unexpected shape (private: undefined),
-    // the resolver must treat it as private/unsafe — not public.
     const octokit: DetectOctokitClient = {
       paginate: async () => [],
       rest: {
@@ -2862,7 +2853,6 @@ describe('proveRepoPublic: explicit private === false check', () => {
         },
         repos: {
           getReleaseByTag: async () => ({data: {draft: false, prerelease: false}}),
-          // Returns private: undefined — unknown shape
           get: async () => ({data: {private: undefined as unknown as boolean}}),
         },
       },
@@ -2880,20 +2870,12 @@ describe('proveRepoPublic: explicit private === false check', () => {
     }
 
     const result = await resolveClaimLiveState({claim, octokit, owner: 'fro-bot', repo: '.github'})
-    // private: undefined must NOT be treated as public — must be private/unsafe
     expect(result.status).toBe('private')
   })
 })
 
-// ---------------------------------------------------------------------------
-// Detect Octokit construction: no-op log handlers suppress request URL leaks
-// ---------------------------------------------------------------------------
-
 describe('detect Octokit options: log suppression', () => {
-  it('RED: buildDetectOctokitOptions returns options with no-op log handlers', () => {
-    // The detect Octokit must not log request URLs to stderr.
-    // buildDetectOctokitOptions must export options with a log object
-    // whose methods are no-ops (do not write to stderr).
+  it('buildDetectOctokitOptions returns options with no-op log handlers', () => {
     const options = buildDetectOctokitOptions('test-token')
     expect(options).toHaveProperty('log')
     const log = options.log as Record<string, unknown>
@@ -2901,15 +2883,813 @@ describe('detect Octokit options: log suppression', () => {
     expect(typeof log.info).toBe('function')
     expect(typeof log.warn).toBe('function')
     expect(typeof log.error).toBe('function')
-    // No-op: calling them must not throw and must not write to stderr
-    ;(log.debug as (msg: string) => void)('GET /repos/marcusrbrown/infra/pulls/579 - 404')
+    ;(log.debug as (msg: string) => void)('GET /repos/example-org/example-repo/pulls/579 - 404')
     ;(log.info as (msg: string) => void)('test')
     ;(log.warn as (msg: string) => void)('test')
     ;(log.error as (msg: string) => void)('test')
   })
 
-  it('RED: buildDetectOctokitOptions includes auth token', () => {
+  it('buildDetectOctokitOptions includes auth token', () => {
     const options = buildDetectOctokitOptions('my-secret-token')
     expect(options.auth).toBe('my-secret-token')
+  })
+})
+
+describe('resolvePlanStatusClaim', () => {
+  it('happy path: explicit plan path claim matches frontmatter status => current', async () => {
+    const fileReader: FileReader = async (path: string) => {
+      if (path === 'docs/plans/my-plan.md') {
+        return '---\ntitle: My Plan\nstatus: active\ntype: feat\ndate: 2026-06-30\n---\n\nContent.'
+      }
+      throw new Error(`unexpected path: ${path}`)
+    }
+
+    const result = await resolvePlanStatusClaim({
+      claimedPath: 'docs/plans/my-plan.md',
+      claimedStatus: 'active',
+      fileReader,
+    })
+
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') {
+      expect(result.state).toBe('active')
+    }
+  })
+
+  it('happy path: explicit plan path claim conflicts with frontmatter status => drifted (resolved with different state)', async () => {
+    const fileReader: FileReader = async (path: string) => {
+      if (path === 'docs/plans/my-plan.md') {
+        return '---\ntitle: My Plan\nstatus: complete\ntype: feat\ndate: 2026-06-30\n---\n\nContent.'
+      }
+      throw new Error(`unexpected path: ${path}`)
+    }
+
+    const result = await resolvePlanStatusClaim({
+      claimedPath: 'docs/plans/my-plan.md',
+      claimedStatus: 'active',
+      fileReader,
+    })
+
+    // Resolver returns the live state; detectStatusTruthClaims will classify as drifted
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') {
+      expect(result.state).toBe('complete')
+    }
+  })
+
+  it('edge: referenced plan file is missing => unavailable (not proposal-eligible)', async () => {
+    const fileReader: FileReader = async () => {
+      throw Object.assign(new Error('ENOENT: no such file'), {code: 'ENOENT'})
+    }
+
+    const result = await resolvePlanStatusClaim({
+      claimedPath: 'docs/plans/nonexistent.md',
+      claimedStatus: 'active',
+      fileReader,
+    })
+
+    expect(result.status).toBe('unavailable')
+  })
+
+  it('edge: frontmatter missing status field => unavailable', async () => {
+    const fileReader: FileReader = async () => {
+      return '---\ntitle: My Plan\ntype: feat\n---\n\nNo status field.'
+    }
+
+    const result = await resolvePlanStatusClaim({
+      claimedPath: 'docs/plans/my-plan.md',
+      claimedStatus: 'active',
+      fileReader,
+    })
+
+    expect(result.status).toBe('unavailable')
+  })
+
+  it('edge: frontmatter status is unsupported value => unavailable', async () => {
+    const fileReader: FileReader = async () => {
+      return '---\ntitle: My Plan\nstatus: in-progress\ntype: feat\n---\n\nContent.'
+    }
+
+    const result = await resolvePlanStatusClaim({
+      claimedPath: 'docs/plans/my-plan.md',
+      claimedStatus: 'active',
+      fileReader,
+    })
+
+    expect(result.status).toBe('unavailable')
+  })
+
+  it('edge: no frontmatter at all => unavailable', async () => {
+    const fileReader: FileReader = async () => {
+      return '# My Plan\n\nNo frontmatter here.'
+    }
+
+    const result = await resolvePlanStatusClaim({
+      claimedPath: 'docs/plans/my-plan.md',
+      claimedStatus: 'active',
+      fileReader,
+    })
+
+    expect(result.status).toBe('unavailable')
+  })
+
+  it('error: file read failure returns unavailable (caller increments file-parse error count)', async () => {
+    const fileReader: FileReader = async () => {
+      throw new Error('permission denied')
+    }
+
+    const result = await resolvePlanStatusClaim({
+      claimedPath: 'docs/plans/my-plan.md',
+      claimedStatus: 'active',
+      fileReader,
+    })
+
+    // File read failure must not throw — returns unavailable so caller can count it
+    expect(result.status).toBe('unavailable')
+  })
+
+  it('supports all conservative status values: active, complete, draft, cancelled, superseded', async () => {
+    const supportedStatuses = ['active', 'complete', 'draft', 'cancelled', 'superseded']
+
+    for (const status of supportedStatuses) {
+      const fileReader: FileReader = async () => {
+        return `---\ntitle: My Plan\nstatus: ${status}\ntype: feat\n---\n\nContent.`
+      }
+
+      const result = await resolvePlanStatusClaim({
+        claimedPath: 'docs/plans/my-plan.md',
+        claimedStatus: status,
+        fileReader,
+      })
+
+      expect(result.status).toBe('resolved')
+      if (result.status === 'resolved') {
+        expect(result.state).toBe(status)
+      }
+    }
+  })
+})
+
+describe('plan-status claim grammar — extractStatusTruthClaimsFromText', () => {
+  it('edge: ambiguous implicit plan-status claim with no explicit path => no claim extracted', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'The plan is active and progressing well.',
+    })
+    const planClaims = claims.filter(c => c.kind === 'plan-status')
+    expect(planClaims).toHaveLength(0)
+  })
+
+  it('edge: self-referential frontmatter status in a plan file does NOT produce a cross-file plan-status claim', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/my-plan.md',
+      text: '---\nstatus: active\ntitle: My Plan\n---\n\nContent.',
+    })
+    const planClaims = claims.filter(c => c.kind === 'plan-status')
+    expect(planClaims).toHaveLength(0)
+  })
+
+  it('happy path: explicit docs/plans/...md path reference in prose produces a plan-status claim', () => {
+    // Grammar: "plan docs/plans/foo.md is active" or "docs/plans/foo.md is active"
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'The plan docs/plans/my-plan.md is active.',
+    })
+    const planClaims = claims.filter(c => c.kind === 'plan-status')
+    expect(planClaims).toHaveLength(1)
+    const claim = planClaims[0]
+    expect(claim?.sourceRef).toBe('docs/plans/my-plan.md')
+    expect(claim?.claimedState).toBe('active')
+  })
+
+  it('happy path: explicit docs/plans/...md path with complete status produces a plan-status claim', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/other-plan.md',
+      text: 'See docs/plans/my-plan.md is complete for prior work.',
+    })
+    const planClaims = claims.filter(c => c.kind === 'plan-status')
+    expect(planClaims).toHaveLength(1)
+    const claim = planClaims[0]
+    expect(claim?.sourceRef).toBe('docs/plans/my-plan.md')
+    expect(claim?.claimedState).toBe('complete')
+  })
+
+  it('edge: plan path reference without a supported status value produces no claim', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'The plan docs/plans/my-plan.md is in-progress.',
+    })
+    const planClaims = claims.filter(c => c.kind === 'plan-status')
+    expect(planClaims).toHaveLength(0)
+  })
+
+  it('edge: plan path reference without explicit status produces no claim', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'See docs/plans/my-plan.md for details.',
+    })
+    const planClaims = claims.filter(c => c.kind === 'plan-status')
+    expect(planClaims).toHaveLength(0)
+  })
+
+  it('edge: plan path not under docs/plans/ produces no claim', () => {
+    // Only docs/plans/...md paths are authoritative plan paths
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'The plan some/other/path.md is active.',
+    })
+    const planClaims = claims.filter(c => c.kind === 'plan-status')
+    expect(planClaims).toHaveLength(0)
+  })
+
+  it('sourceRef is the plan path (not path#status) for cross-file plan-status claims', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'The plan docs/plans/my-plan.md is active.',
+    })
+    const planClaims = claims.filter(c => c.kind === 'plan-status')
+    expect(planClaims).toHaveLength(1)
+    // sourceRef must be the plan path itself, not path#status
+    expect(planClaims[0]?.sourceRef).toBe('docs/plans/my-plan.md')
+    expect(planClaims[0]?.sourceRef).not.toContain('#status')
+  })
+})
+
+describe('plan-status end-to-end — extract → resolve → detect pipeline', () => {
+  it('happy path: explicit plan path claim matches frontmatter => current finding, not proposal-eligible', async () => {
+    const fileReader: FileReader = async (path: string) => {
+      if (path === 'docs/plans/my-plan.md') {
+        return '---\ntitle: My Plan\nstatus: active\ntype: feat\ndate: 2026-06-30\n---\n\nContent.'
+      }
+      throw new Error(`unexpected path: ${path}`)
+    }
+
+    // Extract cross-file plan-status claim from prose
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'The plan docs/plans/my-plan.md is active.',
+    })
+    const claim = claims.find(c => c.kind === 'plan-status')
+    expect(claim).toBeDefined()
+    if (claim === undefined) return
+
+    // Resolve using file-parse resolver
+    const resolverResult = await resolvePlanStatusClaim({
+      claimedPath: claim.sourceRef,
+      claimedStatus: claim.claimedState,
+      fileReader,
+    })
+
+    const resolverResults: Record<string, ResolverResult> = {
+      [`plan-status:${claim.sourceRef}`]: resolverResult,
+    }
+
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.verdict).toBe('current')
+    expect(findings[0]?.proposalEligible).toBe(false)
+  })
+
+  it('happy path: explicit plan path claim conflicts with frontmatter => drifted finding, proposal-eligible', async () => {
+    const fileReader: FileReader = async (path: string) => {
+      if (path === 'docs/plans/my-plan.md') {
+        return '---\ntitle: My Plan\nstatus: complete\ntype: feat\ndate: 2026-06-30\n---\n\nContent.'
+      }
+      throw new Error(`unexpected path: ${path}`)
+    }
+
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'The plan docs/plans/my-plan.md is active.',
+    })
+    const claim = claims.find(c => c.kind === 'plan-status')
+    expect(claim).toBeDefined()
+    if (claim === undefined) return
+
+    const resolverResult = await resolvePlanStatusClaim({
+      claimedPath: claim.sourceRef,
+      claimedStatus: claim.claimedState,
+      fileReader,
+    })
+
+    const resolverResults: Record<string, ResolverResult> = {
+      [`plan-status:${claim.sourceRef}`]: resolverResult,
+    }
+
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.verdict).toBe('drifted')
+    expect(findings[0]?.proposalEligible).toBe(true)
+    if (findings[0]?.verdict === 'drifted') {
+      expect(findings[0].claimedState).toBe('active')
+      expect(findings[0].liveState).toBe('complete')
+    }
+  })
+
+  it('edge: missing plan file => unresolved finding, not proposal-eligible', async () => {
+    const fileReader: FileReader = async () => {
+      throw Object.assign(new Error('ENOENT'), {code: 'ENOENT'})
+    }
+
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'The plan docs/plans/nonexistent.md is active.',
+    })
+    const claim = claims.find(c => c.kind === 'plan-status')
+    expect(claim).toBeDefined()
+    if (claim === undefined) return
+
+    const resolverResult = await resolvePlanStatusClaim({
+      claimedPath: claim.sourceRef,
+      claimedStatus: claim.claimedState,
+      fileReader,
+    })
+
+    const resolverResults: Record<string, ResolverResult> = {
+      [`plan-status:${claim.sourceRef}`]: resolverResult,
+    }
+
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.verdict).toBe('unresolved')
+    expect(findings[0]?.proposalEligible).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// plan-status wiring — runDetect/CLI-level resolution must pass fileReader
+// ---------------------------------------------------------------------------
+
+describe('plan-status wiring — resolveAllClaims with fileReader', () => {
+  it('resolveAllClaims with fileReader resolves plan-status claim to current', async () => {
+    const planStatusClaim: StatusTruthClaim = {
+      kind: 'plan-status',
+      path: 'README.md',
+      sourceRef: 'docs/plans/example.md',
+      claimedState: 'active',
+      normalizedText: 'docs/plans/example.md is active',
+    }
+
+    const fileReader: FileReader = async (path: string) => {
+      if (path === 'docs/plans/example.md') {
+        return '---\ntitle: Example Plan\nstatus: active\ntype: feat\ndate: 2026-06-30\n---\n\nContent.'
+      }
+      throw new Error(`unexpected path: ${path}`)
+    }
+
+    const octokit = makeMockDetectOctokit()
+
+    const {resolverResults} = await resolveAllClaims({
+      claims: [planStatusClaim],
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      fileReader,
+    })
+
+    const findings = detectStatusTruthClaims([planStatusClaim], resolverResults)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.verdict).toBe('current')
+    expect(findings[0]?.proposalEligible).toBe(false)
+  })
+
+  it('resolveAllClaims with fileReader resolves plan-status claim to drifted when status conflicts', async () => {
+    const planStatusClaim: StatusTruthClaim = {
+      kind: 'plan-status',
+      path: 'README.md',
+      sourceRef: 'docs/plans/example.md',
+      claimedState: 'active',
+      normalizedText: 'docs/plans/example.md is active',
+    }
+
+    const fileReader: FileReader = async (path: string) => {
+      if (path === 'docs/plans/example.md') {
+        return '---\ntitle: Example Plan\nstatus: complete\ntype: feat\ndate: 2026-06-30\n---\n\nContent.'
+      }
+      throw new Error(`unexpected path: ${path}`)
+    }
+
+    const octokit = makeMockDetectOctokit()
+
+    const {resolverResults} = await resolveAllClaims({
+      claims: [planStatusClaim],
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      fileReader,
+    })
+
+    const findings = detectStatusTruthClaims([planStatusClaim], resolverResults)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.verdict).toBe('drifted')
+    expect(findings[0]?.proposalEligible).toBe(true)
+    if (findings[0]?.verdict === 'drifted') {
+      expect(findings[0].claimedState).toBe('active')
+      expect(findings[0].liveState).toBe('complete')
+    }
+  })
+
+  it('missing plan file via resolveAllClaims with fileReader stays unresolved', async () => {
+    const planStatusClaim: StatusTruthClaim = {
+      kind: 'plan-status',
+      path: 'README.md',
+      sourceRef: 'docs/plans/nonexistent.md',
+      claimedState: 'active',
+      normalizedText: 'docs/plans/nonexistent.md is active',
+    }
+
+    const fileReader: FileReader = async () => {
+      throw Object.assign(new Error('ENOENT: no such file'), {code: 'ENOENT'})
+    }
+
+    const octokit = makeMockDetectOctokit()
+
+    const {resolverResults} = await resolveAllClaims({
+      claims: [planStatusClaim],
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      fileReader,
+    })
+
+    const findings = detectStatusTruthClaims([planStatusClaim], resolverResults)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.verdict).toBe('unresolved')
+    expect(findings[0]?.proposalEligible).toBe(false)
+  })
+
+  it('full scan→resolve→detect pipeline with fileReader resolves plan-status claim from scanned doc', async () => {
+    const fileLister: FileLister = async () => ['README.md', 'docs/plans/example.md']
+    const fileReader: FileReader = async (path: string) => {
+      if (path === 'README.md') return 'The plan docs/plans/example.md is active.'
+      if (path === 'docs/plans/example.md') {
+        return '---\ntitle: Example Plan\nstatus: active\ntype: feat\ndate: 2026-06-30\n---\n\nContent.'
+      }
+      throw new Error(`unexpected path: ${path}`)
+    }
+
+    const {claims} = await scanStatusTruthClaims({fileLister, fileReader})
+    const planClaims = claims.filter(c => c.kind === 'plan-status')
+    expect(planClaims).toHaveLength(1)
+
+    const octokit = makeMockDetectOctokit()
+
+    const {resolverResults} = await resolveAllClaims({
+      claims,
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      fileReader,
+    })
+
+    const findings = detectStatusTruthClaims(claims, resolverResults)
+    const planFindings = findings.filter(f => f.kind === 'plan-status')
+    expect(planFindings).toHaveLength(1)
+    // Plan file has matching status → current
+    expect(planFindings[0]?.verdict).toBe('current')
+  })
+})
+
+describe('plan-status DEFAULT_ENABLED_KINDS inclusion', () => {
+  it('plan-status is included in DEFAULT_ENABLED_KINDS now that a real resolver exists', () => {
+    expect(DEFAULT_ENABLED_KINDS).toContain('plan-status')
+  })
+
+  it('production scan with default kinds includes plan-status claims from prose', async () => {
+    const fileLister: FileLister = async () => ['README.md']
+    const fileReader: FileReader = async (path: string) => {
+      if (path === 'README.md') return 'The plan docs/plans/my-plan.md is active.'
+      throw new Error(`unexpected: ${path}`)
+    }
+
+    const {claims} = await scanStatusTruthClaims({fileLister, fileReader})
+    const planClaims = claims.filter(c => c.kind === 'plan-status')
+    expect(planClaims).toHaveLength(1)
+  })
+})
+
+describe('plan-status privacy/output safety', () => {
+  it('privacy: plan-status finding artifact contains no raw claim text, source snippets, or private identity tokens', async () => {
+    const fileReader: FileReader = async (path: string) => {
+      if (path === 'docs/plans/my-plan.md') {
+        return '---\ntitle: My Plan\nstatus: complete\ntype: feat\ndate: 2026-06-30\n---\n\nContent.'
+      }
+      throw new Error(`unexpected path: ${path}`)
+    }
+
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'The plan docs/plans/my-plan.md is active.',
+    })
+    const claim = claims.find(c => c.kind === 'plan-status')
+    expect(claim).toBeDefined()
+    if (claim === undefined) return
+
+    const resolverResult = await resolvePlanStatusClaim({
+      claimedPath: claim.sourceRef,
+      claimedStatus: claim.claimedState,
+      fileReader,
+    })
+
+    const resolverResults: Record<string, ResolverResult> = {
+      [`plan-status:${claim.sourceRef}`]: resolverResult,
+    }
+
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+    const report = buildStatusTruthReport({
+      findings,
+      scanComplete: true,
+      generatedAt: '2026-06-30T00:00:00Z',
+      failureClass: null,
+    })
+
+    const artifactJson = JSON.stringify(report)
+
+    // Must not contain raw claim text
+    expect(artifactJson).not.toContain('"normalizedText"')
+    expect(artifactJson).not.toContain('"rawText"')
+    expect(artifactJson).not.toContain('"sourceSnippet"')
+
+    // Fingerprint must be an opaque hex hash, not raw text
+    const finding = report.findings[0]
+    if (finding !== undefined && finding.verdict !== 'unsafe') {
+      expect(finding.fingerprint).toMatch(/^[a-f0-9]{16}$/)
+    }
+
+    // Report must not contain the raw prose claim text
+    expect(artifactJson).not.toContain('The plan docs/plans/my-plan.md is active')
+  })
+
+  it('privacy: validateStatusTruthArtifact rejects plan-status finding with normalizedText field', () => {
+    const finding = makeFinding({
+      kind: 'plan-status',
+      sourceRef: 'docs/plans/my-plan.md',
+      claimedState: 'active',
+      liveState: 'complete',
+      verdict: 'drifted',
+      proposalEligible: true,
+    })
+    // Inject prohibited field
+    const taintedFinding = {...finding, normalizedText: 'the plan docs/plans/my-plan.md is active'}
+    const report = makeReport({
+      status: 'findings',
+      findings: [taintedFinding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const result = validateStatusTruthArtifact(report)
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.reason).toContain('prohibited field')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// plan-status path traversal
+// ---------------------------------------------------------------------------
+
+describe('plan-status path traversal rejection', () => {
+  it('extraction: path with .. segment is not extracted as a plan-status claim', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'docs/plans/../../etc/passwd is active',
+    })
+    const planClaims = claims.filter(c => c.kind === 'plan-status')
+    expect(planClaims).toHaveLength(0)
+  })
+
+  it('extraction: path with encoded traversal segment is not extracted', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'docs/plans/../secret.md is active',
+    })
+    const planClaims = claims.filter(c => c.kind === 'plan-status')
+    expect(planClaims).toHaveLength(0)
+  })
+
+  it('resolver: claimedPath with .. segment returns unavailable without calling fileReader', async () => {
+    let readerCalled = false
+    const fileReader: FileReader = async () => {
+      readerCalled = true
+      return '---\nstatus: active\n---\n'
+    }
+
+    const result = await resolvePlanStatusClaim({
+      claimedPath: 'docs/plans/../../etc/passwd',
+      claimedStatus: 'active',
+      fileReader,
+    })
+
+    expect(result.status).toBe('unavailable')
+    expect(readerCalled).toBe(false)
+  })
+
+  it('resolver: claimedPath resolving outside docs/plans/ returns unavailable without calling fileReader', async () => {
+    let readerCalled = false
+    const fileReader: FileReader = async () => {
+      readerCalled = true
+      return '---\nstatus: active\n---\n'
+    }
+
+    const result = await resolvePlanStatusClaim({
+      claimedPath: 'docs/plans/../other/secret.md',
+      claimedStatus: 'active',
+      fileReader,
+    })
+
+    expect(result.status).toBe('unavailable')
+    expect(readerCalled).toBe(false)
+  })
+
+  it('resolver: valid path under docs/plans/ still resolves correctly', async () => {
+    const fileReader: FileReader = async () => '---\nstatus: active\n---\n'
+
+    const result = await resolvePlanStatusClaim({
+      claimedPath: 'docs/plans/valid-plan.md',
+      claimedStatus: 'active',
+      fileReader,
+    })
+
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') expect(result.state).toBe('active')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// tokenless local run — plan-status resolves without GITHUB_TOKEN
+// ---------------------------------------------------------------------------
+
+describe('plan-status tokenless resolution', () => {
+  it('plan-status claim with fileReader resolves to current without an Octokit/token', async () => {
+    const planStatusClaim: StatusTruthClaim = {
+      kind: 'plan-status',
+      path: 'README.md',
+      sourceRef: 'docs/plans/example.md',
+      claimedState: 'active',
+      normalizedText: 'docs/plans/example.md is active',
+    }
+
+    const fileReader: FileReader = async (path: string) => {
+      if (path === 'docs/plans/example.md') {
+        return '---\ntitle: Example Plan\nstatus: active\n---\n\nContent.'
+      }
+      throw new Error(`unexpected path: ${path}`)
+    }
+
+    // Resolve plan-status claims using only fileReader — no octokit/token needed
+    const resolverResults: Record<string, ResolverResult> = {}
+    const result = await resolvePlanStatusClaim({
+      claimedPath: planStatusClaim.sourceRef,
+      claimedStatus: planStatusClaim.claimedState,
+      fileReader,
+    })
+    resolverResults[`plan-status:${planStatusClaim.sourceRef}`] = result
+
+    const findings = detectStatusTruthClaims([planStatusClaim], resolverResults)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.verdict).toBe('current')
+    expect(findings[0]?.proposalEligible).toBe(false)
+  })
+
+  it('plan-status claim with fileReader resolves to drifted without an Octokit/token', async () => {
+    const planStatusClaim: StatusTruthClaim = {
+      kind: 'plan-status',
+      path: 'README.md',
+      sourceRef: 'docs/plans/example.md',
+      claimedState: 'active',
+      normalizedText: 'docs/plans/example.md is active',
+    }
+
+    const fileReader: FileReader = async (path: string) => {
+      if (path === 'docs/plans/example.md') {
+        return '---\ntitle: Example Plan\nstatus: complete\n---\n\nContent.'
+      }
+      throw new Error(`unexpected path: ${path}`)
+    }
+
+    const resolverResults: Record<string, ResolverResult> = {}
+    const result = await resolvePlanStatusClaim({
+      claimedPath: planStatusClaim.sourceRef,
+      claimedStatus: planStatusClaim.claimedState,
+      fileReader,
+    })
+    resolverResults[`plan-status:${planStatusClaim.sourceRef}`] = result
+
+    const findings = detectStatusTruthClaims([planStatusClaim], resolverResults)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.verdict).toBe('drifted')
+    expect(findings[0]?.proposalEligible).toBe(true)
+    if (findings[0]?.verdict === 'drifted') {
+      expect(findings[0].proposedCorrection).toContain('complete')
+    }
+  })
+
+  it('API-backed claims remain unresolved without token (no fake resolution)', async () => {
+    const prClaim: StatusTruthClaim = {
+      kind: 'pr-state',
+      path: 'README.md',
+      sourceRef: '#42',
+      claimedState: 'open',
+      normalizedText: 'pr #42 is open',
+    }
+
+    // No resolver results for API claims (simulates no-token path)
+    const resolverResults: Record<string, ResolverResult> = {}
+
+    const findings = detectStatusTruthClaims([prClaim], resolverResults)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.verdict).toBe('unresolved')
+    expect(findings[0]?.proposalEligible).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Opportunistic: quoted status values and CRLF frontmatter
+// ---------------------------------------------------------------------------
+
+describe('parsePlanFrontmatterStatus: quoted values and CRLF', () => {
+  it('quoted status value "active" resolves correctly', async () => {
+    const fileReader: FileReader = async () => '---\nstatus: "active"\n---\n\nContent.'
+
+    const result = await resolvePlanStatusClaim({
+      claimedPath: 'docs/plans/my-plan.md',
+      claimedStatus: 'active',
+      fileReader,
+    })
+
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') expect(result.state).toBe('active')
+  })
+
+  it("single-quoted status value 'complete' resolves correctly", async () => {
+    const fileReader: FileReader = async () => "---\nstatus: 'complete'\n---\n\nContent."
+
+    const result = await resolvePlanStatusClaim({
+      claimedPath: 'docs/plans/my-plan.md',
+      claimedStatus: 'complete',
+      fileReader,
+    })
+
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') expect(result.state).toBe('complete')
+  })
+
+  it('CRLF frontmatter resolves correctly', async () => {
+    const fileReader: FileReader = async () => '---\r\nstatus: active\r\ntitle: My Plan\r\n---\r\n\r\nContent.'
+
+    const result = await resolvePlanStatusClaim({
+      claimedPath: 'docs/plans/my-plan.md',
+      claimedStatus: 'active',
+      fileReader,
+    })
+
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') expect(result.state).toBe('active')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Opportunistic: plan-status drift proposedCorrection content
+// ---------------------------------------------------------------------------
+
+describe('plan-status drift: proposedCorrection contains expected status replacement', () => {
+  it('drifted plan-status finding proposedCorrection replaces claimed status with live status', async () => {
+    const fileReader: FileReader = async (path: string) => {
+      if (path === 'docs/plans/my-plan.md') {
+        return '---\ntitle: My Plan\nstatus: complete\n---\n\nContent.'
+      }
+      throw new Error(`unexpected path: ${path}`)
+    }
+
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'README.md',
+      text: 'The plan docs/plans/my-plan.md is active.',
+    })
+    const claim = claims.find(c => c.kind === 'plan-status')
+    expect(claim).toBeDefined()
+    if (claim === undefined) return
+
+    const resolverResult = await resolvePlanStatusClaim({
+      claimedPath: claim.sourceRef,
+      claimedStatus: claim.claimedState,
+      fileReader,
+    })
+
+    const resolverResults: Record<string, ResolverResult> = {
+      [`plan-status:${claim.sourceRef}`]: resolverResult,
+    }
+
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+    expect(findings).toHaveLength(1)
+    const finding = findings[0]
+    expect(finding?.verdict).toBe('drifted')
+    if (finding?.verdict === 'drifted') {
+      expect(finding.proposedCorrection).toBeDefined()
+      // proposedCorrection must contain the live status 'complete'
+      expect(finding.proposedCorrection).toContain('complete')
+      // proposedCorrection must not still say 'active' as the status
+      // (it should have replaced 'active' with 'complete')
+      expect(finding.proposedCorrection).not.toMatch(/\bactive\b/)
+    }
   })
 })

--- a/scripts/status-truth-detect.test.ts
+++ b/scripts/status-truth-detect.test.ts
@@ -2911,7 +2911,6 @@ describe('resolvePlanStatusClaim', () => {
 
     const result = await resolvePlanStatusClaim({
       claimedPath: 'docs/plans/my-plan.md',
-      claimedStatus: 'active',
       fileReader,
     })
 
@@ -2931,7 +2930,6 @@ describe('resolvePlanStatusClaim', () => {
 
     const result = await resolvePlanStatusClaim({
       claimedPath: 'docs/plans/my-plan.md',
-      claimedStatus: 'active',
       fileReader,
     })
 
@@ -2949,7 +2947,6 @@ describe('resolvePlanStatusClaim', () => {
 
     const result = await resolvePlanStatusClaim({
       claimedPath: 'docs/plans/nonexistent.md',
-      claimedStatus: 'active',
       fileReader,
     })
 
@@ -2963,7 +2960,6 @@ describe('resolvePlanStatusClaim', () => {
 
     const result = await resolvePlanStatusClaim({
       claimedPath: 'docs/plans/my-plan.md',
-      claimedStatus: 'active',
       fileReader,
     })
 
@@ -2977,7 +2973,6 @@ describe('resolvePlanStatusClaim', () => {
 
     const result = await resolvePlanStatusClaim({
       claimedPath: 'docs/plans/my-plan.md',
-      claimedStatus: 'active',
       fileReader,
     })
 
@@ -2991,7 +2986,6 @@ describe('resolvePlanStatusClaim', () => {
 
     const result = await resolvePlanStatusClaim({
       claimedPath: 'docs/plans/my-plan.md',
-      claimedStatus: 'active',
       fileReader,
     })
 
@@ -3005,7 +2999,6 @@ describe('resolvePlanStatusClaim', () => {
 
     const result = await resolvePlanStatusClaim({
       claimedPath: 'docs/plans/my-plan.md',
-      claimedStatus: 'active',
       fileReader,
     })
 
@@ -3023,7 +3016,6 @@ describe('resolvePlanStatusClaim', () => {
 
       const result = await resolvePlanStatusClaim({
         claimedPath: 'docs/plans/my-plan.md',
-        claimedStatus: status,
         fileReader,
       })
 
@@ -3141,7 +3133,6 @@ describe('plan-status end-to-end — extract → resolve → detect pipeline', (
     // Resolve using file-parse resolver
     const resolverResult = await resolvePlanStatusClaim({
       claimedPath: claim.sourceRef,
-      claimedStatus: claim.claimedState,
       fileReader,
     })
 
@@ -3173,7 +3164,6 @@ describe('plan-status end-to-end — extract → resolve → detect pipeline', (
 
     const resolverResult = await resolvePlanStatusClaim({
       claimedPath: claim.sourceRef,
-      claimedStatus: claim.claimedState,
       fileReader,
     })
 
@@ -3206,7 +3196,6 @@ describe('plan-status end-to-end — extract → resolve → detect pipeline', (
 
     const resolverResult = await resolvePlanStatusClaim({
       claimedPath: claim.sourceRef,
-      claimedStatus: claim.claimedState,
       fileReader,
     })
 
@@ -3392,7 +3381,6 @@ describe('plan-status privacy/output safety', () => {
 
     const resolverResult = await resolvePlanStatusClaim({
       claimedPath: claim.sourceRef,
-      claimedStatus: claim.claimedState,
       fileReader,
     })
 
@@ -3481,7 +3469,6 @@ describe('plan-status path traversal rejection', () => {
 
     const result = await resolvePlanStatusClaim({
       claimedPath: 'docs/plans/../../etc/passwd',
-      claimedStatus: 'active',
       fileReader,
     })
 
@@ -3498,7 +3485,6 @@ describe('plan-status path traversal rejection', () => {
 
     const result = await resolvePlanStatusClaim({
       claimedPath: 'docs/plans/../other/secret.md',
-      claimedStatus: 'active',
       fileReader,
     })
 
@@ -3511,7 +3497,6 @@ describe('plan-status path traversal rejection', () => {
 
     const result = await resolvePlanStatusClaim({
       claimedPath: 'docs/plans/valid-plan.md',
-      claimedStatus: 'active',
       fileReader,
     })
 
@@ -3545,7 +3530,6 @@ describe('plan-status tokenless resolution', () => {
     const resolverResults: Record<string, ResolverResult> = {}
     const result = await resolvePlanStatusClaim({
       claimedPath: planStatusClaim.sourceRef,
-      claimedStatus: planStatusClaim.claimedState,
       fileReader,
     })
     resolverResults[`plan-status:${planStatusClaim.sourceRef}`] = result
@@ -3575,7 +3559,6 @@ describe('plan-status tokenless resolution', () => {
     const resolverResults: Record<string, ResolverResult> = {}
     const result = await resolvePlanStatusClaim({
       claimedPath: planStatusClaim.sourceRef,
-      claimedStatus: planStatusClaim.claimedState,
       fileReader,
     })
     resolverResults[`plan-status:${planStatusClaim.sourceRef}`] = result
@@ -3618,7 +3601,6 @@ describe('parsePlanFrontmatterStatus: quoted values and CRLF', () => {
 
     const result = await resolvePlanStatusClaim({
       claimedPath: 'docs/plans/my-plan.md',
-      claimedStatus: 'active',
       fileReader,
     })
 
@@ -3631,7 +3613,6 @@ describe('parsePlanFrontmatterStatus: quoted values and CRLF', () => {
 
     const result = await resolvePlanStatusClaim({
       claimedPath: 'docs/plans/my-plan.md',
-      claimedStatus: 'complete',
       fileReader,
     })
 
@@ -3644,7 +3625,6 @@ describe('parsePlanFrontmatterStatus: quoted values and CRLF', () => {
 
     const result = await resolvePlanStatusClaim({
       claimedPath: 'docs/plans/my-plan.md',
-      claimedStatus: 'active',
       fileReader,
     })
 
@@ -3676,7 +3656,6 @@ describe('plan-status drift: proposedCorrection contains expected status replace
 
     const resolverResult = await resolvePlanStatusClaim({
       claimedPath: claim.sourceRef,
-      claimedStatus: claim.claimedState,
       fileReader,
     })
 
@@ -4061,6 +4040,33 @@ describe('resolveRolloutTrackerClaim', () => {
     expect(trackerClaims).toHaveLength(1)
     expect(trackerClaims[0]?.claimedState).toBe('closed')
   })
+
+  it('issue_state merged: snapshot with merged state resolves to "merged" and classifies correctly', async () => {
+    const snapshot = makeRolloutSnapshot([makeSnapshotItem({content_number: 931, issue_state: 'merged'})])
+    const claim = makeClaim({
+      kind: 'rollout-tracker-status',
+      sourceRef: '#931',
+      claimedState: 'open',
+      normalizedText: 'rollout tracker #931 is open',
+    })
+
+    const result = await resolveRolloutTrackerClaim({claim, snapshot})
+
+    expect(result.status).toBe('resolved')
+    if (result.status === 'resolved') {
+      expect(result.state).toBe('merged')
+    }
+
+    // Classify via detectStatusTruthClaims: claimed 'open' vs live 'merged' => drifted
+    const resolverResults = makeResolverResults([{kind: 'rollout-tracker-status', sourceRef: '#931', result}])
+    const findings = detectStatusTruthClaims([claim], resolverResults)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.verdict).toBe('drifted')
+    expect(findings[0]?.proposalEligible).toBe(true)
+    if (findings[0]?.verdict === 'drifted') {
+      expect(findings[0].liveState).toBe('merged')
+    }
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -4374,6 +4380,32 @@ describe('loadRolloutSnapshot: snapshot file loading and validation', () => {
     const result = await loadRolloutSnapshot({snapshotPath: '/tmp/snapshot.json', fileReader})
     // Must return null (validation failed), not the raw object
     expect(result).toBeNull()
+  })
+
+  it('loadRolloutSnapshot writes a generic diagnostic to stderr on file read failure (no path info)', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const fileReader = async (_path: string) => {
+      throw new Error('ENOENT: no such file or directory, open /tmp/secret-path.json')
+    }
+    await loadRolloutSnapshot({snapshotPath: '/tmp/secret-path.json', fileReader})
+    // Must write a diagnostic to stderr
+    expect(stderrSpy).toHaveBeenCalled()
+    // The diagnostic must not contain the raw error detail (which may include path info)
+    const written = stderrSpy.mock.calls.map(c => String(c[0])).join('')
+    expect(written).toContain('snapshot file unavailable')
+    expect(written).not.toContain('secret-path.json')
+    stderrSpy.mockRestore()
+  })
+
+  it('loadRolloutSnapshot writes a generic diagnostic to stderr on malformed JSON (no raw payload)', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const fileReader = async (_path: string) => 'SENSITIVE_PAYLOAD{{{not-json'
+    await loadRolloutSnapshot({snapshotPath: '/tmp/snapshot.json', fileReader})
+    expect(stderrSpy).toHaveBeenCalled()
+    const written = stderrSpy.mock.calls.map(c => String(c[0])).join('')
+    expect(written).toContain('snapshot JSON malformed')
+    expect(written).not.toContain('SENSITIVE_PAYLOAD')
+    stderrSpy.mockRestore()
   })
 })
 

--- a/scripts/status-truth-detect.test.ts
+++ b/scripts/status-truth-detect.test.ts
@@ -730,7 +730,7 @@ describe('type contracts', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Unit 4: validateStatusTruthArtifact tests
+// validateStatusTruthArtifact tests
 // ---------------------------------------------------------------------------
 
 describe('validateStatusTruthArtifact', () => {
@@ -832,7 +832,7 @@ describe('validateStatusTruthArtifact', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Unit 4: Artifact safety contract tests
+// Artifact safety contract tests
 // ---------------------------------------------------------------------------
 
 describe('artifact safety contract', () => {
@@ -3700,7 +3700,7 @@ describe('plan-status drift: proposedCorrection contains expected status replace
 })
 
 // ---------------------------------------------------------------------------
-// U2: Rollout-tracker compound resolver tests
+// Rollout-tracker compound resolver tests
 // ---------------------------------------------------------------------------
 
 /** Build a minimal SnapshotItem for test fixtures. */

--- a/scripts/status-truth-detect.ts
+++ b/scripts/status-truth-detect.ts
@@ -463,7 +463,7 @@ export function isKnownReportVersion(report: StatusTruthJsonReport): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// Unit 4: Text extraction and file scanning
+// Text extraction and file scanning
 // ---------------------------------------------------------------------------
 
 /**
@@ -754,7 +754,7 @@ export async function scanStatusTruthClaims(params: {
 }
 
 // ---------------------------------------------------------------------------
-// Unit 4: GitHub issue body/comment scanning
+// GitHub issue body/comment scanning
 // ---------------------------------------------------------------------------
 
 /**
@@ -905,7 +905,7 @@ export async function scanIssueStatusTruthClaims(params: {
 }
 
 // ---------------------------------------------------------------------------
-// Unit 4: Current-repo resolver helpers
+// Current-repo resolver helpers
 // ---------------------------------------------------------------------------
 
 /**
@@ -1312,7 +1312,7 @@ export async function resolvePlanStatusClaim(params: {
 }
 
 // ---------------------------------------------------------------------------
-// U2: Rollout-tracker compound resolver
+// Rollout-tracker compound resolver
 // ---------------------------------------------------------------------------
 
 /**
@@ -1487,7 +1487,7 @@ export async function resolveAllClaims(params: {
 }
 
 // ---------------------------------------------------------------------------
-// Unit 2: Snapshot loading helper
+// Snapshot loading helper
 // ---------------------------------------------------------------------------
 
 /**
@@ -1610,7 +1610,7 @@ export async function loadRolloutSnapshot(params: {
 }
 
 // ---------------------------------------------------------------------------
-// Unit 4: Artifact validation helper
+// Artifact validation helper
 // ---------------------------------------------------------------------------
 
 /**
@@ -1702,7 +1702,7 @@ export function validateStatusTruthArtifact(
 }
 
 // ---------------------------------------------------------------------------
-// Unit 4: Octokit construction helpers
+// Octokit construction helpers
 // ---------------------------------------------------------------------------
 
 /**
@@ -1743,7 +1743,7 @@ export function buildDetectOctokitOptions(token: string): {
 }
 
 // ---------------------------------------------------------------------------
-// Unit 4: CLI shell
+// CLI shell
 // ---------------------------------------------------------------------------
 
 /**

--- a/scripts/status-truth-detect.ts
+++ b/scripts/status-truth-detect.ts
@@ -1,3 +1,5 @@
+import type {RolloutSnapshot, SnapshotItem} from './rollout-tracker-snapshot.ts'
+
 import {createHash} from 'node:crypto'
 import {readFile, writeFile} from 'node:fs/promises'
 import process from 'node:process'
@@ -1037,8 +1039,10 @@ export async function resolveClaimLiveState(params: {
   repo: string
   /** Optional file reader for plan-status file-parse resolution. */
   fileReader?: FileReader
+  /** Optional rollout snapshot for rollout-tracker-status compound resolution. */
+  snapshot?: RolloutSnapshot | null
 }): Promise<ResolverResult> {
-  const {claim, octokit, owner, repo, fileReader} = params
+  const {claim, octokit, owner, repo, fileReader, snapshot} = params
 
   // ---------------------------------------------------------------------------
   // Cross-repo resolution: publicness proof required before any identity exposure
@@ -1142,8 +1146,13 @@ export async function resolveClaimLiveState(params: {
   }
 
   if (claim.kind === 'rollout-tracker-status') {
-    // Compound resolver: Phase 1 scope cut — mark unavailable
-    return {status: 'unavailable'}
+    // Compound resolver: use snapshot when provided; otherwise unavailable.
+    // snapshot === undefined means no snapshot was passed (Phase 1 behavior preserved).
+    // snapshot === null means snapshot was explicitly passed as unavailable.
+    if (snapshot === undefined) {
+      return {status: 'unavailable'}
+    }
+    return resolveRolloutTrackerClaim({claim, snapshot})
   }
 
   if (claim.kind === 'pr-state') {
@@ -1292,6 +1301,89 @@ export async function resolvePlanStatusClaim(params: {
   return {status: 'resolved', state: liveStatus}
 }
 
+// ---------------------------------------------------------------------------
+// U2: Rollout-tracker compound resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Fixed claim-to-snapshot field map for rollout-tracker-status claims.
+ *
+ * The only field compared is `issue_state`. Project-specific fields (status,
+ * readiness, gate) and volatile fields (issue_labels, issue_closed_at) are
+ * intentionally excluded from claim comparison to prevent arbitrary snapshot
+ * fields from becoming claim sources by accident.
+ *
+ * This map is code-reviewed and tested; it is the sole source of truth for
+ * which snapshot fields are authoritative for rollout-tracker-status claims.
+ */
+const ROLLOUT_TRACKER_CLAIM_FIELD_MAP = {
+  /** The snapshot field that represents the live state for a rollout-tracker-status claim. */
+  liveStateField: 'issue_state',
+} as const
+
+/**
+ * Resolve a rollout-tracker-status claim against a sanitized snapshot.
+ *
+ * Resolution rules:
+ * - `snapshot` is null (unavailable) → `unavailable`
+ * - No matching item found for the claim's sourceRef number → `unavailable`
+ * - Matched item's `issue_state` is null (incomplete data) → `unavailable`
+ * - Matched item's `issue_state` is present → `resolved` with the live state
+ *
+ * The resolver compares claim state only against the fixed field map
+ * (`issue_state`). Raw snapshot payloads, Project field values, issue titles,
+ * and tracker internals are never echoed into the result.
+ *
+ * Pure function: no I/O, no write credentials, no Octokit dependency.
+ *
+ * @param params - Resolution parameters.
+ * @param params.claim - The rollout-tracker-status claim to resolve.
+ * @param params.snapshot - The sanitized snapshot, or null if unavailable.
+ */
+export async function resolveRolloutTrackerClaim(params: {
+  claim: StatusTruthClaim
+  snapshot: RolloutSnapshot | null
+}): Promise<ResolverResult> {
+  const {claim, snapshot} = params
+
+  // Snapshot unavailable → unresolved (never treat as no-drift)
+  if (snapshot === null) {
+    return {status: 'unavailable'}
+  }
+
+  // Extract the issue number from the sourceRef (bare #N format)
+  const match = /^#(\d+)$/u.exec(claim.sourceRef)
+  if (match === null || match[1] === undefined) {
+    return {status: 'unavailable'}
+  }
+  const issueNumber = Number.parseInt(match[1], 10)
+
+  // Find the matching snapshot item by content_number
+  const item = snapshot.items.find(i => i.content_number === issueNumber)
+  if (item === undefined) {
+    return {status: 'unavailable'}
+  }
+
+  // Read the live state from the fixed field map (issue_state only)
+  const liveState = item[ROLLOUT_TRACKER_CLAIM_FIELD_MAP.liveStateField]
+  if (liveState === null) {
+    // Incomplete data — cannot determine live state
+    return {status: 'unavailable'}
+  }
+
+  // Return the live state with sub-resolver results derived from the snapshot.
+  // The snapshot's issue_state satisfies the 'issue-state' sub-resolver requirement.
+  // The 'pr-state' sub-resolver is also satisfied via the same snapshot state
+  // (the snapshot is the authoritative compound source; both sub-resolvers read
+  // from the same issue_state field to avoid double-counting or cross-wiring).
+  // No raw snapshot payload, Project fields, or tracker internals are echoed.
+  const subResolverResults: Record<string, ResolverResult> = {
+    'issue-state': {status: 'resolved', state: liveState},
+    'pr-state': {status: 'resolved', state: liveState},
+  }
+  return {status: 'resolved', state: liveState, subResolverResults}
+}
+
 /**
  * Resolve file-parse claims (plan-status) without an Octokit client.
  *
@@ -1348,6 +1440,10 @@ export async function resolveFileParseClaims(params: {
  * @param params.repo - Repository name.
  * @param params.fileReader - Optional file reader for plan-status file-parse resolution.
  *   Required when plan-status claims are present in the claims list.
+ * @param params.snapshot - Optional rollout snapshot for rollout-tracker-status compound resolution.
+ *   `undefined` (absent) → rollout-tracker claims stay unavailable (Phase 1 behavior).
+ *   `null` → snapshot was attempted but unavailable; rollout-tracker claims stay unavailable.
+ *   `RolloutSnapshot` → snapshot available; rollout-tracker claims resolve against it.
  */
 export async function resolveAllClaims(params: {
   claims: readonly StatusTruthClaim[]
@@ -1355,8 +1451,9 @@ export async function resolveAllClaims(params: {
   owner: string
   repo: string
   fileReader?: FileReader
+  snapshot?: RolloutSnapshot | null
 }): Promise<{resolverResults: Record<string, ResolverResult>; resolveErrors: number}> {
-  const {claims, octokit, owner, repo, fileReader} = params
+  const {claims, octokit, owner, repo, fileReader, snapshot} = params
   const resolverResults: Record<string, ResolverResult> = {}
   let resolveErrors = 0
 
@@ -1369,7 +1466,7 @@ export async function resolveAllClaims(params: {
     seen.add(key)
 
     try {
-      resolverResults[key] = await resolveClaimLiveState({claim, octokit, owner, repo, fileReader})
+      resolverResults[key] = await resolveClaimLiveState({claim, octokit, owner, repo, fileReader, snapshot})
     } catch {
       resolveErrors++
       resolverResults[key] = {status: 'unavailable'}
@@ -1377,6 +1474,129 @@ export async function resolveAllClaims(params: {
   }
 
   return {resolverResults, resolveErrors}
+}
+
+// ---------------------------------------------------------------------------
+// Unit 2: Snapshot loading helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Valid issue_state values for a SnapshotItem.
+ * Null is allowed (item exists but state not yet fetched).
+ */
+const VALID_SNAPSHOT_ISSUE_STATES: ReadonlySet<string> = new Set(['open', 'closed', 'merged'])
+
+/**
+ * Validate a single raw snapshot item from untrusted JSON.
+ *
+ * Conservative validation: rejects unexpected field types.
+ * Returns false if any required field has an unexpected type.
+ *
+ * Fields validated:
+ * - `content_number`: must be a number
+ * - `content_repo`: must be a string
+ * - `issue_state`: must be "open" | "closed" | "merged" | null
+ * - `issue_labels`: must be an array
+ *
+ * Other fields (status, readiness, gate, issue_closed_at) are accepted as-is
+ * since they are not used in claim resolution (only issue_state is authoritative).
+ */
+function isValidSnapshotItem(raw: unknown): boolean {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return false
+  const obj = raw as Record<string, unknown>
+
+  if (typeof obj.content_number !== 'number') return false
+  if (typeof obj.content_repo !== 'string') return false
+
+  // issue_state must be a valid string or null
+  if (obj.issue_state !== null) {
+    if (typeof obj.issue_state !== 'string') return false
+    if (!VALID_SNAPSHOT_ISSUE_STATES.has(obj.issue_state)) return false
+  }
+
+  // issue_labels must be an array
+  if (!Array.isArray(obj.issue_labels)) return false
+
+  return true
+}
+
+/**
+ * Load and validate a rollout snapshot from a JSON file.
+ *
+ * Security: the snapshot file is untrusted input. Schema validation is applied
+ * conservatively; malformed or unexpected payloads return null without throwing
+ * raw payload content into output.
+ *
+ * @param params - Load parameters.
+ * @param params.snapshotPath - Path to the snapshot JSON file, or undefined/empty if absent.
+ * @param params.fileReader - Injected file reader for testability. Defaults to fs.readFile.
+ * @returns The validated snapshot, or null if absent/unavailable/malformed.
+ *
+ * Absence/malformed → null (rollout-tracker claims stay unresolved; no fake drift).
+ * Never throws; never echoes raw payload into output.
+ */
+export async function loadRolloutSnapshot(params: {
+  snapshotPath: string | undefined
+  fileReader?: FileReader
+}): Promise<RolloutSnapshot | null> {
+  const {snapshotPath, fileReader} = params
+
+  // No path → no snapshot available
+  if (snapshotPath === undefined || snapshotPath === '') {
+    return null
+  }
+
+  // Read the file
+  let raw: string
+  try {
+    const reader = fileReader ?? (async (p: string) => readFile(p, 'utf8'))
+    raw = await reader(snapshotPath)
+  } catch {
+    // File read failure (ENOENT, permission denied, etc.) → unavailable
+    // Do not echo the error detail (may contain path info)
+    process.stderr.write('status-truth-detect: snapshot file unavailable; rollout-tracker claims will be unresolved\n')
+    return null
+  }
+
+  // Parse JSON
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    // Malformed JSON → null; do not echo raw payload
+    process.stderr.write('status-truth-detect: snapshot JSON malformed; rollout-tracker claims will be unresolved\n')
+    return null
+  }
+
+  // Validate top-level shape: must be { items: [...] }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    process.stderr.write(
+      'status-truth-detect: snapshot has unexpected shape; rollout-tracker claims will be unresolved\n',
+    )
+    return null
+  }
+
+  const obj = parsed as Record<string, unknown>
+  if (!Array.isArray(obj.items)) {
+    process.stderr.write(
+      'status-truth-detect: snapshot missing items array; rollout-tracker claims will be unresolved\n',
+    )
+    return null
+  }
+
+  // Validate each item conservatively
+  for (const item of obj.items as unknown[]) {
+    if (!isValidSnapshotItem(item)) {
+      // Do not echo item content — may contain sensitive Project field values
+      process.stderr.write(
+        'status-truth-detect: snapshot item failed validation; rollout-tracker claims will be unresolved\n',
+      )
+      return null
+    }
+  }
+
+  // Safe to cast: all items passed validation
+  return {items: obj.items as SnapshotItem[]}
 }
 
 // ---------------------------------------------------------------------------
@@ -1593,6 +1813,12 @@ async function runDetect(): Promise<void> {
       fileReader,
     })
 
+    // Load rollout snapshot (best-effort; absence/failure → null, not a hard error).
+    // The snapshot path is exported by the pre-detect workflow step via env var.
+    // If absent or malformed, rollout-tracker claims remain unresolved (no fake drift).
+    const snapshotPath = process.env.STATUS_TRUTH_ROLLOUT_SNAPSHOT_PATH
+    const snapshot = await loadRolloutSnapshot({snapshotPath, fileReader})
+
     if (token !== undefined && token !== '') {
       const {Octokit} = await import('@octokit/rest')
       const octokit = new Octokit(buildDetectOctokitOptions(token)) as unknown as DetectOctokitClient
@@ -1611,10 +1837,11 @@ async function runDetect(): Promise<void> {
 
       // Resolve all claims (file + issue) against live state.
       // fileReader is passed so plan-status claims can be resolved via file-parse.
+      // snapshot is passed so rollout-tracker-status claims can be resolved via snapshot.
       // resolveAllClaims will overwrite any file-parse entries already in resolverResults
       // with the same result (idempotent), and add API-backed results.
       const allClaims = [...fileClaims, ...issueClaims]
-      const resolved = await resolveAllClaims({claims: allClaims, octokit, owner, repo, fileReader})
+      const resolved = await resolveAllClaims({claims: allClaims, octokit, owner, repo, fileReader, snapshot})
       resolverResults = resolved.resolverResults
       resolveErrors = resolved.resolveErrors
     }

--- a/scripts/status-truth-detect.ts
+++ b/scripts/status-truth-detect.ts
@@ -1150,7 +1150,6 @@ export async function resolveClaimLiveState(params: {
     }
     return resolvePlanStatusClaim({
       claimedPath: claim.sourceRef,
-      claimedStatus: claim.claimedState,
       fileReader,
     })
   }
@@ -1269,12 +1268,10 @@ function parsePlanFrontmatterStatus(content: string): string | null {
  *
  * @param params - Resolver parameters.
  * @param params.claimedPath - Repo-relative path to the target plan file (e.g., `docs/plans/foo.md`).
- * @param params.claimedStatus - The status value claimed in the source document.
  * @param params.fileReader - Injected file reader for testability.
  */
 export async function resolvePlanStatusClaim(params: {
   claimedPath: string
-  claimedStatus: string
   fileReader: FileReader
 }): Promise<ResolverResult> {
   const {claimedPath, fileReader} = params
@@ -1428,7 +1425,6 @@ export async function resolveFileParseClaims(params: {
     if (claim.kind === 'plan-status') {
       resolverResults[key] = await resolvePlanStatusClaim({
         claimedPath: claim.sourceRef,
-        claimedStatus: claim.claimedState,
         fileReader,
       })
     }
@@ -1817,17 +1813,13 @@ async function runDetect(): Promise<void> {
     let issueScanErrors = 0
     let issueClaims: StatusTruthClaim[] = []
 
-    // Resolve file-parse claims (plan-status) without a token — no API needed.
-    let resolverResults: Record<string, ResolverResult> = await resolveFileParseClaims({
-      claims: fileClaims,
-      fileReader,
-    })
-
     // Load rollout snapshot (best-effort; absence/failure → null, not a hard error).
     // The snapshot path is exported by the pre-detect workflow step via env var.
     // If absent or malformed, rollout-tracker claims remain unresolved (no fake drift).
     const snapshotPath = process.env.STATUS_TRUTH_ROLLOUT_SNAPSHOT_PATH
     const snapshot = await loadRolloutSnapshot({snapshotPath, fileReader})
+
+    let resolverResults: Record<string, ResolverResult>
 
     if (token !== undefined && token !== '') {
       const {Octokit} = await import('@octokit/rest')
@@ -1846,16 +1838,16 @@ async function runDetect(): Promise<void> {
       issueScanErrors = issueResult.scanErrors
 
       // Resolve all claims (file + issue) against live state.
-      // fileReader is passed so plan-status claims can be resolved via file-parse.
-      // snapshot is passed so rollout-tracker-status claims can be resolved via snapshot.
-      // resolveAllClaims will overwrite any file-parse entries already in resolverResults
-      // with the same result (idempotent), and add API-backed results.
+      // resolveAllClaims handles file-parse (plan-status) via fileReader, API-backed
+      // claims via octokit, and compound claims via snapshot. No pre-pass needed.
       const allClaims = [...fileClaims, ...issueClaims]
       const resolved = await resolveAllClaims({claims: allClaims, octokit, owner, repo, fileReader, snapshot})
       resolverResults = resolved.resolverResults
       resolveErrors = resolved.resolveErrors
+    } else {
+      // No token: resolve file-parse claims (plan-status) locally; API claims remain unresolved.
+      resolverResults = await resolveFileParseClaims({claims: fileClaims, fileReader})
     }
-    // If no token: API claims remain unresolved; file-parse claims resolved above
 
     // Step 3: Classify all claims into findings
     const allClaims = [...fileClaims, ...issueClaims]

--- a/scripts/status-truth-detect.ts
+++ b/scripts/status-truth-detect.ts
@@ -75,9 +75,28 @@ export const CLAIM_KIND_DEFINITIONS: readonly ClaimKindDefinition[] = [
   {
     kind: 'plan-status',
     resolverType: 'file-parse',
-    pattern: /^status:\s*(active|complete|draft|cancelled|superseded)\s*$/imu,
+    /**
+     * Cross-file plan-status claim grammar.
+     *
+     * Matches explicit prose references to a plan file with a supported status:
+     *   "docs/plans/<name>.md is active"
+     *   "plan docs/plans/<name>.md is complete"
+     *
+     * Groups: [planPath, status]
+     *
+     * Requires an explicit `docs/plans/...md` path so ambiguous self-references
+     * and implicit prose like "the plan is active" are not extracted.
+     * Self-referential frontmatter (status: active in the plan's own file) is
+     * intentionally NOT matched — only cross-file prose claims are extracted.
+     *
+     * Path segments are restricted to `[\w-]+` (word chars and hyphens only),
+     * which prevents `..` traversal segments from matching.
+     */
+    pattern:
+      /\b(?:plan\s+)?(docs\/plans\/(?:[\w-]+\/)*[\w-]+\.md)\s+is\s+(active|complete|draft|cancelled|superseded)\b/iu,
     confidenceRule: 'Current plan frontmatter wins over prose references to the same plan.',
-    suppressionRule: 'Conflicting frontmatter/prose is unresolved, not drifted.',
+    suppressionRule:
+      'Ambiguous self-references, missing files, malformed frontmatter, or unsupported status values are unresolved, not drifted.',
     proposalFields: ['kind', 'path', 'sourceRef', 'claimedState', 'liveState', 'proposedCorrection'],
   },
   {
@@ -565,10 +584,13 @@ export function extractStatusTruthClaimsFromText(params: {path: string; text: st
         sourceRef = `@${tag}`
         claimedState = state.toLowerCase()
       } else if (def.kind === 'plan-status') {
-        // Groups: [state] — frontmatter status field
-        const state = match[1]
-        if (state === undefined) continue
-        sourceRef = `${path}#status`
+        // Groups: [planPath, state] — cross-file prose reference to a plan file
+        // Pattern: "docs/plans/<name>.md is <status>" or "plan docs/plans/<name>.md is <status>"
+        const planPath = match[1]
+        const state = match[2]
+        if (planPath === undefined || state === undefined) continue
+        // sourceRef is the plan path itself (not path#status) for cross-file claims
+        sourceRef = planPath
         claimedState = state.toLowerCase()
       } else {
         continue
@@ -667,17 +689,15 @@ export type FileLister = () => Promise<string[]>
 /**
  * Claim kinds enabled by default in production scans.
  *
- * `plan-status` is intentionally excluded from the default set because
- * `resolveClaimLiveState` returns `unavailable` for it (no file-parse resolver
- * exists yet). Including it would produce 100% unresolved findings with zero
- * signal — pure noise in dry-run output.
- *
- * Callers may opt in by passing `enabledKinds` explicitly.
+ * `plan-status` uses the file-parse resolver (`resolvePlanStatusClaim`).
+ * The grammar requires an explicit `docs/plans/...md` path reference, so
+ * self-referential frontmatter and ambiguous prose do not produce claims.
  */
 export const DEFAULT_ENABLED_KINDS: readonly ClaimKind[] = [
   'pr-state',
   'issue-state',
   'release-tag-state',
+  'plan-status',
   'rollout-tracker-status',
 ]
 
@@ -980,24 +1000,12 @@ export async function listCurrentRepoIssueComments(
 }
 
 /**
- * Resolve a single claim's live state using the injected Octokit client.
- *
- * Current-repo scoped: only resolves claims whose sourceRef is a bare `#N` or `@tag`
- * (no `owner/repo` prefix). Cross-repo or unsupported refs return `unavailable`.
- *
- * PR state: 'open' | 'closed' | 'merged'
- * Issue state: 'open' | 'closed'
- * Release state: 'published' | 'draft'
- * Plan-status: resolved via file-parse (not this function)
- * Rollout-tracker: compound — returns unavailable (Phase 1 scope cut)
- */
-/**
  * Prove that a target repo is public using `repos.get`.
  *
  * Returns `true` if the repo is confirmed public.
  * Returns `false` if the repo is private (`data.private === true`).
- * Throws with `{status: 'private'}` sentinel if the API throws 403/404 or any
- * other error before publicness is confirmed — callers must treat this as private.
+ * Throws if the API throws 403/404 or any other error before publicness is
+ * confirmed — callers must treat this as private.
  *
  * This is the ONLY gate before cross-repo identity is exposed in findings.
  */
@@ -1010,13 +1018,27 @@ async function proveRepoPublic(
   return data.private === false
 }
 
+/**
+ * Resolve a single claim's live state using the injected Octokit client.
+ *
+ * Current-repo scoped: only resolves claims whose sourceRef is a bare `#N` or `@tag`
+ * (no `owner/repo` prefix). Cross-repo or unsupported refs return `unavailable`.
+ *
+ * PR state: 'open' | 'closed' | 'merged'
+ * Issue state: 'open' | 'closed'
+ * Release state: 'published' | 'draft'
+ * Plan-status: resolved via file-parse using the injected fileReader
+ * Rollout-tracker: compound — returns unavailable (Phase 1 scope cut)
+ */
 export async function resolveClaimLiveState(params: {
   claim: StatusTruthClaim
   octokit: DetectOctokitClient
   owner: string
   repo: string
+  /** Optional file reader for plan-status file-parse resolution. */
+  fileReader?: FileReader
 }): Promise<ResolverResult> {
-  const {claim, octokit, owner, repo} = params
+  const {claim, octokit, owner, repo, fileReader} = params
 
   // ---------------------------------------------------------------------------
   // Cross-repo resolution: publicness proof required before any identity exposure
@@ -1105,11 +1127,18 @@ export async function resolveClaimLiveState(params: {
   }
 
   if (claim.kind === 'plan-status') {
-    // plan-status requires cross-file comparison to detect drift, which is out of
-    // Phase 1 scope. Returning the claimedState as live state would always show
-    // 'current' and mask real drift. Mark as unavailable so the finding is
-    // classified as unresolved (honest scope-cut, same as rollout-tracker).
-    return {status: 'unavailable'}
+    // plan-status uses the file-parse resolver: reads the target plan file's
+    // frontmatter and returns the live status value.
+    // sourceRef is the repo-relative plan path (e.g., docs/plans/foo.md).
+    if (fileReader === undefined) {
+      // No file reader injected — unavailable (e.g., called from API-only path)
+      return {status: 'unavailable'}
+    }
+    return resolvePlanStatusClaim({
+      claimedPath: claim.sourceRef,
+      claimedStatus: claim.claimedState,
+      fileReader,
+    })
   }
 
   if (claim.kind === 'rollout-tracker-status') {
@@ -1165,19 +1194,169 @@ export async function resolveClaimLiveState(params: {
   return {status: 'unavailable'}
 }
 
+// ---------------------------------------------------------------------------
+// Plan-status file-parse resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Conservative supported status vocabulary from existing plan frontmatter.
+ * Only these values are recognized as valid plan status; anything else is unresolved.
+ */
+export const SUPPORTED_PLAN_STATUSES: readonly string[] = ['active', 'complete', 'draft', 'cancelled', 'superseded']
+
+/**
+ * Parse YAML frontmatter from plan file content.
+ *
+ * Returns the `status` field value if present and non-empty, or null otherwise.
+ * Does not throw — malformed frontmatter returns null (caller treats as unresolved).
+ *
+ * Pure function: no I/O.
+ */
+function parsePlanFrontmatterStatus(content: string): string | null {
+  // Match YAML frontmatter block: ---\n...\n--- (supports both LF and CRLF line endings)
+  const frontmatterMatch = /^---\r?\n([\s\S]+?)\r?\n---/u.exec(content)
+  if (frontmatterMatch === null || frontmatterMatch[1] === undefined) {
+    return null
+  }
+
+  const frontmatterText = frontmatterMatch[1]
+
+  // Extract status field from frontmatter text using a simple line-based match.
+  // This avoids a full YAML parse dependency while being robust for the known
+  // plan frontmatter format (status is always a simple scalar string value).
+  // Supports unquoted, double-quoted, and single-quoted values (e.g. status: "active").
+  const statusMatch = /^status:\s*["']?(\w+)["']?\s*$/mu.exec(frontmatterText)
+  if (statusMatch === null || statusMatch[1] === undefined) {
+    return null
+  }
+
+  return statusMatch[1].toLowerCase()
+}
+
+/**
+ * Resolve a plan-status claim against the target plan file's frontmatter.
+ *
+ * Resolution rules:
+ * - File read failure → `unavailable` (caller counts as file-parse error)
+ * - No frontmatter or missing status field → `unavailable`
+ * - Status value not in SUPPORTED_PLAN_STATUSES → `unavailable`
+ * - Status present and supported → `resolved` with the live status value
+ *
+ * The resolver returns the live status regardless of whether it matches the
+ * claimed status. `detectStatusTruthClaims` performs the current/drifted
+ * classification by comparing live state to claimed state.
+ *
+ * Raw file content and frontmatter text are never emitted to public output.
+ *
+ * @param params - Resolver parameters.
+ * @param params.claimedPath - Repo-relative path to the target plan file (e.g., `docs/plans/foo.md`).
+ * @param params.claimedStatus - The status value claimed in the source document.
+ * @param params.fileReader - Injected file reader for testability.
+ */
+export async function resolvePlanStatusClaim(params: {
+  claimedPath: string
+  claimedStatus: string
+  fileReader: FileReader
+}): Promise<ResolverResult> {
+  const {claimedPath, fileReader} = params
+
+  // Reject paths containing traversal segments before calling fileReader.
+  // This is a defense-in-depth check: the grammar already excludes `..` via
+  // the `[\w-]+` segment pattern, but the resolver validates independently
+  // so that callers passing arbitrary paths are also protected.
+  if (claimedPath.includes('..') || !claimedPath.startsWith('docs/plans/')) {
+    return {status: 'unavailable'}
+  }
+
+  let content: string
+  try {
+    content = await fileReader(claimedPath)
+  } catch {
+    // File read failure (ENOENT, permission denied, etc.) → unavailable
+    // Caller is responsible for incrementing the file-parse error count
+    return {status: 'unavailable'}
+  }
+
+  const liveStatus = parsePlanFrontmatterStatus(content)
+
+  if (liveStatus === null) {
+    // No frontmatter or missing status field → unresolved
+    return {status: 'unavailable'}
+  }
+
+  if (!SUPPORTED_PLAN_STATUSES.includes(liveStatus)) {
+    // Unsupported status value → unresolved (conservative vocabulary)
+    return {status: 'unavailable'}
+  }
+
+  return {status: 'resolved', state: liveStatus}
+}
+
+/**
+ * Resolve file-parse claims (plan-status) without an Octokit client.
+ *
+ * Only resolves claims whose resolver type is `file-parse`. API-backed and
+ * compound claims are skipped — they remain absent from the returned map,
+ * which `detectStatusTruthClaims` treats as unresolved.
+ *
+ * This is called in `runDetect` before the token-gated API resolution block
+ * so that plan-status findings are produced even when no GITHUB_TOKEN is set.
+ *
+ * @param params - Resolution parameters.
+ * @param params.claims - All extracted claims (mixed kinds).
+ * @param params.fileReader - File reader for reading plan frontmatter.
+ * @returns Resolver results map keyed by `kind:sourceRef` for file-parse claims only.
+ */
+export async function resolveFileParseClaims(params: {
+  claims: readonly StatusTruthClaim[]
+  fileReader: FileReader
+}): Promise<Record<string, ResolverResult>> {
+  const {claims, fileReader} = params
+  const resolverResults: Record<string, ResolverResult> = {}
+  const seen = new Set<string>()
+
+  for (const claim of claims) {
+    const def = CLAIM_KIND_DEFINITIONS.find(d => d.kind === claim.kind)
+    if (def?.resolverType !== 'file-parse') continue
+
+    const key = `${claim.kind}:${claim.sourceRef}`
+    if (seen.has(key)) continue
+    seen.add(key)
+
+    if (claim.kind === 'plan-status') {
+      resolverResults[key] = await resolvePlanStatusClaim({
+        claimedPath: claim.sourceRef,
+        claimedStatus: claim.claimedState,
+        fileReader,
+      })
+    }
+  }
+
+  return resolverResults
+}
+
 /**
  * Resolve all claims against live state using the injected Octokit client.
  *
  * Returns a resolver results map keyed by `kind:sourceRef`.
  * Resolution failures for individual claims are counted but do not abort.
+ *
+ * @param params - Resolution parameters.
+ * @param params.claims - Claims to resolve.
+ * @param params.octokit - Octokit client for API-backed resolution.
+ * @param params.owner - Repository owner.
+ * @param params.repo - Repository name.
+ * @param params.fileReader - Optional file reader for plan-status file-parse resolution.
+ *   Required when plan-status claims are present in the claims list.
  */
 export async function resolveAllClaims(params: {
   claims: readonly StatusTruthClaim[]
   octokit: DetectOctokitClient
   owner: string
   repo: string
+  fileReader?: FileReader
 }): Promise<{resolverResults: Record<string, ResolverResult>; resolveErrors: number}> {
-  const {claims, octokit, owner, repo} = params
+  const {claims, octokit, owner, repo, fileReader} = params
   const resolverResults: Record<string, ResolverResult> = {}
   let resolveErrors = 0
 
@@ -1190,7 +1369,7 @@ export async function resolveAllClaims(params: {
     seen.add(key)
 
     try {
-      resolverResults[key] = await resolveClaimLiveState({claim, octokit, owner, repo})
+      resolverResults[key] = await resolveClaimLiveState({claim, octokit, owner, repo, fileReader})
     } catch {
       resolveErrors++
       resolverResults[key] = {status: 'unavailable'}
@@ -1399,15 +1578,20 @@ async function runDetect(): Promise<void> {
   let report: StatusTruthJsonReport
 
   try {
-    // Step 1: Scan file-system docs for claims (plan-status excluded by default)
+    // Step 1: Scan file-system docs for claims (plan-status included via DEFAULT_ENABLED_KINDS)
     const {claims: fileClaims, scanErrors: fileScanErrors} = await scanStatusTruthClaims({fileLister, fileReader})
 
     // Step 2: Resolve live state and scan GitHub issues (if token available)
     const token = process.env.GITHUB_TOKEN
-    let resolverResults: Record<string, ResolverResult> = {}
     let resolveErrors = 0
     let issueScanErrors = 0
     let issueClaims: StatusTruthClaim[] = []
+
+    // Resolve file-parse claims (plan-status) without a token — no API needed.
+    let resolverResults: Record<string, ResolverResult> = await resolveFileParseClaims({
+      claims: fileClaims,
+      fileReader,
+    })
 
     if (token !== undefined && token !== '') {
       const {Octokit} = await import('@octokit/rest')
@@ -1425,13 +1609,16 @@ async function runDetect(): Promise<void> {
       issueClaims = issueResult.claims
       issueScanErrors = issueResult.scanErrors
 
-      // Resolve all claims (file + issue) against live state
+      // Resolve all claims (file + issue) against live state.
+      // fileReader is passed so plan-status claims can be resolved via file-parse.
+      // resolveAllClaims will overwrite any file-parse entries already in resolverResults
+      // with the same result (idempotent), and add API-backed results.
       const allClaims = [...fileClaims, ...issueClaims]
-      const resolved = await resolveAllClaims({claims: allClaims, octokit, owner, repo})
+      const resolved = await resolveAllClaims({claims: allClaims, octokit, owner, repo, fileReader})
       resolverResults = resolved.resolverResults
       resolveErrors = resolved.resolveErrors
     }
-    // If no token: all API claims remain unresolved (resolverResults stays empty)
+    // If no token: API claims remain unresolved; file-parse claims resolved above
 
     // Step 3: Classify all claims into findings
     const allClaims = [...fileClaims, ...issueClaims]

--- a/scripts/status-truth-detect.ts
+++ b/scripts/status-truth-detect.ts
@@ -248,13 +248,23 @@ export function computeClaimFingerprint(
 /**
  * Build a proposed correction string for a drifted claim.
  * Replaces the claimed state with the live state in the normalized text.
+ *
+ * All claim grammars place the state token at the end of normalizedText
+ * (e.g. "plan docs/plans/active-plan.md is active", "release v1.0-draft is draft").
+ * A first-match \b replacement would corrupt path/tag segments that happen to
+ * contain the same word (e.g. "active" in "active-plan.md"). Instead, we anchor
+ * the match to the trailing position — the last word-boundary occurrence of the
+ * claimed state followed only by non-word characters until end-of-string.
  */
 function buildProposedCorrection(claim: StatusTruthClaim, liveState: string): string {
   // Replace the claimed state token in the normalized text with the live state.
   // Use a replacement function (not a string) so that live-state values containing
   // special replacement tokens like `$&`, `$1`, `$$` are inserted literally.
   const escaped = claim.claimedState.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`)
-  const pattern = new RegExp(String.raw`\b${escaped}\b`, 'iu')
+  // Anchor to the last occurrence: match the claimed state only when followed by
+  // zero or more non-word characters until end-of-string. This prevents replacing
+  // the state word when it appears earlier in the text (e.g. inside a path segment).
+  const pattern = new RegExp(String.raw`\b${escaped}\b(?=\W*$)`, 'iu')
   const corrected = claim.normalizedText.replace(pattern, () => liveState)
   // If replacement didn't change anything, append the correction explicitly
   if (corrected === claim.normalizedText) {

--- a/scripts/status-truth-proposals.test.ts
+++ b/scripts/status-truth-proposals.test.ts
@@ -827,6 +827,30 @@ describe('planStatusTruthProposalActions', () => {
       expect(typeof counts.sameRunDeduplicated).toBe('number')
       expect(typeof counts.malformedMarkers).toBe('number')
       expect(typeof counts.versionRejected).toBe('number')
+      expect(typeof counts.needsOutcomeCooldown).toBe('number')
+    })
+
+    it('needsOutcomeCooldown is surfaced in plannedCounts when a closed-without-outcome issue is within cooldown', () => {
+      const fingerprint = 'abc123def456abcd'
+      const finding = makeDriftedFinding(fingerprint)
+      const report = makeReport({
+        findings: [finding],
+        counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+      })
+      // Closed 2 days ago with no outcome label — within the 7-day cooldown window
+      const closedAt = '2026-06-28T00:00:00Z'
+      const now = new Date('2026-06-30T00:00:00Z')
+      const closedIssue: ExistingProposalIssue = {
+        ...makeClosedIssue(fingerprint, [PROPOSAL_LABEL]),
+        closedAt,
+      }
+
+      const {counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue], now}))
+
+      // Planner must count the cooldown-blocked issue
+      expect(counts.needsOutcomeCooldown).toBe(1)
+      // No reopen during cooldown
+      expect(counts.reopened).toBe(0)
     })
   })
 
@@ -4687,5 +4711,46 @@ describe('manual closure cooldown — workflow summary counts-only', () => {
     // Must not contain raw claim text
     expect(countsJson).not.toContain('docs/plans/example.md')
     expect(countsJson).not.toContain('pr #42')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// plannedCounts assembly — needsOutcomeCooldown surfaced in open result
+// ---------------------------------------------------------------------------
+
+describe('plannedCounts assembly', () => {
+  it('needsOutcomeCooldown from planner is present in the plannedCounts shape', () => {
+    // Simulate the plannedCounts assembly that runOpen() performs.
+    // Verifies that needsOutcomeCooldown is included and not silently dropped.
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    // Closed 1 day ago with no outcome label — within the 7-day cooldown window
+    const closedAt = '2026-06-29T00:00:00Z'
+    const now = new Date('2026-06-30T00:00:00Z')
+    const closedIssue: ExistingProposalIssue = {
+      ...makeClosedIssue(fingerprint, [PROPOSAL_LABEL]),
+      closedAt,
+    }
+
+    const planResult = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue], now}))
+
+    // Assemble plannedCounts the same way runOpen() does
+    const plannedCounts = {
+      versionRejected: planResult.counts.versionRejected,
+      blocked: planResult.counts.blocked,
+      overflowed: planResult.counts.overflowed,
+      sameRunDeduplicated: planResult.counts.sameRunDeduplicated,
+      needsOutcomeCooldown: planResult.counts.needsOutcomeCooldown,
+    }
+
+    // needsOutcomeCooldown must be present and reflect the planner's count
+    expect(typeof plannedCounts.needsOutcomeCooldown).toBe('number')
+    expect(plannedCounts.needsOutcomeCooldown).toBe(1)
+    // No reopen during cooldown
+    expect(planResult.counts.reopened).toBe(0)
   })
 })

--- a/scripts/status-truth-proposals.test.ts
+++ b/scripts/status-truth-proposals.test.ts
@@ -22,6 +22,7 @@ import {
   extractProposalFingerprint,
   extractRedactedCanonicalIds,
   fetchExistingProposalIssues,
+  isWithinCooldown,
   loadRedactedCanonicalIdsFromDisk,
   NOOP_LOG,
   OUTCOME_LABELS,
@@ -360,6 +361,63 @@ describe('planStatusTruthProposalActions', () => {
       // First finding was blocked by privacy gate
       expect(counts.blocked).toBe(1)
       // Second finding was deduplicated (fingerprint already seen)
+      expect(counts.sameRunDeduplicated).toBe(1)
+    })
+
+    it('second finding with same fingerprint as an update-comment path is deduplicated', () => {
+      // Two findings share a fingerprint. The first matches an open issue whose
+      // live-state differs → update-comment. The second (same fingerprint) must
+      // be deduplicated rather than opening a new proposal.
+      const fingerprint = 'abc123def456abcd'
+      const finding1 = makeDriftedFinding(fingerprint)
+      const finding2 = {...makeDriftedFinding(fingerprint), path: 'docs/plans/other.md'}
+      const report = makeReport({
+        findings: [finding1, finding2],
+        counts: {total: 2, current: 0, drifted: 2, unresolved: 0, unsafe: 0, proposal_eligible: 2},
+      })
+      // Open issue with a different recorded live-state → triggers update-comment for finding1
+      const openIssue = makeOpenIssue(fingerprint, {
+        body: `<!-- status-truth:fingerprint=${fingerprint} -->\n<!-- status-truth:live-state=open -->\n\nBody.`,
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [openIssue]}))
+
+      // Exactly one update-comment for the first finding
+      expect(actions.filter(a => a.type === 'update-comment')).toHaveLength(1)
+      // No open actions — second finding must be deduplicated
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+      // Second finding counted as same-run deduplicated
+      expect(counts.sameRunDeduplicated).toBe(1)
+    })
+
+    it('second finding with same fingerprint as a reopen path is deduplicated', () => {
+      // Two findings share a fingerprint. The first matches a non-terminal closed
+      // issue past cooldown → reopen. The second (same fingerprint) must be
+      // deduplicated rather than opening a new proposal.
+      const fingerprint = 'abc123def456abcd'
+      const finding1 = makeDriftedFinding(fingerprint)
+      const finding2 = {...makeDriftedFinding(fingerprint), path: 'docs/plans/other.md'}
+      const report = makeReport({
+        findings: [finding1, finding2],
+        counts: {total: 2, current: 0, drifted: 2, unresolved: 0, unsafe: 0, proposal_eligible: 2},
+      })
+      // Closed non-terminal issue past the 7-day cooldown
+      const pastCooldown = '2026-06-01T00:00:00Z'
+      const closedIssue: ExistingProposalIssue = {
+        ...makeClosedIssue(fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.resolved]),
+        closedAt: pastCooldown,
+      }
+      const now = new Date('2026-06-30T00:00:00Z')
+
+      const {actions, counts} = planStatusTruthProposalActions(
+        makePlanInput({report, existingIssues: [closedIssue], now}),
+      )
+
+      // Exactly one reopen for the first finding
+      expect(actions.filter(a => a.type === 'reopen')).toHaveLength(1)
+      // No open actions — second finding must be deduplicated
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+      // Second finding counted as same-run deduplicated
       expect(counts.sameRunDeduplicated).toBe(1)
     })
   })
@@ -2329,22 +2387,48 @@ describe('manually-fixed auto-close when drift clears', () => {
 })
 
 describe('closed proposal without outcome marker — conservative treatment', () => {
-  it('closed proposal with fingerprint but no outcome label is treated as non-terminal (reopen when drift returns)', () => {
+  it('closed proposal with fingerprint but no outcome label and no closedAt is conservative — no reopen, counted for attention', () => {
     const fingerprint = 'abc123def456abcd'
     const finding = makeDriftedFinding(fingerprint)
     const report = makeReport({
       findings: [finding],
       counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
     })
-    // Closed with only the proposal label — no outcome label
+    // Closed with only the proposal label — no outcome label, no closedAt
     const closedIssue = makeClosedIssue(fingerprint, [PROPOSAL_LABEL])
 
     const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]}))
 
-    // Conservative: no brand-new open; reopen instead
+    // Conservative: no reopen without closedAt (cannot determine cooldown)
+    expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+    expect(actions.filter(a => a.type === 'reopen')).toHaveLength(0)
+    // Counted for operator attention
+    expect(counts.needsOutcomeCooldown).toBeGreaterThanOrEqual(1)
+  })
+
+  it('closed proposal with fingerprint but no outcome label reopens after cooldown when closedAt is past 7 days', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const now = new Date('2026-07-01T12:00:00Z')
+    const closedAt = '2026-06-21T12:00:00Z' // 10 days ago — past cooldown
+    const closedIssue: ExistingProposalIssue = {
+      ...makeClosedIssue(fingerprint, [PROPOSAL_LABEL]),
+      closedAt,
+    }
+
+    const {actions, counts} = planStatusTruthProposalActions(
+      makePlanInput({report, existingIssues: [closedIssue], now}),
+    )
+
+    // Past cooldown: reopen
     expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
     expect(actions.filter(a => a.type === 'reopen')).toHaveLength(1)
     expect(counts.reopened).toBe(1)
+    expect(counts.needsOutcomeCooldown).toBe(0)
   })
 
   it('closed proposal without outcome marker is NOT silently treated as clean (counted for operator attention)', () => {
@@ -4051,5 +4135,490 @@ describe('planStatusTruthProposalActions — outcomeCounts in result', () => {
     expect(result.counts.opened).toBe(0)
     // Outcome counts: one proposed-pending (the existing open issue)
     expect(result.outcomeCounts.proposedPending).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isWithinCooldown — pure date helper
+// ---------------------------------------------------------------------------
+
+describe('isWithinCooldown', () => {
+  it('returns true when closedAt is less than 7 days before now', () => {
+    const now = new Date('2026-07-01T12:00:00Z')
+    const closedAt = '2026-06-28T12:00:00Z' // 3 days ago
+    expect(isWithinCooldown(closedAt, now)).toBe(true)
+  })
+
+  it('returns false when closedAt is exactly 7 days before now', () => {
+    const now = new Date('2026-07-01T12:00:00Z')
+    const closedAt = '2026-06-24T12:00:00Z' // exactly 7 days ago
+    expect(isWithinCooldown(closedAt, now)).toBe(false)
+  })
+
+  it('returns false when closedAt is more than 7 days before now', () => {
+    const now = new Date('2026-07-01T12:00:00Z')
+    const closedAt = '2026-06-20T12:00:00Z' // 11 days ago
+    expect(isWithinCooldown(closedAt, now)).toBe(false)
+  })
+
+  it('returns true when closedAt is 1 second before the 7-day boundary', () => {
+    const now = new Date('2026-07-01T12:00:00Z')
+    // 7 days = 604800 seconds; 1 second less = 604799 seconds ago
+    const closedAt = new Date(now.getTime() - 604799 * 1000).toISOString()
+    expect(isWithinCooldown(closedAt, now)).toBe(true)
+  })
+
+  it('returns false when closedAt is 1 second after the 7-day boundary', () => {
+    const now = new Date('2026-07-01T12:00:00Z')
+    const closedAt = new Date(now.getTime() - 604801 * 1000).toISOString()
+    expect(isWithinCooldown(closedAt, now)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Manual closure cooldown and recurrence behavior
+// ---------------------------------------------------------------------------
+
+describe('manual closure cooldown — closed-without-outcome during cooldown', () => {
+  it('does not reopen and does not open duplicate when closed-without-outcome is within 7-day cooldown', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    // Closed 2 days ago with no outcome label (needs-outcome state)
+    const now = new Date('2026-07-01T12:00:00Z')
+    const closedAt = '2026-06-29T12:00:00Z' // 2 days ago — within cooldown
+    const closedIssue: ExistingProposalIssue = {
+      ...makeClosedIssue(fingerprint, [PROPOSAL_LABEL]),
+      closedAt,
+    }
+
+    const {actions, counts} = planStatusTruthProposalActions(
+      makePlanInput({report, existingIssues: [closedIssue], now}),
+    )
+
+    // Must not reopen during cooldown
+    expect(actions.filter(a => a.type === 'reopen')).toHaveLength(0)
+    // Must not open a duplicate
+    expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+    // Must count as cooldown-blocked for operator attention
+    expect(counts.needsOutcomeCooldown).toBeGreaterThanOrEqual(1)
+  })
+
+  it('counts cooldown-blocked separately from other blocked counts', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const now = new Date('2026-07-01T12:00:00Z')
+    const closedAt = '2026-06-29T12:00:00Z' // within cooldown
+    const closedIssue: ExistingProposalIssue = {
+      ...makeClosedIssue(fingerprint, [PROPOSAL_LABEL]),
+      closedAt,
+    }
+
+    const {counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue], now}))
+
+    // needsOutcomeCooldown is distinct from privacy-blocked (blocked)
+    expect(typeof counts.needsOutcomeCooldown).toBe('number')
+    expect(counts.needsOutcomeCooldown).toBeGreaterThanOrEqual(1)
+    // Privacy-blocked count should not be inflated by cooldown
+    expect(counts.blocked).toBe(0)
+  })
+})
+
+describe('manual closure cooldown — closed-without-outcome after cooldown', () => {
+  it('reopens with recurrence comment when closed-without-outcome is past 7-day cooldown and drift persists', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    // Closed 10 days ago with no outcome label — past cooldown
+    const now = new Date('2026-07-01T12:00:00Z')
+    const closedAt = '2026-06-21T12:00:00Z' // 10 days ago
+    const closedIssue: ExistingProposalIssue = {
+      ...makeClosedIssue(fingerprint, [PROPOSAL_LABEL]),
+      closedAt,
+    }
+
+    const {actions, counts} = planStatusTruthProposalActions(
+      makePlanInput({report, existingIssues: [closedIssue], now}),
+    )
+
+    const reopenActions = actions.filter(a => a.type === 'reopen')
+    expect(reopenActions).toHaveLength(1)
+    const reopenAction = reopenActions[0]
+    if (reopenAction?.type === 'reopen') {
+      expect(reopenAction.issueNumber).toBe(closedIssue.number)
+      expect(reopenAction.comment).toBeTruthy()
+      // Comment must mention recurrence or needs-outcome — not raw claim text
+      expect(reopenAction.comment).toMatch(/recurrence|recurring|needs.?outcome/i)
+    }
+    expect(counts.reopened).toBe(1)
+    expect(counts.needsOutcomeCooldown).toBe(0)
+  })
+
+  it('reopen after cooldown removes resolving labels and adds recurring label', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const now = new Date('2026-07-01T12:00:00Z')
+    const closedAt = '2026-06-21T12:00:00Z' // 10 days ago — past cooldown
+    // Closed with no outcome label (needs-outcome state)
+    const closedIssue: ExistingProposalIssue = {
+      ...makeClosedIssue(fingerprint, [PROPOSAL_LABEL]),
+      closedAt,
+    }
+
+    const {actions} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue], now}))
+
+    const reopenAction = actions.find(a => a.type === 'reopen')
+    if (reopenAction?.type === 'reopen') {
+      // Must add recurring label
+      expect(reopenAction.addLabels).toContain(OUTCOME_LABELS.recurring)
+      // removeLabels should not include non-resolving labels
+      for (const label of reopenAction.removeLabels) {
+        expect([OUTCOME_LABELS.resolved, OUTCOME_LABELS.manuallyFixed]).toContain(label)
+      }
+    }
+  })
+})
+
+describe('manual closure cooldown — terminal labels override cooldown', () => {
+  it('rejected label suppresses recurrence regardless of cooldown period', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    // Closed 10 days ago (past cooldown) but with terminal rejected label
+    const now = new Date('2026-07-01T12:00:00Z')
+    const closedAt = '2026-06-21T12:00:00Z'
+    const closedIssue: ExistingProposalIssue = {
+      ...makeClosedIssue(fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.rejected]),
+      closedAt,
+    }
+
+    const {actions, counts} = planStatusTruthProposalActions(
+      makePlanInput({report, existingIssues: [closedIssue], now}),
+    )
+
+    // Terminal: suppress, not reopen
+    expect(actions.filter(a => a.type === 'reopen')).toHaveLength(0)
+    expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+    expect(counts.suppressed).toBe(1)
+    expect(counts.needsOutcomeCooldown).toBe(0)
+  })
+
+  it('false-positive label suppresses recurrence regardless of cooldown period', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const now = new Date('2026-07-01T12:00:00Z')
+    const closedAt = '2026-06-21T12:00:00Z'
+    const closedIssue: ExistingProposalIssue = {
+      ...makeClosedIssue(fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.falsePositive]),
+      closedAt,
+    }
+
+    const {actions, counts} = planStatusTruthProposalActions(
+      makePlanInput({report, existingIssues: [closedIssue], now}),
+    )
+
+    expect(actions.filter(a => a.type === 'reopen')).toHaveLength(0)
+    expect(counts.suppressed).toBe(1)
+    expect(counts.needsOutcomeCooldown).toBe(0)
+  })
+
+  it('rejected label within cooldown still suppresses (terminal overrides cooldown)', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    // Within cooldown AND terminal — terminal wins
+    const now = new Date('2026-07-01T12:00:00Z')
+    const closedAt = '2026-06-29T12:00:00Z' // 2 days ago — within cooldown
+    const closedIssue: ExistingProposalIssue = {
+      ...makeClosedIssue(fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.rejected]),
+      closedAt,
+    }
+
+    const {actions, counts} = planStatusTruthProposalActions(
+      makePlanInput({report, existingIssues: [closedIssue], now}),
+    )
+
+    expect(actions.filter(a => a.type === 'reopen')).toHaveLength(0)
+    expect(counts.suppressed).toBe(1)
+    expect(counts.needsOutcomeCooldown).toBe(0)
+  })
+})
+
+describe('manual closure cooldown — resolved/manually-fixed clears cooldown', () => {
+  it('resolved label stays quiet when drift is cleared (no reopen, no cooldown count)', () => {
+    const fingerprint = 'abc123def456abcd'
+    // No findings — drift cleared
+    const report = makeReport({
+      findings: [],
+      status: 'clean',
+      scan_complete: true,
+      counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+    })
+    const now = new Date('2026-07-01T12:00:00Z')
+    const closedAt = '2026-06-29T12:00:00Z' // within cooldown, but drift cleared
+    const closedIssue: ExistingProposalIssue = {
+      ...makeClosedIssue(fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.resolved]),
+      closedAt,
+    }
+
+    const {actions, counts} = planStatusTruthProposalActions(
+      makePlanInput({report, existingIssues: [closedIssue], now}),
+    )
+
+    // Drift cleared — no reopen, no cooldown count
+    expect(actions.filter(a => a.type === 'reopen')).toHaveLength(0)
+    expect(counts.needsOutcomeCooldown).toBe(0)
+    // No open either (no drift)
+    expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+  })
+
+  it('manually-fixed label stays quiet when drift is cleared', () => {
+    const fingerprint = 'abc123def456abcd'
+    const report = makeReport({
+      findings: [],
+      status: 'clean',
+      scan_complete: true,
+      counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+    })
+    const now = new Date('2026-07-01T12:00:00Z')
+    const closedAt = '2026-06-29T12:00:00Z'
+    const closedIssue: ExistingProposalIssue = {
+      ...makeClosedIssue(fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.manuallyFixed]),
+      closedAt,
+    }
+
+    const {actions, counts} = planStatusTruthProposalActions(
+      makePlanInput({report, existingIssues: [closedIssue], now}),
+    )
+
+    expect(actions.filter(a => a.type === 'reopen')).toHaveLength(0)
+    expect(counts.needsOutcomeCooldown).toBe(0)
+  })
+
+  it('changed fingerprint (new drift) can open a new proposal even when old fingerprint was resolved', () => {
+    const oldFingerprint = 'abc123def456abcd'
+    const newFingerprint = 'deadbeef12345678'
+    // New drift with different fingerprint
+    const newFinding = makeDriftedFinding(newFingerprint)
+    const report = makeReport({
+      findings: [newFinding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const now = new Date('2026-07-01T12:00:00Z')
+    const closedAt = '2026-06-29T12:00:00Z'
+    // Old fingerprint closed with resolved label
+    const oldClosedIssue: ExistingProposalIssue = {
+      ...makeClosedIssue(oldFingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.resolved]),
+      closedAt,
+    }
+
+    const {actions, counts} = planStatusTruthProposalActions(
+      makePlanInput({report, existingIssues: [oldClosedIssue], now}),
+    )
+
+    // New fingerprint → new open action
+    const openActions = actions.filter(a => a.type === 'open')
+    expect(openActions).toHaveLength(1)
+    if (openActions[0]?.type === 'open') {
+      expect(openActions[0].fingerprint).toBe(newFingerprint)
+    }
+    expect(counts.opened).toBe(1)
+    expect(counts.needsOutcomeCooldown).toBe(0)
+  })
+})
+
+describe('manual closure cooldown — missing closedAt is conservative', () => {
+  it('closed-without-outcome with missing closedAt is counted for attention with no mutation', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const now = new Date('2026-07-01T12:00:00Z')
+    // Closed with no outcome label and no closedAt — conservative: needs attention, no mutation
+    const closedIssue: ExistingProposalIssue = {
+      ...makeClosedIssue(fingerprint, [PROPOSAL_LABEL]),
+      closedAt: null,
+    }
+
+    const {actions, counts} = planStatusTruthProposalActions(
+      makePlanInput({report, existingIssues: [closedIssue], now}),
+    )
+
+    // No reopen (conservative — cannot determine cooldown without closedAt)
+    expect(actions.filter(a => a.type === 'reopen')).toHaveLength(0)
+    // No open (fingerprint already has a closed issue)
+    expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+    // Counted for operator attention
+    expect(counts.needsOutcomeCooldown).toBeGreaterThanOrEqual(1)
+  })
+
+  it('closed-without-outcome with undefined closedAt is also conservative', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const now = new Date('2026-07-01T12:00:00Z')
+    // No closedAt field at all
+    const closedIssue: ExistingProposalIssue = makeClosedIssue(fingerprint, [PROPOSAL_LABEL])
+
+    const {actions, counts} = planStatusTruthProposalActions(
+      makePlanInput({report, existingIssues: [closedIssue], now}),
+    )
+
+    expect(actions.filter(a => a.type === 'reopen')).toHaveLength(0)
+    expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+    expect(counts.needsOutcomeCooldown).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe('manual closure cooldown — mutation cap applies to reopen after cooldown', () => {
+  it('reopen-after-cooldown actions are subject to the mutation cap (priority after update, before open)', () => {
+    const fingerprint1 = 'abc123def456abcd'
+    const fingerprint2 = 'deadbeef12345678'
+    const fingerprint3 = 'cafebabe12345678'
+    const fingerprint4 = 'feedface12345678'
+    const fingerprint5 = 'baadf00d12345678'
+    const fingerprint6 = 'c0ffee0012345678'
+
+    const now = new Date('2026-07-01T12:00:00Z')
+    const pastCooldown = '2026-06-21T12:00:00Z' // 10 days ago
+
+    // 5 closed-without-outcome issues past cooldown + 1 new finding
+    // Cap is 5 — all 5 reopens should fit, but the new open should overflow
+    const closedIssues: ExistingProposalIssue[] = [
+      {...makeClosedIssue(fingerprint1, [PROPOSAL_LABEL], {number: 201}), closedAt: pastCooldown},
+      {...makeClosedIssue(fingerprint2, [PROPOSAL_LABEL], {number: 202}), closedAt: pastCooldown},
+      {...makeClosedIssue(fingerprint3, [PROPOSAL_LABEL], {number: 203}), closedAt: pastCooldown},
+      {...makeClosedIssue(fingerprint4, [PROPOSAL_LABEL], {number: 204}), closedAt: pastCooldown},
+      {...makeClosedIssue(fingerprint5, [PROPOSAL_LABEL], {number: 205}), closedAt: pastCooldown},
+    ]
+
+    // New finding with a different fingerprint (no existing issue)
+    const newFinding = makeDriftedFinding(fingerprint6)
+    const report = makeReport({
+      findings: [
+        makeDriftedFinding(fingerprint1),
+        makeDriftedFinding(fingerprint2),
+        makeDriftedFinding(fingerprint3),
+        makeDriftedFinding(fingerprint4),
+        makeDriftedFinding(fingerprint5),
+        newFinding,
+      ],
+      counts: {total: 6, current: 0, drifted: 6, unresolved: 0, unsafe: 0, proposal_eligible: 6},
+    })
+
+    const {actions, counts} = planStatusTruthProposalActions(
+      makePlanInput({report, existingIssues: closedIssues, mutationCap: 5, now}),
+    )
+
+    // 5 reopens should fit within cap
+    expect(actions.filter(a => a.type === 'reopen')).toHaveLength(5)
+    // The new open should overflow
+    expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+    expect(counts.overflowed).toBeGreaterThanOrEqual(1)
+    expect(counts.reopened).toBe(5)
+  })
+
+  it('reopen-after-cooldown has lower priority than update-comment but higher than open', () => {
+    const fingerprint1 = 'abc123def456abcd' // open issue with changed live-state → update
+    const fingerprint2 = 'deadbeef12345678' // closed-without-outcome past cooldown → reopen
+    const fingerprint3 = 'cafebabe12345678' // new finding → open
+
+    const now = new Date('2026-07-01T12:00:00Z')
+    const pastCooldown = '2026-06-21T12:00:00Z'
+
+    const openIssueWithChangedState = makeOpenIssue(fingerprint1, {
+      body: `<!-- status-truth:fingerprint=${fingerprint1} -->\n<!-- status-truth:live-state=open -->\n\nBody.`,
+    })
+    const closedWithoutOutcome: ExistingProposalIssue = {
+      ...makeClosedIssue(fingerprint2, [PROPOSAL_LABEL], {number: 202}),
+      closedAt: pastCooldown,
+    }
+
+    const report = makeReport({
+      findings: [
+        makeDriftedFinding(fingerprint1), // will trigger update-comment
+        makeDriftedFinding(fingerprint2), // will trigger reopen-after-cooldown
+        makeDriftedFinding(fingerprint3), // will trigger open (new)
+      ],
+      counts: {total: 3, current: 0, drifted: 3, unresolved: 0, unsafe: 0, proposal_eligible: 3},
+    })
+
+    // Cap of 2: update + reopen should fit; open should overflow
+    const {actions, counts} = planStatusTruthProposalActions(
+      makePlanInput({
+        report,
+        existingIssues: [openIssueWithChangedState, closedWithoutOutcome],
+        mutationCap: 2,
+        now,
+      }),
+    )
+
+    expect(actions.filter(a => a.type === 'update-comment')).toHaveLength(1)
+    expect(actions.filter(a => a.type === 'reopen')).toHaveLength(1)
+    expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+    expect(counts.overflowed).toBe(1)
+    expect(counts.updated).toBe(1)
+    expect(counts.reopened).toBe(1)
+  })
+})
+
+describe('manual closure cooldown — workflow summary counts-only', () => {
+  it('counts object contains needsOutcomeCooldown field as a number', () => {
+    const {counts} = planStatusTruthProposalActions(makePlanInput())
+    expect(typeof counts.needsOutcomeCooldown).toBe('number')
+  })
+
+  it('counts object does not expose raw claim text or fingerprints in cooldown fields', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const now = new Date('2026-07-01T12:00:00Z')
+    const closedAt = '2026-06-29T12:00:00Z'
+    const closedIssue: ExistingProposalIssue = {
+      ...makeClosedIssue(fingerprint, [PROPOSAL_LABEL]),
+      closedAt,
+    }
+
+    const {counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue], now}))
+
+    // Counts must be numeric — no raw text
+    const countsJson = JSON.stringify(counts)
+    // Must not contain fingerprint hex strings in the counts output
+    expect(countsJson).not.toContain(fingerprint)
+    // Must not contain raw claim text
+    expect(countsJson).not.toContain('docs/plans/example.md')
+    expect(countsJson).not.toContain('pr #42')
   })
 })

--- a/scripts/status-truth-proposals.test.ts
+++ b/scripts/status-truth-proposals.test.ts
@@ -1,8 +1,6 @@
 /**
- * Tests for the status-truth proposal lifecycle planner (Unit 3) and
- * I/O executor (Unit 4).
+ * Tests for the status-truth proposal lifecycle planner and I/O executor.
  *
- * TDD: tests written before implementation.
  * All tests are pure — no Octokit, no disk I/O.
  */
 
@@ -2977,5 +2975,538 @@ repos:
         expect(action.comment).not.toContain(fixtureNodeId)
       }
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// U3: Proposal cap and overflow visibility
+// ---------------------------------------------------------------------------
+
+// Helper: make N distinct drifted findings with unique fingerprints (hex-safe)
+function makeCapDriftedFindings(count: number) {
+  return Array.from({length: count}, (_, i) => ({
+    kind: 'pr-state' as const,
+    path: `docs/plans/example-${i}.md`,
+    sourceRef: `#${100 + i}`,
+    verdict: 'drifted' as const,
+    fingerprint: `ca${String(i).padStart(14, '0')}`,
+    claimedState: 'open',
+    liveState: 'closed',
+    proposalEligible: true,
+    proposedCorrection: `pr #${100 + i} is closed`,
+  }))
+}
+
+describe('U3: planStatusTruthProposalActions — mutation cap and overflow', () => {
+  describe('scenario 1: more than 5 eligible new proposals — only 5 execute, rest are overflow', () => {
+    it('with 8 new drifted findings, only 5 open actions are planned and 3 are overflow', () => {
+      const findings = makeCapDriftedFindings(8)
+      const report = makeReport({
+        findings,
+        counts: {total: 8, current: 0, drifted: 8, unresolved: 0, unsafe: 0, proposal_eligible: 8},
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+
+      const openActions = actions.filter(a => a.type === 'open')
+      expect(openActions).toHaveLength(5)
+      expect(counts.opened).toBe(5)
+      expect(counts.overflowed).toBe(3)
+    })
+
+    it('with exactly 5 new drifted findings, all 5 execute and overflow is 0', () => {
+      const findings = makeCapDriftedFindings(5)
+      const report = makeReport({
+        findings,
+        counts: {total: 5, current: 0, drifted: 5, unresolved: 0, unsafe: 0, proposal_eligible: 5},
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(5)
+      expect(counts.opened).toBe(5)
+      expect(counts.overflowed).toBe(0)
+    })
+
+    it('with 4 new drifted findings, all 4 execute and overflow is 0', () => {
+      const findings = makeCapDriftedFindings(4)
+      const report = makeReport({
+        findings,
+        counts: {total: 4, current: 0, drifted: 4, unresolved: 0, unsafe: 0, proposal_eligible: 4},
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(4)
+      expect(counts.opened).toBe(4)
+      expect(counts.overflowed).toBe(0)
+    })
+  })
+
+  describe('scenario 2: privacy-blocked proposals do not consume cap slots', () => {
+    it('privacy-blocked findings do not count against the mutation cap', () => {
+      // 3 privacy-blocked findings + 5 safe findings = 5 safe opens, 0 overflow
+      // (blocked findings consume no cap budget)
+      const safeFindings = makeCapDriftedFindings(5)
+      const blockedFindings = Array.from({length: 3}, (_, i) => ({
+        kind: 'pr-state' as const,
+        path: `docs/plans/blocked-${i}.md`,
+        sourceRef: `#${200 + i}`,
+        verdict: 'drifted' as const,
+        fingerprint: `blk${String(i).padStart(13, '0')}`,
+        claimedState: 'open',
+        liveState: 'closed',
+        proposalEligible: true,
+        proposedCorrection: `pr #${200 + i} is closed (private-repo-name)`,
+      }))
+
+      const allFindings = [...blockedFindings, ...safeFindings]
+      const report = makeReport({
+        findings: allFindings,
+        counts: {total: 8, current: 0, drifted: 8, unresolved: 0, unsafe: 0, proposal_eligible: 8},
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(
+        makePlanInput({report, existingIssues: [], publicOutputTokens: makeBlockingTokens()}),
+      )
+
+      // 3 blocked by privacy gate (not cap), 5 safe opens
+      expect(counts.blocked).toBe(3)
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(5)
+      expect(counts.opened).toBe(5)
+      expect(counts.overflowed).toBe(0)
+    })
+
+    it('privacy-blocked findings before cap-eligible findings do not reduce cap budget', () => {
+      // 2 privacy-blocked + 7 safe = 5 opens + 2 overflow (cap=5, blocked don't count)
+      const blockedFindings = Array.from({length: 2}, (_, i) => ({
+        kind: 'pr-state' as const,
+        path: `docs/plans/blocked-${i}.md`,
+        sourceRef: `#${200 + i}`,
+        verdict: 'drifted' as const,
+        fingerprint: `blk${String(i).padStart(13, '0')}`,
+        claimedState: 'open',
+        liveState: 'closed',
+        proposalEligible: true,
+        proposedCorrection: `pr #${200 + i} is closed (private-repo-name)`,
+      }))
+      const safeFindings = makeCapDriftedFindings(7)
+      const allFindings = [...blockedFindings, ...safeFindings]
+      const report = makeReport({
+        findings: allFindings,
+        counts: {total: 9, current: 0, drifted: 9, unresolved: 0, unsafe: 0, proposal_eligible: 9},
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(
+        makePlanInput({report, existingIssues: [], publicOutputTokens: makeBlockingTokens()}),
+      )
+
+      expect(counts.blocked).toBe(2)
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(5)
+      expect(counts.opened).toBe(5)
+      expect(counts.overflowed).toBe(2)
+    })
+  })
+
+  describe('scenario 3: same-run dedupe still prevents duplicates under a cap', () => {
+    it('same-run deduplicated fingerprints do not consume cap slots', () => {
+      // 3 already-created fingerprints + 6 new = 5 opens + 1 overflow
+      // (deduplicated ones don't count against cap)
+      const findings = makeCapDriftedFindings(6)
+      const alreadyCreated = new Set(findings.slice(0, 3).map(f => f.fingerprint))
+      const report = makeReport({
+        findings,
+        counts: {total: 6, current: 0, drifted: 6, unresolved: 0, unsafe: 0, proposal_eligible: 6},
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(
+        makePlanInput({report, existingIssues: [], sameRunCreatedFingerprints: alreadyCreated}),
+      )
+
+      // 3 deduplicated, 3 remaining — all 3 open (under cap)
+      expect(counts.sameRunDeduplicated).toBe(3)
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(3)
+      expect(counts.opened).toBe(3)
+      expect(counts.overflowed).toBe(0)
+    })
+
+    it('cap does not allow duplicates when same fingerprint appears multiple times in findings', () => {
+      // Same fingerprint appearing twice — second should be deduplicated, not overflow
+      const fp = 'capdedup00000001'
+      const finding1 = {
+        kind: 'pr-state' as const,
+        path: 'docs/plans/a.md',
+        sourceRef: '#1',
+        verdict: 'drifted' as const,
+        fingerprint: fp,
+        claimedState: 'open',
+        liveState: 'closed',
+        proposalEligible: true,
+        proposedCorrection: 'pr #1 is closed',
+      }
+      const finding2 = {...finding1, path: 'docs/plans/b.md'}
+      const report = makeReport({
+        findings: [finding1, finding2],
+        counts: {total: 2, current: 0, drifted: 2, unresolved: 0, unsafe: 0, proposal_eligible: 2},
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+
+      // Only 1 open (first occurrence), second is deduplicated
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(1)
+      expect(counts.sameRunDeduplicated).toBe(1)
+      expect(counts.overflowed).toBe(0)
+    })
+  })
+
+  describe('scenario 4: priority order — close/update/reopen before open when over cap', () => {
+    it('close actions get priority over open actions when cap is exhausted', () => {
+      // 3 open issues to close (drift cleared) + 4 new findings to open
+      // Cap=5: 3 closes + 2 opens = 5 total; 2 opens overflow
+      const openFingerprints = ['c105e0000000001a', 'c105e0000000002b', 'c105e0000000003c']
+      const openIssues = openFingerprints.map((fp, i) =>
+        makeOpenIssue(fp, {
+          number: 300 + i,
+          title: `Status truth: pr-state drift in docs/plans/close-${i}.md`,
+        }),
+      )
+
+      // 4 new drifted findings (no existing issues for these)
+      const newFindings = makeCapDriftedFindings(4)
+      // Report has no findings for the open issues (drift cleared) + 4 new findings
+      const report = makeReport({
+        findings: newFindings,
+        counts: {total: 4, current: 0, drifted: 4, unresolved: 0, unsafe: 0, proposal_eligible: 4},
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: openIssues}))
+
+      // 3 closes (priority) + 2 opens (remaining cap) = 5 total
+      expect(actions.filter(a => a.type === 'close')).toHaveLength(3)
+      expect(counts.closed).toBe(3)
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(2)
+      expect(counts.opened).toBe(2)
+      expect(counts.overflowed).toBe(2)
+    })
+
+    it('update actions get priority over open actions when cap is exhausted', () => {
+      // 4 existing open issues with changed live-state (update-comment) + 4 new findings
+      // Cap=5: 4 updates + 1 open = 5; 3 opens overflow
+      const updateFingerprints = Array.from({length: 4}, (_, i) => `a1b2c3d4e5f6000${i + 1}`)
+      const existingOpenIssues = updateFingerprints.map((fp, i) =>
+        makeOpenIssue(fp, {
+          number: 400 + i,
+          title: `Status truth: pr-state drift in docs/plans/update-${i}.md`,
+          // Has a different live-state recorded → triggers update-comment
+          body: `<!-- status-truth:fingerprint=${fp} -->\n<!-- status-truth:live-state=open -->\n\nBody.`,
+        }),
+      )
+
+      // Findings for the existing issues (live-state changed to 'closed')
+      const updateFindings = updateFingerprints.map((fp, i) => ({
+        kind: 'pr-state' as const,
+        path: `docs/plans/update-${i}.md`,
+        sourceRef: `#${400 + i}`,
+        verdict: 'drifted' as const,
+        fingerprint: fp,
+        claimedState: 'open',
+        liveState: 'closed', // different from recorded 'open'
+        proposalEligible: true,
+        proposedCorrection: `pr #${400 + i} is closed`,
+      }))
+
+      // 4 new findings (no existing issues)
+      const newFindings = makeCapDriftedFindings(4)
+      const allFindings = [...updateFindings, ...newFindings]
+      const report = makeReport({
+        findings: allFindings,
+        counts: {total: 8, current: 0, drifted: 8, unresolved: 0, unsafe: 0, proposal_eligible: 8},
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(
+        makePlanInput({report, existingIssues: existingOpenIssues}),
+      )
+
+      // 4 updates (priority) + 1 open (remaining cap) = 5; 3 opens overflow
+      expect(actions.filter(a => a.type === 'update-comment')).toHaveLength(4)
+      expect(counts.updated).toBe(4)
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(1)
+      expect(counts.opened).toBe(1)
+      expect(counts.overflowed).toBe(3)
+    })
+
+    it('reopen actions get priority over open actions when cap is exhausted', () => {
+      // 3 closed non-terminal issues (reopen) + 4 new findings
+      // Cap=5: 3 reopens + 2 opens = 5; 2 opens overflow
+      const reopenFingerprints = ['e0e0e0000000001a', 'e0e0e0000000002b', 'e0e0e0000000003c']
+      const closedIssues = reopenFingerprints.map((fp, i) =>
+        makeClosedIssue(fp, [PROPOSAL_LABEL, OUTCOME_LABELS.resolved], {
+          number: 500 + i,
+          title: `Status truth: pr-state drift in docs/plans/reopen-${i}.md`,
+        }),
+      )
+
+      // Findings for the closed issues (drift returned)
+      const reopenFindings = reopenFingerprints.map((fp, i) => ({
+        kind: 'pr-state' as const,
+        path: `docs/plans/reopen-${i}.md`,
+        sourceRef: `#${500 + i}`,
+        verdict: 'drifted' as const,
+        fingerprint: fp,
+        claimedState: 'open',
+        liveState: 'closed',
+        proposalEligible: true,
+        proposedCorrection: `pr #${500 + i} is closed`,
+      }))
+
+      // 4 new findings (no existing issues)
+      const newFindings = makeCapDriftedFindings(4)
+      const allFindings = [...reopenFindings, ...newFindings]
+      const report = makeReport({
+        findings: allFindings,
+        counts: {total: 7, current: 0, drifted: 7, unresolved: 0, unsafe: 0, proposal_eligible: 7},
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: closedIssues}))
+
+      // 3 reopens (priority) + 2 opens (remaining cap) = 5; 2 opens overflow
+      expect(actions.filter(a => a.type === 'reopen')).toHaveLength(3)
+      expect(counts.reopened).toBe(3)
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(2)
+      expect(counts.opened).toBe(2)
+      expect(counts.overflowed).toBe(2)
+    })
+
+    it('full priority order: close > update > reopen > open when all compete for cap', () => {
+      // 2 closes + 1 update + 1 reopen + 4 new opens
+      // Cap=5: 2 closes + 1 update + 1 reopen + 1 open = 5; 3 opens overflow
+      const closeFps = ['c1a2b3d4e5f60001', 'c1a2b3d4e5f60002']
+      const updateFp = 'a1b2c3d4e5f60001'
+      const reopenFp = 'e0e0e0f0a0b00001'
+
+      const openIssuesToClose = closeFps.map((fp, i) =>
+        makeOpenIssue(fp, {
+          number: 600 + i,
+          title: `Status truth: pr-state drift in docs/plans/close-pri-${i}.md`,
+        }),
+      )
+
+      const openIssueToUpdate = makeOpenIssue(updateFp, {
+        number: 610,
+        title: 'Status truth: pr-state drift in docs/plans/update-pri.md',
+        body: `<!-- status-truth:fingerprint=${updateFp} -->\n<!-- status-truth:live-state=open -->\n\nBody.`,
+      })
+
+      const closedIssueToReopen = makeClosedIssue(reopenFp, [PROPOSAL_LABEL, OUTCOME_LABELS.resolved], {
+        number: 620,
+        title: 'Status truth: pr-state drift in docs/plans/reopen-pri.md',
+      })
+
+      // Findings: update finding (live-state changed), reopen finding, 4 new findings
+      const updateFinding = {
+        kind: 'pr-state' as const,
+        path: 'docs/plans/update-pri.md',
+        sourceRef: '#610',
+        verdict: 'drifted' as const,
+        fingerprint: updateFp,
+        claimedState: 'open',
+        liveState: 'closed',
+        proposalEligible: true,
+        proposedCorrection: 'pr #610 is closed',
+      }
+      const reopenFinding = {
+        kind: 'pr-state' as const,
+        path: 'docs/plans/reopen-pri.md',
+        sourceRef: '#620',
+        verdict: 'drifted' as const,
+        fingerprint: reopenFp,
+        claimedState: 'open',
+        liveState: 'closed',
+        proposalEligible: true,
+        proposedCorrection: 'pr #620 is closed',
+      }
+      const newFindings = makeCapDriftedFindings(4)
+      // Report has no findings for the close issues (drift cleared)
+      const allFindings = [updateFinding, reopenFinding, ...newFindings]
+      const report = makeReport({
+        findings: allFindings,
+        counts: {total: 6, current: 0, drifted: 6, unresolved: 0, unsafe: 0, proposal_eligible: 6},
+      })
+
+      const existingIssues = [...openIssuesToClose, openIssueToUpdate, closedIssueToReopen]
+      const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues}))
+
+      // Priority: 2 closes + 1 update + 1 reopen + 1 open = 5; 3 opens overflow
+      expect(actions.filter(a => a.type === 'close')).toHaveLength(2)
+      expect(counts.closed).toBe(2)
+      expect(actions.filter(a => a.type === 'update-comment')).toHaveLength(1)
+      expect(counts.updated).toBe(1)
+      expect(actions.filter(a => a.type === 'reopen')).toHaveLength(1)
+      expect(counts.reopened).toBe(1)
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(1)
+      expect(counts.opened).toBe(1)
+      expect(counts.overflowed).toBe(3)
+    })
+  })
+
+  describe('scenario 5: overflowed actions are visible in JSON output and summary fields', () => {
+    it('overflowed count is present in ProposalCounts and is a number', () => {
+      const findings = makeCapDriftedFindings(8)
+      const report = makeReport({
+        findings,
+        counts: {total: 8, current: 0, drifted: 8, unresolved: 0, unsafe: 0, proposal_eligible: 8},
+      })
+
+      const {counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+
+      expect(typeof counts.overflowed).toBe('number')
+      expect(counts.overflowed).toBe(3)
+    })
+
+    it('overflowed count is 0 when under cap', () => {
+      const findings = makeCapDriftedFindings(3)
+      const report = makeReport({
+        findings,
+        counts: {total: 3, current: 0, drifted: 3, unresolved: 0, unsafe: 0, proposal_eligible: 3},
+      })
+
+      const {counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+
+      expect(counts.overflowed).toBe(0)
+    })
+
+    it('counts shape includes overflowed field alongside existing fields', () => {
+      const {counts} = planStatusTruthProposalActions(makePlanInput())
+
+      // All existing fields still present
+      expect(typeof counts.opened).toBe('number')
+      expect(typeof counts.updated).toBe('number')
+      expect(typeof counts.reopened).toBe('number')
+      expect(typeof counts.closed).toBe('number')
+      expect(typeof counts.suppressed).toBe('number')
+      expect(typeof counts.blocked).toBe('number')
+      expect(typeof counts.noAction).toBe('number')
+      expect(typeof counts.sameRunDeduplicated).toBe('number')
+      expect(typeof counts.malformedMarkers).toBe('number')
+      expect(typeof counts.versionRejected).toBe('number')
+      // New overflow field
+      expect(typeof counts.overflowed).toBe('number')
+    })
+
+    it('overflowed actions do not appear as open/reopen/update/close actions in the actions array', () => {
+      const findings = makeCapDriftedFindings(8)
+      const report = makeReport({
+        findings,
+        counts: {total: 8, current: 0, drifted: 8, unresolved: 0, unsafe: 0, proposal_eligible: 8},
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+
+      // Total mutating actions must not exceed cap
+      const mutatingActions = actions.filter(
+        a => a.type === 'open' || a.type === 'update-comment' || a.type === 'reopen' || a.type === 'close',
+      )
+      expect(mutatingActions.length).toBeLessThanOrEqual(5)
+      // Overflow is counted, not silently dropped
+      expect(counts.overflowed).toBe(3)
+      // opened + overflowed = total eligible new opens
+      expect(counts.opened + counts.overflowed).toBe(8)
+    })
+  })
+
+  describe('scenario 6: dry-run and live mode count accurately under cap', () => {
+    it('dry-run: planned counts reflect cap enforcement (opened=5, overflowed=3)', async () => {
+      const findings = makeCapDriftedFindings(8)
+      const report = makeReport({
+        findings,
+        counts: {total: 8, current: 0, drifted: 8, unresolved: 0, unsafe: 0, proposal_eligible: 8},
+      })
+
+      const planResult = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+
+      // Planner enforces cap
+      expect(planResult.counts.opened).toBe(5)
+      expect(planResult.counts.overflowed).toBe(3)
+      expect(planResult.actions.filter(a => a.type === 'open')).toHaveLength(5)
+
+      // Dry-run executor counts the planned actions (already capped)
+      const {octokit, store} = makeMockOctokit()
+      const execResult = await executeStatusTruthProposalActions({
+        octokit,
+        owner: 'fro-bot',
+        repo: '.github',
+        actions: planResult.actions,
+        dryRun: true,
+        sameRunCreatedFingerprints: new Set<string>(),
+      })
+
+      // No mutations in dry-run
+      expect(store.created).toHaveLength(0)
+      // Dry-run counts match planned (already capped at 5)
+      expect(execResult.counts.opened).toBe(5)
+      expect(execResult.dryRun).toBe(true)
+    })
+
+    it('live mode: executor opens exactly the capped number of issues', async () => {
+      const findings = makeCapDriftedFindings(8)
+      const report = makeReport({
+        findings,
+        counts: {total: 8, current: 0, drifted: 8, unresolved: 0, unsafe: 0, proposal_eligible: 8},
+      })
+
+      const planResult = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+
+      // Planner enforces cap
+      expect(planResult.actions.filter(a => a.type === 'open')).toHaveLength(5)
+
+      // Live executor opens exactly 5
+      const {octokit, store} = makeMockOctokit()
+      const execResult = await executeStatusTruthProposalActions({
+        octokit,
+        owner: 'fro-bot',
+        repo: '.github',
+        actions: planResult.actions,
+        dryRun: false,
+        sameRunCreatedFingerprints: new Set<string>(),
+      })
+
+      expect(store.created).toHaveLength(5)
+      expect(execResult.counts.opened).toBe(5)
+      expect(execResult.dryRun).toBe(false)
+    })
+  })
+
+  describe('custom cap via mutationCap parameter', () => {
+    it('mutationCap=3 limits to 3 opens from 8 findings', () => {
+      const findings = makeCapDriftedFindings(8)
+      const report = makeReport({
+        findings,
+        counts: {total: 8, current: 0, drifted: 8, unresolved: 0, unsafe: 0, proposal_eligible: 8},
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(
+        makePlanInput({report, existingIssues: [], mutationCap: 3}),
+      )
+
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(3)
+      expect(counts.opened).toBe(3)
+      expect(counts.overflowed).toBe(5)
+    })
+
+    it('mutationCap=0 overflows all findings', () => {
+      const findings = makeCapDriftedFindings(3)
+      const report = makeReport({
+        findings,
+        counts: {total: 3, current: 0, drifted: 3, unresolved: 0, unsafe: 0, proposal_eligible: 3},
+      })
+
+      const {actions, counts} = planStatusTruthProposalActions(
+        makePlanInput({report, existingIssues: [], mutationCap: 0}),
+      )
+
+      expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+      expect(counts.opened).toBe(0)
+      expect(counts.overflowed).toBe(3)
+    })
   })
 })

--- a/scripts/status-truth-proposals.test.ts
+++ b/scripts/status-truth-proposals.test.ts
@@ -493,6 +493,24 @@ describe('planStatusTruthProposalActions', () => {
       expect(actions.filter(a => a.type === 'close')).toHaveLength(0)
     })
 
+    it('does NOT close open proposal when report includes unsafe findings (fail-closed on inaccessible prior drift)', () => {
+      const fingerprint = 'abc123def456abcd'
+      const report = makeReport({
+        findings: [makeUnsafeFinding()],
+        status: 'findings',
+        scan_complete: true,
+        counts: {total: 1, current: 0, drifted: 0, unresolved: 0, unsafe: 1, proposal_eligible: 0},
+      })
+      // An open proposal whose fingerprint is NOT in the current findings (drift appears cleared)
+      const existingIssue = makeOpenIssue(fingerprint)
+
+      const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [existingIssue]}))
+
+      // Must NOT close: unsafe findings mean prior drift may be inaccessible/private, not genuinely cleared
+      expect(actions.filter(a => a.type === 'close')).toHaveLength(0)
+      expect(counts.closed).toBe(0)
+    })
+
     it('does NOT close when close-comment is blocked by token-load failure', () => {
       const fingerprint = 'abc123def456abcd'
       const report = makeReport({
@@ -1409,12 +1427,15 @@ function makeFetchOctokit(
         }) => {
           if (params.state === 'open') {
             if (overrides.openThrows === true) throw new Error('API error')
-            return {data: openIssues}
+            // Paginate: slice by per_page and page
+            const start = (params.page - 1) * params.per_page
+            return {data: openIssues.slice(start, start + params.per_page)}
           }
           if (overrides.closedThrows === true) throw new Error('API error')
           if (overrides.closedPage2Throws === true && params.page === 2) throw new Error('API error page 2')
-          // Return closed issues only on page 1; empty on page 2
-          return {data: params.page === 1 ? closedIssues : []}
+          // Paginate: slice by per_page and page
+          const start = (params.page - 1) * params.per_page
+          return {data: closedIssues.slice(start, start + params.per_page)}
         },
       },
     },
@@ -1490,23 +1511,69 @@ describe('fetchExistingProposalIssues', () => {
     expect(issues).toHaveLength(0)
   })
 
-  it('returns page-1 closed issues when page-2 closed fetch throws (best-effort pagination)', async () => {
-    const fp = 'abc123def456abcd'
-    const closedIssues = [
-      makeIssueListItem(
-        200,
-        'closed',
-        [PROPOSAL_LABEL, OUTCOME_LABELS.resolved],
-        `<!-- status-truth:fingerprint=${fp} -->`,
-      ),
-    ]
+  it('throws when closed page-2 fetch throws (fail-closed: all pagination errors propagate)', async () => {
+    // Build exactly per_page (100) closed issues on page 1 so pagination continues to page 2.
+    const closedIssues: IssueListItem[] = Array.from({length: 100}, (_, i) =>
+      makeIssueListItem(200 + i, 'closed', [PROPOSAL_LABEL, OUTCOME_LABELS.resolved], null),
+    )
     const octokit = makeFetchOctokit({closedIssues, closedPage2Throws: true})
 
-    // Page-2 failure is best-effort; page-1 results should still be returned
+    // Page-2 failure propagates — fail-closed, no partial results
+    await expect(fetchExistingProposalIssues({octokit, owner: 'fro-bot', repo: '.github'})).rejects.toThrow(
+      'API error page 2',
+    )
+  })
+
+  it('fetches all closed issues across multiple pages (no truncation beyond 100)', async () => {
+    // Build 150 closed issues spread across two pages of 100 each.
+    // The mock slices by per_page/page, so page 1 returns items 0-99 and page 2 returns items 100-149.
+    const closedIssues: IssueListItem[] = Array.from({length: 150}, (_, i) =>
+      makeIssueListItem(
+        300 + i,
+        'closed',
+        [PROPOSAL_LABEL, OUTCOME_LABELS.resolved],
+        `<!-- status-truth:fingerprint=${String(i).padStart(16, '0')} -->`,
+      ),
+    )
+    const octokit = makeFetchOctokit({closedIssues})
+
     const issues = await fetchExistingProposalIssues({octokit, owner: 'fro-bot', repo: '.github'})
 
-    expect(issues.filter(i => i.state === 'closed')).toHaveLength(1)
-    expect(issues[0]?.number).toBe(200)
+    const closed = issues.filter(i => i.state === 'closed')
+    expect(closed).toHaveLength(150)
+    // Verify issues from the second page (numbers 400-449) are present
+    const secondPageNumbers = closed.map(i => i.number).filter(n => n >= 400)
+    expect(secondPageNumbers.length).toBe(50)
+  })
+
+  it('outcome counts include closed issues beyond the first 100', async () => {
+    // 120 closed issues: first 100 are accepted, last 20 are rejected.
+    // Without full pagination, the 20 rejected issues on page 2 would be missed.
+    const closedIssues: IssueListItem[] = [
+      ...Array.from({length: 100}, (_, i) =>
+        makeIssueListItem(
+          500 + i,
+          'closed',
+          [PROPOSAL_LABEL, OUTCOME_LABELS.accepted],
+          `<!-- status-truth:fingerprint=${String(i).padStart(16, '0')} -->`,
+        ),
+      ),
+      ...Array.from({length: 20}, (_, i) =>
+        makeIssueListItem(
+          600 + i,
+          'closed',
+          [PROPOSAL_LABEL, OUTCOME_LABELS.rejected],
+          `<!-- status-truth:fingerprint=${String(100 + i).padStart(16, '0')} -->`,
+        ),
+      ),
+    ]
+    const octokit = makeFetchOctokit({closedIssues})
+
+    const issues = await fetchExistingProposalIssues({octokit, owner: 'fro-bot', repo: '.github'})
+    const counts = buildOutcomeCounts(issues)
+
+    expect(counts.explicitAccepted).toBe(100)
+    expect(counts.explicitRejected).toBe(20)
   })
 })
 

--- a/scripts/status-truth-proposals.test.ts
+++ b/scripts/status-truth-proposals.test.ts
@@ -9,12 +9,15 @@ import type {
   ExecuteStatusTruthProposalActionsInput,
   ExistingProposalIssue,
   IssueListItem,
+  OutcomeCounts,
   PlanStatusTruthProposalActionsInput,
   StatusTruthOctokitClient,
 } from './status-truth-proposals.ts'
 import type {PublicOutputTokens} from './status-truth-public-output.ts'
 import {describe, expect, it} from 'vitest'
 import {
+  buildOutcomeCounts,
+  classifyProposalOutcome,
   executeStatusTruthProposalActions,
   extractProposalFingerprint,
   extractRedactedCanonicalIds,
@@ -765,11 +768,11 @@ describe('planStatusTruthProposalActions', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Unit 4: executeStatusTruthProposalActions (I/O shell with injected client)
+// executeStatusTruthProposalActions (I/O shell with injected client)
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// Minimal Octokit mock for Unit 4 tests
+// Minimal Octokit mock for executor tests
 // ---------------------------------------------------------------------------
 
 interface MockIssueStore {
@@ -1286,7 +1289,7 @@ describe('executeStatusTruthProposalActions', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Unit 4 corrections: fetchExistingProposalIssues tests
+// fetchExistingProposalIssues tests
 // ---------------------------------------------------------------------------
 
 function makeIssueListItem(
@@ -1750,7 +1753,7 @@ describe('redactedCanonicalIds mutation test — private node_id blocks proposal
 })
 
 // ---------------------------------------------------------------------------
-// Unit 4 hardening: label gate must block on ANY missing required label
+// Label gate must block on any missing required label
 // ---------------------------------------------------------------------------
 
 describe('executeStatusTruthProposalActions label gate — all required labels', () => {
@@ -1902,7 +1905,7 @@ describe('executeStatusTruthProposalActions label gate — all required labels',
 })
 
 // ---------------------------------------------------------------------------
-// Unit 4 hardening: live fetch failure blocks mutations
+// Live fetch failure blocks mutations
 // ---------------------------------------------------------------------------
 
 describe('fetchExistingProposalIssues fail-closed behavior', () => {
@@ -1923,7 +1926,7 @@ describe('fetchExistingProposalIssues fail-closed behavior', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Unit 4 corrections: open planning uses fetched existing issues
+// Open planning uses fetched existing issues
 // ---------------------------------------------------------------------------
 
 describe('planStatusTruthProposalActions with fetched existing issues', () => {
@@ -2011,7 +2014,7 @@ describe('planStatusTruthProposalActions with fetched existing issues', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Unit 5: Accuracy signal and operator-facing proposal UX
+// Accuracy signal and operator-facing proposal UX
 // ---------------------------------------------------------------------------
 
 describe('per-kind usefulness counters', () => {
@@ -2979,7 +2982,7 @@ repos:
 })
 
 // ---------------------------------------------------------------------------
-// U3: Proposal cap and overflow visibility
+// Proposal cap and overflow visibility
 // ---------------------------------------------------------------------------
 
 // Helper: make N distinct drifted findings with unique fingerprints (hex-safe)
@@ -2997,7 +3000,7 @@ function makeCapDriftedFindings(count: number) {
   }))
 }
 
-describe('U3: planStatusTruthProposalActions — mutation cap and overflow', () => {
+describe('planStatusTruthProposalActions — mutation cap and overflow', () => {
   describe('scenario 1: more than 5 eligible new proposals — only 5 execute, rest are overflow', () => {
     it('with 8 new drifted findings, only 5 open actions are planned and 3 are overflow', () => {
       const findings = makeCapDriftedFindings(8)
@@ -3508,5 +3511,545 @@ describe('U3: planStatusTruthProposalActions — mutation cap and overflow', () 
       expect(counts.opened).toBe(0)
       expect(counts.overflowed).toBe(3)
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Outcome classification read-model
+// ---------------------------------------------------------------------------
+
+describe('classifyProposalOutcome — pure outcome state classifier', () => {
+  // Scenario 1: Open proposal without terminal labels => proposed/pending
+  it('open proposal with only the proposal label classifies as proposed-pending', () => {
+    const issue = makeOpenIssue('abc123def456abcd')
+    const outcome = classifyProposalOutcome(issue, false)
+    expect(outcome).toBe('proposed-pending')
+  })
+
+  it('open proposal with no outcome labels classifies as proposed-pending', () => {
+    const issue = makeOpenIssue('abc123def456abcd', {labels: [PROPOSAL_LABEL]})
+    const outcome = classifyProposalOutcome(issue, false)
+    expect(outcome).toBe('proposed-pending')
+  })
+
+  // Scenario 2: Accepted/rejected/false-positive labels classify terminal outcomes
+  it('closed proposal with accepted label classifies as explicit-accepted', () => {
+    const issue = makeClosedIssue('abc123def456abcd', [PROPOSAL_LABEL, OUTCOME_LABELS.accepted])
+    const outcome = classifyProposalOutcome(issue, false)
+    expect(outcome).toBe('explicit-accepted')
+  })
+
+  it('closed proposal with rejected label classifies as explicit-rejected', () => {
+    const issue = makeClosedIssue('abc123def456abcd', [PROPOSAL_LABEL, OUTCOME_LABELS.rejected])
+    const outcome = classifyProposalOutcome(issue, false)
+    expect(outcome).toBe('explicit-rejected')
+  })
+
+  it('closed proposal with false-positive label classifies as false-positive', () => {
+    const issue = makeClosedIssue('abc123def456abcd', [PROPOSAL_LABEL, OUTCOME_LABELS.falsePositive])
+    const outcome = classifyProposalOutcome(issue, false)
+    expect(outcome).toBe('false-positive')
+  })
+
+  // Scenario 3: Drift-cleared proposal classifies resolved-positive without adding accepted
+  it('closed proposal with resolved label classifies as resolved-positive (not explicit-accepted)', () => {
+    const issue = makeClosedIssue('abc123def456abcd', [PROPOSAL_LABEL, OUTCOME_LABELS.resolved])
+    const outcome = classifyProposalOutcome(issue, false)
+    expect(outcome).toBe('resolved-positive')
+    // Must NOT be explicit-accepted — resolved positive is bot-inferred, not human-confirmed
+    expect(outcome).not.toBe('explicit-accepted')
+  })
+
+  it('closed proposal with manually-fixed label classifies as resolved-positive', () => {
+    const issue = makeClosedIssue('abc123def456abcd', [PROPOSAL_LABEL, OUTCOME_LABELS.manuallyFixed])
+    const outcome = classifyProposalOutcome(issue, false)
+    expect(outcome).toBe('resolved-positive')
+  })
+
+  // Scenario 4: Closed issue without terminal/resolution label — outcome depends on driftActive
+  it('closed proposal with only the proposal label (no outcome label) and driftActive=false classifies as resolved-positive', () => {
+    // Drift cleared (fingerprint not in current scan) → resolved-positive
+    const issue = makeClosedIssue('abc123def456abcd', [PROPOSAL_LABEL])
+    const outcome = classifyProposalOutcome(issue, false)
+    expect(outcome).toBe('resolved-positive')
+    // Must NOT be explicit-rejected
+    expect(outcome).not.toBe('explicit-rejected')
+  })
+
+  it('closed proposal with only the proposal label (no outcome label) and driftActive=true classifies as needs-outcome', () => {
+    // Drift still active (fingerprint in current scan) → needs-outcome
+    const issue = makeClosedIssue('abc123def456abcd', [PROPOSAL_LABEL])
+    const outcome = classifyProposalOutcome(issue, true)
+    expect(outcome).toBe('needs-outcome')
+    // Must NOT be explicit-rejected
+    expect(outcome).not.toBe('explicit-rejected')
+  })
+
+  // Conflicting labels: mutually exclusive outcome labels present together
+  it('closed proposal with both accepted and rejected labels classifies as conflicting-labels', () => {
+    const issue = makeClosedIssue('abc123def456abcd', [
+      PROPOSAL_LABEL,
+      OUTCOME_LABELS.accepted,
+      OUTCOME_LABELS.rejected,
+    ])
+    const outcome = classifyProposalOutcome(issue, false)
+    expect(outcome).toBe('conflicting-labels')
+  })
+
+  it('closed proposal with both accepted and false-positive labels classifies as conflicting-labels', () => {
+    const issue = makeClosedIssue('abc123def456abcd', [
+      PROPOSAL_LABEL,
+      OUTCOME_LABELS.accepted,
+      OUTCOME_LABELS.falsePositive,
+    ])
+    const outcome = classifyProposalOutcome(issue, false)
+    expect(outcome).toBe('conflicting-labels')
+  })
+
+  it('closed proposal with both rejected and false-positive labels classifies as conflicting-labels', () => {
+    const issue = makeClosedIssue('abc123def456abcd', [
+      PROPOSAL_LABEL,
+      OUTCOME_LABELS.rejected,
+      OUTCOME_LABELS.falsePositive,
+    ])
+    const outcome = classifyProposalOutcome(issue, false)
+    expect(outcome).toBe('conflicting-labels')
+  })
+
+  // Superseded lifecycle state
+  it('closed proposal with superseded label classifies as superseded', () => {
+    const issue = makeClosedIssue('abc123def456abcd', [PROPOSAL_LABEL, OUTCOME_LABELS.superseded])
+    const outcome = classifyProposalOutcome(issue, false)
+    expect(outcome).toBe('superseded')
+  })
+
+  // Malformed: unrecognized status-truth:* label
+  it('closed proposal with unrecognized status-truth:* label classifies as malformed-outcome', () => {
+    const issue = makeClosedIssue('abc123def456abcd', [PROPOSAL_LABEL, 'status-truth:unknown-state'])
+    const outcome = classifyProposalOutcome(issue, false)
+    expect(outcome).toBe('malformed-outcome')
+  })
+
+  // Error path: malformed outcome markers do not crash
+  it('issue with no fingerprint marker still classifies without throwing', () => {
+    const issue: ExistingProposalIssue = {
+      number: 999,
+      state: 'closed',
+      labels: [PROPOSAL_LABEL, OUTCOME_LABELS.accepted],
+      title: 'Status truth: something',
+      body: null,
+    }
+    // Should not throw — returns a valid outcome state
+    expect(() => classifyProposalOutcome(issue, false)).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Outcome counts are emitted separately from action counts
+// ---------------------------------------------------------------------------
+
+describe('buildOutcomeCounts — outcome read-model counts separate from action counts', () => {
+  // Scenario 5: Outcome counts are emitted separately from action counts
+  it('buildOutcomeCounts returns outcome counts without action counts', () => {
+    // fp5 has no outcome label; with no driftActiveFingerprints (default empty set),
+    // driftActive=false → resolved-positive (drift cleared without explicit label).
+    // To get needsOutcome=1, pass fp5's fingerprint as drift-active.
+    const fp5Fingerprint = 'deadbeef12345678'
+    const fp5Issue = makeClosedIssue(fp5Fingerprint, [PROPOSAL_LABEL], {
+      body: `<!-- status-truth:fingerprint=${fp5Fingerprint} -->\n\nSome body text.`,
+    })
+    const issues: ExistingProposalIssue[] = [
+      makeClosedIssue('fp1', [PROPOSAL_LABEL, OUTCOME_LABELS.accepted]),
+      makeClosedIssue('fp2', [PROPOSAL_LABEL, OUTCOME_LABELS.rejected]),
+      makeClosedIssue('fp3', [PROPOSAL_LABEL, OUTCOME_LABELS.falsePositive]),
+      makeClosedIssue('fp4', [PROPOSAL_LABEL, OUTCOME_LABELS.resolved]),
+      fp5Issue,
+      makeOpenIssue('fp6'),
+    ]
+
+    // Pass fp5's fingerprint as drift-active so it classifies as needs-outcome
+    const outcomeCounts = buildOutcomeCounts(issues, new Set([fp5Fingerprint]))
+
+    // Outcome counts are present and correct
+    expect(outcomeCounts.explicitAccepted).toBe(1)
+    expect(outcomeCounts.explicitRejected).toBe(1)
+    expect(outcomeCounts.falsePositive).toBe(1)
+    expect(outcomeCounts.resolvedPositive).toBe(1)
+    expect(outcomeCounts.needsOutcome).toBe(1)
+    expect(outcomeCounts.proposedPending).toBe(1)
+
+    // Outcome counts object must NOT contain action-level fields
+    const keys = Object.keys(outcomeCounts)
+    expect(keys).not.toContain('opened')
+    expect(keys).not.toContain('updated')
+    expect(keys).not.toContain('reopened')
+    expect(keys).not.toContain('closed')
+    expect(keys).not.toContain('suppressed')
+    expect(keys).not.toContain('blocked')
+    expect(keys).not.toContain('overflowed')
+  })
+
+  it('buildOutcomeCounts counts conflicting-labels issues for operator attention', () => {
+    const issues: ExistingProposalIssue[] = [
+      makeClosedIssue('fp1', [PROPOSAL_LABEL, OUTCOME_LABELS.accepted, OUTCOME_LABELS.rejected]),
+      makeClosedIssue('fp2', [PROPOSAL_LABEL, OUTCOME_LABELS.accepted, OUTCOME_LABELS.falsePositive]),
+    ]
+
+    const outcomeCounts = buildOutcomeCounts(issues)
+
+    expect(outcomeCounts.conflictingLabels).toBe(2)
+    // Conflicting issues must NOT contribute to accuracy math
+    expect(outcomeCounts.explicitAccepted).toBe(0)
+    expect(outcomeCounts.explicitRejected).toBe(0)
+    expect(outcomeCounts.falsePositive).toBe(0)
+  })
+
+  it('buildOutcomeCounts counts malformed-outcome issues for operator attention', () => {
+    const issues: ExistingProposalIssue[] = [makeClosedIssue('fp1', [PROPOSAL_LABEL, 'status-truth:unknown-state'])]
+
+    const outcomeCounts = buildOutcomeCounts(issues)
+
+    expect(outcomeCounts.malformedOutcome).toBe(1)
+    // Malformed issues must NOT contribute to accuracy math
+    expect(outcomeCounts.explicitAccepted).toBe(0)
+    expect(outcomeCounts.explicitRejected).toBe(0)
+    expect(outcomeCounts.falsePositive).toBe(0)
+  })
+
+  it('buildOutcomeCounts returns zero counts for empty issue list', () => {
+    const outcomeCounts = buildOutcomeCounts([])
+
+    expect(outcomeCounts.explicitAccepted).toBe(0)
+    expect(outcomeCounts.explicitRejected).toBe(0)
+    expect(outcomeCounts.falsePositive).toBe(0)
+    expect(outcomeCounts.resolvedPositive).toBe(0)
+    expect(outcomeCounts.needsOutcome).toBe(0)
+    expect(outcomeCounts.proposedPending).toBe(0)
+    expect(outcomeCounts.conflictingLabels).toBe(0)
+    expect(outcomeCounts.malformedOutcome).toBe(0)
+    expect(outcomeCounts.superseded).toBe(0)
+  })
+
+  // Scenario 6: No raw issue body/title/fingerprint leaks into outcome summary/output
+  it('buildOutcomeCounts output contains only numeric counts — no raw issue body, title, or fingerprint', () => {
+    const issues: ExistingProposalIssue[] = [
+      makeClosedIssue('abc123def456abcd', [PROPOSAL_LABEL, OUTCOME_LABELS.accepted], {
+        title: 'Status truth: pr-state drift in docs/plans/secret-path.md',
+        body: '<!-- status-truth:fingerprint=abc123def456abcd -->\n\nSensitive body content.',
+      }),
+    ]
+
+    const outcomeCounts = buildOutcomeCounts(issues)
+    const json = JSON.stringify(outcomeCounts)
+
+    // No raw issue body, title, or fingerprint in the output
+    expect(json).not.toContain('secret-path')
+    expect(json).not.toContain('Sensitive body content')
+    expect(json).not.toContain('abc123def456abcd')
+    expect(json).not.toContain('Status truth:')
+
+    // Only numeric counts
+    for (const value of Object.values(outcomeCounts)) {
+      expect(typeof value).toBe('number')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// conflictingLabels count in ProposalCounts
+// ---------------------------------------------------------------------------
+
+describe('conflictingLabels count in planStatusTruthProposalActions', () => {
+  it('issue with conflicting accepted+rejected labels increments conflictingLabels count', () => {
+    const fingerprint = 'abc123def456abcd'
+    const report = makeReport({
+      findings: [],
+      status: 'clean',
+      scan_complete: true,
+      counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+    })
+    const conflictingIssue = makeClosedIssue(fingerprint, [
+      PROPOSAL_LABEL,
+      OUTCOME_LABELS.accepted,
+      OUTCOME_LABELS.rejected,
+    ])
+
+    const {counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [conflictingIssue]}))
+
+    expect(counts.conflictingLabels).toBeGreaterThanOrEqual(1)
+    // Must NOT contribute to usefulnessByKind accuracy math
+    const kindCounts = counts.usefulnessByKind
+    for (const kind of Object.keys(kindCounts)) {
+      const entry = kindCounts[kind]
+      if (entry !== undefined) {
+        expect(entry.accepted).toBe(0)
+        expect(entry.rejected).toBe(0)
+        expect(entry.falsePositive).toBe(0)
+      }
+    }
+  })
+
+  it('issue with conflicting accepted+false-positive labels increments conflictingLabels count', () => {
+    const fingerprint = 'abc123def456abcd'
+    const report = makeReport({
+      findings: [],
+      status: 'clean',
+      scan_complete: true,
+      counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+    })
+    const conflictingIssue = makeClosedIssue(fingerprint, [
+      PROPOSAL_LABEL,
+      OUTCOME_LABELS.accepted,
+      OUTCOME_LABELS.falsePositive,
+    ])
+
+    const {counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [conflictingIssue]}))
+
+    expect(counts.conflictingLabels).toBeGreaterThanOrEqual(1)
+  })
+
+  it('conflictingLabels count is separate from malformedOutcomeMarkers count', () => {
+    const fingerprint1 = 'abc123def456abcd'
+    const fingerprint2 = 'deadbeef12345678'
+    const report = makeReport({
+      findings: [],
+      status: 'clean',
+      scan_complete: true,
+      counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+    })
+    // One conflicting (accepted+rejected), one malformed (unknown label)
+    const conflictingIssue = makeClosedIssue(fingerprint1, [
+      PROPOSAL_LABEL,
+      OUTCOME_LABELS.accepted,
+      OUTCOME_LABELS.rejected,
+    ])
+    const malformedIssue: ExistingProposalIssue = {
+      number: 301,
+      state: 'closed',
+      labels: [PROPOSAL_LABEL, 'status-truth:unknown-state'],
+      title: 'Status truth: pr-state drift in docs/plans/example.md',
+      body: `<!-- status-truth:fingerprint=${fingerprint2} -->\n\nBody.`,
+    }
+
+    const {counts} = planStatusTruthProposalActions(
+      makePlanInput({report, existingIssues: [conflictingIssue, malformedIssue]}),
+    )
+
+    expect(counts.conflictingLabels).toBe(1)
+    expect(counts.malformedOutcomeMarkers).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// classifyProposalOutcome — driftActive parameter
+// ---------------------------------------------------------------------------
+
+describe('classifyProposalOutcome — driftActive parameter', () => {
+  it('closed issue with no terminal label and driftActive=false classifies as resolved-positive', () => {
+    // Closed with only the proposal label (no outcome label), drift no longer active.
+    // The fingerprint is not in the current scan → resolved-positive (drift cleared without explicit label).
+    const issue: ExistingProposalIssue = {
+      number: 100,
+      state: 'closed',
+      labels: [PROPOSAL_LABEL],
+      title: 'Status truth: pr-state drift in docs/plans/example.md',
+      body: '<!-- status-truth:fingerprint=abc123def456abcd -->\n\nBody.',
+    }
+    expect(classifyProposalOutcome(issue, false)).toBe('resolved-positive')
+  })
+
+  it('closed issue with no terminal label and driftActive=true classifies as needs-outcome', () => {
+    // Closed with only the proposal label (no outcome label), drift still active.
+    // The fingerprint is still in the current scan → needs-outcome (operator attention required).
+    const issue: ExistingProposalIssue = {
+      number: 100,
+      state: 'closed',
+      labels: [PROPOSAL_LABEL],
+      title: 'Status truth: pr-state drift in docs/plans/example.md',
+      body: '<!-- status-truth:fingerprint=abc123def456abcd -->\n\nBody.',
+    }
+    expect(classifyProposalOutcome(issue, true)).toBe('needs-outcome')
+  })
+
+  it('open issue always classifies as proposed-pending regardless of driftActive', () => {
+    const issue: ExistingProposalIssue = {
+      number: 100,
+      state: 'open',
+      labels: [PROPOSAL_LABEL],
+      title: 'Status truth: pr-state drift in docs/plans/example.md',
+      body: '<!-- status-truth:fingerprint=abc123def456abcd -->\n\nBody.',
+    }
+    expect(classifyProposalOutcome(issue, false)).toBe('proposed-pending')
+    expect(classifyProposalOutcome(issue, true)).toBe('proposed-pending')
+  })
+
+  it('closed issue with resolved label classifies as resolved-positive regardless of driftActive', () => {
+    const issue: ExistingProposalIssue = {
+      number: 100,
+      state: 'closed',
+      labels: [PROPOSAL_LABEL, OUTCOME_LABELS.resolved],
+      title: 'Status truth: pr-state drift in docs/plans/example.md',
+      body: '<!-- status-truth:fingerprint=abc123def456abcd -->\n\nBody.',
+    }
+    expect(classifyProposalOutcome(issue, false)).toBe('resolved-positive')
+    expect(classifyProposalOutcome(issue, true)).toBe('resolved-positive')
+  })
+
+  it('closed issue with manually-fixed label classifies as resolved-positive regardless of driftActive', () => {
+    const issue: ExistingProposalIssue = {
+      number: 100,
+      state: 'closed',
+      labels: [PROPOSAL_LABEL, OUTCOME_LABELS.manuallyFixed],
+      title: 'Status truth: pr-state drift in docs/plans/example.md',
+      body: '<!-- status-truth:fingerprint=abc123def456abcd -->\n\nBody.',
+    }
+    expect(classifyProposalOutcome(issue, false)).toBe('resolved-positive')
+    expect(classifyProposalOutcome(issue, true)).toBe('resolved-positive')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// outcomeCounts in planStatusTruthProposalActions result
+// ---------------------------------------------------------------------------
+
+describe('planStatusTruthProposalActions — outcomeCounts in result', () => {
+  it('result includes outcomeCounts field separate from counts and countsByKind', () => {
+    const {counts, countsByKind, outcomeCounts} = planStatusTruthProposalActions(makePlanInput()) as {
+      counts: unknown
+      countsByKind: unknown
+      outcomeCounts: OutcomeCounts
+    }
+
+    expect(outcomeCounts).toBeDefined()
+    expect(counts).toBeDefined()
+    expect(countsByKind).toBeDefined()
+    // outcomeCounts must be a separate object from counts
+    expect(outcomeCounts).not.toBe(counts)
+  })
+
+  it('outcomeCounts has all required fields as numbers', () => {
+    const result = planStatusTruthProposalActions(makePlanInput()) as {outcomeCounts: OutcomeCounts}
+
+    const oc = result.outcomeCounts
+    expect(typeof oc.proposedPending).toBe('number')
+    expect(typeof oc.explicitAccepted).toBe('number')
+    expect(typeof oc.explicitRejected).toBe('number')
+    expect(typeof oc.falsePositive).toBe('number')
+    expect(typeof oc.resolvedPositive).toBe('number')
+    expect(typeof oc.superseded).toBe('number')
+    expect(typeof oc.needsOutcome).toBe('number')
+    expect(typeof oc.conflictingLabels).toBe('number')
+    expect(typeof oc.malformedOutcome).toBe('number')
+  })
+
+  it('outcomeCounts.proposedPending counts open proposal issues', () => {
+    const fingerprint = 'abc123def456abcd'
+    const report = makeReport({
+      findings: [],
+      status: 'clean',
+      scan_complete: true,
+      counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+    })
+    const openIssue = makeOpenIssue(fingerprint)
+
+    const result = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [openIssue]})) as {
+      outcomeCounts: OutcomeCounts
+    }
+
+    expect(result.outcomeCounts.proposedPending).toBe(1)
+  })
+
+  it('outcomeCounts.explicitAccepted counts closed issues with accepted label', () => {
+    const fingerprint = 'abc123def456abcd'
+    const report = makeReport({
+      findings: [],
+      status: 'clean',
+      scan_complete: true,
+      counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+    })
+    const closedIssue = makeClosedIssue(fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.accepted])
+
+    const result = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]})) as {
+      outcomeCounts: OutcomeCounts
+    }
+
+    expect(result.outcomeCounts.explicitAccepted).toBe(1)
+  })
+
+  it('outcomeCounts.resolvedPositive counts closed issues with resolved label', () => {
+    const fingerprint = 'abc123def456abcd'
+    const report = makeReport({
+      findings: [],
+      status: 'clean',
+      scan_complete: true,
+      counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+    })
+    const closedIssue = makeClosedIssue(fingerprint, [PROPOSAL_LABEL, OUTCOME_LABELS.resolved])
+
+    const result = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]})) as {
+      outcomeCounts: OutcomeCounts
+    }
+
+    expect(result.outcomeCounts.resolvedPositive).toBe(1)
+  })
+
+  it('outcomeCounts.needsOutcome counts closed issues with no outcome label when drift is active', () => {
+    // Closed with only proposal label, drift still active (fingerprint in report findings)
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    // Closed with no outcome label — drift is active so this is needs-outcome
+    const closedIssue = makeClosedIssue(fingerprint, [PROPOSAL_LABEL])
+
+    const result = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]})) as {
+      outcomeCounts: OutcomeCounts
+    }
+
+    expect(result.outcomeCounts.needsOutcome).toBe(1)
+  })
+
+  it('outcomeCounts.resolvedPositive counts closed issues with no outcome label when drift is NOT active', () => {
+    // Closed with only proposal label, drift cleared (fingerprint not in report findings)
+    const fingerprint = 'abc123def456abcd'
+    const report = makeReport({
+      findings: [],
+      status: 'clean',
+      scan_complete: true,
+      counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+    })
+    // Closed with no outcome label — drift cleared so this is resolved-positive
+    const closedIssue = makeClosedIssue(fingerprint, [PROPOSAL_LABEL])
+
+    const result = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [closedIssue]})) as {
+      outcomeCounts: OutcomeCounts
+    }
+
+    expect(result.outcomeCounts.resolvedPositive).toBe(1)
+    expect(result.outcomeCounts.needsOutcome).toBe(0)
+  })
+
+  it('outcomeCounts is separate from action counts (counts) and plannedCounts', () => {
+    // outcomeCounts reflects existing issue state, not actions taken this run
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding(fingerprint)
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const openIssue = makeOpenIssue(fingerprint)
+
+    const result = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [openIssue]})) as {
+      counts: {opened: number; noAction: number}
+      outcomeCounts: OutcomeCounts
+    }
+
+    // Action counts: no-action (existing open issue, drift unchanged)
+    expect(result.counts.noAction).toBeGreaterThanOrEqual(1)
+    expect(result.counts.opened).toBe(0)
+    // Outcome counts: one proposed-pending (the existing open issue)
+    expect(result.outcomeCounts.proposedPending).toBe(1)
   })
 })

--- a/scripts/status-truth-proposals.ts
+++ b/scripts/status-truth-proposals.ts
@@ -188,6 +188,231 @@ const FINGERPRINT_MARKER_PATTERN = /<!-- status-truth:fingerprint=([a-f0-9]+) --
 const LIVE_STATE_MARKER_PATTERN = /<!-- status-truth:live-state=([\w-]+) -->/u
 
 // ---------------------------------------------------------------------------
+// Outcome classification read-model
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical outcome states for a proposal issue.
+ *
+ * These states are derived from the issue's labels and open/closed state.
+ * They are read-only classifications — no mutation behavior here.
+ *
+ * | State | Derivation |
+ * |---|---|
+ * | proposed-pending | Open issue with no terminal/resolution label |
+ * | explicit-accepted | Closed with `status-truth:accepted` label |
+ * | explicit-rejected | Closed with `status-truth:rejected` label (terminal) |
+ * | false-positive | Closed with `status-truth:false-positive` label (terminal) |
+ * | resolved-positive | Closed with `status-truth:resolved` or `status-truth:manually-fixed` |
+ * | superseded | Closed with `status-truth:superseded` label |
+ * | needs-outcome | Closed with no recognized outcome label |
+ * | conflicting-labels | Closed with mutually exclusive outcome labels (e.g. accepted+rejected) |
+ * | malformed-outcome | Closed with unrecognized `status-truth:*` label |
+ */
+export type ProposalOutcomeState =
+  | 'proposed-pending'
+  | 'explicit-accepted'
+  | 'explicit-rejected'
+  | 'false-positive'
+  | 'resolved-positive'
+  | 'superseded'
+  | 'needs-outcome'
+  | 'conflicting-labels'
+  | 'malformed-outcome'
+
+/**
+ * Mutually exclusive accuracy signal labels.
+ * An issue with more than one of these is conflicting.
+ */
+const ACCURACY_SIGNAL_LABELS_SET: readonly string[] = [
+  OUTCOME_LABELS.accepted,
+  OUTCOME_LABELS.rejected,
+  OUTCOME_LABELS.falsePositive,
+]
+
+/**
+ * Classify a proposal issue into a canonical outcome state.
+ *
+ * Pure function: no I/O, no side effects. Deterministic from inputs.
+ *
+ * Classification rules (in priority order):
+ * 1. Open issue → proposed-pending (regardless of labels)
+ * 2. Closed issue with multiple mutually exclusive accuracy signal labels → conflicting-labels
+ * 3. Closed issue with unrecognized `status-truth:*` label → malformed-outcome
+ * 4. Closed issue with `accepted` label → explicit-accepted
+ * 5. Closed issue with `rejected` label → explicit-rejected
+ * 6. Closed issue with `false-positive` label → false-positive
+ * 7. Closed issue with `resolved` or `manually-fixed` label → resolved-positive
+ * 8. Closed issue with `superseded` label → superseded
+ * 9. Closed issue with no recognized outcome label + drift still active → needs-outcome
+ * 10. Closed issue with no recognized outcome label + drift cleared → resolved-positive
+ *
+ * @param issue - The proposal issue to classify.
+ * @param driftActive - Whether the same drift fingerprint is still active in the current scan.
+ *   When false, a closed issue with no terminal/resolution label is classified as resolved-positive
+ *   (drift cleared without an explicit label). When true, it remains needs-outcome.
+ */
+export function classifyProposalOutcome(issue: ExistingProposalIssue, driftActive: boolean): ProposalOutcomeState {
+  // Rule 1: Open issue → proposed-pending
+  if (issue.state === 'open') {
+    return 'proposed-pending'
+  }
+
+  // Extract status-truth:* outcome labels (excluding the primary proposal label)
+  const outcomeLabels = issue.labels.filter(l => l !== PROPOSAL_LABEL && l.startsWith('status-truth:'))
+
+  // Rule 2: Conflicting accuracy signal labels (mutually exclusive)
+  const accuracySignals = outcomeLabels.filter(l => ACCURACY_SIGNAL_LABELS_SET.includes(l))
+  if (accuracySignals.length > 1) {
+    return 'conflicting-labels'
+  }
+
+  // Rule 3: Unrecognized status-truth:* label → malformed-outcome
+  const unrecognized = outcomeLabels.filter(l => !ALL_RECOGNIZED_OUTCOME_LABELS.includes(l))
+  if (unrecognized.length > 0) {
+    return 'malformed-outcome'
+  }
+
+  // Rules 4-8: Single recognized outcome label
+  if (outcomeLabels.includes(OUTCOME_LABELS.accepted)) return 'explicit-accepted'
+  if (outcomeLabels.includes(OUTCOME_LABELS.rejected)) return 'explicit-rejected'
+  if (outcomeLabels.includes(OUTCOME_LABELS.falsePositive)) return 'false-positive'
+  if (outcomeLabels.includes(OUTCOME_LABELS.resolved) || outcomeLabels.includes(OUTCOME_LABELS.manuallyFixed)) {
+    return 'resolved-positive'
+  }
+  if (outcomeLabels.includes(OUTCOME_LABELS.superseded)) return 'superseded'
+
+  // Rules 9-10: No recognized outcome label — use driftActive to distinguish
+  // If drift is no longer active (fingerprint not in current scan), the issue was
+  // closed without an explicit label but the drift has cleared → resolved-positive.
+  // If drift is still active, the issue needs operator attention → needs-outcome.
+  if (!driftActive) return 'resolved-positive'
+  return 'needs-outcome'
+}
+
+/**
+ * Aggregate outcome counts from a set of proposal issues.
+ *
+ * Pure function: no I/O, no side effects.
+ * Output is counts-only: no raw issue bodies, titles, paths, or fingerprints.
+ *
+ * Counts are separated from action counts (opened/updated/reopened/closed/suppressed).
+ * This is the read-model for operator outcome signal — used for accuracy math and
+ * operator attention, not for lifecycle mutation decisions.
+ */
+export interface OutcomeCounts {
+  /** Open proposals with no terminal/resolution label. */
+  readonly proposedPending: number
+  /** Closed proposals with explicit `accepted` label (human-confirmed positive). */
+  readonly explicitAccepted: number
+  /** Closed proposals with explicit `rejected` label (terminal suppression). */
+  readonly explicitRejected: number
+  /** Closed proposals with `false-positive` label (terminal suppression). */
+  readonly falsePositive: number
+  /**
+   * Closed proposals with `resolved` or `manually-fixed` label.
+   * Positive signal without impersonating explicit human acceptance.
+   */
+  readonly resolvedPositive: number
+  /** Closed proposals with `superseded` label. */
+  readonly superseded: number
+  /**
+   * Closed proposals with no recognized outcome label.
+   * Excluded from accuracy math; counted for operator attention.
+   */
+  readonly needsOutcome: number
+  /**
+   * Closed proposals with mutually exclusive outcome labels (e.g. accepted+rejected).
+   * Excluded from accuracy math; counted for operator attention.
+   */
+  readonly conflictingLabels: number
+  /**
+   * Closed proposals with unrecognized `status-truth:*` labels.
+   * Excluded from accuracy math; counted for operator attention.
+   */
+  readonly malformedOutcome: number
+}
+
+/**
+ * Build aggregate outcome counts from a list of existing proposal issues.
+ *
+ * Pure function: no I/O, no side effects. Deterministic from inputs.
+ * Output is counts-only — no raw issue bodies, titles, paths, or fingerprints.
+ *
+ * @param issues - Existing proposal issues (open and closed).
+ * @param driftActiveFingerprints - Set of fingerprints that are still active in the current scan.
+ *   Used to distinguish resolved-positive (drift cleared) from needs-outcome (drift still active)
+ *   for closed issues with no terminal/resolution label. Defaults to empty set (all drift cleared).
+ */
+export function buildOutcomeCounts(
+  issues: readonly ExistingProposalIssue[],
+  driftActiveFingerprints: ReadonlySet<string> = new Set<string>(),
+): OutcomeCounts {
+  let proposedPending = 0
+  let explicitAccepted = 0
+  let explicitRejected = 0
+  let falsePositive = 0
+  let resolvedPositive = 0
+  let superseded = 0
+  let needsOutcome = 0
+  let conflictingLabels = 0
+  let malformedOutcome = 0
+
+  for (const issue of issues) {
+    // Only classify issues that have the proposal label
+    if (!issue.labels.includes(PROPOSAL_LABEL)) continue
+
+    // Determine if this issue's fingerprint is still active in the current scan.
+    // Extract fingerprint from body to check against driftActiveFingerprints.
+    const fp = extractProposalFingerprint(issue.body)
+    const driftActive = fp !== null && driftActiveFingerprints.has(fp)
+
+    const state = classifyProposalOutcome(issue, driftActive)
+    switch (state) {
+      case 'proposed-pending':
+        proposedPending++
+        break
+      case 'explicit-accepted':
+        explicitAccepted++
+        break
+      case 'explicit-rejected':
+        explicitRejected++
+        break
+      case 'false-positive':
+        falsePositive++
+        break
+      case 'resolved-positive':
+        resolvedPositive++
+        break
+      case 'superseded':
+        superseded++
+        break
+      case 'needs-outcome':
+        needsOutcome++
+        break
+      case 'conflicting-labels':
+        conflictingLabels++
+        break
+      case 'malformed-outcome':
+        malformedOutcome++
+        break
+    }
+  }
+
+  return {
+    proposedPending,
+    explicitAccepted,
+    explicitRejected,
+    falsePositive,
+    resolvedPositive,
+    superseded,
+    needsOutcome,
+    conflictingLabels,
+    malformedOutcome,
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Input/output types
 // ---------------------------------------------------------------------------
 
@@ -290,6 +515,13 @@ export interface ProposalCounts {
    */
   readonly malformedOutcomeMarkers: number
   /**
+   * Closed issues with mutually exclusive outcome labels present together
+   * (e.g. accepted+rejected, accepted+false-positive, rejected+false-positive).
+   * Excluded from accuracy math; counted for operator attention.
+   * These are distinct from malformedOutcomeMarkers (which have unrecognized labels).
+   */
+  readonly conflictingLabels: number
+  /**
    * Per-kind accuracy signal from accepted/rejected/false-positive outcomes.
    * Computed from all existing issues with recognized outcome labels.
    * Excludes malformed/unknown labels.
@@ -328,6 +560,13 @@ export interface PlanStatusTruthProposalActionsResult {
    * Counts-only: no paths, fingerprints, or claim text.
    */
   readonly countsByKind: Readonly<Record<string, KindActionCounts>>
+  /**
+   * Aggregate outcome counts from all existing proposal issues.
+   * Read-model for operator outcome signal — separate from action counts (counts)
+   * and planned per-kind counts (countsByKind). Reflects the current state of all
+   * proposal issues, not the actions taken in this run.
+   */
+  readonly outcomeCounts: OutcomeCounts
 }
 
 // ---------------------------------------------------------------------------
@@ -480,9 +719,11 @@ export function planStatusTruthProposalActions(
         versionRejected: 1,
         closedWithoutOutcome: 0,
         malformedOutcomeMarkers: 0,
+        conflictingLabels: 0,
         usefulnessByKind: {},
       },
       countsByKind: {},
+      outcomeCounts: buildOutcomeCounts(existingIssues),
     }
   }
 
@@ -511,9 +752,11 @@ export function planStatusTruthProposalActions(
         versionRejected: 0,
         closedWithoutOutcome: 0,
         malformedOutcomeMarkers: 0,
+        conflictingLabels: 0,
         usefulnessByKind: {},
       },
       countsByKind: {},
+      outcomeCounts: buildOutcomeCounts(existingIssues),
     }
   }
 
@@ -525,6 +768,7 @@ export function planStatusTruthProposalActions(
   const usefulnessByKind: Record<string, {accepted: number; rejected: number; falsePositive: number}> = {}
   let closedWithoutOutcome = 0
   let malformedOutcomeMarkers = 0
+  let conflictingLabels = 0
 
   for (const issue of existingIssues) {
     const fp = extractProposalFingerprint(issue.body)
@@ -548,6 +792,12 @@ export function planStatusTruthProposalActions(
       const recognizedOutcomeLabels = outcomeLabels.filter(l => ALL_RECOGNIZED_OUTCOME_LABELS.includes(l))
       const unrecognizedOutcomeLabels = outcomeLabels.filter(l => !ALL_RECOGNIZED_OUTCOME_LABELS.includes(l))
 
+      // Check for conflicting accuracy signal labels (mutually exclusive).
+      // This is distinct from malformedOutcomeMarkers (which have unrecognized labels).
+      // Conflicting = multiple accuracy signal labels on the same issue (e.g. accepted+rejected).
+      const accuracySignalsPresent = recognizedOutcomeLabels.filter(l => ACCURACY_SIGNAL_LABELS.includes(l))
+      const hasConflictingAccuracySignals = accuracySignalsPresent.length > 1
+
       if (unrecognizedOutcomeLabels.length > 0) {
         // Mixed or malformed outcome markers: increment counter and skip accuracy math entirely.
         // Conservative: if ANY unrecognized status-truth:* label is present alongside a recognized
@@ -555,13 +805,19 @@ export function planStatusTruthProposalActions(
         // The recognized label is NOT included in usefulnessByKind to avoid polluting accuracy math
         // with ambiguous outcome state.
         malformedOutcomeMarkers++
+      } else if (hasConflictingAccuracySignals) {
+        // Conflicting accuracy signal labels (e.g. accepted+rejected, accepted+false-positive).
+        // Excluded from accuracy math; counted for operator attention.
+        // These are recognized labels but mutually exclusive — the issue state is ambiguous.
+        conflictingLabels++
       } else if (outcomeLabels.length === 0) {
         // Closed with no outcome label at all — count for operator attention
         closedWithoutOutcome++
       } else {
-        // Only accumulate accuracy signals when there are NO unrecognized outcome labels.
+        // Only accumulate accuracy signals when there are NO unrecognized outcome labels
+        // and NO conflicting accuracy signal labels.
         // This is intentionally conservative: we only count recognized accuracy signal labels
-        // on issues that have no malformed/unknown outcome markers.
+        // on issues that have no malformed/unknown outcome markers and no conflicts.
         for (const label of recognizedOutcomeLabels) {
           if (!ACCURACY_SIGNAL_LABELS.includes(label)) continue
 
@@ -907,14 +1163,16 @@ export function planStatusTruthProposalActions(
       versionRejected: 0,
       closedWithoutOutcome,
       malformedOutcomeMarkers,
+      conflictingLabels,
       usefulnessByKind,
     },
     countsByKind,
+    outcomeCounts: buildOutcomeCounts(existingIssues, activeFingerprintsInReport),
   }
 }
 
 // ---------------------------------------------------------------------------
-// Unit 4: I/O executor types
+// I/O executor types
 // ---------------------------------------------------------------------------
 
 /**
@@ -1165,7 +1423,7 @@ export interface ExecuteStatusTruthProposalActionsResult {
 }
 
 // ---------------------------------------------------------------------------
-// Unit 4: Label preflight helper
+// Label preflight helper
 // ---------------------------------------------------------------------------
 
 function isApiStatus(error: unknown, status: number): boolean {
@@ -1235,7 +1493,7 @@ async function ensureStatusTruthLabels(
 }
 
 // ---------------------------------------------------------------------------
-// Unit 4: I/O executor
+// I/O executor
 // ---------------------------------------------------------------------------
 
 /**
@@ -1423,7 +1681,7 @@ export async function executeStatusTruthProposalActions(
 }
 
 // ---------------------------------------------------------------------------
-// Unit 4: CLI shell for the open/proposals step
+// CLI shell for the open/proposals step
 // ---------------------------------------------------------------------------
 
 /** No-op log handler object — suppresses all Octokit default logger output. */
@@ -1474,6 +1732,13 @@ interface OpenResult {
    * not present in executor counts.
    */
   plannedCounts: Pick<ProposalCounts, 'versionRejected' | 'blocked' | 'overflowed' | 'sameRunDeduplicated'>
+  /**
+   * Aggregate outcome counts from all existing proposal issues (read-model).
+   * Separate from action counts (counts) and planned counts (plannedCounts).
+   * Reflects the current state of all proposal issues, not the actions taken this run.
+   * Counts-only: no raw issue bodies, titles, paths, or fingerprints.
+   */
+  outcomeCounts: OutcomeCounts
 }
 
 /**
@@ -1640,6 +1905,7 @@ async function runOpen(): Promise<void> {
       overflowed: planResult.counts.overflowed,
       sameRunDeduplicated: planResult.counts.sameRunDeduplicated,
     },
+    outcomeCounts: planResult.outcomeCounts,
   }
 
   const resultJson = `${JSON.stringify(result)}\n`

--- a/scripts/status-truth-proposals.ts
+++ b/scripts/status-truth-proposals.ts
@@ -221,16 +221,6 @@ export type ProposalOutcomeState =
   | 'malformed-outcome'
 
 /**
- * Mutually exclusive accuracy signal labels.
- * An issue with more than one of these is conflicting.
- */
-const ACCURACY_SIGNAL_LABELS_SET: readonly string[] = [
-  OUTCOME_LABELS.accepted,
-  OUTCOME_LABELS.rejected,
-  OUTCOME_LABELS.falsePositive,
-]
-
-/**
  * Classify a proposal issue into a canonical outcome state.
  *
  * Pure function: no I/O, no side effects. Deterministic from inputs.
@@ -262,7 +252,7 @@ export function classifyProposalOutcome(issue: ExistingProposalIssue, driftActiv
   const outcomeLabels = issue.labels.filter(l => l !== PROPOSAL_LABEL && l.startsWith('status-truth:'))
 
   // Rule 2: Conflicting accuracy signal labels (mutually exclusive)
-  const accuracySignals = outcomeLabels.filter(l => ACCURACY_SIGNAL_LABELS_SET.includes(l))
+  const accuracySignals = outcomeLabels.filter(l => ACCURACY_SIGNAL_LABELS.includes(l))
   if (accuracySignals.length > 1) {
     return 'conflicting-labels'
   }
@@ -423,6 +413,12 @@ export interface ExistingProposalIssue {
   readonly labels: readonly string[]
   readonly title: string
   readonly body: string | null | undefined
+  /**
+   * ISO 8601 timestamp when the issue was closed, if available from the API.
+   * Used to compute cooldown for closed-without-outcome issues.
+   * Absent or null when the API does not return this field.
+   */
+  readonly closedAt?: string | null
 }
 
 /** Open a new proposal issue. */
@@ -510,6 +506,13 @@ export interface ProposalCounts {
    */
   readonly closedWithoutOutcome: number
   /**
+   * Closed-without-outcome issues that are within the seven-day cooldown window,
+   * or that have no closedAt timestamp (conservative: treated as needs-attention).
+   * These are not reopened; counted for operator attention.
+   * Distinct from privacy-blocked (blocked) and overflow (overflowed).
+   */
+  readonly needsOutcomeCooldown: number
+  /**
    * Closed issues with a valid fingerprint but an unrecognized/malformed outcome label.
    * Counted for operator attention; excluded from usefulnessByKind accuracy math.
    */
@@ -549,6 +552,11 @@ export interface PlanStatusTruthProposalActionsInput {
    * Defaults to 5.
    */
   readonly mutationCap?: number
+  /**
+   * Current timestamp for cooldown calculations. Defaults to `new Date()`.
+   * Injectable for deterministic tests.
+   */
+  readonly now?: Date
 }
 
 /** Result of the pure lifecycle planner. */
@@ -612,6 +620,27 @@ function buildFingerprintMarker(fingerprint: string): string {
  */
 function buildLiveStateMarker(liveState: string): string {
   return `<!-- ${LIVE_STATE_MARKER_PREFIX}${liveState} -->`
+}
+
+// ---------------------------------------------------------------------------
+// Cooldown helper
+// ---------------------------------------------------------------------------
+
+/** Seven-day cooldown duration in milliseconds. */
+const COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000
+
+/**
+ * Returns true when the given ISO 8601 closedAt timestamp is within the
+ * seven-day cooldown window relative to `now`.
+ *
+ * Pure function: no I/O, no side effects. Accepts `now` for deterministic tests.
+ *
+ * Boundary: exactly seven days ago is NOT within cooldown (returns false).
+ */
+export function isWithinCooldown(closedAt: string, now: Date): boolean {
+  const closedMs = new Date(closedAt).getTime()
+  const elapsedMs = now.getTime() - closedMs
+  return elapsedMs < COOLDOWN_MS
 }
 
 // ---------------------------------------------------------------------------
@@ -700,6 +729,7 @@ export function planStatusTruthProposalActions(
   input: PlanStatusTruthProposalActionsInput,
 ): PlanStatusTruthProposalActionsResult {
   const {report, existingIssues, publicOutputTokens, sameRunCreatedFingerprints} = input
+  const now = input.now ?? new Date()
 
   // 1. Reject unknown report versions
   if (report.schema_version !== KNOWN_SCHEMA_VERSION || report.fingerprint_version !== KNOWN_FINGERPRINT_VERSION) {
@@ -718,6 +748,7 @@ export function planStatusTruthProposalActions(
         malformedMarkers: 0,
         versionRejected: 1,
         closedWithoutOutcome: 0,
+        needsOutcomeCooldown: 0,
         malformedOutcomeMarkers: 0,
         conflictingLabels: 0,
         usefulnessByKind: {},
@@ -751,6 +782,7 @@ export function planStatusTruthProposalActions(
         malformedMarkers: 0,
         versionRejected: 0,
         closedWithoutOutcome: 0,
+        needsOutcomeCooldown: 0,
         malformedOutcomeMarkers: 0,
         conflictingLabels: 0,
         usefulnessByKind: {},
@@ -866,10 +898,10 @@ export function planStatusTruthProposalActions(
   // Track which fingerprints are active in this report (for close-on-clear)
   const activeFingerprintsInReport = new Set<string>()
 
-  // Track fingerprints planned for open in this planner call (same-run dedup within one report).
-  // Prevents duplicate open actions when the same fingerprint appears in multiple findings
+  // Track fingerprints handled in this planner call (same-run dedup within one report).
+  // Prevents duplicate lifecycle actions when the same fingerprint appears in multiple findings
   // (e.g. same claim text in two files) within a single report.
-  const plannedOpenFingerprints = new Set<string>(sameRunCreatedFingerprints)
+  const plannedActionFingerprints = new Set<string>(sameRunCreatedFingerprints)
 
   // ---------------------------------------------------------------------------
   // Two-pass cap approach:
@@ -895,6 +927,7 @@ export function planStatusTruthProposalActions(
   let blocked = 0
   let noAction = 0
   let sameRunDeduplicated = 0
+  let needsOutcomeCooldown = 0
 
   // 3. Process proposal-eligible findings — collect candidates into priority buckets
   for (const finding of report.findings) {
@@ -908,8 +941,8 @@ export function planStatusTruthProposalActions(
     activeFingerprintsInReport.add(fingerprint)
 
     // a. Same-run dedup: skip if already created this run or already planned in this call.
-    // plannedOpenFingerprints starts with sameRunCreatedFingerprints and grows as we plan opens.
-    if (plannedOpenFingerprints.has(fingerprint)) {
+    // plannedActionFingerprints starts with sameRunCreatedFingerprints and grows as actions are planned.
+    if (plannedActionFingerprints.has(fingerprint)) {
       sameRunDeduplicated++
       continue
     }
@@ -917,6 +950,8 @@ export function planStatusTruthProposalActions(
     // b. Check for terminal suppression
     const closedIssue = closedByFingerprint.get(fingerprint)
     if (closedIssue !== undefined && hasTerminalLabel(closedIssue.labels)) {
+      // Mark fingerprint as handled so any duplicate finding in this report is skipped.
+      plannedActionFingerprints.add(fingerprint)
       suppressActions.push({
         type: 'suppress',
         fingerprint,
@@ -930,6 +965,9 @@ export function planStatusTruthProposalActions(
     // c. Check for matching open issue
     const openIssue = openByFingerprint.get(fingerprint)
     if (openIssue !== undefined) {
+      // Mark fingerprint as handled so any duplicate finding in this report is skipped.
+      plannedActionFingerprints.add(fingerprint)
+
       // Compare recorded live-state to current live-state
       const recordedLiveState = extractRecordedLiveState(openIssue.body)
       const currentLiveState = finding.liveState
@@ -960,8 +998,34 @@ export function planStatusTruthProposalActions(
       continue
     }
 
-    // d. Check for matching non-terminal closed issue → candidate reopen
+    // d. Check for matching non-terminal closed issue → candidate reopen (with cooldown check)
     if (closedIssue !== undefined && !hasTerminalLabel(closedIssue.labels)) {
+      // Mark fingerprint as handled so any duplicate finding in this report is skipped.
+      plannedActionFingerprints.add(fingerprint)
+
+      // Determine if this is a closed-without-outcome (needs-outcome) issue.
+      // A closed issue with no recognized outcome label is in needs-outcome state.
+      const outcomeLabels = closedIssue.labels.filter(l => l !== PROPOSAL_LABEL && l.startsWith('status-truth:'))
+      const hasRecognizedOutcomeLabel = outcomeLabels.some(l => ALL_RECOGNIZED_OUTCOME_LABELS.includes(l))
+      const isClosedWithoutOutcome = !hasRecognizedOutcomeLabel
+
+      if (isClosedWithoutOutcome) {
+        // Apply cooldown: if closedAt is missing or within 7 days, block reopen.
+        // Conservative: missing closedAt → treat as needs-attention, no mutation.
+        const closedAt = closedIssue.closedAt
+        if (closedAt === null || closedAt === undefined) {
+          // Cannot determine cooldown — conservative: count for attention, no mutation
+          needsOutcomeCooldown++
+          continue
+        }
+        if (isWithinCooldown(closedAt, now)) {
+          // Within cooldown — do not reopen, count for operator attention
+          needsOutcomeCooldown++
+          continue
+        }
+        // Past cooldown — fall through to reopen with recurrence comment
+      }
+
       const comment = buildRecurrenceComment(report.generated_at)
       const gateResult = applyPublicOutputGate({
         surface: 'recurrence-comment',
@@ -990,7 +1054,7 @@ export function planStatusTruthProposalActions(
     // subsequent same-fingerprint findings in this report are still deduplicated.
     // Without this, a second finding with the same fingerprint but a safe correction
     // would slip through after the first was blocked, opening an unintended proposal.
-    plannedOpenFingerprints.add(fingerprint)
+    plannedActionFingerprints.add(fingerprint)
 
     const title = buildProposalTitle(finding)
     const body = buildProposalBody(finding, report.generated_at)
@@ -1162,6 +1226,7 @@ export function planStatusTruthProposalActions(
       malformedMarkers,
       versionRejected: 0,
       closedWithoutOutcome,
+      needsOutcomeCooldown,
       malformedOutcomeMarkers,
       conflictingLabels,
       usefulnessByKind,
@@ -1185,6 +1250,8 @@ export interface IssueListItem {
   readonly title: string
   readonly body: string | null | undefined
   readonly labels: readonly (string | {readonly name?: string | null | undefined})[]
+  /** ISO 8601 timestamp when the issue was closed, if available from the API. */
+  readonly closed_at?: string | null
 }
 
 /**
@@ -1321,6 +1388,7 @@ export async function fetchExistingProposalIssues(params: {
         labels: labelNames,
         title: issue.title,
         body: issue.body,
+        closedAt: issue.closed_at ?? null,
       })
     }
   }

--- a/scripts/status-truth-proposals.ts
+++ b/scripts/status-truth-proposals.ts
@@ -1,11 +1,11 @@
 /**
  * Proposal lifecycle planner and I/O executor for the status-truth maintenance loop.
  *
- * Unit 3 — Pure lifecycle planner:
+ * Planner:
  * Converts drifted, privacy-safe status claims into deterministic GitHub issue
  * lifecycle actions without touching GitHub.
  *
- * Unit 4 — I/O executor:
+ * Executor:
  * Executes planned proposal actions against GitHub via an injected Octokit-like
  * client. Supports dry-run mode (counts only, no mutations), label gating
  * (fail-closed if required labels cannot be confirmed), and same-run dedup.
@@ -269,6 +269,12 @@ export interface ProposalCounts {
   readonly closed: number
   readonly suppressed: number
   readonly blocked: number
+  /**
+   * Mutating actions that were planned but blocked by the per-run mutation cap.
+   * These are distinct from privacy-blocked actions (counted in `blocked`).
+   * Overflow is a blocked outcome, not failed work — it must not hide scan completeness.
+   */
+  readonly overflowed: number
   readonly noAction: number
   readonly sameRunDeduplicated: number
   readonly malformedMarkers: number
@@ -304,6 +310,13 @@ export interface PlanStatusTruthProposalActionsInput {
    * Prevents duplicate proposals when GitHub issue listing lags same-run writes.
    */
   readonly sameRunCreatedFingerprints: ReadonlySet<string>
+  /**
+   * Maximum number of mutating proposal actions (open, update-comment, reopen, close)
+   * allowed per run. Evaluated after privacy blocking and same-run dedupe.
+   * Actions beyond the cap are counted as overflowed (planned-but-blocked).
+   * Defaults to 5.
+   */
+  readonly mutationCap?: number
 }
 
 /** Result of the pure lifecycle planner. */
@@ -460,6 +473,7 @@ export function planStatusTruthProposalActions(
         closed: 0,
         suppressed: 0,
         blocked: 0,
+        overflowed: 0,
         noAction: 0,
         sameRunDeduplicated: 0,
         malformedMarkers: 0,
@@ -490,6 +504,7 @@ export function planStatusTruthProposalActions(
         closed: 0,
         suppressed: 0,
         blocked: blockedCount,
+        overflowed: 0,
         noAction: 0,
         sameRunDeduplicated: 0,
         malformedMarkers: 0,
@@ -572,14 +587,9 @@ export function planStatusTruthProposalActions(
     }
   }
 
-  const actions: ProposalAction[] = []
-  let opened = 0
-  let updated = 0
-  let reopened = 0
-  let suppressed = 0
-  let blocked = 0
-  let noAction = 0
-  let sameRunDeduplicated = 0
+  // Per-run mutation cap (default 5). Evaluated after privacy blocking and same-run dedupe.
+  // Suppress actions are not mutating and do not count against the cap.
+  const mutationCap = input.mutationCap ?? 5
 
   // Per-kind action counts for workflow/open result summary (counts-only, no paths or fingerprints).
   const countsByKind: Record<
@@ -605,7 +615,32 @@ export function planStatusTruthProposalActions(
   // (e.g. same claim text in two files) within a single report.
   const plannedOpenFingerprints = new Set<string>(sameRunCreatedFingerprints)
 
-  // 3. Process proposal-eligible findings
+  // ---------------------------------------------------------------------------
+  // Two-pass cap approach:
+  // Pass 1: Collect all candidate mutating actions (privacy-gated, deduplicated)
+  //         into priority buckets. Privacy-blocked and deduplicated actions do NOT
+  //         consume cap budget.
+  // Pass 2: Apply cap across buckets in deterministic priority order:
+  //         close > update > reopen > open
+  //         Actions beyond the cap become overflow (planned-but-blocked counts).
+  // ---------------------------------------------------------------------------
+
+  // Priority buckets for cap enforcement
+  const candidateCloses: CloseAction[] = []
+  const candidateUpdates: UpdateCommentAction[] = []
+  const candidateReopens: ReopenAction[] = []
+  const candidateOpens: OpenAction[] = []
+  const suppressActions: SuppressAction[] = []
+
+  // Track per-kind for suppressed (not cap-limited)
+  const suppressedKinds: string[] = []
+
+  let suppressed = 0
+  let blocked = 0
+  let noAction = 0
+  let sameRunDeduplicated = 0
+
+  // 3. Process proposal-eligible findings — collect candidates into priority buckets
   for (const finding of report.findings) {
     // Skip unsafe findings — they have no identity-bearing fields and are never proposal-eligible
     if (!isPublicFinding(finding)) continue
@@ -626,13 +661,13 @@ export function planStatusTruthProposalActions(
     // b. Check for terminal suppression
     const closedIssue = closedByFingerprint.get(fingerprint)
     if (closedIssue !== undefined && hasTerminalLabel(closedIssue.labels)) {
-      actions.push({
+      suppressActions.push({
         type: 'suppress',
         fingerprint,
         reason: 'terminal outcome label on closed proposal',
       })
       suppressed++
-      incrementKindCount(kind, 'suppressed')
+      suppressedKinds.push(kind)
       continue
     }
 
@@ -644,7 +679,7 @@ export function planStatusTruthProposalActions(
       const currentLiveState = finding.liveState
 
       if (recordedLiveState !== null && currentLiveState !== undefined && recordedLiveState !== currentLiveState) {
-        // Live-state details changed — plan one update comment
+        // Live-state details changed — candidate update comment (privacy-gated)
         const comment = buildUpdateComment(finding, report.generated_at)
         const gateResult = applyPublicOutputGate({
           surface: 'proposal-comment',
@@ -653,16 +688,15 @@ export function planStatusTruthProposalActions(
           fingerprint,
         })
         if (!gateResult.allowed) {
+          // Privacy-blocked: does NOT consume cap budget
           blocked++
           continue
         }
-        actions.push({
+        candidateUpdates.push({
           type: 'update-comment',
           issueNumber: openIssue.number,
           comment: gateResult.sanitizedContent,
         })
-        updated++
-        incrementKindCount(kind, 'updated')
       } else {
         // Drift unchanged — no action to avoid comment spam
         noAction++
@@ -670,7 +704,7 @@ export function planStatusTruthProposalActions(
       continue
     }
 
-    // d. Check for matching non-terminal closed issue → reopen
+    // d. Check for matching non-terminal closed issue → candidate reopen
     if (closedIssue !== undefined && !hasTerminalLabel(closedIssue.labels)) {
       const comment = buildRecurrenceComment(report.generated_at)
       const gateResult = applyPublicOutputGate({
@@ -680,23 +714,22 @@ export function planStatusTruthProposalActions(
         fingerprint,
       })
       if (!gateResult.allowed) {
+        // Privacy-blocked: does NOT consume cap budget
         blocked++
         continue
       }
       const removeLabels = closedIssue.labels.filter(l => RESOLVING_LABELS.includes(l))
-      actions.push({
+      candidateReopens.push({
         type: 'reopen',
         issueNumber: closedIssue.number,
         comment: gateResult.sanitizedContent,
         removeLabels,
         addLabels: [OUTCOME_LABELS.recurring],
       })
-      reopened++
-      incrementKindCount(kind, 'reopened')
       continue
     }
 
-    // e. New finding — open a proposal after privacy gating
+    // e. New finding — candidate open after privacy gating
     // Mark this fingerprint as seen before gating so that if the gate blocks,
     // subsequent same-fingerprint findings in this report are still deduplicated.
     // Without this, a second finding with the same fingerprint but a safe correction
@@ -713,6 +746,7 @@ export function planStatusTruthProposalActions(
       fingerprint,
     })
     if (!titleGate.allowed) {
+      // Privacy-blocked: does NOT consume cap budget
       blocked++
       continue
     }
@@ -724,26 +758,24 @@ export function planStatusTruthProposalActions(
       fingerprint,
     })
     if (!bodyGate.allowed) {
+      // Privacy-blocked: does NOT consume cap budget
       blocked++
       continue
     }
 
-    actions.push({
+    candidateOpens.push({
       type: 'open',
       fingerprint,
       title: titleGate.sanitizedContent,
       body: bodyGate.sanitizedContent,
       labels: [PROPOSAL_LABEL],
     })
-    opened++
-    incrementKindCount(kind, 'opened')
   }
 
-  // 4. Close-on-clear: only when scan is complete and not execution-failure.
+  // 4. Close-on-clear candidates: only when scan is complete and not execution-failure.
   // At this point we have already returned early for execution-failure and scan_complete=false,
   // so report.scan_complete is always true here. The check is kept for clarity.
   const canClose = report.scan_complete
-  let closed = 0
 
   if (canClose) {
     for (const [fp, openIssue] of openByFingerprint) {
@@ -756,22 +788,107 @@ export function planStatusTruthProposalActions(
           fingerprint: fp,
         })
         if (!gateResult.allowed) {
+          // Privacy-blocked: does NOT consume cap budget
           blocked++
           continue
         }
-        actions.push({
+        candidateCloses.push({
           type: 'close',
           issueNumber: openIssue.number,
           labels: [OUTCOME_LABELS.resolved],
           comment: gateResult.sanitizedContent,
         })
-        closed++
-        // Infer kind from open issue title for countsByKind
-        const titleMatch = /^Status truth: ([\w-]+) drift/u.exec(openIssue.title)
-        const kind = titleMatch?.[1] ?? 'unknown'
-        incrementKindCount(kind, 'closed')
       }
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pass 2: Apply mutation cap in priority order: close > update > reopen > open
+  // Actions beyond the cap are counted as overflowed (planned-but-blocked).
+  // Suppress actions are not mutating and are always included.
+  // ---------------------------------------------------------------------------
+
+  const actions: ProposalAction[] = [...suppressActions]
+  let opened = 0
+  let updated = 0
+  let reopened = 0
+  let closed = 0
+  let overflowed = 0
+  let remainingCap = mutationCap
+
+  // Priority 1: close actions
+  for (const action of candidateCloses) {
+    if (remainingCap > 0) {
+      actions.push(action)
+      closed++
+      remainingCap--
+      // Infer kind from open issue title for countsByKind
+      const titleMatch = /^Status truth: ([\w-]+) drift/u.exec(
+        openByFingerprint.get(
+          // Extract fingerprint from close action — find the open issue by number
+          [...openByFingerprint.entries()].find(([, issue]) => issue.number === action.issueNumber)?.[0] ?? '',
+        )?.title ?? '',
+      )
+      const kind = titleMatch?.[1] ?? 'unknown'
+      incrementKindCount(kind, 'closed')
+    } else {
+      overflowed++
+    }
+  }
+
+  // Priority 2: update-comment actions
+  // We need to track which finding corresponds to each update to get the kind.
+  // Since candidateUpdates are collected in finding order, we need to look up kind
+  // from the openByFingerprint map via issueNumber.
+  for (const action of candidateUpdates) {
+    if (remainingCap > 0) {
+      actions.push(action)
+      updated++
+      remainingCap--
+      // Infer kind from open issue title
+      const openIssue = [...openByFingerprint.values()].find(i => i.number === action.issueNumber)
+      const titleMatch = /^Status truth: ([\w-]+) drift/u.exec(openIssue?.title ?? '')
+      const kind = titleMatch?.[1] ?? 'unknown'
+      incrementKindCount(kind, 'updated')
+    } else {
+      overflowed++
+    }
+  }
+
+  // Priority 3: reopen actions
+  for (const action of candidateReopens) {
+    if (remainingCap > 0) {
+      actions.push(action)
+      reopened++
+      remainingCap--
+      // Infer kind from closed issue title
+      const closedIssue = [...closedByFingerprint.values()].find(i => i.number === action.issueNumber)
+      const titleMatch = /^Status truth: ([\w-]+) drift/u.exec(closedIssue?.title ?? '')
+      const kind = titleMatch?.[1] ?? 'unknown'
+      incrementKindCount(kind, 'reopened')
+    } else {
+      overflowed++
+    }
+  }
+
+  // Priority 4: open actions (lowest priority)
+  for (const action of candidateOpens) {
+    if (remainingCap > 0) {
+      actions.push(action)
+      opened++
+      remainingCap--
+      // Infer kind from the action's title
+      const titleMatch = /^Status truth: ([\w-]+) drift/u.exec(action.title)
+      const kind = titleMatch?.[1] ?? 'unknown'
+      incrementKindCount(kind, 'opened')
+    } else {
+      overflowed++
+    }
+  }
+
+  // Add suppressed kind counts (not cap-limited)
+  for (const kind of suppressedKinds) {
+    incrementKindCount(kind, 'suppressed')
   }
 
   return {
@@ -783,6 +900,7 @@ export function planStatusTruthProposalActions(
       closed,
       suppressed,
       blocked,
+      overflowed,
       noAction,
       sameRunDeduplicated,
       malformedMarkers,
@@ -1352,9 +1470,10 @@ interface OpenResult {
   plannedCountsByKind: Readonly<Record<string, KindActionCounts>>
   /**
    * Aggregate planned counts from the planner (counts-only).
-   * Includes versionRejected and other planner-level counters not present in executor counts.
+   * Includes versionRejected, blocked, overflowed, and other planner-level counters
+   * not present in executor counts.
    */
-  plannedCounts: Pick<ProposalCounts, 'versionRejected' | 'blocked' | 'sameRunDeduplicated'>
+  plannedCounts: Pick<ProposalCounts, 'versionRejected' | 'blocked' | 'overflowed' | 'sameRunDeduplicated'>
 }
 
 /**
@@ -1518,6 +1637,7 @@ async function runOpen(): Promise<void> {
     plannedCounts: {
       versionRejected: planResult.counts.versionRejected,
       blocked: planResult.counts.blocked,
+      overflowed: planResult.counts.overflowed,
       sameRunDeduplicated: planResult.counts.sameRunDeduplicated,
     },
   }

--- a/scripts/status-truth-proposals.ts
+++ b/scripts/status-truth-proposals.ts
@@ -1816,7 +1816,10 @@ interface OpenResult {
    * Includes versionRejected, blocked, overflowed, and other planner-level counters
    * not present in executor counts.
    */
-  plannedCounts: Pick<ProposalCounts, 'versionRejected' | 'blocked' | 'overflowed' | 'sameRunDeduplicated'>
+  plannedCounts: Pick<
+    ProposalCounts,
+    'versionRejected' | 'blocked' | 'overflowed' | 'sameRunDeduplicated' | 'needsOutcomeCooldown'
+  >
   /**
    * Aggregate outcome counts from all existing proposal issues (read-model).
    * Separate from action counts (counts) and planned counts (plannedCounts).
@@ -1989,6 +1992,7 @@ async function runOpen(): Promise<void> {
       blocked: planResult.counts.blocked,
       overflowed: planResult.counts.overflowed,
       sameRunDeduplicated: planResult.counts.sameRunDeduplicated,
+      needsOutcomeCooldown: planResult.counts.needsOutcomeCooldown,
     },
     outcomeCounts: planResult.outcomeCounts,
   }

--- a/scripts/status-truth-proposals.ts
+++ b/scripts/status-truth-proposals.ts
@@ -1092,10 +1092,11 @@ export function planStatusTruthProposalActions(
     })
   }
 
-  // 4. Close-on-clear candidates: only when scan is complete and not execution-failure.
-  // At this point we have already returned early for execution-failure and scan_complete=false,
-  // so report.scan_complete is always true here. The check is kept for clarity.
-  const canClose = report.scan_complete
+  // 4. Close-on-clear candidates: only when scan is complete, not execution-failure,
+  // and no unsafe findings are present. Unsafe findings indicate that some claims
+  // could not be proven public — prior drift may simply be inaccessible/private now,
+  // not genuinely cleared. Closing proposals under that uncertainty would be incorrect.
+  const canClose = report.scan_complete && report.counts.unsafe === 0
 
   if (canClose) {
     for (const [fp, openIssue] of openByFingerprint) {
@@ -1315,10 +1316,30 @@ export interface StatusTruthOctokitClient {
 }
 
 /**
+ * Fetch all pages of issues from a single `listForRepo` call until an empty page is returned.
+ *
+ * Any API error is propagated to the caller (fail-closed).
+ */
+async function paginateAll(
+  listFn: (page: number) => Promise<{data: IssueListItem[]}>,
+  perPage = 100,
+): Promise<IssueListItem[]> {
+  const all: IssueListItem[] = []
+  let page = 1
+  for (;;) {
+    const response = await listFn(page)
+    all.push(...response.data)
+    if (response.data.length < perPage) break
+    page++
+  }
+  return all
+}
+
+/**
  * Fetch existing status-truth proposal issues from GitHub.
  *
- * Fetches open issues and recent closed issues (last 2 pages) labeled with
- * PROPOSAL_LABEL. Filters to only issues that have the proposal label.
+ * Fetches all open and all closed issues labeled with PROPOSAL_LABEL using
+ * exhaustive pagination. Filters to only issues that have the proposal label.
  * Returns them as ExistingProposalIssue[] for the lifecycle planner.
  *
  * Fail-closed in live mode: any API error is re-thrown so the caller can
@@ -1335,17 +1356,22 @@ export async function fetchExistingProposalIssues(params: {
   const {octokit, owner, repo} = params
   const issues: ExistingProposalIssue[] = []
 
-  // Fetch open issues with the proposal label.
+  // Fetch all open issues with the proposal label.
   // Any error is propagated to the caller (fail-closed in live mode).
-  const openResponse = await octokit.rest.issues.listForRepo({
-    owner,
-    repo,
-    labels: PROPOSAL_LABEL,
-    state: 'open',
-    per_page: 100,
-    page: 1,
-  })
-  for (const issue of openResponse.data) {
+  const perPage = 100
+  const openItems = await paginateAll(
+    async page =>
+      octokit.rest.issues.listForRepo({
+        owner,
+        repo,
+        labels: PROPOSAL_LABEL,
+        state: 'open',
+        per_page: perPage,
+        page,
+      }),
+    perPage,
+  )
+  for (const issue of openItems) {
     const labelNames = issue.labels.map(l => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean)
     if (!labelNames.includes(PROPOSAL_LABEL)) continue
     issues.push({
@@ -1357,40 +1383,31 @@ export async function fetchExistingProposalIssues(params: {
     })
   }
 
-  // Fetch recent closed issues with the proposal label (2 pages).
-  // Any error on the first page is propagated; subsequent pages are best-effort.
-  for (const page of [1, 2]) {
-    let closedResponse: {data: IssueListItem[]}
-    try {
-      closedResponse = await octokit.rest.issues.listForRepo({
+  // Fetch all closed issues with the proposal label.
+  // Any error is propagated to the caller (fail-closed in live mode).
+  const closedItems = await paginateAll(
+    async page =>
+      octokit.rest.issues.listForRepo({
         owner,
         repo,
         labels: PROPOSAL_LABEL,
         state: 'closed',
-        per_page: 50,
+        per_page: perPage,
         page,
-      })
-    } catch (error: unknown) {
-      if (page === 1) {
-        // First closed page failure is fatal — propagate to caller
-        throw error
-      }
-      // Subsequent pages: best-effort; stop pagination
-      break
-    }
-    if (closedResponse.data.length === 0) break
-    for (const issue of closedResponse.data) {
-      const labelNames = issue.labels.map(l => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean)
-      if (!labelNames.includes(PROPOSAL_LABEL)) continue
-      issues.push({
-        number: issue.number,
-        state: 'closed',
-        labels: labelNames,
-        title: issue.title,
-        body: issue.body,
-        closedAt: issue.closed_at ?? null,
-      })
-    }
+      }),
+    perPage,
+  )
+  for (const issue of closedItems) {
+    const labelNames = issue.labels.map(l => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean)
+    if (!labelNames.includes(PROPOSAL_LABEL)) continue
+    issues.push({
+      number: issue.number,
+      state: 'closed',
+      labels: labelNames,
+      title: issue.title,
+      body: issue.body,
+      closedAt: issue.closed_at ?? null,
+    })
   }
 
   return issues


### PR DESCRIPTION
## Summary

Completes the next status-truth signal slice for the A2 self-maintenance loop.

- Resolves file-backed `plan-status` claims and rollout-tracker snapshot claims
- Adds proposal caps, overflow reporting, outcome counts, and seven-day cooldown handling for manually closed proposals
- Hardens workflow permissions, snapshot handling, public-output safety, and proposal pagination
- Updates docs to reflect the active status-truth signal foundation and current workflow inventory

## Verification

- `pnpm bootstrap && pnpm check-types && pnpm lint && pnpm test`
- `actionlint .github/workflows/status-truth.yaml`

## Notes

Bounded correction PR execution remains disabled. Graduation still requires observed proposal outcomes by claim kind.
