### PR TITLE
feat: add plan-consistency self-audit claim kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,14 @@ Use `status-truth:superseded` when a newer finding or a broader correction makes
 
 **Workflow summary:** Each run emits aggregate counts by claim kind (opened, updated, reopened, closed, suppressed). No file paths, fingerprints, or claim text appear in workflow logs — evidence lives in the proposal issues after privacy gating.
 
+**Plan-consistency proposals:**
+
+Every plan under `docs/plans/` is checked automatically for consistency between its frontmatter `status` and its implementation-unit checkboxes (`- [x] **Unit N: ...**`). No prose claim is required — the checkboxes are the claim.
+
+The drift rule: a plan marked `active` whose units are all checked gets a proposal to flip its status to `complete`. Everything else is either current or unresolved — unchecked units on a `complete` plan, unsupported status values, and unrecognizable unit markers are all counted as unresolved and never proposed.
+
+Applying `status-truth:rejected` or `status-truth:false-positive` to a plan-consistency proposal permanently exempts that plan from future consistency proposals. Removing or renaming a plan file clears its finding on the next scan; any open proposal for it auto-closes as resolved.
+
 ## Development
 
 ### Code Quality Standards

--- a/docs/brainstorms/2026-07-02-plan-consistency-claim-kind-requirements.md
+++ b/docs/brainstorms/2026-07-02-plan-consistency-claim-kind-requirements.md
@@ -1,0 +1,187 @@
+---
+date: 2026-07-02
+topic: plan-consistency-claim-kind
+title: Plan-consistency claim kind for Status Truth
+---
+
+# Plan-consistency claim kind for Status Truth
+
+## Summary
+
+Add a self-audit claim kind to the Status Truth loop: every plan under `docs/plans/` is implicitly
+checked for consistency between its frontmatter `status` and its implementation-unit completion
+markers. A shipped plan whose frontmatter still says `active` becomes a drifted finding and a
+proposal issue through the existing proposal machinery.
+
+---
+
+## Problem Frame
+
+Plan frontmatter goes stale silently. On 2026-07-02, three shipped capture plans still carried
+`status: active` a week after their PRs merged; the drift was found only by manual reconciliation
+during an A2 review. The existing `plan-status` claim kind cannot catch this class: it verifies
+cross-file prose claims against frontmatter, so when the frontmatter itself is the stale artifact
+and nobody wrote a prose claim about the plan, the drift is invisible to the loop.
+
+Each plan already carries its own evidence of completion — per-unit checkboxes or per-unit status
+lines — sitting in the same file as the frontmatter that contradicts them. No scanned surface, no
+seeding convention, and no API call is needed to compare the two.
+
+---
+
+## Actors
+
+- A1. Marcus: reviews proposal issues, applies outcome labels, fixes stale frontmatter.
+- A2. Fro Bot: audits the plan corpus during Status Truth runs and plans proposals for drifted
+  plans.
+- A3. Plan authors (human or agent sessions): produce the frontmatter and unit markers the audit
+  reads.
+
+---
+
+## Requirements
+
+**Audit model**
+
+- R1. Every file under `docs/plans/` is audited on each Status Truth run without requiring a prose
+  claim or seeded sentence.
+- R2. The audit emits one synthetic claim per plan file, fingerprinted by plan path and claim kind,
+  flowing through the existing report contract, privacy gates, proposal caps, and outcome-label
+  lifecycle.
+- R3. The audit is file-parse only: no GitHub API calls, no tracker snapshot, no write credentials.
+
+**Unit-marker grammar**
+
+- R4. The audit recognizes exactly one unit-completion encoding: checkbox units
+  (`- [x] **Unit N: ...**` / `- [ ] **Unit N: ...**`).
+- R5. When a plan contains no recognizable unit markers, or its markers are malformed or mixed in a
+  way the grammar cannot classify, the finding is unresolved, never drifted.
+- R6. The one heading-encoded plan in the corpus
+  (`docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md`) is normalized to
+  checkbox encoding as part of this slice, so the audited corpus is uniformly checkbox-encoded at
+  launch.
+
+**Drift matrix**
+
+- R7. When frontmatter status is `active` and every recognized unit is marked complete, the finding
+  is drifted and proposal-eligible with proposed correction `status: complete`.
+- R8. When frontmatter status is `complete` and at least one recognized unit is not marked
+  complete, the finding is unresolved (attention signal), not drifted.
+- R9. When frontmatter status is missing, malformed, or outside the supported vocabulary of the
+  existing plan-status resolver, the finding is unresolved.
+- R10. All other combinations — `active` with unfinished units, `complete` with all units done,
+  `draft`, `cancelled`, or `superseded` with any unit state — are current.
+
+**Output safety**
+
+- R11. Workflow summaries and logs stay counts-only for this kind; plan paths and unit details
+  appear only in artifacts and proposal bodies after the existing public-output gate. Plan paths
+  are public repo paths and are safe in gated output.
+- R12. Proposal bodies, evidence fields, and correction copy carry only normalized data: plan path,
+  frontmatter status value, and unit counts. Raw plan body text, unit titles, and frontmatter
+  excerpts are never copied into any public artifact.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R7.** Given a plan with `status: active` whose units are all `[x]`, when
+  the Status Truth scan runs, one drifted, proposal-eligible finding is produced with proposed
+  correction `status: complete` — without any prose claim referencing the plan.
+- AE2. **Covers R8.** Given a plan with `status: complete` and one unchecked unit, when the scan
+  runs, the finding is unresolved and no proposal is planned.
+- AE3. **Covers R5.** Given a plan with no Implementation Units section, when the scan runs, the
+  finding is unresolved and no proposal is planned.
+- AE4. **Covers R9.** Given a plan with `status: code-complete-pending-verification`, when the scan
+  runs, the finding is unresolved.
+- AE5. **Covers R4, R5.** Given a plan whose units use a non-checkbox encoding (for example
+  `### U1.` headings with `Status:` lines), when the scan runs, the finding is unresolved and no
+  proposal is planned.
+- AE6. **Covers R2.** Given more drifted plans than remaining mutation budget, when proposal
+  planning runs, overflow findings are reported as blocked counts under the existing cap.
+- AE7. **Covers R12.** Given a drifted plan whose body text contains an arbitrary repo reference,
+  when a proposal is rendered, the proposal body contains the plan path, claimed status, live unit
+  counts, and proposed correction — and no sentence copied from the plan body.
+
+---
+
+## Success Criteria
+
+- Replaying the audit against the pre-reconciliation tree from 2026-07-02 yields exactly three
+  drifted findings (the three stale capture plans) and zero false positives across the rest of the
+  corpus.
+- On the reconciled corpus with the heading-encoded plan normalized, the audit yields zero drifted
+  findings and exactly one expected unresolved finding
+  (`2026-06-15-001`, unsupported status `code-complete-pending-verification`).
+- A future stale-frontmatter plan produces a proposal issue on the next Status Truth run instead of
+  waiting for manual reconciliation.
+- Planning can proceed without inventing behavior: drift matrix, unit grammar, and lifecycle
+  integration are all specified here.
+
+---
+
+## Scope Boundaries
+
+- No completion-date inference (`completed:` values come from humans or other tooling, not this
+  audit).
+- No cross-checking `completed:` dates against merge history.
+- No prose rewriting or plan-body edits; the proposal proposes a frontmatter correction only.
+- No auditing of non-plan documents (brainstorms, solutions, README).
+- No bounded correction PR execution; proposals only, consistent with the A2 graduation gate.
+- No corpus-wide format migration beyond normalizing the single heading-encoded plan (R6).
+- No cross-kind dedupe of correlated findings in v1: a stale plan with a prose claim in
+  `docs/status.md` may produce one self-audit finding and one prose-claim finding; the mutation cap
+  bounds the noise and fixing the frontmatter clears both.
+
+---
+
+## Key Decisions
+
+- **Self-audit over prose claims:** seeding prose claims for every plan recreates the
+  signal-starvation problem this kind exists to fix; the corpus is small, local, and public, so
+  implicit full coverage is safe and cheap.
+- **One-directional drift:** only `active` + all-units-done drifts. The reverse
+  (`complete` + unchecked) has legitimate explanations (descoped units, summary-style plans) and
+  fails toward attention instead of proposals — protecting the first outcome-collecting claim kinds
+  from false positives.
+- **Proposal-eligible from day one:** the existing mutation cap, dry-run-first workflow, and
+  post-reconciliation zero-drift baseline bound the blast radius.
+- **Checkbox-only grammar with corpus normalization:** the corpus survey (2026-07-02) found 24
+  checkbox-encoded plans and 1 heading-encoded plan. Supporting a second grammar forever for one
+  file is worse than normalizing the file; the odd plan converts to checkbox encoding in this
+  slice and unrecognized encodings degrade to unresolved, which is honest signal.
+- **Terminal labels are per-plan opt-outs:** the synthetic claim fingerprints by plan path and
+  kind, so a `rejected` or `false-positive` label permanently exempts that plan from future
+  consistency proposals. This is intended semantics — the label says "my convention differs for
+  this plan; stop auditing it" — and the operator docs must state it.
+- **Implicit coverage is still a reviewable change:** the A2 rule that new claim kinds land as
+  reviewable repo changes is satisfied by this document and its implementing PR; what is reviewed
+  is the kind's definition and drift matrix, not a per-plan seeding decision.
+
+---
+
+## Dependencies / Assumptions
+
+- Status Truth detect/proposal foundation (`scripts/status-truth-detect.ts`,
+  `scripts/status-truth-proposals.ts`, `.github/workflows/status-truth.yaml`) remains the host.
+- The existing extraction path is regex-over-text only; synthetic per-file claims need a new
+  file-level claim builder alongside `extractStatusTruthClaimsFromText`. Planning owns the seam
+  design; the report contract, privacy gates, caps, and lifecycle stay shared.
+- Assumption (validated 2026-07-02): after normalizing the one heading-encoded plan, every current
+  plan uses checkbox unit encoding or has no units; re-run the corpus survey during planning to
+  catch changes.
+- The supported status vocabulary stays aligned with the existing plan-status resolver
+  (`SUPPORTED_PLAN_STATUSES`).
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R2][Technical] Whether the synthetic claim reuses the `plan-status` proposal body
+  template or needs kind-specific correction copy (bounded by R12 either way).
+- [Affects R4][Technical] Exact tolerance for unit-marker variations (bold-less unit labels,
+  nested checkbox lists, lettered sub-units) — characterize from the corpus while writing tests.
+- [Affects R7][Technical] Whether a drifted finding's proposed correction should also suggest a
+  `completed:` date placeholder or leave the field to the operator.

--- a/docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md
+++ b/docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md
@@ -257,9 +257,7 @@ flowchart TB
 
 ## Implementation Units
 
