### PR TITLE
fix: exempt rollout-tracker claims from cross-repo suppression

### DIFF
--- a/scripts/status-truth-detect.test.ts
+++ b/scripts/status-truth-detect.test.ts
@@ -1083,6 +1083,16 @@ describe('extractStatusTruthClaimsFromText', () => {
       }
     }
   })
+
+  it('rollout-tracker-status is exempt from cross-repo bare-#N suppression: "rollout tracker #3512 is open" is extracted despite fro-bot/.github#3512 elsewhere in text', () => {
+    const claims = extractStatusTruthClaimsFromText({
+      path: 'docs/plans/example.md',
+      text: 'See fro-bot/.github#3512 for context. rollout tracker #3512 is open.',
+    })
+    const trackerClaims = claims.filter(c => c.kind === 'rollout-tracker-status' && c.sourceRef === '#3512')
+    expect(trackerClaims).toHaveLength(1)
+    expect(trackerClaims[0]?.claimedState).toBe('open')
+  })
 })
 
 describe('scanStatusTruthClaims', () => {

--- a/scripts/status-truth-detect.ts
+++ b/scripts/status-truth-detect.ts
@@ -552,8 +552,10 @@ function extractCrossRepoNumbers(text: string): Set<string> {
  * - normalizedText: the normalized match text
  *
  * Cross-repo references: if a number appears in an owner/repo#N context
- * anywhere in the text, bare #N claims for that number are skipped to
- * prevent misresolution as current-repo references.
+ * anywhere in the text, bare #N claims for pr-state/issue-state are skipped
+ * to prevent misresolution as current-repo references. rollout-tracker-status
+ * is exempt: its grammar ("rollout tracker #N is <state>") is unambiguous and
+ * resolves via the rollout board snapshot, which is cross-repo-aware.
  */
 export function extractStatusTruthClaimsFromText(params: {path: string; text: string}): StatusTruthClaim[] {
   const {path, text} = params
@@ -585,7 +587,9 @@ export function extractStatusTruthClaimsFromText(params: {path: string; text: st
         // Skip if this number appears in a cross-repo reference in the same text.
         // This prevents "fro-bot/agent#1033 PR #1033 is open" from producing
         // a bare #1033 that the resolver would treat as a current-repo reference.
-        if (crossRepoNumbers.has(number)) continue
+        // rollout-tracker-status is exempt: its grammar is unambiguous and its
+        // resolver is cross-repo-aware via the rollout board snapshot.
+        if (def.kind !== 'rollout-tracker-status' && crossRepoNumbers.has(number)) continue
         sourceRef = `#${number}`
         claimedState = state.toLowerCase()
       } else if (def.kind === 'release-tag-state') {


### PR DESCRIPTION
## Problem

Document-scoped cross-repo-number suppression in `extractStatusTruthClaimsFromText` silently drops legitimate `rollout tracker #N is <state>` claims whenever the same document also references the issue in `owner/repo#N` form. The rollout tracker issue's own text contains `fro-bot/.github#3512`, so any canonical rollout-tracker claim about it can never be extracted.

## Fix

Exempt `rollout-tracker-status` from bare-`#N` suppression. Its grammar (`rollout tracker #N is <state>`) cannot be confused with cross-repo shorthand, and it resolves through the rollout board snapshot, which keys items by `content_number` and is cross-repo-aware. `pr-state` and `issue-state` suppression is unchanged and regression-guarded.

## Verification

- New test: rollout-tracker claim extracted despite an `owner/repo#N` reference to the same number in the document (failed before the fix, passes after).
- Existing cross-repo suppression tests for `pr-state`/`issue-state` still pass.
- `pnpm check-types`, `pnpm lint`, `pnpm test` (37 files, 1896 tests) all green.