### PR TITLE
docs: seed machine-verifiable status claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ The `node_id` for each tracked repo is stored in `metadata/repos.yaml` on the `d
 
 ### Status-Truth Proposals
 
+Machine-verifiable claims live in [docs/status.md](docs/status.md).
+
 The **Status Truth** workflow detects drift between documented status claims and live GitHub state, then opens fingerprinted proposal issues for review. Each proposal contains structured evidence fields (kind, claimed state, live state, proposed correction) and a hidden fingerprint marker for lifecycle tracking.
 
 **Reviewing a proposal:**

--- a/docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md
+++ b/docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md
@@ -1,9 +1,10 @@
 ---
 title: 'feat: Add status-truth maintenance loop'
 type: feat
-status: active
+status: complete
 date: 2026-06-26
 deepened: 2026-06-27
+completed: 2026-07-02
 origin: docs/brainstorms/2026-06-26-a2-self-maintenance-portfolio-requirements.md
 ---
 
@@ -31,6 +32,8 @@ Bounded correction PRs remain disabled until proposal outcomes establish per-kin
 The next dependency for downstream A2 features is collecting accepted, rejected, false-positive,
 resolved, and needs-outcome proposal signal against representative tracker/coordination claims before
 graduating any claim kind to correction PRs.
+
+The follow-up signal slice landed; docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md is complete.
 
 ## Problem Frame
 

--- a/docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md
+++ b/docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md
@@ -1,8 +1,9 @@
 ---
 title: 'feat: Complete status-truth signal generation'
 type: feat
-status: active
+status: complete
 date: 2026-06-30
+completed: 2026-07-02
 origin: docs/brainstorms/2026-06-26-a2-self-maintenance-portfolio-requirements.md
 ---
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,0 +1,13 @@
+# Control-Plane Status
+
+This page carries machine-verifiable status claims. The [Status Truth workflow](../.github/workflows/status-truth.yaml) scans this file and opens proposal issues when a claim drifts from live GitHub state.
+
+## Coordination
+
+The Gateway operator rollout tracker #3512 is open.
+
+## Plans
+
+docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md is complete.
+
+docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md is complete.


### PR DESCRIPTION
## What

The Status Truth loop is operational but signal-starved: no scanned prose uses the canonical claim grammar, so resolvers never produce drift or proposal outcomes, and graduation math has nothing to measure.

- Add `docs/status.md`, a control-plane status page carrying canonical machine-verifiable claims: the rollout tracker state and both status-truth plan statuses.
- Close out both status-truth plans (`status: complete`, `completed: 2026-07-02`) — all implementation units merged via #3601.
- Add a cross-plan claim sentence to the maintenance-loop plan's implementation status.
- Point the README Status-Truth Proposals section at the status page.

## Why

Seeded claims are true today and verified against the extraction grammar (1 rollout-tracker-status + 2 plan-status claims extract from `docs/status.md`). When any of them drifts — tracker closes, a plan status changes — the next Status Truth run produces a real proposal, exercising the full proposal/outcome loop that bounded PR graduation depends on.

## Verification

- Claim extraction verified against `extractStatusTruthClaimsFromText` for both edited surfaces.
- No self-referential plan claims.
- `pnpm check-types`, `pnpm lint`, `pnpm test` all green.