-### U1. Plan-status file resolver
-
-Status: complete.
+- [x] **Unit 1: Plan-status file resolver**
 
 **Goal:** Resolve public claims about plan status against current plan metadata.
 
@@ -305,16 +303,14 @@ claims.
 - Plan-status findings participate in the same report contract and proposal eligibility rules as
   existing API-backed findings.
 
-### U2. Rollout-tracker compound resolver
-
-Status: complete.
+- [x] **Unit 2: Rollout-tracker compound resolver**
 
 **Goal:** Resolve rollout-tracker claims through the existing tracker snapshot rather than treating
 them as permanently unavailable.
 
 **Requirements:** R1, R3, R4, R5
 
-**Dependencies:** U1 only for shared test helpers; otherwise can proceed independently from the same
+**Dependencies:** Unit 1 only for shared test helpers; otherwise can proceed independently from the same
 foundation.
 
 **Files:**
@@ -360,15 +356,13 @@ foundation.
 - Rollout-tracker claims produce current/drifted/unresolved counts from the snapshot contract without
   adding Project writes or leaking tracker internals to public summaries.
 
-### U3. Proposal caps and overflow reporting
-
-Status: complete.
+- [x] **Unit 3: Proposal caps and overflow reporting**
 
 **Goal:** Prevent a useful drift run from opening too many issues or comments at once.
 
 **Requirements:** R5, R6, R8
 
-**Dependencies:** Existing proposal planner; can be developed before U1/U2 and exercised with fixture
+**Dependencies:** Existing proposal planner; can be developed before Unit 1/Unit 2 and exercised with fixture
 findings.
 
 **Files:**
@@ -403,15 +397,13 @@ findings.
 **Verification:**
 - A synthetic high-drift report cannot create unbounded issue noise in dry-run or live mode.
 
-### U4. Outcome classification and accuracy math
-
-Status: complete.
+- [x] **Unit 4: Outcome classification and accuracy math**
 
 **Goal:** Classify proposal outcomes into a stable usefulness signal without mutating issue state.
 
 **Requirements:** R7, R8
 
-**Dependencies:** U3 for cap-aware lifecycle planning.
+**Dependencies:** Unit 3 for cap-aware lifecycle planning.
 
 **Files:**
 - Modify: `scripts/status-truth-proposals.ts`
@@ -448,15 +440,13 @@ changes.
 **Verification:**
 - Operator outcome labels can drive future graduation decisions without requiring workflow-log review.
 
-### U5. Manual closure cooldown and recurrence behavior
-
-Status: complete.
+- [x] **Unit 5: Manual closure cooldown and recurrence behavior**
 
 **Goal:** Prevent bot-versus-operator loops while preserving recurrence handling for unresolved drift.
 
 **Requirements:** R7, R8
 
-**Dependencies:** U4.
+**Dependencies:** Unit 4.
 
 **Files:**
 - Modify: `scripts/status-truth-proposals.ts`
@@ -498,15 +488,13 @@ Status: complete.
 - Manual proposal closure cannot cause immediate bot aggression, and persistent recurrence still has a
   documented path back to operator attention.
 
-### U6. Documentation and operational calibration
-
-Status: complete.
+- [x] **Unit 6: Documentation and operational calibration**
 
 **Goal:** Keep the plan, operator docs, and reusable learnings aligned with the completed signal slice.
 
 **Requirements:** R5, R6, R7, R8
 
-**Dependencies:** U1-U5.
+**Dependencies:** Units 1-5.
 
 **Files:**
 - Modify: `docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md`

