### PR TITLE
docs: reconcile shipped capture plans and seed their status claims

### DIFF
--- a/docs/plans/2026-06-22-003-feat-enrich-capture-digest-plan.md
+++ b/docs/plans/2026-06-22-003-feat-enrich-capture-digest-plan.md
@@ -1,8 +1,9 @@
 ---
 title: 'feat: enrich the learning-capture digest with review-thread content'
 type: feat
-status: active
+status: complete
 date: 2026-06-22
+completed: 2026-06-22
 origin: docs/brainstorms/2026-06-22-skill-saving-grow-and-learn-requirements.md
 ---
 

--- a/docs/plans/2026-06-22-004-feat-c2-failed-then-fixed-capture-plan.md
+++ b/docs/plans/2026-06-22-004-feat-c2-failed-then-fixed-capture-plan.md
@@ -1,8 +1,9 @@
 ---
 title: 'feat: C2 failed-then-fixed capture trigger'
 type: feat
-status: active
+status: complete
 date: 2026-06-22
+completed: 2026-06-24
 origin: docs/brainstorms/2026-06-22-c2-failed-then-fixed-capture-requirements.md
 ---
 

--- a/docs/plans/2026-06-23-001-fix-merged-candidate-evidence-plan.md
+++ b/docs/plans/2026-06-23-001-fix-merged-candidate-evidence-plan.md
@@ -1,8 +1,9 @@
 ---
 title: 'fix: attach ci-fix evidence to dual-trigger candidates'
 type: fix
-status: active
+status: complete
 date: 2026-06-23
+completed: 2026-06-24
 origin: docs/brainstorms/2026-06-23-merged-candidate-evidence-requirements.md
 ---
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -8,6 +8,12 @@ The Gateway operator rollout tracker #3512 is open.
 
 ## Plans
 
+docs/plans/2026-06-22-003-feat-enrich-capture-digest-plan.md is complete.
+
+docs/plans/2026-06-22-004-feat-c2-failed-then-fixed-capture-plan.md is complete.
+
+docs/plans/2026-06-23-001-fix-merged-candidate-evidence-plan.md is complete.
+
 docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md is complete.
 
 docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md is complete.


### PR DESCRIPTION
## What

Three learning-capture plans shipped in June but their frontmatter still said `status: active`:

| Plan | Shipped via | Completed |
|---|---|---|
| `2026-06-22-003` enrich-capture-digest | #3556 | 2026-06-22 |
| `2026-06-22-004` c2-failed-then-fixed-capture | #3568 / #3574 | 2026-06-24 |
| `2026-06-23-001` merged-candidate-evidence | #3581 | 2026-06-24 |

- Mark all three `status: complete` with merge-derived `completed` dates.
- Add their plan-status claims to `docs/status.md` so the Status Truth loop watches them from now on.

## Verification

- Claim extraction on `docs/status.md`: exactly 6 claims (5 plan-status complete + 1 rollout-tracker open).
- All three edited plans resolve `complete` through `resolvePlanStatusClaim`.
- `pnpm check-types`, `pnpm lint`, `pnpm test` green.