--- a/docs/plans/2026-07-02-001-feat-plan-consistency-claim-kind-plan.md
+++ b/docs/plans/2026-07-02-001-feat-plan-consistency-claim-kind-plan.md
@@ -1,0 +1,326 @@
+---
+title: 'feat: Plan-consistency claim kind for Status Truth'
+type: feat
+status: complete
+date: 2026-07-02
+completed: 2026-07-02
+origin: docs/brainstorms/2026-07-02-plan-consistency-claim-kind-requirements.md
+---
+
+# feat: Plan-consistency claim kind for Status Truth
+
+## Overview
+
+Add a self-audit claim kind to the Status Truth loop. Every plan under `docs/plans/` is implicitly
+checked for consistency between its frontmatter `status` and its implementation-unit checkbox
+markers. A shipped plan whose frontmatter still says `active` becomes a drifted finding and a
+proposal issue through the existing proposal machinery — without requiring a prose claim or seeded
+sentence.
+
+## Problem Frame
+
+Plan frontmatter goes stale silently. Three shipped capture plans carried `status: active` a week
+after their PRs merged; the drift was found only by manual reconciliation (see origin:
+`docs/brainstorms/2026-07-02-plan-consistency-claim-kind-requirements.md`). The existing
+`plan-status` kind verifies cross-file prose claims against frontmatter, so when the frontmatter
+itself is stale and no prose claim exists, the loop is blind. Each plan already carries its own
+completion evidence — unit checkboxes — in the same file as the contradicting frontmatter.
+
+## Requirements Trace
+
+From the origin document:
+
+- R1. Every `docs/plans/*.md` audited each run, no prose claim required.
+- R2. One synthetic claim per plan, fingerprinted by plan path and claim kind, flowing through the
+  existing report contract, privacy gates, caps, and outcome-label lifecycle.
+- R3. File-parse only: no API calls, no snapshot, no write credentials.
+- R4. Checkbox unit grammar only (`- [x] **Unit N: ...**` / `- [ ] **Unit N: ...**`).
+- R5. Unrecognizable/malformed unit markers → unresolved, never drifted.
+- R6. Normalize the one heading-encoded plan to checkbox encoding in this slice.
+- R7. `active` + all units checked → drifted, proposal-eligible, correction `status: complete`.
+- R8. `complete` + any unchecked unit → unresolved.
+- R9. Missing/malformed/unsupported frontmatter status → unresolved.
+- R10. All other combinations → current.
+- R11. Counts-only summaries and logs; details only in gated artifacts/proposals.
+- R12. Every public surface a plan-consistency finding touches — report artifact JSON, proposal
+  title, proposal body, update/recurrence/close comments, and stdout summary — carries normalized
+  data only (path, normalized status, unit counts). Raw plan body text, unit titles, and
+  frontmatter excerpts never appear on any of them.
+
+## Scope Boundaries
+
+- No completion-date inference or `completed:` cross-checks against merge history.
+- No plan-body edits by the loop; proposals suggest a frontmatter correction only.
+- No auditing of non-plan documents.
+- No bounded correction PR execution (A2 graduation gate unchanged).
+- No corpus-wide format migration beyond the single R6 normalization.
+- No cross-kind dedupe of correlated findings (a stale plan with a prose claim in `docs/status.md`
+  may yield two findings; the mutation cap bounds noise).
+- No new malformed-attention counter: malformed states are plain unresolved in v1.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/status-truth-detect.ts` — host module. Key seams: `ClaimKind` union (~line 7);
+  `CLAIM_KIND_DEFINITIONS` (regex-extraction registry — the new kind does NOT join it);
+  `StatusTruthClaim` interface; `computeClaimFingerprint(kind, path, sourceRef, normalizedText)`;
+  `classifyClaim` (naive `liveState === claimedState` equality — insufficient for this kind, see
+  Key Technical Decisions); `parsePlanFrontmatterStatus` and `SUPPORTED_PLAN_STATUSES` (reuse);
+  `resolveFileParseClaims` (file-parse resolver precedent); `runDetect` orchestration
+  (fileLister/read → scan → resolve → classify → report).
+- `scripts/status-truth-proposals.ts` — planner consumes generic `PublicStatusTruthFinding`
+  fields; no kind-specific plumbing expected. Body copy in `buildProposalTitle`/`buildProposalBody`;
+  all surfaces gated via `applyPublicOutputGate`.
+- `scripts/status-truth-public-output.ts` — gate API unchanged.
+- `.github/workflows/status-truth.yaml` — unchanged; plans are already inside the scanned
+  `docs/**/*.md` set and the report/summary path is kind-agnostic.
+- No existing checkbox parser anywhere in `scripts/` — the unit-marker parser is net-new.
+- Test fixture patterns: `makeClaim`/`makeReport`/`makeFinding` helpers and inline-string
+  `FileReader` fakes in `scripts/status-truth-detect.test.ts`.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/pure-core-privacy-gates-shared-module-2026-06-22.md`: keep
+  parsing/classification pure; file-read failures live in the I/O shell.
+- `docs/solutions/best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md`: fail
+  closed on ambiguity at the trusted chokepoint.
+- `docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md`: verify every
+  public surface (report artifact, proposal title/body, summary) for the normalized-data-only rule.
+- `docs/solutions/integration-issues/wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md`:
+  report-only machinery; failures still produce durable reports.
+
+## Key Technical Decisions
+
+- **Separate synthetic claim builder, not a `CLAIM_KIND_DEFINITIONS` entry:** the extraction
+  registry is regex-over-text; forcing a pattern would be fiction. A file-level builder emits one
+  synthetic claim per plan from already-read file contents inside `runDetect`.
+- **Single resolver returns the final verdict:** `classifyClaim` equality would mark `complete` +
+  unchecked units as drifted, violating R8. The plan-consistency resolver is one function that
+  returns the final verdict (`current | drifted | unresolved`) from the R7–R10 matrix; no
+  equality-based fallback path exists for this kind. The matrix is encoded in exactly one place
+  and table-tested.
+- **Stable fingerprint excludes unit state:** fingerprint inputs are kind, path, and a constant
+  normalized text (no checkbox counts), so a plan's fingerprint is stable across drift episodes.
+  Terminal labels (`rejected`/`false-positive`) therefore act as permanent per-plan opt-outs —
+  intended semantics, documented in README operator docs.
+- **claimedState is normalized at ingestion:** the claim carries the frontmatter status only when
+  it is in `SUPPORTED_PLAN_STATUSES`; anything else collapses to the fixed sentinel `unsupported`
+  before the claim is built, so arbitrary frontmatter text can never reach report JSON or any
+  public surface. liveState is the unit-derived state. Proposed correction copy is built from
+  normalized fields only (R12), not from `buildProposedCorrection`'s text-replacement path.
+- **Plan deletion or rename clears the finding:** a removed/renamed plan drops its fingerprint
+  from the next complete scan, and the existing close-on-clear lifecycle closes any open proposal
+  as a resolved positive. Accepted v1 semantics: the audited inconsistency ceased to exist with
+  the file. The rename case re-emerges under the new path's fingerprint if drift persists.
+- **Reuse `parsePlanFrontmatterStatus` and `SUPPORTED_PLAN_STATUSES`:** one frontmatter grammar
+  across plan-status and plan-consistency kinds.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Does the planner need kind-specific changes? No — findings that fit `PublicStatusTruthFinding`
+  flow through generic lifecycle, caps, and gates.
+- Does the workflow need changes? No — file enumeration, report artifact, and counts-only summary
+  are kind-agnostic.
+
+### Deferred to Implementation
+
+- Exact tolerance for checkbox variations (bold-less labels, nested lists, lettered sub-units):
+  characterize from the corpus while writing parser tests; anything outside the recognized grammar
+  is unresolved.
+- Whether the proposal body reuses the shared body template verbatim or adds a unit-count line:
+  bounded either way by R12.
+
+## Implementation Units
+
+- [x] **Unit 1: Checkbox unit-marker parser**
+
+**Goal:** Pure parser extracting unit-completion counts from plan markdown.
+
+**Requirements:** R4, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `scripts/status-truth-detect.ts`
+- Test: `scripts/status-truth-detect.test.ts`
+
+**Approach:**
+- Pure function: plan file content in, `{checkedUnits, uncheckedUnits}` or a no-markers/malformed
+  signal out. No I/O.
+- Recognize only `- [x] **Unit N: ...**` / `- [ ] **Unit N: ...**` top-level markers; everything
+  else (including `### U<n>.` heading units) is unrecognized.
+- Checkboxes outside unit-marker form (verification checklists, nested task lists) must not count.
+
+**Execution note:** Test-first; this parser is the correctness seam for the whole kind.
+
+**Test scenarios:**
+- Happy path: mixed checked/unchecked unit markers → exact counts.
+- Edge case: checkboxes that are not unit markers (plain `- [x]` list items, indented sub-tasks) →
+  not counted.
+- Edge case: no unit markers at all → no-markers signal.
+- Edge case: heading-encoded units (`### U1.` + `Status:` lines) → no-markers signal (unrecognized
+  encoding).
+- Edge case: bold-less or malformed unit labels → not counted as units.
+
+**Verification:**
+- Parser results over the current 25-plan corpus match a manual survey (24 checkbox plans counted
+  correctly; the heading-encoded plan reports no recognizable markers until Unit 4 normalizes it).
+
+- [x] **Unit 2: Synthetic claim builder and drift-matrix resolver**
+
+**Goal:** Emit one plan-consistency claim per plan file and classify it per the drift matrix.
+
+**Requirements:** R1, R2, R3, R7, R8, R9, R10
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `scripts/status-truth-detect.ts`
+- Test: `scripts/status-truth-detect.test.ts`
+
+**Approach:**
+- Add `plan-consistency` to the `ClaimKind` union; do not add a `CLAIM_KIND_DEFINITIONS` entry.
+- The scan shell consumes file contents internally and returns only claims, so the builder makes
+  its own bounded second pass: reuse the injected `fileLister`/`fileReader` seams, filter to
+  `docs/plans/*.md`, and read each plan (small corpus; avoids widening the scan API and keeps the
+  pure-core/shell split).
+- Emit one synthetic claim per plan: claimedState from `parsePlanFrontmatterStatus` normalized to
+  `SUPPORTED_PLAN_STATUSES` or the `unsupported` sentinel; sourceRef = plan path; constant
+  normalized text for fingerprint stability.
+- Resolver applies the one-directional drift matrix: only `active` + all-checked is drifted
+  (correction `status: complete`); `complete` + unchecked, unsupported status, missing frontmatter,
+  and no/malformed markers are unresolved; all else current.
+- Proposed correction is built from normalized fields only.
+
+**Execution note:** Test-first with table tests over the full drift matrix.
+
+**Test scenarios:**
+- Happy path: `active` + all `[x]` → drifted, proposal-eligible, correction `status: complete`
+  (AE1).
+- Happy path: `complete` + all `[x]` → current.
+- Edge case: `complete` + one `[ ]` → unresolved, not proposal-eligible (AE2).
+- Edge case: no Implementation Units section → unresolved (AE3).
+- Edge case: `status: code-complete-pending-verification` → unresolved with claimedState
+  `unsupported`, not the raw string (AE4).
+- Privacy path: a malformed multi-word `status:` value never appears verbatim in the claim,
+  report JSON, or any rendered surface.
+- Edge case: heading-encoded units → unresolved (AE5).
+- Edge case: `draft`/`cancelled`/`superseded` with any unit state → current.
+- Edge case: fingerprint identical for the same plan across differing unit states.
+- Error path: file read failure → unresolved via the shell's failure accounting, no clean report
+  fabrication.
+
+**Verification:**
+- Replaying the three pre-reconciliation stale capture plans as fixtures yields exactly three
+  drifted findings; the remaining corpus yields zero drifted.
+
+- [x] **Unit 3: Detect-flow integration and report wiring**
+
+**Goal:** Plan-consistency findings appear in the report with correct counts and proposal flow.
+
+**Requirements:** R2, R11, R12
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `scripts/status-truth-detect.ts`
+- Test: `scripts/status-truth-detect.test.ts`
+- Test: `scripts/status-truth-proposals.test.ts`
+
+**Approach:**
+- Wire the builder into `runDetect` between file scan and classification; reuse the existing
+  fileLister/FileReader seams so tests inject fixtures.
+- Findings enter the shared report (`findings`, `counts`) with no new report fields.
+- Confirm planner passthrough: a drifted plan-consistency finding plans an open action, is capped,
+  deduped, and gated exactly like existing kinds.
+
+**Test scenarios:**
+- Integration: full detect run over fixture corpus produces plan-consistency findings alongside
+  prose-claim findings in one report.
+- Integration: drifted plan-consistency finding flows through proposal planning (open action,
+  fingerprint marker, gated body) with no planner changes (AE1, AE6 cap behavior).
+- Privacy: rendered proposal body for a drifted fixture contains path, statuses, unit counts, and
+  correction — and no sentence copied from the plan body (AE7).
+- Privacy: one assertion per public surface (report JSON finding fields, proposal title, proposal
+  body, update/recurrence/close comments, stdout summary) proving only normalized fields are
+  emitted for plan-consistency findings.
+- Integration: deleting a fixture plan between two runs closes its open proposal via the existing
+  close-on-clear path (documented v1 semantics).
+
+**Verification:**
+- A dry-run-shaped local execution over the real corpus reports the expected verdict distribution
+  (zero drifted, one unresolved for the unsupported-status plan after Unit 4 lands).
+
+- [x] **Unit 4: Corpus normalization and operator docs**
+
+**Goal:** Uniform checkbox corpus at launch and documented operator semantics.
+
+**Requirements:** R6, plus terminal-label semantics documentation
+
+**Dependencies:** Units 1–3 (verification uses the parser)
+
+**Files:**
+- Modify: `docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md`
+- Modify: `README.md`
+
+**Approach:**
+- Convert the plan's `### U<n>.` + `Status: complete.` units to `- [x] **Unit N: ...**` checkbox
+  encoding, preserving all body content.
+- README Status-Truth section: document the plan-consistency kind, the drift matrix in operator
+  terms, and that `rejected`/`false-positive` labels permanently exempt a plan from consistency
+  proposals.
+
+**Test scenarios:**
+- Test expectation: none — docs-only unit; correctness is verified by Unit 1's parser accepting
+  the normalized plan and by markdown lint.
+
+**Verification:**
+- The normalized plan resolves current (`complete` + all checked) through the new resolver.
+- README documents the kind, matrix, and opt-out semantics without plan-speak or private
+  identifiers.
+
+## System-Wide Impact
+
+- **Interaction graph:** detect gains one synthetic-claim pass; planner, gate, workflow, and
+  schedule untouched.
+- **Error propagation:** file-read and parse failures degrade to unresolved counts; no failure
+  path fabricates a clean report.
+- **State lifecycle risks:** stable per-plan fingerprints mean terminal labels suppress a plan
+  forever (intended, documented); correlated prose+consistency findings for one stale plan are
+  accepted and bounded by the mutation cap; plan deletion/rename auto-closes its proposal as a
+  resolved positive (accepted v1 semantics, documented in README).
+- **Dogfooding closeout:** this plan itself becomes `active` + all-units-checked at completion;
+  its own closing PR must flip the frontmatter to `complete` in the same commit that checks the
+  last unit, or the first post-merge run correctly proposes the fix — an acceptable live test, not
+  a failure.
+- **API surface parity:** report schema unchanged (new kind value only); consumers reading counts
+  by verdict are unaffected.
+- **Integration coverage:** report-to-proposal handoff for the new kind is tested end-to-end at
+  the planner boundary.
+- **Unchanged invariants:** proposal-only boundary, mutation caps, cooldowns, outcome labels,
+  branch protection, credential split, and counts-only telemetry all remain as shipped.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Checkbox grammar miscounts non-unit checklists | Grammar anchored to `**Unit N:**` label form; non-matching checkboxes ignored; corpus-survey verification in Unit 1. |
+| Fingerprint instability re-fires suppressed proposals | Fingerprint excludes unit state by construction; test asserts stability across drift episodes. |
+| Proposal body echoes plan text | Body built from normalized fields only; AE7 privacy test pins it; existing gate is a second layer. |
+| Correlated duplicate proposals annoy the operator | Accepted v1 trade-off; cap bounds volume; revisit only if it proves noisy. |
+| Drift matrix regression via naive equality reuse | Matrix encoded in one resolver with exhaustive table tests. |
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-07-02-plan-consistency-claim-kind-requirements.md](../brainstorms/2026-07-02-plan-consistency-claim-kind-requirements.md)
+- Related code: `scripts/status-truth-detect.ts`, `scripts/status-truth-proposals.ts`,
+  `scripts/status-truth-public-output.ts`, `.github/workflows/status-truth.yaml`
+- Prior plans: [docs/plans/2026-06-26-001-feat-status-truth-maintenance-loop-plan.md](2026-06-26-001-feat-status-truth-maintenance-loop-plan.md),
+  [docs/plans/2026-06-30-001-feat-status-truth-signal-completion-plan.md](2026-06-30-001-feat-status-truth-signal-completion-plan.md)
+- Related learnings: `docs/solutions/best-practices/pure-core-privacy-gates-shared-module-2026-06-22.md`,
+  `docs/solutions/best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md`,
+  `docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md`,
+  `docs/solutions/integration-issues/wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md`

--- a/scripts/status-truth-detect.test.ts
+++ b/scripts/status-truth-detect.test.ts
@@ -22,6 +22,7 @@ import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {
   buildDetectOctokitOptions,
+  buildPlanConsistencyClaim,
   buildStatusTruthReport,
   CLAIM_KIND_DEFINITIONS,
   computeClaimFingerprint,
@@ -35,12 +36,15 @@ import {
   listCurrentRepoIssues,
   loadRolloutSnapshot,
   normalizeClaimText,
+  parsePlanUnitCheckboxes,
   resolveAllClaims,
   resolveClaimLiveState,
   resolveFileParseClaims,
+  resolvePlanConsistencyVerdict,
   resolvePlanStatusClaim,
   resolveRolloutTrackerClaim,
   scanIssueStatusTruthClaims,
+  scanPlanConsistencyFindings,
   scanStatusTruthClaims,
   selectDetectFailureClass,
   validateStatusTruthArtifact,
@@ -155,6 +159,11 @@ describe('CLAIM_KIND_DEFINITIONS', () => {
   it('release-tag-state is an API resolver', () => {
     const def = CLAIM_KIND_DEFINITIONS.find(d => d.kind === 'release-tag-state')
     expect(def?.resolverType).toBe('api')
+  })
+
+  it('plan-consistency does NOT join the regex-extraction registry (synthetic claims only)', () => {
+    const def = CLAIM_KIND_DEFINITIONS.find(d => d.kind === 'plan-consistency')
+    expect(def).toBeUndefined()
   })
 })
 
@@ -723,9 +732,16 @@ describe('type contracts', () => {
     expect(types).toHaveLength(3)
   })
 
-  it('ClaimKind union covers all five expected values', () => {
-    const kinds: ClaimKind[] = ['pr-state', 'issue-state', 'release-tag-state', 'plan-status', 'rollout-tracker-status']
-    expect(kinds).toHaveLength(5)
+  it('ClaimKind union covers all six expected values', () => {
+    const kinds: ClaimKind[] = [
+      'pr-state',
+      'issue-state',
+      'release-tag-state',
+      'plan-status',
+      'rollout-tracker-status',
+      'plan-consistency',
+    ]
+    expect(kinds).toHaveLength(6)
   })
 })
 
@@ -4493,5 +4509,558 @@ describe('buildProposedCorrection: trailing-state replacement via detect pipelin
       // The trailing state must be replaced
       expect(finding.proposedCorrection).not.toMatch(/\bpublished\s*$/)
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parsePlanUnitCheckboxes — pure checkbox unit-marker parser
+// ---------------------------------------------------------------------------
+
+describe('parsePlanUnitCheckboxes', () => {
+  it('happy path: mixed checked/unchecked unit markers produce exact counts', () => {
+    const content = [
+      '## Implementation Units',
+      '',
+      '- [x] **Unit 1: First unit**',
+      '',
+      'Body text for unit 1.',
+      '',
+      '- [ ] **Unit 2: Second unit**',
+      '',
+      'Body text for unit 2.',
+      '',
+      '- [x] **Unit 3: Third unit**',
+      '',
+    ].join('\n')
+
+    const result = parsePlanUnitCheckboxes(content)
+    expect(result.recognized).toBe(true)
+    if (result.recognized) {
+      expect(result.checkedUnits).toBe(2)
+      expect(result.uncheckedUnits).toBe(1)
+    }
+  })
+
+  it('edge case: plain non-unit checkboxes are not counted', () => {
+    const content = [
+      '- [x] **Unit 1: Real unit**',
+      '',
+      '**Checklist:**',
+      '- [x] Provision the droplet',
+      '- [ ] Rotate the secret',
+      '',
+      '**Test scenarios:**',
+      '- [x] Happy path covered',
+      '  - [x] nested sub-task',
+      '  - [ ] another nested sub-task',
+    ].join('\n')
+
+    const result = parsePlanUnitCheckboxes(content)
+    expect(result.recognized).toBe(true)
+    if (result.recognized) {
+      expect(result.checkedUnits).toBe(1)
+      expect(result.uncheckedUnits).toBe(0)
+    }
+  })
+
+  it('edge case: no unit markers at all yields the no-markers signal', () => {
+    const content = '## Overview\n\nJust prose, no checkboxes anywhere in this plan.\n'
+    const result = parsePlanUnitCheckboxes(content)
+    expect(result.recognized).toBe(false)
+  })
+
+  it('edge case: heading-encoded units (### U1. + Status: lines) are unrecognized', () => {
+    const content = [
+      '### U1. Persona Document',
+      '',
+      'Status: complete.',
+      '',
+      '### U2. Metadata Structure',
+      '',
+      'Status: complete.',
+    ].join('\n')
+
+    const result = parsePlanUnitCheckboxes(content)
+    expect(result.recognized).toBe(false)
+  })
+
+  it('edge case: bold-less unit labels are not counted as units', () => {
+    const content = ['- [x] Unit 1: Not bold, should not count', '- [ ] Unit 2: Also not bold'].join('\n')
+    const result = parsePlanUnitCheckboxes(content)
+    expect(result.recognized).toBe(false)
+  })
+
+  it('edge case: malformed unit label missing the "Unit N:" prefix is not counted', () => {
+    const content = ['- [x] **Not a unit label**', '- [ ] **Also not a unit label**'].join('\n')
+    const result = parsePlanUnitCheckboxes(content)
+    expect(result.recognized).toBe(false)
+  })
+
+  it('indented unit-shaped checkboxes (not top-level) are not counted as units', () => {
+    const content = ['Some section', '', '  - [x] **Unit 1: Indented, should not count**'].join('\n')
+    const result = parsePlanUnitCheckboxes(content)
+    expect(result.recognized).toBe(false)
+  })
+
+  it('all-checked units: checkedUnits equals total, uncheckedUnits is zero', () => {
+    const content = ['- [x] **Unit 1: First**', '- [x] **Unit 2: Second**', '- [x] **Unit 3: Third**'].join('\n')
+    const result = parsePlanUnitCheckboxes(content)
+    expect(result.recognized).toBe(true)
+    if (result.recognized) {
+      expect(result.checkedUnits).toBe(3)
+      expect(result.uncheckedUnits).toBe(0)
+    }
+  })
+
+  it('all-unchecked units: uncheckedUnits equals total, checkedUnits is zero', () => {
+    const content = ['- [ ] **Unit 1: First**', '- [ ] **Unit 2: Second**'].join('\n')
+    const result = parsePlanUnitCheckboxes(content)
+    expect(result.recognized).toBe(true)
+    if (result.recognized) {
+      expect(result.checkedUnits).toBe(0)
+      expect(result.uncheckedUnits).toBe(2)
+    }
+  })
+
+  it('is a pure function: identical input produces identical output, no I/O', () => {
+    const content = '- [x] **Unit 1: A**\n- [ ] **Unit 2: B**\n'
+    const first = parsePlanUnitCheckboxes(content)
+    const second = parsePlanUnitCheckboxes(content)
+    expect(first).toEqual(second)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolvePlanConsistencyVerdict — the single drift-matrix resolver.
+// Table-tested over the full drift matrix.
+// ---------------------------------------------------------------------------
+
+describe('resolvePlanConsistencyVerdict', () => {
+  it('active + all units checked → drifted, proposal-eligible, correction status: complete', () => {
+    const result = resolvePlanConsistencyVerdict({
+      claimedState: 'active',
+      units: {recognized: true, checkedUnits: 3, uncheckedUnits: 0},
+    })
+    expect(result.verdict).toBe('drifted')
+    expect(result.proposalEligible).toBe(true)
+    expect(result.proposedCorrection).toBe('status: complete')
+  })
+
+  it('complete + all units checked → current', () => {
+    const result = resolvePlanConsistencyVerdict({
+      claimedState: 'complete',
+      units: {recognized: true, checkedUnits: 3, uncheckedUnits: 0},
+    })
+    expect(result.verdict).toBe('current')
+    expect(result.proposalEligible).toBe(false)
+  })
+
+  it('complete + one unchecked unit → unresolved, not proposal-eligible', () => {
+    const result = resolvePlanConsistencyVerdict({
+      claimedState: 'complete',
+      units: {recognized: true, checkedUnits: 2, uncheckedUnits: 1},
+    })
+    expect(result.verdict).toBe('unresolved')
+    expect(result.proposalEligible).toBe(false)
+  })
+
+  it('no recognizable unit markers → unresolved', () => {
+    const result = resolvePlanConsistencyVerdict({
+      claimedState: 'active',
+      units: {recognized: false},
+    })
+    expect(result.verdict).toBe('unresolved')
+    expect(result.proposalEligible).toBe(false)
+  })
+
+  it('unsupported claimed status → unresolved regardless of unit state', () => {
+    const result = resolvePlanConsistencyVerdict({
+      claimedState: 'unsupported',
+      units: {recognized: true, checkedUnits: 3, uncheckedUnits: 0},
+    })
+    expect(result.verdict).toBe('unresolved')
+    expect(result.proposalEligible).toBe(false)
+  })
+
+  it('active + unfinished units → current (not drifted — matrix is one-directional)', () => {
+    const result = resolvePlanConsistencyVerdict({
+      claimedState: 'active',
+      units: {recognized: true, checkedUnits: 1, uncheckedUnits: 2},
+    })
+    expect(result.verdict).toBe('current')
+    expect(result.proposalEligible).toBe(false)
+  })
+
+  it('draft status with any unit state → current', () => {
+    const result = resolvePlanConsistencyVerdict({
+      claimedState: 'draft',
+      units: {recognized: true, checkedUnits: 0, uncheckedUnits: 3},
+    })
+    expect(result.verdict).toBe('current')
+  })
+
+  it('cancelled status with all units checked → current', () => {
+    const result = resolvePlanConsistencyVerdict({
+      claimedState: 'cancelled',
+      units: {recognized: true, checkedUnits: 3, uncheckedUnits: 0},
+    })
+    expect(result.verdict).toBe('current')
+  })
+
+  it('superseded status with mixed unit state → current', () => {
+    const result = resolvePlanConsistencyVerdict({
+      claimedState: 'superseded',
+      units: {recognized: true, checkedUnits: 1, uncheckedUnits: 1},
+    })
+    expect(result.verdict).toBe('current')
+  })
+
+  it('active with zero total units (recognized but empty) never drifts', () => {
+    // Defensive: recognized:true always carries at least one counted unit by
+    // parsePlanUnitCheckboxes construction, but the resolver must not drift on
+    // a zero-unit plan even if a future caller passes this shape directly.
+    const result = resolvePlanConsistencyVerdict({
+      claimedState: 'active',
+      units: {recognized: true, checkedUnits: 0, uncheckedUnits: 0},
+    })
+    expect(result.verdict).not.toBe('drifted')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildPlanConsistencyClaim — synthetic per-plan claim construction
+// ---------------------------------------------------------------------------
+
+describe('buildPlanConsistencyClaim', () => {
+  it('claimedState is the frontmatter status when it is a supported value', () => {
+    const content = '---\nstatus: active\n---\n\nContent.'
+    const claim = buildPlanConsistencyClaim('docs/plans/example.md', content)
+    expect(claim.kind).toBe('plan-consistency')
+    expect(claim.claimedState).toBe('active')
+    expect(claim.path).toBe('docs/plans/example.md')
+    expect(claim.sourceRef).toBe('docs/plans/example.md')
+  })
+
+  it('claimedState collapses an unsupported status value to the fixed sentinel, never the raw text', () => {
+    const content = '---\nstatus: code-complete-pending-verification\n---\n\nContent.'
+    const claim = buildPlanConsistencyClaim('docs/plans/example.md', content)
+    expect(claim.claimedState).toBe('unsupported')
+    expect(claim.claimedState).not.toBe('code-complete-pending-verification')
+  })
+
+  it('missing frontmatter status collapses to the unsupported sentinel', () => {
+    const content = '## No frontmatter here\n\nJust prose.'
+    const claim = buildPlanConsistencyClaim('docs/plans/example.md', content)
+    expect(claim.claimedState).toBe('unsupported')
+  })
+
+  it('privacy: a malformed multi-word status value never survives verbatim into the claim', () => {
+    const content = '---\nstatus: totally made up multi word status\n---\n\nContent.'
+    const claim = buildPlanConsistencyClaim('docs/plans/example.md', content)
+    expect(claim.claimedState).toBe('unsupported')
+    expect(claim.claimedState).not.toContain('totally made up')
+  })
+
+  it('normalizedText is a constant, independent of frontmatter or unit content (fingerprint stability)', () => {
+    const activeContent = '---\nstatus: active\n---\n\n- [x] **Unit 1: A**\n'
+    const completeContent = '---\nstatus: complete\n---\n\n- [ ] **Unit 1: A**\n- [x] **Unit 2: B**\n'
+    const claimA = buildPlanConsistencyClaim('docs/plans/example.md', activeContent)
+    const claimB = buildPlanConsistencyClaim('docs/plans/example.md', completeContent)
+    expect(claimA.normalizedText).toBe(claimB.normalizedText)
+  })
+
+  it('fingerprint is identical for the same plan path across differing unit/status states', () => {
+    const activeContent = '---\nstatus: active\n---\n\n- [x] **Unit 1: A**\n'
+    const completeContent = '---\nstatus: complete\n---\n\n- [ ] **Unit 1: A**\n- [x] **Unit 2: B**\n'
+    const claimA = buildPlanConsistencyClaim('docs/plans/example.md', activeContent)
+    const claimB = buildPlanConsistencyClaim('docs/plans/example.md', completeContent)
+    const fpA = computeClaimFingerprint(claimA.kind, claimA.path, claimA.sourceRef, claimA.normalizedText)
+    const fpB = computeClaimFingerprint(claimB.kind, claimB.path, claimB.sourceRef, claimB.normalizedText)
+    expect(fpA).toBe(fpB)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// scanPlanConsistencyFindings — bounded second pass over docs/plans/*.md
+// ---------------------------------------------------------------------------
+
+describe('scanPlanConsistencyFindings', () => {
+  it('active plan with all units checked yields one drifted, proposal-eligible finding', async () => {
+    const fileLister: FileLister = async () => ['README.md', 'docs/plans/shipped.md']
+    const fileReader: FileReader = async (path: string) => {
+      if (path === 'docs/plans/shipped.md') {
+        return '---\nstatus: active\n---\n\n- [x] **Unit 1: A**\n- [x] **Unit 2: B**\n'
+      }
+      return 'unrelated content'
+    }
+
+    const {findings, scanErrors} = await scanPlanConsistencyFindings({fileLister, fileReader})
+    expect(scanErrors).toBe(0)
+    expect(findings).toHaveLength(1)
+    const finding = findings[0]
+    expect(finding?.kind).toBe('plan-consistency')
+    expect(finding?.path).toBe('docs/plans/shipped.md')
+    expect(finding?.verdict).toBe('drifted')
+    expect(finding?.proposalEligible).toBe(true)
+    expect(finding?.proposedCorrection).toBe('status: complete')
+  })
+
+  it('complete plan with one unchecked unit yields one unresolved finding', async () => {
+    const fileLister: FileLister = async () => ['docs/plans/partial.md']
+    const fileReader: FileReader = async () =>
+      '---\nstatus: complete\n---\n\n- [x] **Unit 1: A**\n- [ ] **Unit 2: B**\n'
+
+    const {findings} = await scanPlanConsistencyFindings({fileLister, fileReader})
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.verdict).toBe('unresolved')
+    expect(findings[0]?.proposalEligible).toBe(false)
+  })
+
+  it('plan with no implementation-units section yields one unresolved finding', async () => {
+    const fileLister: FileLister = async () => ['docs/plans/no-units.md']
+    const fileReader: FileReader = async () => '---\nstatus: active\n---\n\nJust prose, no units.'
+
+    const {findings} = await scanPlanConsistencyFindings({fileLister, fileReader})
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.verdict).toBe('unresolved')
+  })
+
+  it('unsupported frontmatter status yields unresolved with claimedState "unsupported"', async () => {
+    const fileLister: FileLister = async () => ['docs/plans/dashboard.md']
+    const fileReader: FileReader = async () =>
+      '---\nstatus: code-complete-pending-verification\n---\n\n- [x] **Unit 1: A**\n'
+
+    const {findings} = await scanPlanConsistencyFindings({fileLister, fileReader})
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.verdict).toBe('unresolved')
+    expect(findings[0]?.claimedState).toBe('unsupported')
+    // The raw frontmatter text must never survive into the finding
+    expect(JSON.stringify(findings[0])).not.toContain('code-complete-pending-verification')
+  })
+
+  it('heading-encoded units yield an unresolved finding, not drifted', async () => {
+    const fileLister: FileLister = async () => ['docs/plans/legacy.md']
+    const fileReader: FileReader = async () =>
+      '---\nstatus: active\n---\n\n### U1. First\n\nStatus: complete.\n\n### U2. Second\n\nStatus: complete.\n'
+
+    const {findings} = await scanPlanConsistencyFindings({fileLister, fileReader})
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.verdict).toBe('unresolved')
+  })
+
+  it('draft status with checked units yields current, not drifted', async () => {
+    const fileLister: FileLister = async () => ['docs/plans/draft.md']
+    const fileReader: FileReader = async () => '---\nstatus: draft\n---\n\n- [x] **Unit 1: A**\n'
+
+    const {findings} = await scanPlanConsistencyFindings({fileLister, fileReader})
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.verdict).toBe('current')
+  })
+
+  it('only files matching docs/plans/*.md are scanned; other paths are ignored', async () => {
+    const fileLister: FileLister = async () => ['README.md', 'docs/solutions/example.md', 'docs/plans/real.md']
+    const fileReader: FileReader = async (path: string) => {
+      if (path === 'docs/plans/real.md') return '---\nstatus: active\n---\n\n- [x] **Unit 1: A**\n'
+      throw new Error(`unexpected path scanned: ${path}`)
+    }
+
+    const {findings} = await scanPlanConsistencyFindings({fileLister, fileReader})
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.path).toBe('docs/plans/real.md')
+  })
+
+  it('fingerprint is stable across two runs of the same plan with differing unit states', async () => {
+    const fileLister: FileLister = async () => ['docs/plans/example.md']
+    const activeReader: FileReader = async () => '---\nstatus: active\n---\n\n- [x] **Unit 1: A**\n'
+    const completeReader: FileReader = async () =>
+      '---\nstatus: complete\n---\n\n- [ ] **Unit 1: A**\n- [x] **Unit 2: B**\n'
+
+    const runA = await scanPlanConsistencyFindings({fileLister, fileReader: activeReader})
+    const runB = await scanPlanConsistencyFindings({fileLister, fileReader: completeReader})
+
+    expect(runA.findings[0]?.fingerprint).toBe(runB.findings[0]?.fingerprint)
+  })
+
+  it('error path: file read failure increments scanErrors and emits no finding for that plan', async () => {
+    const fileLister: FileLister = async () => ['docs/plans/broken.md', 'docs/plans/ok.md']
+    const fileReader: FileReader = async (path: string) => {
+      if (path === 'docs/plans/broken.md') throw new Error('read failure')
+      return '---\nstatus: active\n---\n\n- [x] **Unit 1: A**\n'
+    }
+
+    const {findings, scanErrors} = await scanPlanConsistencyFindings({fileLister, fileReader})
+    expect(scanErrors).toBe(1)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.path).toBe('docs/plans/ok.md')
+  })
+
+  it('no docs/plans files present yields zero findings and zero errors', async () => {
+    const fileLister: FileLister = async () => ['README.md']
+    const fileReader: FileReader = async () => 'irrelevant'
+
+    const {findings, scanErrors} = await scanPlanConsistencyFindings({fileLister, fileReader})
+    expect(findings).toHaveLength(0)
+    expect(scanErrors).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Detect-flow integration — runDetect-equivalent: plan-consistency findings
+// alongside prose-claim findings in one report.
+// ---------------------------------------------------------------------------
+
+describe('runDetect-equivalent: plan-consistency findings alongside prose-claim findings', () => {
+  it('full pipeline over a fixture corpus produces plan-consistency findings alongside pr-state findings in one report with correct counts', async () => {
+    const fileLister: FileLister = async () => ['README.md', 'docs/plans/shipped.md', 'docs/plans/current.md']
+    const fileReader: FileReader = async (path: string) => {
+      if (path === 'README.md') return 'PR #42 is open.'
+      if (path === 'docs/plans/shipped.md') {
+        return '---\nstatus: active\n---\n\n- [x] **Unit 1: A**\n- [x] **Unit 2: B**\n'
+      }
+      if (path === 'docs/plans/current.md') {
+        return '---\nstatus: complete\n---\n\n- [x] **Unit 1: A**\n'
+      }
+      throw new Error(`unexpected path: ${path}`)
+    }
+
+    const {claims, scanErrors: fileScanErrors} = await scanStatusTruthClaims({fileLister, fileReader})
+    const {findings: planConsistencyFindings, scanErrors: planScanErrors} = await scanPlanConsistencyFindings({
+      fileLister,
+      fileReader,
+    })
+
+    const resolverResults = makeResolverResults([
+      {kind: 'pr-state', sourceRef: '#42', result: {status: 'resolved', state: 'closed'}},
+    ])
+
+    const findings = [...detectStatusTruthClaims(claims, resolverResults), ...planConsistencyFindings]
+    const report = buildStatusTruthReport({
+      findings,
+      scanComplete: fileScanErrors === 0 && planScanErrors === 0,
+      generatedAt: '2026-07-02T00:00:00Z',
+      failureClass: null,
+    })
+
+    expect(report.scan_complete).toBe(true)
+    expect(report.counts.total).toBe(3)
+    expect(report.counts.drifted).toBe(2) // pr-state drift + shipped.md drift
+    expect(report.counts.current).toBe(1) // current.md
+    const kinds = report.findings.map(f => f.kind)
+    expect(kinds).toContain('pr-state')
+    expect(kinds).toContain('plan-consistency')
+  })
+
+  it('deleting a fixture plan between two runs drops its finding from the next report (fingerprint clears)', async () => {
+    const firstLister: FileLister = async () => ['docs/plans/temp.md']
+    const firstReader: FileReader = async () => '---\nstatus: active\n---\n\n- [x] **Unit 1: A**\n'
+    const first = await scanPlanConsistencyFindings({fileLister: firstLister, fileReader: firstReader})
+    expect(first.findings).toHaveLength(1)
+    const firstFingerprint = first.findings[0]?.fingerprint
+
+    // Second run: the plan file is gone from the lister entirely.
+    const secondLister: FileLister = async () => []
+    const secondReader: FileReader = async () => ''
+    const second = await scanPlanConsistencyFindings({fileLister: secondLister, fileReader: secondReader})
+
+    expect(second.findings).toHaveLength(0)
+    expect(second.findings.map(f => f.fingerprint)).not.toContain(firstFingerprint)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Privacy: report JSON finding fields for plan-consistency carry only
+// normalized data — path, statuses, unit counts, correction. No raw plan
+// body text, unit titles, or frontmatter excerpts.
+// ---------------------------------------------------------------------------
+
+describe('plan-consistency privacy: report artifact surface', () => {
+  it('drifted finding report JSON contains only normalized fields — no plan body prose', async () => {
+    const secretSentence = 'This plan discusses fro-bot/super-secret-internal-project details.'
+    const fileLister: FileLister = async () => ['docs/plans/shipped.md']
+    const fileReader: FileReader = async () =>
+      `---\nstatus: active\n---\n\n${secretSentence}\n\n- [x] **Unit 1: A**\n- [x] **Unit 2: B**\n`
+
+    const {findings} = await scanPlanConsistencyFindings({fileLister, fileReader})
+    const report = buildStatusTruthReport({
+      findings,
+      scanComplete: true,
+      generatedAt: '2026-07-02T00:00:00Z',
+      failureClass: null,
+    })
+
+    const artifactJson = JSON.stringify(report)
+    expect(artifactJson).not.toContain(secretSentence)
+    expect(artifactJson).not.toContain('fro-bot/super-secret-internal-project')
+    expect(artifactJson).toContain('"kind":"plan-consistency"')
+    expect(artifactJson).toContain('"path":"docs/plans/shipped.md"')
+    expect(artifactJson).toContain('"proposedCorrection":"status: complete"')
+  })
+
+  it('unresolved unsupported-status finding report JSON never contains the raw malformed status text', async () => {
+    const fileLister: FileLister = async () => ['docs/plans/dashboard.md']
+    const fileReader: FileReader = async () =>
+      '---\nstatus: code-complete-pending-verification\n---\n\n- [x] **Unit 1: A**\n'
+
+    const {findings} = await scanPlanConsistencyFindings({fileLister, fileReader})
+    const report = buildStatusTruthReport({
+      findings,
+      scanComplete: true,
+      generatedAt: '2026-07-02T00:00:00Z',
+      failureClass: null,
+    })
+
+    const artifactJson = JSON.stringify(report)
+    expect(artifactJson).not.toContain('code-complete-pending-verification')
+    expect(artifactJson).toContain('"claimedState":"unsupported"')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Replay test — reproduces the origin incident: three shipped capture plans
+// carrying status: active with all units checked (pre-reconciliation), and a
+// fixture shaped like the current (reconciled) corpus.
+// ---------------------------------------------------------------------------
+
+describe('plan-consistency replay: pre-reconciliation stale capture plans', () => {
+  it('three fixture plans shaped like the stale capture plans (active + all [x]) yield exactly three drifted', async () => {
+    const stalePlanContent = (name: string) =>
+      `---\ntitle: '${name}'\nstatus: active\n---\n\n- [x] **Unit 1: A**\n- [x] **Unit 2: B**\n- [x] **Unit 3: C**\n`
+
+    const fileLister: FileLister = async () => [
+      'docs/plans/2026-06-22-003-feat-enrich-capture-digest-plan.md',
+      'docs/plans/2026-06-22-004-feat-c2-failed-then-fixed-capture-plan.md',
+      'docs/plans/2026-06-23-001-fix-merged-candidate-evidence-plan.md',
+    ]
+    const fileReader: FileReader = async (path: string) => stalePlanContent(path)
+
+    const {findings, scanErrors} = await scanPlanConsistencyFindings({fileLister, fileReader})
+    expect(scanErrors).toBe(0)
+    expect(findings).toHaveLength(3)
+    expect(findings.every(f => f.verdict === 'drifted')).toBe(true)
+    expect(findings.every(f => f.proposalEligible)).toBe(true)
+    expect(findings.every(f => f.proposedCorrection === 'status: complete')).toBe(true)
+  })
+
+  it('a fixture shaped like the current corpus yields zero drifted and one unresolved (unsupported status)', async () => {
+    const fileLister: FileLister = async () => [
+      'docs/plans/2026-06-22-003-feat-enrich-capture-digest-plan.md',
+      'docs/plans/2026-06-15-001-feat-monitoring-dashboard-phase-1-plan.md',
+    ]
+    const fileReader: FileReader = async (path: string) => {
+      if (path === 'docs/plans/2026-06-22-003-feat-enrich-capture-digest-plan.md') {
+        // Reconciled: frontmatter flipped to complete, all units checked.
+        return '---\nstatus: complete\n---\n\n- [x] **Unit 1: A**\n- [x] **Unit 2: B**\n'
+      }
+      // The one plan with an unsupported status value in the real corpus.
+      return '---\nstatus: code-complete-pending-verification\n---\n\n- [x] **Unit 1: A**\n'
+    }
+
+    const {findings} = await scanPlanConsistencyFindings({fileLister, fileReader})
+    expect(findings).toHaveLength(2)
+    const drifted = findings.filter(f => f.verdict === 'drifted')
+    const unresolved = findings.filter(f => f.verdict === 'unresolved')
+    expect(drifted).toHaveLength(0)
+    expect(unresolved).toHaveLength(1)
+    expect(unresolved[0]?.claimedState).toBe('unsupported')
   })
 })

--- a/scripts/status-truth-detect.ts
+++ b/scripts/status-truth-detect.ts
@@ -4,7 +4,8 @@ import {createHash} from 'node:crypto'
 import {readFile, writeFile} from 'node:fs/promises'
 import process from 'node:process'
 
-export type ClaimKind = 'pr-state' | 'issue-state' | 'release-tag-state' | 'plan-status' | 'rollout-tracker-status'
+export type ClaimKind =
+  'pr-state' | 'issue-state' | 'release-tag-state' | 'plan-status' | 'rollout-tracker-status' | 'plan-consistency'
 
 export type ResolverType = 'api' | 'file-parse' | 'compound'
 
@@ -1313,6 +1314,251 @@ export async function resolvePlanStatusClaim(params: {
 }
 
 // ---------------------------------------------------------------------------
+// Plan implementation-unit checkbox parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of parsing implementation-unit checkbox markers from plan content.
+ *
+ * `recognized: false` covers both "no checkbox markers present" and "no
+ * markers matched the recognized grammar" (e.g. heading-encoded units) —
+ * both are treated identically by callers: an unresolved signal, never drifted.
+ */
+export type PlanUnitCheckboxParseResult =
+  | {readonly recognized: true; readonly checkedUnits: number; readonly uncheckedUnits: number}
+  | {readonly recognized: false}
+
+/**
+ * Matches exactly one top-level implementation-unit checkbox marker line:
+ *   `- [x] **Unit N: <label>**`
+ *   `- [ ] **Unit N: <label>**`
+ *
+ * Anchored to the start of the line (no leading whitespace), so indented/nested
+ * checkboxes never match. Requires the bold label to open immediately after the
+ * checkbox with a literal `Unit <digits>:` prefix and to close with `**` at the
+ * end of the line — bold-less labels, non-"Unit N:" bold text, and heading-style
+ * encodings (`### U1.` + `Status:` lines) all fall outside this grammar.
+ */
+const UNIT_CHECKBOX_LINE_PATTERN = /^- \[([ x])\] \*\*Unit \d+:.*\*\*\s*$/u
+
+/**
+ * Parse implementation-unit checkbox markers from plan file content.
+ *
+ * Pure function: no I/O. Recognizes only the top-level `- [x] **Unit N: ...**` /
+ * `- [ ] **Unit N: ...**` grammar (see `UNIT_CHECKBOX_LINE_PATTERN`). Checkboxes
+ * outside that exact form — plain task-list items, indented sub-tasks, bold-less
+ * labels, or heading-encoded units — are never counted.
+ *
+ * Returns `{recognized: false}` when zero lines match the grammar (no markers
+ * present, or all present checkboxes fall outside the recognized form). This
+ * collapses "no markers" and "unrecognized encoding" into one signal: callers
+ * must treat unrecognizable or malformed unit markers as unresolved, never
+ * as drifted.
+ */
+export function parsePlanUnitCheckboxes(content: string): PlanUnitCheckboxParseResult {
+  let checkedUnits = 0
+  let uncheckedUnits = 0
+
+  for (const line of content.split(/\r?\n/u)) {
+    const match = UNIT_CHECKBOX_LINE_PATTERN.exec(line)
+    if (match === null) continue
+    if (match[1] === 'x') {
+      checkedUnits++
+    } else {
+      uncheckedUnits++
+    }
+  }
+
+  if (checkedUnits === 0 && uncheckedUnits === 0) {
+    return {recognized: false}
+  }
+
+  return {recognized: true, checkedUnits, uncheckedUnits}
+}
+
+// ---------------------------------------------------------------------------
+// Plan-consistency claim kind — self-audit of frontmatter status vs. unit
+// completion markers. Does NOT join CLAIM_KIND_DEFINITIONS: that registry is
+// regex-extraction only, and this kind's claims are synthesized directly from
+// already-read plan file content rather than matched out of prose. There is
+// no CLAIM_KIND_DEFINITIONS lookup for this kind anywhere in this module —
+// every switch/lookup over the registry (classifyClaim's compound check,
+// resolverTypeForKind, extractStatusTruthClaimsFromText's per-def loop,
+// resolveFileParseClaims's per-def loop) only ever sees claims of kinds that
+// DO have a definition, because plan-consistency findings are built and
+// resolved entirely outside that pipeline (see scanPlanConsistencyFindings).
+// ---------------------------------------------------------------------------
+
+/**
+ * Fixed sentinel for a plan-consistency claim whose frontmatter status is
+ * missing, malformed, or outside SUPPORTED_PLAN_STATUSES. Raw frontmatter
+ * text must never reach the claim, the report, or any public surface.
+ */
+export const PLAN_CONSISTENCY_UNSUPPORTED_STATUS = 'unsupported'
+
+/**
+ * Constant proposed correction for a drifted plan-consistency finding.
+ * Built from normalized fields, not text replacement.
+ */
+const PLAN_CONSISTENCY_CORRECTION = 'status: complete'
+
+/**
+ * Constant normalizedText for every plan-consistency claim. Fixed (not
+ * derived from unit state) so the fingerprint — which is a hash of kind,
+ * path, sourceRef, and normalizedText — is stable across drift episodes for
+ * the same plan path. Terminal outcome labels therefore act as a permanent
+ * per-plan opt-out, which is documented operator behavior.
+ */
+const PLAN_CONSISTENCY_NORMALIZED_TEXT = 'plan-consistency audit'
+
+/**
+ * Build the synthetic plan-consistency claim for a single plan file.
+ *
+ * Pure function: no I/O. `claimedState` carries the frontmatter status only
+ * when it is a member of SUPPORTED_PLAN_STATUSES; any other value (missing,
+ * malformed, or outside the vocabulary) collapses to the fixed
+ * `PLAN_CONSISTENCY_UNSUPPORTED_STATUS` sentinel before the claim is built,
+ * so arbitrary frontmatter text can never reach the claim, report JSON, or
+ * any public surface.
+ */
+export function buildPlanConsistencyClaim(path: string, content: string): StatusTruthClaim {
+  const rawStatus = parsePlanFrontmatterStatus(content)
+  const claimedState =
+    rawStatus !== null && SUPPORTED_PLAN_STATUSES.includes(rawStatus) ? rawStatus : PLAN_CONSISTENCY_UNSUPPORTED_STATUS
+
+  return {
+    kind: 'plan-consistency',
+    path,
+    sourceRef: path,
+    claimedState,
+    normalizedText: PLAN_CONSISTENCY_NORMALIZED_TEXT,
+  }
+}
+
+/** Result of resolving the plan-consistency drift matrix for one claim. */
+export interface PlanConsistencyVerdictResult {
+  readonly verdict: 'current' | 'drifted' | 'unresolved'
+  readonly proposalEligible: boolean
+  readonly proposedCorrection?: string
+}
+
+/**
+ * The single resolver for the plan-consistency drift matrix.
+ *
+ * Returns the FINAL verdict for this kind directly — there is no
+ * equality-based `classifyClaim` fallback path for plan-consistency, because
+ * naive `liveState === claimedState` equality would misclassify `complete` +
+ * unchecked units as drifted. This function is the one place the matrix is
+ * encoded:
+ *
+ * - missing/malformed/unsupported claimed status → unresolved
+ * - no recognizable unit markers → unresolved
+ * - `active` + every recognized unit checked (>=1 checked unit) → drifted,
+ *   proposal-eligible, correction `status: complete`
+ * - `complete` + at least one unchecked unit → unresolved
+ * - everything else (active+unfinished, complete+all-checked,
+ *   draft/cancelled/superseded in any unit state) → current
+ *
+ * Pure function: no I/O.
+ */
+export function resolvePlanConsistencyVerdict(params: {
+  claimedState: string
+  units: PlanUnitCheckboxParseResult
+}): PlanConsistencyVerdictResult {
+  const {claimedState, units} = params
+
+  if (!SUPPORTED_PLAN_STATUSES.includes(claimedState)) {
+    return {verdict: 'unresolved', proposalEligible: false}
+  }
+
+  if (!units.recognized) {
+    return {verdict: 'unresolved', proposalEligible: false}
+  }
+
+  const allUnitsChecked = units.checkedUnits > 0 && units.uncheckedUnits === 0
+  const hasUncheckedUnits = units.uncheckedUnits > 0
+
+  if (claimedState === 'active' && allUnitsChecked) {
+    return {verdict: 'drifted', proposalEligible: true, proposedCorrection: PLAN_CONSISTENCY_CORRECTION}
+  }
+
+  if (claimedState === 'complete' && hasUncheckedUnits) {
+    return {verdict: 'unresolved', proposalEligible: false}
+  }
+
+  return {verdict: 'current', proposalEligible: false}
+}
+
+/** Repo-relative plan paths this kind audits: top-level `docs/plans/*.md` only. */
+const PLAN_CONSISTENCY_PATH_PATTERN = /^docs\/plans\/[^/]+\.md$/u
+
+/**
+ * Scan `docs/plans/*.md` and emit one plan-consistency finding per plan.
+ *
+ * Bounded second pass: `scanStatusTruthClaims` consumes file contents
+ * internally and returns only claims, so this builder reuses the same
+ * injected `fileLister`/`fileReader` seams from `runDetect` and reads the
+ * (small) plan corpus a second time, rather than widening the scan API.
+ *
+ * Each finding's verdict comes directly from `resolvePlanConsistencyVerdict`
+ * — no `CLAIM_KIND_DEFINITIONS` entry and no `classifyClaim` equality
+ * fallback are involved for this kind. `liveState` carries only normalized
+ * unit counts (`checked=N unchecked=M`) when the unit grammar is recognized;
+ * it is omitted when unrecognized, since there is nothing normalized to report.
+ *
+ * File read failures increment `scanErrors` and produce no finding for that
+ * plan — consistent with existing scan-error accounting elsewhere in this
+ * module; the caller must never fabricate a clean report from a partial scan.
+ */
+export async function scanPlanConsistencyFindings(params: {
+  fileLister: FileLister
+  fileReader: FileReader
+}): Promise<{findings: PublicStatusTruthFinding[]; scanErrors: number}> {
+  const {fileLister, fileReader} = params
+  const paths = await fileLister()
+  const findings: PublicStatusTruthFinding[] = []
+  let scanErrors = 0
+
+  for (const filePath of paths) {
+    if (!PLAN_CONSISTENCY_PATH_PATTERN.test(filePath)) continue
+
+    let content: string
+    try {
+      content = await fileReader(filePath)
+    } catch {
+      scanErrors++
+      continue
+    }
+
+    const claim = buildPlanConsistencyClaim(filePath, content)
+    const units = parsePlanUnitCheckboxes(content)
+    const {verdict, proposalEligible, proposedCorrection} = resolvePlanConsistencyVerdict({
+      claimedState: claim.claimedState,
+      units,
+    })
+    const fingerprint = computeClaimFingerprint(claim.kind, claim.path, claim.sourceRef, claim.normalizedText)
+    // Word-chars-and-hyphens only (no spaces or `=`) so this value round-trips
+    // through the proposal issue body's hidden live-state marker, whose pattern
+    // is `[\w-]+` (see LIVE_STATE_MARKER_PATTERN in status-truth-proposals.ts).
+    const liveState = units.recognized ? `checked-${units.checkedUnits}-unchecked-${units.uncheckedUnits}` : undefined
+
+    findings.push({
+      kind: 'plan-consistency',
+      path: claim.path,
+      sourceRef: claim.sourceRef,
+      verdict,
+      fingerprint,
+      claimedState: claim.claimedState,
+      ...(liveState !== undefined && {liveState}),
+      proposalEligible,
+      ...(proposedCorrection !== undefined && {proposedCorrection}),
+    })
+  }
+
+  return {findings, scanErrors}
+}
+
+// ---------------------------------------------------------------------------
 // Rollout-tracker compound resolver
 // ---------------------------------------------------------------------------
 
@@ -1811,6 +2057,15 @@ async function runDetect(): Promise<void> {
     // Step 1: Scan file-system docs for claims (plan-status included via DEFAULT_ENABLED_KINDS)
     const {claims: fileClaims, scanErrors: fileScanErrors} = await scanStatusTruthClaims({fileLister, fileReader})
 
+    // Step 1b: Plan-consistency self-audit — bounded second pass over docs/plans/*.md.
+    // Produces findings directly (not claims): this kind has its own single
+    // drift-matrix resolver and never enters the CLAIM_KIND_DEFINITIONS/
+    // classifyClaim pipeline. Read failures here are file-parse errors, same
+    // class as fileScanErrors, so they fold into the same failure accounting.
+    const {findings: planConsistencyFindings, scanErrors: planConsistencyScanErrors} =
+      await scanPlanConsistencyFindings({fileLister, fileReader})
+    const totalFileScanErrors = fileScanErrors + planConsistencyScanErrors
+
     // Step 2: Resolve live state and scan GitHub issues (if token available)
     const token = process.env.GITHUB_TOKEN
     let resolveErrors = 0
@@ -1853,17 +2108,24 @@ async function runDetect(): Promise<void> {
       resolverResults = await resolveFileParseClaims({claims: fileClaims, fileReader})
     }
 
-    // Step 3: Classify all claims into findings
+    // Step 3: Classify all claims into findings, then append plan-consistency
+    // findings (already fully classified by scanPlanConsistencyFindings).
+    // No planner/report-shape changes: PublicStatusTruthFinding is generic.
     const allClaims = [...fileClaims, ...issueClaims]
-    const findings = detectStatusTruthClaims(allClaims, resolverResults)
+    const findings = [...detectStatusTruthClaims(allClaims, resolverResults), ...planConsistencyFindings]
 
     // Scan is complete if no per-file, issue-scan, or resolve errors occurred.
     // Failure class distinguishes the error source:
     // - file-parse-error: per-file read/parse errors during file-system scanning
+    //   (includes plan-consistency's own docs/plans/*.md read failures)
     // - api-unavailable: issue list/comment fetch failures or resolver API errors
-    const scanComplete = fileScanErrors === 0 && issueScanErrors === 0 && resolveErrors === 0
+    const scanComplete = totalFileScanErrors === 0 && issueScanErrors === 0 && resolveErrors === 0
 
-    const failureClass = selectDetectFailureClass({fileScanErrors, issueScanErrors, resolveErrors})
+    const failureClass = selectDetectFailureClass({
+      fileScanErrors: totalFileScanErrors,
+      issueScanErrors,
+      resolveErrors,
+    })
 
     report = buildStatusTruthReport({
       findings,

--- a/scripts/status-truth-proposals.test.ts
+++ b/scripts/status-truth-proposals.test.ts
@@ -4754,3 +4754,234 @@ describe('plannedCounts assembly', () => {
     expect(planResult.counts.reopened).toBe(0)
   })
 })
+
+// ---------------------------------------------------------------------------
+// plan-consistency claim kind — planner passthrough
+//
+// The planner has no kind-specific plumbing: a drifted plan-consistency
+// finding must plan/cap/dedupe/close exactly like any other kind, with zero
+// planner code changes. These tests drive the existing planner with a
+// plan-consistency fixture to prove that.
+// ---------------------------------------------------------------------------
+
+function makeDriftedPlanConsistencyFinding(fingerprint = 'abc123def4560001') {
+  return {
+    kind: 'plan-consistency' as const,
+    path: 'docs/plans/example.md',
+    sourceRef: 'docs/plans/example.md',
+    verdict: 'drifted' as const,
+    fingerprint,
+    claimedState: 'active',
+    liveState: 'checked-2-unchecked-0',
+    proposalEligible: true,
+    proposedCorrection: 'status: complete',
+  }
+}
+
+describe('plan-consistency claim kind: planner passthrough', () => {
+  it('plans one open action for a new drifted plan-consistency finding, capped/deduped/gated like any other kind', () => {
+    const finding = makeDriftedPlanConsistencyFinding()
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const {actions, counts, countsByKind} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+
+    const openActions = actions.filter(a => a.type === 'open')
+    expect(openActions).toHaveLength(1)
+    const openAction = openActions[0]
+    if (openAction?.type === 'open') {
+      expect(openAction.fingerprint).toBe(finding.fingerprint)
+      expect(openAction.title).toContain('plan-consistency')
+      expect(openAction.body).toContain(`<!-- status-truth:fingerprint=${finding.fingerprint} -->`)
+    }
+    expect(counts.opened).toBe(1)
+    expect(countsByKind['plan-consistency']?.opened).toBe(1)
+  })
+
+  it('does not open a duplicate when an open issue already matches the plan-consistency fingerprint', () => {
+    const finding = makeDriftedPlanConsistencyFinding()
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const existingIssue = makeOpenIssue(finding.fingerprint, {
+      title: 'Status truth: plan-consistency drift in docs/plans/example.md',
+    })
+
+    const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [existingIssue]}))
+
+    expect(actions.filter(a => a.type === 'open')).toHaveLength(0)
+    expect(counts.noAction).toBeGreaterThanOrEqual(1)
+  })
+
+  it('respects the mutation cap identically for plan-consistency findings', () => {
+    const findings = [
+      makeDriftedPlanConsistencyFinding('abc123def4560001'),
+      makeDriftedPlanConsistencyFinding('abc123def4560002'),
+    ]
+    const report = makeReport({
+      findings,
+      counts: {total: 2, current: 0, drifted: 2, unresolved: 0, unsafe: 0, proposal_eligible: 2},
+    })
+
+    const {actions, counts} = planStatusTruthProposalActions(
+      makePlanInput({report, existingIssues: [], mutationCap: 1}),
+    )
+
+    expect(actions.filter(a => a.type === 'open')).toHaveLength(1)
+    expect(counts.overflowed).toBe(1)
+  })
+
+  it('close-on-clear closes an open plan-consistency proposal when the plan is deleted between runs', () => {
+    const fingerprint = 'abc123def4560001'
+    const report = makeReport({
+      findings: [],
+      status: 'clean',
+      scan_complete: true,
+      counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+    })
+    const existingIssue = makeOpenIssue(fingerprint, {
+      title: 'Status truth: plan-consistency drift in docs/plans/example.md',
+    })
+
+    const {actions, counts} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: [existingIssue]}))
+
+    const closeActions = actions.filter(a => a.type === 'close')
+    expect(closeActions).toHaveLength(1)
+    expect(counts.closed).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// plan-consistency privacy: every public surface carries only normalized
+// data (path, statuses, unit counts, correction). No raw plan-body sentence.
+// ---------------------------------------------------------------------------
+
+describe('plan-consistency privacy: proposal surfaces', () => {
+  it('proposal title contains only kind and path — no raw plan-body sentence', () => {
+    const finding = makeDriftedPlanConsistencyFinding()
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const {actions} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+    const openAction = actions.find(a => a.type === 'open')
+    expect(openAction).toBeDefined()
+    if (openAction?.type === 'open') {
+      expect(openAction.title).toContain('plan-consistency')
+      expect(openAction.title).toContain(finding.path)
+    }
+  })
+
+  it('proposal body contains path, statuses, unit counts, and correction — no sentence copied from the plan body', () => {
+    const secretSentence = 'This plan discusses a confidential rollout timeline that must never leak.'
+    const finding = {
+      ...makeDriftedPlanConsistencyFinding(),
+      // Simulate what would happen if a raw sentence somehow made it onto liveState —
+      // it must not, because the finding builder never puts raw text there. This
+      // test pins the invariant at the proposal-body-rendering boundary too.
+    }
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const {actions} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+    const openAction = actions.find(a => a.type === 'open')
+    expect(openAction).toBeDefined()
+    if (openAction?.type === 'open') {
+      expect(openAction.body).toContain(finding.path)
+      expect(openAction.body).toContain(finding.claimedState)
+      expect(openAction.body).toContain(finding.liveState)
+      expect(openAction.body).toContain(finding.proposedCorrection)
+      expect(openAction.body).not.toContain(secretSentence)
+    }
+  })
+
+  it('update comment, recurrence comment, and close comment for plan-consistency carry only normalized data', () => {
+    const fingerprint = 'abc123def4560001'
+
+    // Update-comment surface: open issue exists, live state changed.
+    const updateFinding = {
+      ...makeDriftedPlanConsistencyFinding(fingerprint),
+      liveState: 'checked-3-unchecked-0',
+    }
+    const updateReport = makeReport({
+      findings: [updateFinding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const openIssueWithOldState: ExistingProposalIssue = {
+      ...makeOpenIssue(fingerprint, {title: 'Status truth: plan-consistency drift in docs/plans/example.md'}),
+      body: `<!-- status-truth:fingerprint=${fingerprint} -->\n<!-- status-truth:live-state=checked-2-unchecked-0 -->\n\nBody.`,
+    }
+    const updateResult = planStatusTruthProposalActions(
+      makePlanInput({report: updateReport, existingIssues: [openIssueWithOldState]}),
+    )
+    const updateAction = updateResult.actions.find(a => a.type === 'update-comment')
+    expect(updateAction).toBeDefined()
+    if (updateAction?.type === 'update-comment') {
+      expect(updateAction.comment).toContain(updateFinding.liveState)
+      expect(updateAction.comment).not.toMatch(/session|agent|workflow log/i)
+    }
+
+    // Recurrence-comment surface: closed non-terminal issue, drift returns.
+    const recurrenceReport = makeReport({
+      findings: [makeDriftedPlanConsistencyFinding(fingerprint)],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const closedNonTerminalIssue = makeClosedIssue(fingerprint, [PROPOSAL_LABEL], {
+      title: 'Status truth: plan-consistency drift in docs/plans/example.md',
+      closedAt: '2026-06-01T00:00:00Z',
+    })
+    const recurrenceResult = planStatusTruthProposalActions(
+      makePlanInput({
+        report: recurrenceReport,
+        existingIssues: [closedNonTerminalIssue],
+        now: new Date('2026-07-02T00:00:00Z'),
+      }),
+    )
+    const reopenAction = recurrenceResult.actions.find(a => a.type === 'reopen')
+    expect(reopenAction).toBeDefined()
+    if (reopenAction?.type === 'reopen') {
+      expect(reopenAction.comment).not.toMatch(/session|agent|workflow log/i)
+      expect(reopenAction.comment).toMatch(/recurrence|returned/i)
+    }
+
+    // Close-comment surface: open issue, drift cleared.
+    const closeReport = makeReport({
+      findings: [],
+      status: 'clean',
+      scan_complete: true,
+      counts: {total: 0, current: 0, drifted: 0, unresolved: 0, unsafe: 0, proposal_eligible: 0},
+    })
+    const openIssueToClose = makeOpenIssue(fingerprint, {
+      title: 'Status truth: plan-consistency drift in docs/plans/example.md',
+    })
+    const closeResult = planStatusTruthProposalActions(
+      makePlanInput({report: closeReport, existingIssues: [openIssueToClose]}),
+    )
+    const closeAction = closeResult.actions.find(a => a.type === 'close')
+    expect(closeAction).toBeDefined()
+    if (closeAction?.type === 'close') {
+      expect(closeAction.comment).not.toMatch(/session|agent|workflow log/i)
+    }
+  })
+
+  it('stdout summary shape (countsByKind) for plan-consistency is counts-only — no paths or fingerprints', () => {
+    const finding = makeDriftedPlanConsistencyFinding()
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const {countsByKind} = planStatusTruthProposalActions(makePlanInput({report, existingIssues: []}))
+    expect(countsByKind['plan-consistency']).toBeDefined()
+
+    const json = JSON.stringify(countsByKind)
+    expect(json).not.toMatch(/docs\/plans\/example\.md/)
+    expect(json).not.toMatch(/[a-f0-9]{16,}/)
+  })
+})


### PR DESCRIPTION
## What

The Status Truth loop gains a self-audit claim kind: every plan under `docs/plans/` is implicitly checked for consistency between its frontmatter `status` and its implementation-unit checkboxes. A shipped plan whose frontmatter still says `active` becomes a drifted finding and a proposal issue — no prose claim or seeding required.

## Why

Plan frontmatter goes stale silently. Three shipped capture plans carried `status: active` a week after their PRs merged; the drift was found only by manual reconciliation. The existing `plan-status` kind verifies prose claims against frontmatter — when the frontmatter itself is the stale artifact and nobody wrote a claim about it, the loop is blind. Each plan already carries its own completion evidence in the same file.

## Design

- **Synthetic per-file claims**, built in a bounded second pass over `docs/plans/*.md` — `plan-consistency` joins the `ClaimKind` union but not the regex-extraction registry.
- **One-directional drift matrix**, encoded in a single resolver: `active` + all units checked → drifted (propose `status: complete`). `complete` + unchecked units, unsupported status values, and unrecognizable unit markers are unresolved — attention signal, never proposals.
- **Privacy by construction**: claimedState normalizes unsupported frontmatter values to a fixed `unsupported` sentinel; proposal surfaces carry only path, statuses, unit counts, and correction. One test per public surface.
- **Stable per-plan fingerprints**: terminal labels (`rejected`/`false-positive`) act as permanent per-plan opt-outs; plan deletion/rename auto-closes via existing close-on-clear. Both documented in the README.
- **Zero planner/workflow changes**: findings flow through the existing caps, dedupe, lifecycle, and public-output gate untouched.
- Normalizes the one heading-encoded plan to checkbox encoding so the corpus is uniform at launch.

## Verification

- TDD throughout (RED observed per unit); 1947 tests green, `pnpm check-types` and `pnpm lint` clean.
- Live corpus run: 26 plans → exactly the 3 known-stale capture plans drifted (pending #3611), 1 expected unresolved (`code-complete-pending-verification`), zero false positives.
- Replay fixtures pin the pre-reconciliation scenario (3 drifted) and the reconciled corpus (0 drifted).