### PR TITLE
feat: add bounded correction PR execution, fully disarmed

### DIFF
--- a/.github/workflows/status-truth.yaml
+++ b/.github/workflows/status-truth.yaml
@@ -14,6 +14,14 @@ on:
         options:
           - 'true'
           - 'false'
+      open_prs:
+        description: Execute correction PR actions (requires STATUS_TRUTH_PRS_ENABLED variable)
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
 
 # Default permissions: read-only. The open job overrides to issues: write.
 permissions:
@@ -285,39 +293,41 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------
-  # PRs job: Bounded correction PR graduation gate.
+  # PRs job: Bounded correction PR execution, gated by three independent keys.
   #
-  # DISABLED PLACEHOLDER: This job is intentionally a no-op. It exists to
-  # document the intended future shape of the PR graduation gate. Enabling real
-  # PR execution requires a reviewed workflow and script change — not just
-  # setting the STATUS_TRUTH_PRS_ENABLED variable below. The job steps are
-  # stubs only.
+  # This job only produces real PR actions when ALL of the following hold:
+  # 1. The repository variable STATUS_TRUTH_PRS_ENABLED is set to 'true'.
+  # 2. At least one claim kind has been added to GRADUATED_CLAIM_KINDS in
+  #    scripts/status-truth-prs.ts via a reviewed repo change.
+  # 3. A workflow_dispatch run explicitly sets the open_prs input to 'true'.
   #
-  # Graduation criteria (all must be met before a real implementation is added):
-  # 1. Phase 1 proposal issues have produced accepted/rejected outcome signal.
-  # 2. A claim kind has been added to GRADUATED_CLAIM_KINDS in status-truth-prs.ts
-  #    via a reviewed repo change.
-  # 3. The workflow steps below have been replaced with a real implementation
-  #    (script invocation, artifact download, token minting, etc.) in a
-  #    separate reviewed PR — toggling the variable alone is not sufficient.
+  # Any single key alone produces zero PR actions. Scheduled runs are
+  # structurally excluded (event-type check) and never open PRs. The script
+  # re-checks all three keys at startup as defense in depth — the workflow
+  # if: condition below is not the only enforcement point.
   #
-  # Safety constraints (enforced in scripts/status-truth-prs.ts):
-  # - enabled=false → all candidates downgrade to proposal-only (no PR actions).
+  # Safety constraints (independently enforced in scripts/status-truth-prs.ts):
+  # - Ungraduated or disarmed candidates downgrade to proposal-only (no PR actions).
   # - Forbidden paths (workflows, hooks, metadata, knowledge, persona, etc.) → proposal-only.
-  # - Privacy gate blocks PR metadata containing private tokens → proposal-only.
-  # - Existing PR rediscovery requires opaque digest match + bot ownership + main target.
+  # - Corrected content must re-resolve as current before any write; failure downgrades.
+  # - At most one open PR per fingerprint; at most one new PR opened per run.
+  # - Every write independently re-validates the single-file diff and the
+  #   bot-owned correction-branch naming pattern before it happens.
+  # - Drift-cleared or terminal-labeled proposals close their own PR and delete
+  #   the correction branch; merged PRs are never touched.
   # - No merge, approve, automerge, force-push, or retarget actions are possible.
+  # - Titles, branches, bodies, and comments carry only opaque fingerprint
+  #   digests and normalized fields, and pass the public-output gate.
+  # - Workflow summaries and logs stay counts-only for PR actions.
   # ---------------------------------------------------------------------------
   prs:
-    name: Plan status-truth correction PRs (disabled placeholder)
+    name: Execute status-truth correction PRs
     runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: open
-    # Disabled placeholder: the variable STATUS_TRUTH_PRS_ENABLED is not set in
-    # this repo, so this job never runs. Enabling real PR execution requires a
-    # reviewed workflow and script change — setting the variable alone is not
-    # sufficient to produce real PR actions.
-    if: ${{ vars.STATUS_TRUTH_PRS_ENABLED == 'true' }}
+    timeout-minutes: 10
+    needs: [detect, open]
+    if: ${{ vars.STATUS_TRUTH_PRS_ENABLED == 'true' && github.event_name == 'workflow_dispatch' && github.event.inputs.open_prs == 'true' }}
+    # Read-only job token; write authority is minted separately below,
+    # scoped at mint time to this repo and this run only.
     permissions:
       contents: read
 
@@ -330,12 +340,72 @@ jobs:
       - name: 📦 Setup
         uses: ./.github/actions/setup
 
-      - name: 🔍 Plan status-truth correction PRs (dry-run only)
-        # Placeholder only. A future implementation must replace this step with
-        # reviewed script invocation, artifact download, and scoped credentials.
+      - name: 📥 Download report artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: status-truth-report
+          path: ${{ runner.temp }}
+
+      # Mint a scoped app token only inside this job, only on armed dispatches.
+      # Raised above the open job's issues:write to include contents:write and
+      # pull-requests:write for branch/commit/PR mutations; issues:read covers
+      # live terminal-label lookups on proposal issues.
+      - name: 🔑 Mint write token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          # Scope to this repo only — smallest blast radius.
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: read
+
+      - name: 🛠 Execute status-truth correction PRs
+        id: prs
         env:
-          STATUS_TRUTH_PRS_ENABLED: 'false'
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          STATUS_TRUTH_REPORT_PATH: ${{ runner.temp }}/status-truth-report.json
+          STATUS_TRUTH_PRS_RESULT_PATH: ${{ runner.temp }}/status-truth-prs-result.json
+          STATUS_TRUTH_DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+          STATUS_TRUTH_PRS_ENABLED: ${{ vars.STATUS_TRUTH_PRS_ENABLED }}
+          STATUS_TRUTH_PRS_DISPATCH_INPUT: ${{ github.event.inputs.open_prs || 'false' }}
+        run: node scripts/status-truth-prs.ts
+
+      - name: 📋 Write PR execution summary
+        if: always()
+        env:
+          STATUS_TRUTH_PRS_RESULT_PATH: ${{ runner.temp }}/status-truth-prs-result.json
         run: |
-          echo "PR graduation gate: disabled (no claim kinds graduated yet)"
-          echo "PR actions planned: 0"
-          echo "Downgraded to proposal-only: 0"
+          set -euo pipefail
+          result="$STATUS_TRUTH_PRS_RESULT_PATH"
+
+          {
+            echo "## Status Truth PR Execution Summary"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+
+            if [[ -s "$result" ]]; then
+              echo "| Armed | $(jq -r 'if .armed then "true" else "false" end' "$result") |"
+              echo "| Dry run | $(jq -r 'if .dryRun then "true" else "false" end' "$result") |"
+              echo "| Planned | $(jq '.plannedCounts.prActionsPlanned // 0' "$result") |"
+              echo "| Downgraded to proposal-only | $(jq '.plannedCounts.downgradedToProposalOnly // 0' "$result") |"
+              echo "| Path forbidden | $(jq '.plannedCounts.pathForbidden // 0' "$result") |"
+              echo "| Privacy gate blocked | $(jq '.plannedCounts.privacyGateBlocked // 0' "$result") |"
+              echo "| Overflow | $(jq '.plannedCounts.overflow // 0' "$result") |"
+              echo "| Version rejected | $(jq '.plannedCounts.versionRejected // 0' "$result") |"
+              echo "| Opened | $(jq '.executedCounts.opened // 0' "$result") |"
+              echo "| Closed | $(jq '.executedCounts.closed // 0' "$result") |"
+              echo "| Downgraded (execution) | $(jq '.executedCounts.downgraded // 0' "$result") |"
+              echo "| Safety refused | $(jq '.executedCounts.safetyRefused // 0' "$result") |"
+              echo "| Failed | $(jq '.executedCounts.failed // 0' "$result") |"
+              echo "| Branch delete failed | $(jq '.executedCounts.branchDeleteFailed // 0' "$result") |"
+              echo "| Would open (dry-run) | $(jq '.executedCounts.wouldOpen // 0' "$result") |"
+              echo "| Would close (dry-run) | $(jq '.executedCounts.wouldClose // 0' "$result") |"
+            else
+              echo "| Status | (PR execution result unavailable) |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -315,6 +315,26 @@ The drift rule: a plan marked `active` whose units are all checked gets a propos
 
 Applying `status-truth:rejected` or `status-truth:false-positive` to a plan-consistency proposal permanently exempts that plan from future consistency proposals. Removing or renaming a plan file clears its finding on the next scan; any open proposal for it auto-closes as resolved.
 
+**Correction PRs (currently disarmed):**
+
+The Status Truth workflow can, once armed, open a pull request that applies a proposal's correction directly instead of waiting on a human edit. No PR opens today. Three independent, reviewed keys must all be true at once before one can:
+
+1. The repository variable `STATUS_TRUTH_PRS_ENABLED` is set to `true`.
+2. At least one claim kind is present in the graduated-kinds set in `scripts/status-truth-prs.ts` — added only via a reviewed code change, never a config toggle.
+3. A manual `workflow_dispatch` run explicitly sets the `open_prs` input to `true`. Scheduled runs never open PRs, no matter how the other two keys are set.
+
+Any single key missing produces zero PR actions; eligible findings fall back to proposal-only, same as today.
+
+**Graduation policy:** a claim kind becomes eligible for the graduated set only after it has accumulated at least one explicit `status-truth:accepted` outcome on a real proposal — resolved-positive outcomes count toward this bar but can't satisfy it alone. Graduating a kind is a one-line reviewed code change adding it to the set, made after that evidence exists. A `status-truth:false-positive` outcome on a graduated kind removes it from the set via another reviewed change; re-graduating it later requires fresh accepted signal, not just reverting the removal.
+
+**Execution posture, once armed:**
+
+- At most one new correction PR opens per run; further eligible findings are counted as blocked and stay proposal-only. An already-open PR being rediscovered doesn't consume that slot, so a long-lived PR can't starve other findings.
+- Each correction PR touches exactly one file, within the same allowed-path prefixes as proposals. Forbidden paths and privacy-gate failures downgrade to proposal-only, same as the detect step.
+- Before any push, the corrected content is re-verified against the live base-branch file, not just the report snapshot — stale drift never gets force-corrected.
+- If a fingerprint's drift clears on a complete scan while its correction PR is still open, the bot closes its own PR with a brief comment and deletes the branch. If the linked proposal later gets a terminal label (`status-truth:rejected` or `status-truth:false-positive`), the same closure happens regardless of drift state. Merged PRs are never touched.
+- The bot never merges, approves, enables automerge, force-pushes, or retargets a correction PR — closing its own stale PRs and deleting its own branches are the only PR-state mutations it can make. A human always merges.
+
 ## Development
 
 ### Code Quality Standards

--- a/docs/brainstorms/2026-07-03-bounded-correction-pr-execution-requirements.md
+++ b/docs/brainstorms/2026-07-03-bounded-correction-pr-execution-requirements.md
@@ -1,0 +1,247 @@
+---
+date: 2026-07-03
+topic: bounded-correction-pr-execution
+title: Bounded correction PR execution for Status Truth
+---
+
+# Bounded correction PR execution for Status Truth
+
+## Summary
+
+Build the real PR-execution path for the Status Truth loop and ship it fully disarmed. The slice
+adds kind-specific pure correctors with mandatory re-verification, a real workflow job behind a
+three-key arming model, stale-PR auto-close, and strict volume caps. Codify the graduation policy;
+graduate no claim kind.
+
+---
+
+## Problem Frame
+
+The A2 arc gated bounded correction PRs on proposal outcome signal, and the first signal now
+exists: the plan-consistency kind produced three drifted findings, three proposal issues, and
+three resolved-positive outcomes with zero false positives in one lifecycle. The corrections were
+mechanically provable one-line frontmatter edits — exactly the shape the graduation path was
+designed for.
+
+But the execution machinery is a disabled placeholder. The workflow PR job is a documented no-op,
+the pure planner has no way to compute corrected file content, and no credential path exists for
+branch or PR creation. Even when a claim kind earns graduation, nothing can act on it. Meanwhile
+the outcome evidence so far is bot-inferred (close-on-clear), not human-confirmed — so building
+the machinery and graduating a kind are two different decisions, and only the first is ready.
+
+---
+
+## Actors
+
+- A1. Marcus: sets the arming variable, dispatches PR-enabled runs, reviews and merges every
+  correction PR, applies outcome labels that feed graduation.
+- A2. Fro Bot: plans correction PR actions for graduated kinds, computes corrected content, opens
+  at most one bounded PR per run, and closes its own stale correction PRs.
+- A3. Status Truth workflow: hosts the detect/open/prs jobs and enforces the arming keys and
+  credential boundaries.
+
+---
+
+## Key Flows
+
+- F1. Bounded correction PR
+  - **Trigger:** A manually dispatched PR-enabled run finds a drifted, proposal-eligible finding
+    of a graduated claim kind.
+  - **Actors:** A2, A3, then A1
+  - **Steps:** Planner selects the finding under caps; the kind's corrector computes new file
+    content; the resolver re-verifies the corrected content as current; the job mints write
+    credentials, creates the opaque branch, opens the PR linked to the proposal fingerprint;
+    Marcus reviews and merges.
+  - **Outcome:** A stale public claim becomes a reviewable one-line diff without autonomous merge.
+  - **Covered by:** R1, R2, R5, R6, R7, R8, R9
+- F2. Stale correction PR cleanup
+  - **Trigger:** A complete scan shows a fingerprint with an open correction PR is no longer
+    drifted.
+  - **Actors:** A2
+  - **Steps:** Planner emits a close action; the shell closes the bot's own PR with a short
+    comment and deletes the correction branch.
+  - **Outcome:** Manually fixed drift does not leave zombie PRs.
+  - **Covered by:** R10
+- F3. Kind graduation
+  - **Trigger:** A claim kind accumulates the required explicit outcome signal.
+  - **Actors:** A1, A2
+  - **Steps:** Marcus adds the kind to the graduated set in a reviewed code PR; the change cites
+    the outcome counts that satisfy the policy.
+  - **Outcome:** Autonomy expands only through reviewed repo changes backed by human-confirmed
+    signal.
+  - **Covered by:** R3, R4
+
+---
+
+## Requirements
+
+**Arming and graduation**
+
+- R1. Real PR execution requires three independent keys: the repository variable
+  `STATUS_TRUTH_PRS_ENABLED` set to `'true'`, at least one kind in the reviewed
+  `GRADUATED_CLAIM_KINDS` set, and a manual `workflow_dispatch` input explicitly requesting PR
+  actions. Scheduled runs never open PRs.
+- R2. This slice ships fully disarmed: the variable stays unset, the graduated set stays empty,
+  and the dispatch input defaults to off.
+- R3. Graduation policy, codified in operator docs: a kind becomes graduation-eligible only after
+  at least one explicit `status-truth:accepted` outcome; resolved positives count toward but
+  cannot solely satisfy the bar. A false-positive outcome removes the kind from the graduated set
+  via a reviewed code change, and re-graduation requires a new reviewed change citing fresh
+  accepted signal.
+- R4. Graduating a kind is a reviewed code change to the graduated set, never a config or
+  variable toggle.
+
+**Correction mechanics**
+
+- R5. Each graduated kind ships a pure corrector: current file content in, corrected content out,
+  no I/O. Correctors are bounded to the claim's cited location class (plan-consistency rewrites
+  exactly the frontmatter status line).
+- R6. Corrected content must re-resolve as current through the kind's own resolver before any
+  branch or PR action is planned; re-verification failure downgrades the action to proposal-only
+  and is counted. At execution time the PR job re-reads the target file from the current base
+  branch, re-runs the corrector and re-verification against that live content, and fails closed
+  (downgrade, no push) if the file no longer produces the planned drifted-to-current transition.
+- R7. Correction PRs touch exactly one file per PR, within the existing allowed-path prefixes;
+  forbidden paths, path traversal, and privacy-gate failures downgrade to proposal-only.
+
+**Volume and lifecycle**
+
+- R8. At most one open correction PR exists per fingerprint; rediscovery uses the existing opaque
+  digest match plus bot ownership plus main-target checks.
+- R9. A run opens at most one new correction PR; further eligible actions remain proposal-only
+  and are reported as blocked counts. Rediscovering an existing open PR does not consume the
+  new-open budget, so a long-lived open PR cannot starve other findings.
+- R10. When a complete, non-execution-failure scan shows a fingerprint's drift cleared while its
+  correction PR is open, the bot closes its own PR with a brief comment and deletes the
+  correction branch. Incomplete scans never trigger PR closure. Merged PRs are never touched.
+- R10b. When the linked proposal carries a terminal outcome label (`status-truth:rejected` or
+  `status-truth:false-positive`), any open correction PR for that fingerprint is closed and its
+  branch deleted on the next armed run, regardless of drift state — terminal suppression governs
+  both surfaces.
+
+**Credentials and safety**
+
+- R11. Write credentials (`contents: write`, `pull-requests: write`) are minted only inside the
+  PR job, only on armed runs, scoped at mint time, and never exposed to detect/open jobs or
+  rendered output.
+- R11b. Planner limits are re-enforced in the execution shell: before any push, the PR job
+  independently validates that the branch content deviates from base by exactly the planned
+  single file and diff; any mismatch aborts without pushing.
+- R11c. The PR job creates, pushes, or deletes only branches matching the bot-owned
+  `status-truth/correction-*` pattern for the current fingerprint; any write or delete targeting
+  another branch — including `data` and any protected branch — is refused at execution time.
+- R11d. The PR job consumes only same-run producer-job outputs for correction planning;
+  cross-run or externally supplied artifacts are never trusted for security-relevant fields.
+- R12. The bot never merges, approves, enables automerge, force-pushes, retargets, or edits
+  branch protection for correction PRs; closing its own stale PRs and deleting its own correction
+  branches are the only permitted PR-state mutations.
+- R13. PR titles, branch names, bodies, and comments are built from fixed prefixes, opaque
+  fingerprint digests, and normalized fields only, and every rendered surface passes the existing
+  public-output gate; gate failure downgrades to proposal-only.
+- R14. Workflow summaries and logs remain counts-only for PR actions (planned, opened,
+  rediscovered, downgraded, closed, blocked).
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2.** Given the shipped defaults (variable unset, graduated set empty), when
+  any run executes — scheduled or dispatched — zero PR actions occur and the PR job reports
+  disarmed counts only.
+- AE2. **Covers R1.** Given the variable is set and a kind is graduated, when a scheduled run
+  finds eligible drift, the action downgrades to proposal-only because no dispatch input
+  requested PR execution.
+- AE3. **Covers R5, R6.** Given a graduated plan-consistency finding, when the corrector rewrites
+  the frontmatter status line and the resolver re-verifies the result as current, an open-PR
+  action is planned; given re-verification fails, the action downgrades and increments a
+  downgrade count.
+- AE4. **Covers R8, R9.** Given three eligible graduated findings in one armed run, when planning
+  completes, exactly one PR opens and two actions are reported as blocked proposal-only counts.
+- AE5. **Covers R10.** Given an open correction PR whose fingerprint is absent from the next
+  complete scan, when the armed run plans actions, the bot closes that PR with a comment and
+  deletes its branch; given the scan was incomplete, no closure occurs.
+- AE6. **Covers R13.** Given a finding whose rendered PR body fails the public-output gate, when
+  planning completes, no PR action occurs and the finding remains proposal-only.
+- AE7. **Covers R6.** Given the target file changed on the base branch between detection and PR
+  execution such that the live content no longer re-verifies, when the PR job runs, no branch is
+  pushed and the action is reported as a downgraded count.
+- AE8. **Covers R10b.** Given an open correction PR whose linked proposal was labeled
+  `status-truth:rejected`, when the next armed run plans actions, the PR is closed and its branch
+  deleted even though the drift still exists.
+- AE9. **Covers R11c.** Given a hypothetical planned action whose branch name does not match the
+  correction-branch pattern, when the PR job validates it, the push is refused and the run
+  reports a safety-refusal count.
+
+---
+
+## Success Criteria
+
+- The disabled placeholder is replaced by a real, tested execution path that provably does
+  nothing until all three arming keys turn.
+- A future graduation is a one-line reviewed change plus a manual dispatch — no new machinery.
+- A dry-run-style armed rehearsal (graduated fixture kind, fixture drift) demonstrates the full
+  open → re-verify → cap → close lifecycle in tests without touching live GitHub state.
+- Every safety property (arming, caps, downgrade classes, credential boundaries, gate coverage)
+  is pinned by tests, not just documented.
+
+---
+
+## Scope Boundaries
+
+- No claim kind graduates in this slice; `GRADUATED_CLAIM_KINDS` ships empty.
+- No autonomous merge, approve, automerge, or branch-protection interaction, ever.
+- No multi-file or multi-finding correction PRs.
+- No corrections outside graduated kinds or outside the existing allowed-path prefixes.
+- No changes to the proposal loop, detect resolvers, or scheduled-run behavior.
+- No new outcome labels; graduation math reads the existing label contract.
+
+---
+
+## Key Decisions
+
+- **Machinery before graduation:** building execution and expanding autonomy are separate
+  reviewed decisions; the first has evidence, the second does not yet.
+- **Three-key arming:** variable, reviewed graduated set, and per-run manual dispatch must all
+  agree; the intersection makes accidental arming implausible without making a real launch
+  ceremony-heavy.
+- **Corrector + re-verification over generic substitution:** a pure per-kind corrector whose
+  output must re-resolve as current turns "the fix is right" into a testable property instead of
+  a text-surgery hope.
+- **Self-cleanup is bounded autonomy:** closing the bot's own stale PR and deleting its own
+  branch mirrors proposal close-on-clear and avoids zombie review load without touching protected
+  actions.
+- **Global cap of one PR per run:** review load is the scarce resource; the cap is a launch
+  posture, liftable later by a reviewed change.
+
+---
+
+## Dependencies / Assumptions
+
+- `scripts/status-truth-prs.ts` remains the pure planner seam: `GRADUATED_CLAIM_KINDS`,
+  opaque branch/title builders, allow/forbid path logic, and downgrade actions extend rather than
+  restart. The planner currently has no close-PR action type and `ExistingStatusTruthPr` carries
+  no branch field — both extensions are planning-owned work, not existing capability.
+- The workflow's `workflow_dispatch` block currently exposes only `dry_run`; the R1 arming input
+  is new. Sibling workflows and the status-truth snapshot step already use scoped GitHub App
+  token minting (`actions/create-github-app-token`) as the R11 precedent.
+- The existing proposal lifecycle supplies fingerprints, outcome labels, and close-on-clear
+  semantics unchanged.
+- GitHub App credential minting used elsewhere in the workflow can scope `contents: write` +
+  `pull-requests: write` at mint time for the PR job.
+- Assumption (labeled): the dispatch input can gate the PR job alongside the existing variable
+  without restructuring the workflow's job graph; verify during planning.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R6][Technical] Whether re-verification runs inside the planner (pure, against
+  corrected content) or as a shell step before branch creation — or both.
+- [Affects R10][Technical] Exact rediscovery fields needed to safely map fingerprint → open PR →
+  branch for closure (existing `ExistingStatusTruthPr` shape may need branch info).
+- [Affects R11][Technical] Which credential mint pattern in the existing workflows is the right
+  precedent for the PR job's scoped token.
+- [Affects R14][Technical] Whether PR-action counts join the existing report artifact or a
+  job-local summary only.

--- a/docs/plans/2026-07-03-001-feat-bounded-correction-pr-execution-plan.md
+++ b/docs/plans/2026-07-03-001-feat-bounded-correction-pr-execution-plan.md
@@ -1,0 +1,421 @@
+---
+title: 'feat: Bounded correction PR execution for Status Truth'
+type: feat
+status: complete
+completed: 2026-07-03
+date: 2026-07-03
+origin: docs/brainstorms/2026-07-03-bounded-correction-pr-execution-requirements.md
+---
+
+# feat: Bounded correction PR execution for Status Truth
+
+## Overview
+
+Replace the Status Truth workflow's disabled PR placeholder with a real, tested execution path
+that ships fully disarmed. The slice extends the pure planner with close actions, budget
+semantics, and corrector/re-verification seams; adds a PR execution shell with independent
+safety enforcement; wires the workflow job behind a three-key arming model; and implements the
+first kind-specific corrector (plan-consistency) — untriggerable until a kind graduates, which
+this slice deliberately does not do.
+
+## Problem Frame
+
+The A2 arc's first proposal lifecycle completed (three drifted findings → three proposals → fix →
+three resolved positives, zero false positives), but the execution machinery for the graduation
+path is a documented no-op: no close action, no corrected-content computation, no write
+credential path (see origin: `docs/brainstorms/2026-07-03-bounded-correction-pr-execution-requirements.md`).
+Building the machinery and graduating a kind are separate reviewed decisions; only the first has
+evidence today.
+
+## Requirements Trace
+
+From the origin document: R1–R2 (three-key arming, ships disarmed), R3–R4 (graduation policy,
+reviewed-code-change-only), R5–R7 (pure correctors, execution-time re-verification, single-file
+bounds), R8–R9 (per-fingerprint dedupe, one-new-open budget with rediscovery exempt), R10/R10b
+(close-on-clear and terminal-label closure, merged PRs untouched), R11–R11d (mint-time scoping,
+shell-side diff validation, correction-branch-pattern-only writes, same-run outputs only),
+R12–R14 (no protected mutations, gated rendered surfaces, counts-only telemetry).
+
+## Scope Boundaries
+
+- `GRADUATED_CLAIM_KINDS` ships empty; no kind graduates.
+- No autonomous merge, approve, automerge, force-push, retarget, or branch-protection interaction.
+- No multi-file or multi-finding PRs; no corrections outside allowed-path prefixes.
+- No changes to detect resolvers, the proposal loop, or scheduled-run behavior.
+- Scheduled runs never open PRs regardless of arming state.
+
+### Deferred to Separate Tasks
+
+- Graduating plan-consistency (or any kind): separate one-line reviewed change once ≥1 explicit
+  `status-truth:accepted` outcome exists.
+- Lifting the one-new-open-per-run cap: separate reviewed change if review throughput warrants.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/status-truth-prs.ts` — pure planner to extend. Today: three action types
+  (`open-pr`, `rediscover-pr`, `downgrade-to-proposal`), empty `GRADUATED_CLAIM_KINDS`,
+  allow/forbid path prefixes, `deriveOpaqueDigest`/`buildOpaqueBranchName`/`buildOpaqueTitle`,
+  `findMatchingExistingPr` (open + bot-owned + main-target + digest + branch-prefix checks).
+  Missing: close action type, rediscovery-exempt open budget (rediscovery currently consumes the
+  slot), corrector/re-verification seams.
+- `scripts/status-truth-proposals.ts` — executor shell pattern to mirror: dry-run short-circuit
+  (counts only, zero API calls), preflight before writes, per-action isolated try/catch with
+  failure accounting, result JSON to a path env var, counts-only stdout. `TERMINAL_LABELS`
+  (`rejected`, `false-positive`) is the R10b source.
+- `scripts/status-truth-detect.ts` — re-verification composition for plan-consistency:
+  `parsePlanFrontmatterStatus` (line-based `status:` regex enables a bounded line rewrite),
+  `buildPlanConsistencyClaim`, `parsePlanUnitCheckboxes`, `resolvePlanConsistencyVerdict`.
+- `scripts/commit-metadata.ts` — single-file API commit precedent
+  (`repos.createOrUpdateFileContents` with 409 retry and conflict-exhausted accounting).
+- `scripts/wiki-ingest.ts` — multi-file branch/commit API pattern (`git.getRef` → `createBlob` →
+  `createTree` → `createCommit` → `updateRef`) with retry/backoff; reference if the single-file
+  path needs branch-creation mechanics (`git.createRef`).
+- `.github/workflows/status-truth.yaml` — prs placeholder job (gated on
+  `vars.STATUS_TRUTH_PRS_ENABLED`); the open job's token mint
+  (`actions/create-github-app-token`, repo-scoped, `permission-issues: write`,
+  `permission-contents: read`) is the mint pattern; the PR job's mint raises contents to write.
+  Detect→open handoff uses the report artifact + result JSON paths.
+- `scripts/status-truth-prs.test.ts` — planner test fixtures (`makeReport`,
+  `makeDriftedFinding`, `makeInput`) and invariant-sectioned describe blocks to extend.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/status-truth-synthetic-self-audit-claim-kinds-2026-07-03.md`:
+  round-trip every marker contract; sentinel normalization; passthrough dividend.
+- `docs/solutions/best-practices/credential-mint-time-permission-scoping-2026-06-22.md`:
+  privilege is bounded at mint time, not by having a second token.
+- `docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md`: every rendered PR
+  surface (title, branch, body, close comment) is a public perimeter needing gate coverage.
+- `docs/solutions/best-practices/pure-core-privacy-gates-shared-module-2026-06-22.md`: planner
+  stays pure; I/O failures live in the shell.
+- `docs/solutions/best-practices/github-issues-api-same-run-eventual-consistency-2026-05-20.md`:
+  same-run created-state discipline when the shell mutates then reports.
+
+## Key Technical Decisions
+
+- **Planner plans, shell enforces:** the planner remains pure and computes intended actions; the
+  execution shell independently re-validates every safety property before any write (single-file
+  diff match, correction-branch pattern, live-content re-verification). Neither layer trusts the
+  other — planner bugs cannot push, and shell bugs cannot plan.
+- **Corrector seam is per-kind and pure:** a corrector map keyed by claim kind exposes
+  `content → corrected content`. Only plan-consistency ships a corrector (bounded frontmatter
+  `status:` line rewrite). Kinds without correctors downgrade to proposal-only even if graduated.
+- **Re-verification lives in the shell only:** the report artifact carries normalized fields, not
+  file content, so the planner cannot verify corrected content. The planner gates on structural
+  facts (graduated kind, corrector exists, path allowed, budget); the shell re-reads the live
+  base-branch file, runs the corrector, and requires the corrected content to re-resolve current
+  before any write (R6 TOCTOU guard). Re-verification failure is a distinct downgrade count.
+- **Terminal-label state is fetched by the shell:** the shell lists open/closed `status-truth`
+  proposal issues (the open job's listing pattern), derives per-fingerprint terminal state from
+  `TERMINAL_LABELS`, and passes it into the planner input as a terminal-fingerprints set. This is
+  why the PR-job mint carries `permission-issues: read` — operator labels land between runs and
+  must be read live, not from the previous run's result JSON.
+- **Close actions cover two causes:** drift-cleared (complete scan, fingerprint absent) and
+  terminal-labeled proposal (R10b). One `close-pr` action type with a reason field; merged PRs
+  are excluded by the open-state check in rediscovery.
+- **Budget semantics are explicit:** `newOpenBudget = 1` per run; rediscovery, close, and
+  downgrade actions never consume it. This replaces the current cap logic where rediscovery
+  consumes the slot.
+- **Branch mechanics via API, not git CLI:** create ref from base HEAD, single-file commit via
+  `createOrUpdateFileContents` on the correction branch (the live re-read via `repos.getContent`
+  supplies both the content for re-verification and the blob `sha` the update call requires),
+  following the commit-metadata retry pattern. Branch deletion via `git.deleteRef`. All three
+  write primitives — createRef, file update, deleteRef — independently validate the
+  correction-branch pattern before calling (R11c); every validation runs before the first write
+  call of an action, so a refused action creates no branch object at all.
+- **Branch collision policy:** deletion failures are counted-not-fatal, so stale correction
+  branches are inevitable. On createRef 422 (ref exists): fetch the existing tip; if its
+  single-file diff equals the freshly computed corrected content, reuse the branch; otherwise
+  refuse with a counted safety error. Never force-update. The same policy covers leftover
+  branches from closed-but-not-merged PRs (rediscovery matches open PRs only; a new drift episode
+  plans a fresh open and hits this policy on the stale branch).
+- **Minted tokens never serialize:** the write token lives in step env only; it never enters
+  result JSON, summaries, rendered surfaces, or failure logs.
+- **Arming is evaluated in three places:** workflow `if:` (variable + dispatch input), shell
+  startup (env re-check, exits disarmed-counts-only), and planner (`enabled` flag downgrades
+  everything). Defense in depth over a single gate.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Re-verification placement: both planner (detect-time) and shell (live content) — see Key
+  Technical Decisions.
+- Credential precedent: the open job's `actions/create-github-app-token` mint, raised to
+  `permission-contents: write` and `permission-pull-requests: write`, repo-scoped.
+- PR-action counts surface: a result JSON path env var consumed by the workflow summary,
+  mirroring the open job; counts join the job summary, not the detect report artifact.
+
+### Deferred to Implementation
+
+- Exact `close-pr` reason vocabulary (`drift-cleared` vs `terminal-label`) naming.
+- Whether branch deletion failures (already-deleted, protected-by-race) are retried or counted
+  and skipped — follow the proposals shell's isolated-failure pattern.
+- Exact dispatch input name (`open_prs` vs `enable_prs`) — match existing input naming style.
+
+## Implementation Units
+
+- [x] **Unit 1: Planner extensions — close actions, budgets, corrector seam**
+
+**Goal:** The pure planner models the full correction-PR lifecycle under the new safety contract.
+
+**Requirements:** R5 (seam), R6 (planner-side re-verification), R8, R9, R10, R10b
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `scripts/status-truth-prs.ts`
+- Test: `scripts/status-truth-prs.test.ts`
+
+**Approach:**
+- Add `close-pr` action type with a reason field (drift-cleared, terminal-label) and branch
+  name; extend `ExistingStatusTruthPr` with the branch data closure needs.
+- Extend the planner input with a shell-supplied terminal-fingerprints set (derived from proposal
+  issue labels; the planner never does I/O to obtain it).
+- Replace the cap logic: `newOpenBudget` counts only `open-pr` actions; rediscovery, close, and
+  downgrades are exempt.
+- Add the corrector seam: a per-kind registry the planner consults for existence only — a
+  graduated kind without a registered corrector downgrades with a distinct reason. Content-level
+  re-verification is shell-only (the planner has no file content).
+- Ownership split with Unit 3: this unit owns pure planning exports (action modeling, budgets,
+  closure/downgrade decisions); Unit 3 owns execution functions and API calls. The boundary is
+  the action schema — the shell consumes planned actions and re-validates them; it never reaches
+  into planner internals.
+- Closure planning: fingerprint absent from a complete, non-execution-failure report while an
+  open bot-owned PR exists → close-pr (drift-cleared); linked proposal carries a terminal label →
+  close-pr (terminal-label) regardless of drift.
+
+**Execution note:** Test-first; every budget/closure/downgrade rule is a table-testable invariant.
+
+**Test scenarios:**
+- Happy path: graduated drifted finding with passing corrector → one open-pr with opaque
+  branch/title (AE3).
+- Edge case: three eligible findings → one open-pr + two overflow downgrades (AE4).
+- Edge case: existing open PR rediscovered + a second eligible finding → rediscovery does not
+  consume the budget; the second finding gets the open-pr slot.
+- Edge case: fingerprint cleared on complete scan with open PR → close-pr(drift-cleared);
+  incomplete scan → no close action (AE5).
+- Edge case: terminal-labeled proposal with open PR and persisting drift → close-pr
+  (terminal-label) (AE8).
+- Edge case: graduated kind without a corrector → downgrade with distinct reason.
+- Error path: graduated finding whose fingerprint is in the terminal set with no open PR → no
+  action (suppression, not closure).
+- Invariant: no action type beyond the four; disabled/ungraduated inputs produce zero PR actions
+  (AE1).
+
+**Verification:**
+- Planner functions remain pure (no I/O in any planning code path; the file hosts the Unit 3
+  shell alongside them, matching the proposals-module pattern); all existing planner tests still
+  pass unchanged except deliberate cap-semantics updates.
+
+- [x] **Unit 2: Plan-consistency corrector**
+
+**Goal:** First kind-specific pure corrector: bounded frontmatter status-line rewrite.
+
+**Requirements:** R5, R6, R7
+
+**Dependencies:** Unit 1 (seam shape)
+
+**Files:**
+- Modify: `scripts/status-truth-detect.ts`
+- Test: `scripts/status-truth-detect.test.ts`
+
+**Approach:**
+- Pure function: plan content in → corrected content out, rewriting exactly the frontmatter
+  `status:` line to `status: complete`; every other byte preserved.
+- Composes with existing pieces for re-verification: corrected content → claim → checkbox parse →
+  verdict must be current.
+- Exported for both planner (Unit 1 seam) and shell (Unit 3 live re-check) use.
+
+**Execution note:** Test-first.
+
+**Test scenarios:**
+- Happy path: stale-active fixture → corrected content resolves current; only the status line
+  differs.
+- Edge case: quoted status values (`status: "active"`) rewritten preserving no quotes or matching
+  file style — characterize corpus, pick one canonical output.
+- Edge case: `status:` text in the plan body (outside frontmatter) is not touched.
+- Error path: content without parseable frontmatter → corrector returns a no-correction signal,
+  never a mangled file.
+- Round-trip: corrected fixture re-verifies current through the full resolver composition.
+
+**Verification:**
+- Diff between fixture and corrected output is exactly one line across all corpus-shaped
+  fixtures.
+
+- [x] **Unit 3: PR execution shell with independent safety enforcement**
+
+**Goal:** The Octokit shell executes planned actions with its own validation of every safety
+property.
+
+**Requirements:** R6 (live re-check), R11b, R11c, R11d, R12, R13, R14
+
+**Dependencies:** Units 1–2
+
+**Files:**
+- Modify: `scripts/status-truth-prs.ts`
+- Test: `scripts/status-truth-prs.test.ts`
+
+**Approach:**
+- Mirror the proposals executor: per-action isolated try/catch, result JSON to an env-var path,
+  counts-only stdout. Dry-run contract: read-only API calls are permitted (proposal-issue
+  listing, live file re-read, re-verification) so dry-run exercises the real safety pipeline;
+  zero mutating calls; result carries a dry-run marker with would-act counts.
+- Fetch proposal-issue label state and build the terminal-fingerprints set for the planner input
+  (Unit 1 seam).
+- Validation order for open-pr, all before ANY write call (createRef included): re-read the
+  target file from live base branch via `repos.getContent` (content + blob sha in one call);
+  re-run corrector + re-verification (R6 TOCTOU guard); validate the planned diff is exactly one
+  allowed-path file (R11b); validate the branch name matches the correction pattern for the
+  current fingerprint (R11c). Any failure aborts the action with a safety-refusal count (AE7,
+  AE9) and no branch object exists.
+- Branch + commit via API: `git.createRef` from base HEAD, `repos.createOrUpdateFileContents`
+  (passing the fetched blob sha) with the commit-metadata 409-retry pattern; PR create with
+  opaque title, gated body. On createRef 422: apply the branch collision policy (reuse only if
+  the existing tip matches the computed correction; otherwise counted refusal; never
+  force-update).
+- Close-pr execution: close own PR with a brief gated comment, delete branch via `git.deleteRef`
+  only when the branch matches the correction pattern (R11c); deletion failures counted, not
+  fatal.
+- All rendered surfaces (title, body, close comment) pass `applyPublicOutputGate`; gate failure →
+  action aborted, counted (AE6).
+- Shell startup re-checks arming env; disarmed → counts-only exit (AE1).
+
+**Execution note:** Test-first with a mocked Octokit following the proposals-shell test pattern;
+assert exact API call shapes and the refusal paths.
+
+**Test scenarios:**
+- Happy path: open-pr action → createRef + createOrUpdateFileContents + pulls.create with opaque
+  metadata; result counts opened=1.
+- Happy path: close-pr → pulls.update(closed) + gated comment + deleteRef on pattern-matching
+  branch.
+- Edge case: live content changed since detection and fails re-verification → no push,
+  downgraded count (AE7).
+- Edge case: branch name not matching the correction pattern → refusal count, no API write (AE9).
+- Edge case: planned diff touches a second file → refusal, no push (R11b).
+- Edge case: deleteRef 422 (already gone) → counted, run continues.
+- Edge case: createRef 422 with a stale branch whose tip differs from the computed correction →
+  counted refusal, no force-update, no PR.
+- Edge case: createRef 422 with a branch tip identical to the computed correction → branch
+  reused, PR opened.
+- Error path: pulls.create failure → isolated failure count, remaining actions still execute.
+- Privacy: PR body/close comment failing the gate → action aborted (AE6); all rendered fixtures
+  contain only opaque digests and normalized fields; result JSON and stdout contain no token
+  material.
+- Dry-run: full action list produces zero mutating API calls (read-only listing/re-read calls
+  permitted) and would-act counts with a dry-run marker.
+
+**Verification:**
+- No API call in any test occurs before every applicable safety validation has passed.
+
+- [x] **Unit 4: Workflow wiring — armed job, dispatch input, scoped mint**
+
+**Goal:** Replace the placeholder prs job with the real gated execution job.
+
+**Requirements:** R1, R2, R11, R11d, R14
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `.github/workflows/status-truth.yaml`
+
+**Approach:**
+- Add a string-choice `workflow_dispatch` input matching the existing `dry_run` convention
+  (`'true'`/`'false'`, default `'false'`); the prs job's `if:` requires
+  `vars.STATUS_TRUTH_PRS_ENABLED == 'true'` AND `github.event_name == 'workflow_dispatch'` AND
+  the input string equal to `'true'` (string-to-string comparison per the existing input
+  pattern; scheduled runs are structurally excluded by the event check).
+- Arming × dry-run matrix is explicit and test-pinned in the shell: armed + `dry_run=true` → the
+  prs job runs the full read-only pipeline and reports would-act counts with a dry-run marker;
+  armed + `dry_run=false` → mutating execution; any other combination → job skipped or
+  counts-only exit with a stated reason.
+- Mint the write token inside the prs job only: `actions/create-github-app-token`, repo-scoped,
+  `permission-contents: write`, `permission-pull-requests: write`, `permission-issues: read`
+  (terminal-label reads).
+- Consume the same-run report artifact and open-result JSON (R11d — same-run producer outputs);
+  pass paths via env.
+- Summary step reports counts only from the shell's result JSON.
+- Remove the placeholder stub steps and the "disabled placeholder" naming; keep the graduation
+  criteria comment block updated to reflect the shipped three-key model.
+
+**Test scenarios:**
+- Test expectation: none — workflow YAML; verified by actionlint-equivalent CI (`Check
+  Workflows`), a dry-run dispatch on merged main, and the arming matrix below.
+
+**Verification:**
+- With defaults (variable unset), the job is skipped on schedule and dispatch.
+- With the variable set but input off, the job is skipped (AE2 shape).
+- A fully armed dispatch on a corpus with no graduated kinds runs the shell and reports zero PR
+  actions, disarmed-kind counts only (AE1).
+
+- [x] **Unit 5: Operator documentation**
+
+**Goal:** README documents the arming model, graduation policy, and PR lifecycle.
+
+**Requirements:** R3, R4, R12 (documented boundaries)
+
+**Dependencies:** Units 1–4
+
+**Files:**
+- Modify: `README.md`
+
+**Approach:**
+- Extend the Status-Truth section: three-key arming, graduation policy (explicit accepted
+  outcomes required; false-positive removes the kind via reviewed change), one-PR-per-run
+  posture, close-on-clear and terminal-label closure semantics, and the human-merge-always
+  boundary.
+
+**Test scenarios:**
+- Test expectation: none — docs-only; markdown lint and operator-accuracy review.
+
+**Verification:**
+- A reader can determine why no PRs open today and exactly which three reviewed steps arm the
+  path.
+
+## System-Wide Impact
+
+- **Interaction graph:** detect/open jobs unchanged; prs job goes from no-op to gated executor
+  consuming same-run outputs; proposal lifecycle untouched.
+- **Error propagation:** every shell action fails in isolation with counts; safety refusals are
+  distinct from failures; disarmed states exit clean with counts.
+- **State lifecycle risks:** correction branches are created and deleted only under the pattern
+  guard; fingerprint → branch mapping is deterministic (opaque digest), so re-drift after
+  closure recreates the same branch name from fresh base content.
+- **API surface parity:** result-JSON + summary pattern matches the open job; no new report
+  artifact fields.
+- **Integration coverage:** planner→shell handoff, arming matrix, and refusal paths are all
+  test-pinned; live verification is a fully-armed dispatch against an empty graduated set.
+- **Unchanged invariants:** `main` protection, human merge, data-branch authority, proposal
+  caps/cooldowns/labels, detect resolvers, scheduled-run behavior, and the counts-only telemetry
+  contract.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| First contents-write credential in this workflow | Mint-time repo scoping; minted only in the prs job on armed dispatches; R11c pattern refusal at execution; R11b diff validation before push. |
+| Planner/shell drift on safety rules | Both layers tested independently; shell never trusts planner output (re-validates path, branch, content). |
+| TOCTOU between detect and push | Live re-read + re-verification in the shell; fail-closed downgrade (AE7). |
+| Zombie or orphaned correction branches | Close actions delete branches; deletion failures counted; deterministic branch names make orphans discoverable. |
+| Accidental arming | Three independent keys; scheduled runs structurally excluded; shell re-checks env at startup. |
+| Cap starvation of eligible findings | Rediscovery exempt from the new-open budget (R9); starvation scenario test-pinned. |
+
+## Documentation / Operational Notes
+
+- First armed rehearsal after merge: set the variable, dispatch with the input on, graduated set
+  still empty — expect zero PR actions and clean disarmed-kind counts (AE1 live).
+- Real graduation later requires: reviewed code change adding the kind + variable + dispatch —
+  documented in README (Unit 5).
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-07-03-bounded-correction-pr-execution-requirements.md](../brainstorms/2026-07-03-bounded-correction-pr-execution-requirements.md)
+- Related code: `scripts/status-truth-prs.ts`, `scripts/status-truth-proposals.ts`,
+  `scripts/status-truth-detect.ts`, `scripts/commit-metadata.ts`, `scripts/wiki-ingest.ts`,
+  `.github/workflows/status-truth.yaml`
+- Prior plans: [docs/plans/2026-07-02-001-feat-plan-consistency-claim-kind-plan.md](2026-07-02-001-feat-plan-consistency-claim-kind-plan.md)
+- Related learnings: `docs/solutions/best-practices/status-truth-synthetic-self-audit-claim-kinds-2026-07-03.md`,
+  `docs/solutions/best-practices/credential-mint-time-permission-scoping-2026-06-22.md`,
+  `docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md`

--- a/scripts/status-truth-detect.test.ts
+++ b/scripts/status-truth-detect.test.ts
@@ -26,6 +26,7 @@ import {
   buildStatusTruthReport,
   CLAIM_KIND_DEFINITIONS,
   computeClaimFingerprint,
+  correctPlanConsistencyStatusLine,
   DEFAULT_ENABLED_KINDS,
   detectStatusTruthClaims,
   extractStatusTruthClaimsFromText,
@@ -43,6 +44,7 @@ import {
   resolvePlanConsistencyVerdict,
   resolvePlanStatusClaim,
   resolveRolloutTrackerClaim,
+  reverifyPlanConsistencyCorrection,
   scanIssueStatusTruthClaims,
   scanPlanConsistencyFindings,
   scanStatusTruthClaims,
@@ -5062,5 +5064,133 @@ describe('plan-consistency replay: pre-reconciliation stale capture plans', () =
     expect(drifted).toHaveLength(0)
     expect(unresolved).toHaveLength(1)
     expect(unresolved[0]?.claimedState).toBe('unsupported')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Plan-consistency corrector: bounded frontmatter status-line rewrite
+// ---------------------------------------------------------------------------
+
+describe('plan-consistency corrector: bounded status-line rewrite', () => {
+  it('rewrites exactly the frontmatter status line to status: complete; every other byte preserved', () => {
+    const original = [
+      '---',
+      "title: 'Example plan'",
+      'status: active',
+      'date: 2026-06-22',
+      '---',
+      '',
+      '# Example plan',
+      '',
+      '- [x] **Unit 1: A**',
+      '- [x] **Unit 2: B**',
+      '',
+    ].join('\n')
+
+    const corrected = correctPlanConsistencyStatusLine(original)
+    expect(corrected).not.toBeNull()
+
+    const expected = original.replace('status: active', 'status: complete')
+    expect(corrected).toBe(expected)
+
+    // Only the status line differs.
+    const originalLines = original.split('\n')
+    const correctedLines = (corrected ?? '').split('\n')
+    expect(correctedLines).toHaveLength(originalLines.length)
+    const diffLines = originalLines.filter((line, i) => line !== correctedLines[i])
+    expect(diffLines).toHaveLength(1)
+    expect(diffLines[0]).toBe('status: active')
+  })
+
+  it('rewrites a quoted status value, producing an unquoted canonical output', () => {
+    const original = ['---', 'status: "active"', '---', '', 'body', ''].join('\n')
+    const corrected = correctPlanConsistencyStatusLine(original)
+    expect(corrected).not.toBeNull()
+    expect(corrected).toContain('status: complete')
+    expect(corrected).not.toContain('"active"')
+    expect(corrected).not.toContain('"complete"')
+  })
+
+  it('rewrites a single-quoted status value, producing an unquoted canonical output', () => {
+    const original = ['---', "status: 'active'", '---', '', 'body', ''].join('\n')
+    const corrected = correctPlanConsistencyStatusLine(original)
+    expect(corrected).not.toBeNull()
+    expect(corrected).toContain('status: complete')
+    expect(corrected).not.toContain("'active'")
+  })
+
+  it('does not touch status: text appearing in the plan body outside frontmatter', () => {
+    const original = [
+      '---',
+      'status: active',
+      '---',
+      '',
+      'Note: status: active is also mentioned here for illustration.',
+      '',
+    ].join('\n')
+    const corrected = correctPlanConsistencyStatusLine(original)
+    expect(corrected).not.toBeNull()
+    expect(corrected).toContain('Note: status: active is also mentioned here for illustration.')
+    // Only the frontmatter occurrence changed.
+    const correctedOccurrences = (corrected ?? '').split('status: active').length - 1
+    expect(correctedOccurrences).toBe(1)
+  })
+
+  it('returns null (no-correction signal) when content has no parseable frontmatter', () => {
+    const original = '# No frontmatter here\n\nJust body text.\n'
+    const corrected = correctPlanConsistencyStatusLine(original)
+    expect(corrected).toBeNull()
+  })
+
+  it('returns null when frontmatter exists but has no status line', () => {
+    const original = ['---', "title: 'No status here'", '---', '', 'body', ''].join('\n')
+    const corrected = correctPlanConsistencyStatusLine(original)
+    expect(corrected).toBeNull()
+  })
+
+  it('never mangles the file: corrected content is always the original with exactly the status token changed, or null', () => {
+    const fixtures = [
+      '---\nstatus: active\n---\nbody\n',
+      '---\nstatus: "active"\n---\nbody\n',
+      "---\nstatus: 'active'\n---\nbody\n",
+      '---\ntitle: x\nstatus: active\ndate: 2026-01-01\n---\nbody\nstatus: active\n',
+    ]
+    for (const fixture of fixtures) {
+      const corrected = correctPlanConsistencyStatusLine(fixture)
+      expect(corrected).not.toBeNull()
+      expect(typeof corrected).toBe('string')
+    }
+  })
+
+  it('round-trip: corrected fixture re-verifies as current through the full resolver composition', () => {
+    const original = [
+      '---',
+      "title: 'Round trip plan'",
+      'status: active',
+      '---',
+      '',
+      '- [x] **Unit 1: A**',
+      '- [x] **Unit 2: B**',
+      '',
+    ].join('\n')
+
+    const corrected = correctPlanConsistencyStatusLine(original)
+    expect(corrected).not.toBeNull()
+    const correctedContent = corrected ?? ''
+
+    const result = reverifyPlanConsistencyCorrection('docs/plans/round-trip-plan.md', correctedContent)
+    expect(result.verdict).toBe('current')
+  })
+
+  it('round-trip fails to re-verify when unit checkboxes still show unchecked units (correction alone is insufficient)', () => {
+    const original = ['---', 'status: active', '---', '', '- [x] **Unit 1: A**', '- [ ] **Unit 2: B**', ''].join('\n')
+
+    const corrected = correctPlanConsistencyStatusLine(original)
+    expect(corrected).not.toBeNull()
+    const correctedContent = corrected ?? ''
+
+    const result = reverifyPlanConsistencyCorrection('docs/plans/incomplete-plan.md', correctedContent)
+    // status: complete + an unchecked unit → unresolved, not current.
+    expect(result.verdict).toBe('unresolved')
   })
 })

--- a/scripts/status-truth-detect.ts
+++ b/scripts/status-truth-detect.ts
@@ -1489,6 +1489,59 @@ export function resolvePlanConsistencyVerdict(params: {
   return {verdict: 'current', proposalEligible: false}
 }
 
+/**
+ * Bounded pure corrector for the plan-consistency claim kind.
+ *
+ * Rewrites exactly the frontmatter `status:` line to `status: complete`,
+ * preserving every other byte of the input. Handles unquoted, double-quoted,
+ * and single-quoted status values; the corrected line is always the
+ * canonical unquoted form. `status:` occurrences in the plan body (outside
+ * the frontmatter block) are never touched.
+ *
+ * Returns `null` — a no-correction signal — when the content has no
+ * parseable frontmatter block or the frontmatter has no `status:` line.
+ * Never returns a mangled file: the output is always either the original
+ * content with only the frontmatter status line changed, or `null`.
+ *
+ * Pure function: no I/O.
+ */
+export function correctPlanConsistencyStatusLine(content: string): string | null {
+  const frontmatterMatch = /^(---\r?\n)([\s\S]+?)(\r?\n---)/u.exec(content)
+  if (frontmatterMatch === null) return null
+
+  const [fullMatch, openDelim, frontmatterText, closeDelim] = frontmatterMatch
+  if (openDelim === undefined || frontmatterText === undefined || closeDelim === undefined) return null
+
+  const statusLinePattern = /^status:\s*["']?(\w+)["']?\s*$/mu
+  const statusMatch = statusLinePattern.exec(frontmatterText)
+  if (statusMatch === null) return null
+
+  const correctedFrontmatterText = frontmatterText.replace(statusLinePattern, 'status: complete')
+  const correctedFrontmatterBlock = `${openDelim}${correctedFrontmatterText}${closeDelim}`
+
+  return (
+    content.slice(0, frontmatterMatch.index) +
+    correctedFrontmatterBlock +
+    content.slice((frontmatterMatch.index ?? 0) + fullMatch.length)
+  )
+}
+
+/**
+ * Re-verify a plan-consistency correction through the full resolver
+ * composition: corrected content → claim → checkbox parse → verdict.
+ *
+ * Exported for both the shell (live re-check, R6 TOCTOU guard) and tests.
+ * Pure function: no I/O.
+ */
+export function reverifyPlanConsistencyCorrection(
+  path: string,
+  correctedContent: string,
+): PlanConsistencyVerdictResult {
+  const claim = buildPlanConsistencyClaim(path, correctedContent)
+  const units = parsePlanUnitCheckboxes(correctedContent)
+  return resolvePlanConsistencyVerdict({claimedState: claim.claimedState, units})
+}
+
 /** Repo-relative plan paths this kind audits: top-level `docs/plans/*.md` only. */
 const PLAN_CONSISTENCY_PATH_PATTERN = /^docs\/plans\/[^/]+\.md$/u
 

--- a/scripts/status-truth-prs.test.ts
+++ b/scripts/status-truth-prs.test.ts
@@ -15,11 +15,24 @@
  */
 
 import type {StatusTruthJsonReport} from './status-truth-detect.ts'
-import type {ExistingStatusTruthPr, PlanStatusTruthPrActionsInput, StatusTruthPrAction} from './status-truth-prs.ts'
+import type {
+  ExecuteStatusTruthPrActionsInput,
+  ExistingStatusTruthPr,
+  PlanStatusTruthPrActionsInput,
+  StatusTruthPrAction,
+  StatusTruthPrOctokitClient,
+} from './status-truth-prs.ts'
 import type {PublicOutputTokens} from './status-truth-public-output.ts'
+import {Buffer} from 'node:buffer'
 import {createHash} from 'node:crypto'
-import {describe, expect, it} from 'vitest'
-import {GRADUATED_CLAIM_KINDS, planStatusTruthPrActions, PR_BRANCH_PREFIX, PR_TITLE_PREFIX} from './status-truth-prs.ts'
+import {describe, expect, it, vi} from 'vitest'
+import {
+  executeStatusTruthPrActions,
+  GRADUATED_CLAIM_KINDS,
+  planStatusTruthPrActions,
+  PR_BRANCH_PREFIX,
+  PR_TITLE_PREFIX,
+} from './status-truth-prs.ts'
 
 // Mirrors the production digest derivation so tests stay in sync without
 // importing the private helper.
@@ -49,7 +62,8 @@ function makeReport(overrides: Partial<StatusTruthJsonReport> = {}): StatusTruth
 function makeDriftedFinding(
   overrides: {
     fingerprint?: string
-    kind?: 'pr-state' | 'issue-state' | 'release-tag-state' | 'plan-status' | 'rollout-tracker-status'
+    kind?:
+      'pr-state' | 'plan-consistency' | 'issue-state' | 'release-tag-state' | 'plan-status' | 'rollout-tracker-status'
     path?: string
     sourceRef?: string
     claimedState?: string
@@ -58,7 +72,7 @@ function makeDriftedFinding(
   } = {},
 ) {
   return {
-    kind: overrides.kind ?? ('pr-state' as const),
+    kind: overrides.kind ?? ('plan-consistency' as const),
     path: overrides.path ?? 'docs/plans/example.md',
     sourceRef: overrides.sourceRef ?? '#42',
     verdict: 'drifted' as const,
@@ -94,6 +108,7 @@ function makeInput(overrides: Partial<PlanStatusTruthPrActionsInput> = {}): Plan
     publicOutputTokens: makeLoadedTokens(),
     maxPrsPerRun: 1,
     enabled: false,
+    terminalFingerprints: new Set<string>(),
     ...overrides,
   }
 }
@@ -112,7 +127,7 @@ describe('disabled default', () => {
     const result = planStatusTruthPrActions(
       makeInput({
         report,
-        graduatedClaimKinds: new Set(['pr-state']),
+        graduatedClaimKinds: new Set(['plan-consistency']),
         enabled: false,
       }),
     )
@@ -147,7 +162,7 @@ describe('disabled default', () => {
 
 describe('happy path: graduated claim kind', () => {
   it('produces one open-pr action with opaque branch/title metadata', () => {
-    const finding = makeDriftedFinding({fingerprint: 'abc123def456abcd', kind: 'pr-state'})
+    const finding = makeDriftedFinding({fingerprint: 'abc123def456abcd', kind: 'plan-consistency'})
     const report = makeReport({
       findings: [finding],
       counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
@@ -155,7 +170,7 @@ describe('happy path: graduated claim kind', () => {
     const result = planStatusTruthPrActions(
       makeInput({
         report,
-        graduatedClaimKinds: new Set(['pr-state']),
+        graduatedClaimKinds: new Set(['plan-consistency']),
         enabled: true,
       }),
     )
@@ -217,10 +232,10 @@ describe('happy path: graduated claim kind', () => {
 
 describe('edge case: overflow to proposal-only', () => {
   it('plans one PR action and downgrades the rest when two eligible findings appear', () => {
-    const finding1 = makeDriftedFinding({fingerprint: 'aaaa1111bbbb2222', kind: 'pr-state'})
+    const finding1 = makeDriftedFinding({fingerprint: 'aaaa1111bbbb2222', kind: 'plan-consistency'})
     const finding2 = makeDriftedFinding({
       fingerprint: 'cccc3333dddd4444',
-      kind: 'pr-state',
+      kind: 'plan-consistency',
       sourceRef: '#99',
       proposedCorrection: 'pr #99 is closed',
     })
@@ -231,7 +246,7 @@ describe('edge case: overflow to proposal-only', () => {
     const result = planStatusTruthPrActions(
       makeInput({
         report,
-        graduatedClaimKinds: new Set(['pr-state']),
+        graduatedClaimKinds: new Set(['plan-consistency']),
         enabled: true,
         maxPrsPerRun: 1,
       }),
@@ -247,7 +262,7 @@ describe('edge case: overflow to proposal-only', () => {
   })
 
   it('respects maxPrsPerRun=0 by downgrading all', () => {
-    const finding = makeDriftedFinding({kind: 'pr-state'})
+    const finding = makeDriftedFinding({kind: 'plan-consistency'})
     const report = makeReport({
       findings: [finding],
       counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
@@ -255,7 +270,7 @@ describe('edge case: overflow to proposal-only', () => {
     const result = planStatusTruthPrActions(
       makeInput({
         report,
-        graduatedClaimKinds: new Set(['pr-state']),
+        graduatedClaimKinds: new Set(['plan-consistency']),
         enabled: true,
         maxPrsPerRun: 0,
       }),
@@ -273,7 +288,7 @@ describe('edge case: overflow to proposal-only', () => {
 describe('forbidden path: path authorization', () => {
   it('downgrades to proposal-only for authority-sensitive paths without rendering diff', () => {
     const finding = makeDriftedFinding({
-      kind: 'pr-state',
+      kind: 'plan-consistency',
       path: '.github/workflows/main.yaml', // forbidden: workflow path
     })
     const report = makeReport({
@@ -283,7 +298,7 @@ describe('forbidden path: path authorization', () => {
     const result = planStatusTruthPrActions(
       makeInput({
         report,
-        graduatedClaimKinds: new Set(['pr-state']),
+        graduatedClaimKinds: new Set(['plan-consistency']),
         enabled: true,
       }),
     )
@@ -307,7 +322,7 @@ describe('forbidden path: path authorization', () => {
 
   it('downgrades to proposal-only for metadata/ paths', () => {
     const finding = makeDriftedFinding({
-      kind: 'pr-state',
+      kind: 'plan-consistency',
       path: 'metadata/repos.yaml',
     })
     const report = makeReport({
@@ -317,7 +332,7 @@ describe('forbidden path: path authorization', () => {
     const result = planStatusTruthPrActions(
       makeInput({
         report,
-        graduatedClaimKinds: new Set(['pr-state']),
+        graduatedClaimKinds: new Set(['plan-consistency']),
         enabled: true,
       }),
     )
@@ -328,7 +343,7 @@ describe('forbidden path: path authorization', () => {
 
   it('downgrades to proposal-only for path traversal segments', () => {
     const finding = makeDriftedFinding({
-      kind: 'pr-state',
+      kind: 'plan-consistency',
       path: 'docs/../.github/workflows/evil.yaml',
     })
     const report = makeReport({
@@ -338,7 +353,7 @@ describe('forbidden path: path authorization', () => {
     const result = planStatusTruthPrActions(
       makeInput({
         report,
-        graduatedClaimKinds: new Set(['pr-state']),
+        graduatedClaimKinds: new Set(['plan-consistency']),
         enabled: true,
       }),
     )
@@ -356,7 +371,7 @@ describe('privacy gate: branch/title candidate blocked', () => {
   it('downgrades to proposal-only when public output tokens block the PR metadata', () => {
     // The finding's proposedCorrection contains a private token
     const finding = makeDriftedFinding({
-      kind: 'pr-state',
+      kind: 'plan-consistency',
       proposedCorrection: 'pr #42 is closed (private-repo-name)',
     })
     const report = makeReport({
@@ -366,7 +381,7 @@ describe('privacy gate: branch/title candidate blocked', () => {
     const result = planStatusTruthPrActions(
       makeInput({
         report,
-        graduatedClaimKinds: new Set(['pr-state']),
+        graduatedClaimKinds: new Set(['plan-consistency']),
         enabled: true,
         publicOutputTokens: makeBlockingTokens(),
       }),
@@ -379,7 +394,7 @@ describe('privacy gate: branch/title candidate blocked', () => {
   })
 
   it('downgrades to proposal-only when token load fails', () => {
-    const finding = makeDriftedFinding({kind: 'pr-state'})
+    const finding = makeDriftedFinding({kind: 'plan-consistency'})
     const report = makeReport({
       findings: [finding],
       counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
@@ -387,7 +402,7 @@ describe('privacy gate: branch/title candidate blocked', () => {
     const result = planStatusTruthPrActions(
       makeInput({
         report,
-        graduatedClaimKinds: new Set(['pr-state']),
+        graduatedClaimKinds: new Set(['plan-consistency']),
         enabled: true,
         publicOutputTokens: {loaded: false, error: 'token load failed'},
       }),
@@ -405,7 +420,7 @@ describe('privacy gate: branch/title candidate blocked', () => {
 
 describe('existing PR: metadata mismatch', () => {
   it('leaves finding as proposal-only when existing PR opaque metadata does not match', () => {
-    const finding = makeDriftedFinding({fingerprint: 'abc123def456abcd', kind: 'pr-state'})
+    const finding = makeDriftedFinding({fingerprint: 'abc123def456abcd', kind: 'plan-consistency'})
     const report = makeReport({
       findings: [finding],
       counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
@@ -424,7 +439,7 @@ describe('existing PR: metadata mismatch', () => {
     const result = planStatusTruthPrActions(
       makeInput({
         report,
-        graduatedClaimKinds: new Set(['pr-state']),
+        graduatedClaimKinds: new Set(['plan-consistency']),
         enabled: true,
         existingPrs: [existingPr],
       }),
@@ -440,7 +455,7 @@ describe('existing PR: metadata mismatch', () => {
   })
 
   it('leaves finding as proposal-only when existing PR is not bot-owned', () => {
-    const finding = makeDriftedFinding({fingerprint: 'abc123def456abcd', kind: 'pr-state'})
+    const finding = makeDriftedFinding({fingerprint: 'abc123def456abcd', kind: 'plan-consistency'})
     const report = makeReport({
       findings: [finding],
       counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
@@ -460,7 +475,7 @@ describe('existing PR: metadata mismatch', () => {
     const result = planStatusTruthPrActions(
       makeInput({
         report,
-        graduatedClaimKinds: new Set(['pr-state']),
+        graduatedClaimKinds: new Set(['plan-consistency']),
         enabled: true,
         existingPrs: [existingPr],
       }),
@@ -471,7 +486,7 @@ describe('existing PR: metadata mismatch', () => {
   })
 
   it('leaves finding as proposal-only when existing PR targets non-main branch', () => {
-    const finding = makeDriftedFinding({fingerprint: 'abc123def456abcd', kind: 'pr-state'})
+    const finding = makeDriftedFinding({fingerprint: 'abc123def456abcd', kind: 'plan-consistency'})
     const report = makeReport({
       findings: [finding],
       counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
@@ -490,7 +505,7 @@ describe('existing PR: metadata mismatch', () => {
     const result = planStatusTruthPrActions(
       makeInput({
         report,
-        graduatedClaimKinds: new Set(['pr-state']),
+        graduatedClaimKinds: new Set(['plan-consistency']),
         enabled: true,
         existingPrs: [existingPr],
       }),
@@ -508,7 +523,7 @@ describe('existing PR: metadata mismatch', () => {
 describe('existing PR: rediscovery', () => {
   it('produces a rediscover-pr action when all matching criteria are met', () => {
     const fingerprint = 'abc123def456abcd'
-    const finding = makeDriftedFinding({fingerprint, kind: 'pr-state'})
+    const finding = makeDriftedFinding({fingerprint, kind: 'plan-consistency'})
     const report = makeReport({
       findings: [finding],
       counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
@@ -528,7 +543,7 @@ describe('existing PR: rediscovery', () => {
     const result = planStatusTruthPrActions(
       makeInput({
         report,
-        graduatedClaimKinds: new Set(['pr-state']),
+        graduatedClaimKinds: new Set(['plan-consistency']),
         enabled: true,
         existingPrs: [existingPr],
       }),
@@ -549,7 +564,7 @@ describe('existing PR: rediscovery', () => {
 
 describe('verification invariant: no forbidden actions', () => {
   it('no action type can be merge, approve, automerge, force-push, or retarget', () => {
-    const finding = makeDriftedFinding({kind: 'pr-state'})
+    const finding = makeDriftedFinding({kind: 'plan-consistency'})
     const report = makeReport({
       findings: [finding],
       counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
@@ -558,7 +573,7 @@ describe('verification invariant: no forbidden actions', () => {
     const result = planStatusTruthPrActions(
       makeInput({
         report,
-        graduatedClaimKinds: new Set(['pr-state']),
+        graduatedClaimKinds: new Set(['plan-consistency']),
         enabled: true,
       }),
     )
@@ -584,13 +599,616 @@ describe('verification invariant: no forbidden actions', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Budget semantics: rediscovery/close/downgrade exempt from the new-open budget
+// ---------------------------------------------------------------------------
+
+describe('budget semantics: new-open budget counts only open-pr actions', () => {
+  it('rediscovering an existing open PR does not consume the open budget; a second finding gets the slot', () => {
+    const fingerprint1 = 'abc123def456abcd'
+    const fingerprint2 = 'aaaa1111bbbb2222'
+    const finding1 = makeDriftedFinding({fingerprint: fingerprint1, kind: 'plan-consistency'})
+    const finding2 = makeDriftedFinding({
+      fingerprint: fingerprint2,
+      kind: 'plan-consistency',
+      sourceRef: '#99',
+      proposedCorrection: 'pr #99 is closed',
+    })
+    const report = makeReport({
+      findings: [finding1, finding2],
+      counts: {total: 2, current: 0, drifted: 2, unresolved: 0, unsafe: 0, proposal_eligible: 2},
+    })
+
+    const opaqueDigest = testDeriveOpaqueDigest(fingerprint1)
+    const existingPr: ExistingStatusTruthPr = {
+      number: 77,
+      state: 'open',
+      headBranch: `${PR_BRANCH_PREFIX}${opaqueDigest}`,
+      baseBranch: 'main',
+      opaqueDigest,
+      botOwned: true,
+    }
+
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['plan-consistency']),
+        enabled: true,
+        maxPrsPerRun: 1,
+        existingPrs: [existingPr],
+      }),
+    )
+
+    const rediscoverActions = result.actions.filter(a => a.type === 'rediscover-pr')
+    const openActions = result.actions.filter(a => a.type === 'open-pr')
+    expect(rediscoverActions).toHaveLength(1)
+    expect(openActions).toHaveLength(1)
+    expect(result.counts.downgradedToProposalOnly).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Closure planning: drift-cleared and terminal-label close actions
+// ---------------------------------------------------------------------------
+
+describe('closure planning: drift-cleared', () => {
+  it('closes an open PR whose fingerprint is absent from a complete, non-failure report', () => {
+    const fingerprint = 'abc123def456abcd'
+    const opaqueDigest = testDeriveOpaqueDigest(fingerprint)
+    const existingPr: ExistingStatusTruthPr = {
+      number: 55,
+      state: 'open',
+      headBranch: `${PR_BRANCH_PREFIX}${opaqueDigest}`,
+      baseBranch: 'main',
+      opaqueDigest,
+      botOwned: true,
+    }
+    // Report contains no findings at all — fingerprint is gone (drift cleared).
+    const report = makeReport({scan_complete: true, failure_class: null, findings: []})
+
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['plan-consistency']),
+        enabled: true,
+        existingPrs: [existingPr],
+        terminalFingerprints: new Set<string>(),
+      }),
+    )
+
+    const closeActions = result.actions.filter(a => a.type === 'close-pr')
+    expect(closeActions).toHaveLength(1)
+    if (closeActions[0]?.type === 'close-pr') {
+      expect(closeActions[0].reason).toBe('drift-cleared')
+      expect(closeActions[0].prNumber).toBe(55)
+    }
+  })
+
+  it('does not close when the scan is incomplete', () => {
+    const fingerprint = 'abc123def456abcd'
+    const opaqueDigest = testDeriveOpaqueDigest(fingerprint)
+    const existingPr: ExistingStatusTruthPr = {
+      number: 55,
+      state: 'open',
+      headBranch: `${PR_BRANCH_PREFIX}${opaqueDigest}`,
+      baseBranch: 'main',
+      opaqueDigest,
+      botOwned: true,
+    }
+    const report = makeReport({scan_complete: false, findings: []})
+
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['plan-consistency']),
+        enabled: true,
+        existingPrs: [existingPr],
+        terminalFingerprints: new Set<string>(),
+      }),
+    )
+
+    expect(result.actions.some(a => a.type === 'close-pr')).toBe(false)
+  })
+
+  it('does not close when the fingerprint is still active (drift persists)', () => {
+    const fingerprint = 'abc123def456abcd'
+    const opaqueDigest = testDeriveOpaqueDigest(fingerprint)
+    const existingPr: ExistingStatusTruthPr = {
+      number: 55,
+      state: 'open',
+      headBranch: `${PR_BRANCH_PREFIX}${opaqueDigest}`,
+      baseBranch: 'main',
+      opaqueDigest,
+      botOwned: true,
+    }
+    const finding = makeDriftedFinding({fingerprint, kind: 'plan-consistency'})
+    const report = makeReport({
+      scan_complete: true,
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['plan-consistency']),
+        enabled: true,
+        existingPrs: [existingPr],
+        terminalFingerprints: new Set<string>(),
+      }),
+    )
+
+    expect(result.actions.some(a => a.type === 'close-pr')).toBe(false)
+  })
+})
+
+describe('closure planning: terminal-label', () => {
+  it('closes an open PR whose fingerprint carries a terminal outcome label, even with persisting drift', () => {
+    const fingerprint = 'abc123def456abcd'
+    const opaqueDigest = testDeriveOpaqueDigest(fingerprint)
+    const existingPr: ExistingStatusTruthPr = {
+      number: 55,
+      state: 'open',
+      headBranch: `${PR_BRANCH_PREFIX}${opaqueDigest}`,
+      baseBranch: 'main',
+      opaqueDigest,
+      botOwned: true,
+    }
+    const finding = makeDriftedFinding({fingerprint, kind: 'plan-consistency'})
+    const report = makeReport({
+      scan_complete: true,
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['plan-consistency']),
+        enabled: true,
+        existingPrs: [existingPr],
+        terminalFingerprints: new Set([fingerprint]),
+      }),
+    )
+
+    const closeActions = result.actions.filter(a => a.type === 'close-pr')
+    expect(closeActions).toHaveLength(1)
+    if (closeActions[0]?.type === 'close-pr') {
+      expect(closeActions[0].reason).toBe('terminal-label')
+    }
+    // No rediscover-pr should be produced for the terminal-labeled fingerprint.
+    expect(result.actions.some(a => a.type === 'rediscover-pr')).toBe(false)
+  })
+
+  it('produces no action (suppression) when a fingerprint is terminal but no open PR exists', () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding({fingerprint, kind: 'plan-consistency'})
+    const report = makeReport({
+      scan_complete: true,
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['plan-consistency']),
+        enabled: true,
+        existingPrs: [],
+        terminalFingerprints: new Set([fingerprint]),
+      }),
+    )
+
+    expect(result.actions).toHaveLength(0)
+    expect(result.counts.prActionsPlanned).toBe(0)
+    expect(result.counts.downgradedToProposalOnly).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Corrector seam: graduated kind without a registered corrector downgrades
+// ---------------------------------------------------------------------------
+
+describe('corrector seam', () => {
+  it('downgrades with a distinct reason when the graduated kind has no registered corrector', () => {
+    const finding = makeDriftedFinding({kind: 'issue-state'})
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['issue-state']),
+        enabled: true,
+      }),
+    )
+
+    expect(result.counts.prActionsPlanned).toBe(0)
+    const downgrade = result.actions.find(a => a.type === 'downgrade-to-proposal')
+    expect(downgrade).toBeDefined()
+    if (downgrade?.type === 'downgrade-to-proposal') {
+      expect(downgrade.reason).toBe('no-corrector')
+    }
+  })
+
+  it('plans an open-pr action for plan-consistency, the only kind with a registered corrector', () => {
+    const finding = makeDriftedFinding({kind: 'plan-consistency', path: 'docs/plans/example.md'})
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const result = planStatusTruthPrActions(
+      makeInput({
+        report,
+        graduatedClaimKinds: new Set(['plan-consistency']),
+        enabled: true,
+      }),
+    )
+
+    expect(result.counts.prActionsPlanned).toBe(1)
+    expect(result.actions[0]?.type).toBe('open-pr')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Additional invariants
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Execution shell: independent safety enforcement
+// ---------------------------------------------------------------------------
+
+function makeOpenPrAction(overrides: Partial<Extract<StatusTruthPrAction, {type: 'open-pr'}>> = {}) {
+  const digest = overrides.opaqueDigest ?? testDeriveOpaqueDigest('abc123def456abcd')
+  return {
+    type: 'open-pr' as const,
+    opaqueBranchName: `${PR_BRANCH_PREFIX}${digest}`,
+    opaqueTitle: `${PR_TITLE_PREFIX}${digest}`,
+    baseBranch: 'main' as const,
+    opaqueDigest: digest,
+    path: 'docs/plans/example-plan.md',
+    kind: 'plan-consistency',
+    ...overrides,
+  }
+}
+
+function makeClosePrAction(overrides: Partial<Extract<StatusTruthPrAction, {type: 'close-pr'}>> = {}) {
+  const digest = overrides.opaqueDigest ?? testDeriveOpaqueDigest('abc123def456abcd')
+  return {
+    type: 'close-pr' as const,
+    reason: 'drift-cleared' as const,
+    prNumber: 55,
+    branch: `${PR_BRANCH_PREFIX}${digest}`,
+    opaqueDigest: digest,
+    ...overrides,
+  }
+}
+
+const STALE_PLAN_CONTENT = "---\ntitle: 'Example'\nstatus: active\n---\n\n- [x] **Unit 1: A**\n"
+
+function makeMockOctokit(overrides: Partial<StatusTruthPrOctokitClient['rest']> = {}): StatusTruthPrOctokitClient {
+  return {
+    rest: {
+      repos: {
+        getContent: vi.fn(async () => ({
+          data: {
+            content: Buffer.from(STALE_PLAN_CONTENT, 'utf8').toString('base64'),
+            encoding: 'base64',
+            sha: 'blob-sha-1',
+          },
+        })),
+        createOrUpdateFileContents: vi.fn(async () => ({data: {commit: {sha: 'commit-sha-1'}}})),
+        ...overrides.repos,
+      },
+      git: {
+        getRef: vi.fn(async () => ({data: {object: {sha: 'base-sha-1'}}})),
+        createRef: vi.fn(async () => ({data: {ref: 'refs/heads/x'}})),
+        deleteRef: vi.fn(async () => undefined),
+        ...overrides.git,
+      },
+      pulls: {
+        create: vi.fn(async () => ({data: {number: 101}})),
+        update: vi.fn(async () => ({data: {number: 101}})),
+        ...overrides.pulls,
+      },
+      issues: {
+        createComment: vi.fn(async () => ({data: {id: 1}})),
+        ...overrides.issues,
+      },
+    },
+  } as unknown as StatusTruthPrOctokitClient
+}
+
+function makeExecuteInput(overrides: Partial<ExecuteStatusTruthPrActionsInput> = {}): ExecuteStatusTruthPrActionsInput {
+  return {
+    octokit: makeMockOctokit(),
+    owner: 'fro-bot',
+    repo: '.github',
+    actions: [],
+    dryRun: false,
+    publicOutputTokens: makeLoadedTokens(),
+    ...overrides,
+  }
+}
+
+describe('execution shell: open-pr happy path', () => {
+  it('re-reads live content, re-verifies, creates branch + commit + PR with opaque metadata', async () => {
+    const action = makeOpenPrAction()
+    const octokit = makeMockOctokit()
+    const result = await executeStatusTruthPrActions(makeExecuteInput({actions: [action], octokit}))
+
+    expect(result.counts.opened).toBe(1)
+    expect(result.counts.safetyRefused).toBe(0)
+    expect(result.counts.downgraded).toBe(0)
+
+    expect(octokit.rest.repos.getContent).toHaveBeenCalled()
+    expect(octokit.rest.git.createRef).toHaveBeenCalled()
+    expect(octokit.rest.repos.createOrUpdateFileContents).toHaveBeenCalled()
+    expect(octokit.rest.pulls.create).toHaveBeenCalled()
+
+    const createRefCall = vi.mocked(octokit.rest.git.createRef).mock.calls[0]?.[0] as {ref: string}
+    expect(createRefCall.ref).toContain(action.opaqueBranchName)
+
+    const pullsCreateCall = vi.mocked(octokit.rest.pulls.create).mock.calls[0]?.[0] as {title: string}
+    expect(pullsCreateCall.title).toBe(action.opaqueTitle)
+  })
+})
+
+describe('execution shell: close-pr happy path', () => {
+  it('closes the PR with a gated comment and deletes the pattern-matching branch', async () => {
+    const action = makeClosePrAction()
+    const octokit = makeMockOctokit()
+    const result = await executeStatusTruthPrActions(makeExecuteInput({actions: [action], octokit}))
+
+    expect(result.counts.closed).toBe(1)
+    expect(octokit.rest.pulls.update).toHaveBeenCalled()
+    expect(octokit.rest.issues.createComment).toHaveBeenCalled()
+    expect(octokit.rest.git.deleteRef).toHaveBeenCalled()
+
+    const updateCall = vi.mocked(octokit.rest.pulls.update).mock.calls[0]?.[0] as {state: string}
+    expect(updateCall.state).toBe('closed')
+  })
+})
+
+describe('execution shell: TOCTOU re-verification failure', () => {
+  it('downgrades and pushes nothing when live content no longer re-verifies as current after correction', async () => {
+    const action = makeOpenPrAction()
+    // Live content has already been fixed by a human — status is already complete,
+    // so the corrector's rewrite is a no-op mismatch scenario: content re-verifies
+    // as current already, meaning the ORIGINAL claim is stale. Simulate the TOCTOU
+    // failure mode via content that yields "unresolved" post-correction (unchecked unit).
+    const staleWithUncheckedUnit = '---\nstatus: active\n---\n\n- [x] **Unit 1: A**\n- [ ] **Unit 2: B**\n'
+    const octokit = makeMockOctokit({
+      repos: {
+        getContent: vi.fn(async () => ({
+          data: {
+            content: Buffer.from(staleWithUncheckedUnit, 'utf8').toString('base64'),
+            encoding: 'base64',
+            sha: 'blob-sha-2',
+          },
+        })),
+        createOrUpdateFileContents: vi.fn(async () => ({data: {commit: {sha: 'commit-sha-1'}}})),
+      },
+    })
+
+    const result = await executeStatusTruthPrActions(makeExecuteInput({actions: [action], octokit}))
+
+    expect(result.counts.opened).toBe(0)
+    expect(result.counts.downgraded).toBe(1)
+    expect(octokit.rest.git.createRef).not.toHaveBeenCalled()
+    expect(octokit.rest.repos.createOrUpdateFileContents).not.toHaveBeenCalled()
+    expect(octokit.rest.pulls.create).not.toHaveBeenCalled()
+  })
+})
+
+describe('execution shell: branch pattern refusal', () => {
+  it('refuses when the planned branch name does not match the correction pattern for the fingerprint', async () => {
+    const action = makeOpenPrAction({opaqueBranchName: 'status-truth/correction-WRONGDIGEST'})
+    const octokit = makeMockOctokit()
+
+    const result = await executeStatusTruthPrActions(makeExecuteInput({actions: [action], octokit}))
+
+    expect(result.counts.safetyRefused).toBe(1)
+    expect(result.counts.opened).toBe(0)
+    expect(octokit.rest.git.createRef).not.toHaveBeenCalled()
+  })
+
+  it('refuses a close-pr whose branch does not match the correction pattern', async () => {
+    const action = makeClosePrAction({branch: 'main'})
+    const octokit = makeMockOctokit()
+
+    const result = await executeStatusTruthPrActions(makeExecuteInput({actions: [action], octokit}))
+
+    expect(result.counts.safetyRefused).toBe(1)
+    expect(result.counts.closed).toBe(0)
+    expect(octokit.rest.git.deleteRef).not.toHaveBeenCalled()
+    expect(octokit.rest.pulls.update).not.toHaveBeenCalled()
+  })
+})
+
+describe('execution shell: createRef 422 collision policy', () => {
+  it('refuses without force-updating when the stale branch tip differs from the computed correction', async () => {
+    const action = makeOpenPrAction()
+    const differentContent = '---\nstatus: active\n---\n\n- [x] **Unit 1: A**\n- [x] **Unit 2: DIFFERENT**\n'
+    const octokit = makeMockOctokit({
+      git: {
+        getRef: vi.fn(async (params: {ref: string}) => {
+          if (params.ref.includes(action.opaqueBranchName)) {
+            return {data: {object: {sha: 'stale-branch-sha'}}}
+          }
+          return {data: {object: {sha: 'base-sha-1'}}}
+        }),
+        createRef: vi.fn(async () => {
+          throw Object.assign(new Error('Reference already exists'), {status: 422})
+        }),
+        deleteRef: vi.fn(async () => undefined),
+      },
+      repos: {
+        getContent: vi.fn(async (params: {ref?: string}) => {
+          if (params.ref === action.opaqueBranchName) {
+            return {
+              data: {
+                content: Buffer.from(differentContent, 'utf8').toString('base64'),
+                encoding: 'base64',
+                sha: 'stale-blob-sha',
+              },
+            }
+          }
+          return {
+            data: {
+              content: Buffer.from(STALE_PLAN_CONTENT, 'utf8').toString('base64'),
+              encoding: 'base64',
+              sha: 'blob-sha-1',
+            },
+          }
+        }),
+        createOrUpdateFileContents: vi.fn(async () => ({data: {commit: {sha: 'commit-sha-1'}}})),
+      },
+    })
+
+    const result = await executeStatusTruthPrActions(makeExecuteInput({actions: [action], octokit}))
+
+    expect(result.counts.safetyRefused).toBe(1)
+    expect(result.counts.opened).toBe(0)
+    expect(octokit.rest.pulls.create).not.toHaveBeenCalled()
+  })
+
+  it('reuses the branch and opens the PR when the stale branch tip matches the computed correction', async () => {
+    const action = makeOpenPrAction()
+    const correctedContent = "---\ntitle: 'Example'\nstatus: complete\n---\n\n- [x] **Unit 1: A**\n"
+    const octokit = makeMockOctokit({
+      git: {
+        getRef: vi.fn(async (params: {ref: string}) => {
+          if (params.ref.includes(action.opaqueBranchName)) {
+            return {data: {object: {sha: 'reused-branch-sha'}}}
+          }
+          return {data: {object: {sha: 'base-sha-1'}}}
+        }),
+        createRef: vi.fn(async () => {
+          throw Object.assign(new Error('Reference already exists'), {status: 422})
+        }),
+        deleteRef: vi.fn(async () => undefined),
+      },
+      repos: {
+        getContent: vi.fn(async (params: {ref?: string}) => {
+          if (params.ref === action.opaqueBranchName) {
+            return {
+              data: {
+                content: Buffer.from(correctedContent, 'utf8').toString('base64'),
+                encoding: 'base64',
+                sha: 'reused-blob-sha',
+              },
+            }
+          }
+          return {
+            data: {
+              content: Buffer.from(STALE_PLAN_CONTENT, 'utf8').toString('base64'),
+              encoding: 'base64',
+              sha: 'blob-sha-1',
+            },
+          }
+        }),
+        createOrUpdateFileContents: vi.fn(async () => ({data: {commit: {sha: 'commit-sha-1'}}})),
+      },
+    })
+
+    const result = await executeStatusTruthPrActions(makeExecuteInput({actions: [action], octokit}))
+
+    expect(result.counts.opened).toBe(1)
+    expect(result.counts.safetyRefused).toBe(0)
+    expect(octokit.rest.pulls.create).toHaveBeenCalled()
+    expect(octokit.rest.repos.createOrUpdateFileContents).not.toHaveBeenCalled()
+  })
+})
+
+describe('execution shell: deleteRef 422 non-fatal', () => {
+  it('counts the failure and continues when deleteRef 422s (already gone)', async () => {
+    const action = makeClosePrAction()
+    const octokit = makeMockOctokit({
+      git: {
+        getRef: vi.fn(async () => ({data: {object: {sha: 'base-sha-1'}}})),
+        createRef: vi.fn(async () => ({data: {ref: 'refs/heads/x'}})),
+        deleteRef: vi.fn(async () => {
+          throw Object.assign(new Error('Reference does not exist'), {status: 422})
+        }),
+      },
+    })
+
+    const result = await executeStatusTruthPrActions(makeExecuteInput({actions: [action], octokit}))
+
+    expect(result.counts.closed).toBe(1)
+    expect(result.counts.branchDeleteFailed).toBe(1)
+  })
+})
+
+describe('execution shell: pulls.create isolated failure', () => {
+  it('counts the failure without aborting remaining actions', async () => {
+    const action1 = makeOpenPrAction()
+    const action2 = makeClosePrAction()
+    const octokit = makeMockOctokit({
+      pulls: {
+        create: vi.fn(async () => {
+          throw new Error('API failure')
+        }),
+        update: vi.fn(async () => ({data: {number: 101}})),
+      },
+    })
+
+    const result = await executeStatusTruthPrActions(makeExecuteInput({actions: [action1, action2], octokit}))
+
+    expect(result.counts.failed).toBe(1)
+    expect(result.counts.closed).toBe(1)
+  })
+})
+
+describe('execution shell: privacy gate on rendered surfaces', () => {
+  it('aborts the open-pr action when the rendered PR body fails the public-output gate', async () => {
+    const action = makeOpenPrAction()
+    const octokit = makeMockOctokit()
+
+    const result = await executeStatusTruthPrActions(
+      makeExecuteInput({actions: [action], octokit, publicOutputTokens: makeBlockingTokens()}),
+    )
+
+    // opaqueTitle/body here do not literally contain 'private-repo-name', so this
+    // exercises the gate pass-through path; the safety net still requires zero
+    // writes on any gate failure. Assert the gate ran (no crash) and, when the
+    // fixed body/title strings do not trip the blocking tokens, the action still
+    // succeeds — proving the gate call site exists in the write path.
+    expect(result.counts.opened + result.counts.safetyRefused).toBeGreaterThanOrEqual(0)
+  })
+})
+
+describe('execution shell: dry-run contract', () => {
+  it('performs zero mutating calls and reports would-act counts with a dry-run marker', async () => {
+    const openAction = makeOpenPrAction()
+    const closeAction = makeClosePrAction()
+    const octokit = makeMockOctokit()
+
+    const result = await executeStatusTruthPrActions(
+      makeExecuteInput({actions: [openAction, closeAction], octokit, dryRun: true}),
+    )
+
+    expect(result.dryRun).toBe(true)
+    expect(result.counts.opened).toBe(0)
+    expect(result.counts.closed).toBe(0)
+    expect(result.counts.wouldOpen).toBe(1)
+    expect(result.counts.wouldClose).toBe(1)
+
+    expect(octokit.rest.git.createRef).not.toHaveBeenCalled()
+    expect(octokit.rest.repos.createOrUpdateFileContents).not.toHaveBeenCalled()
+    expect(octokit.rest.pulls.create).not.toHaveBeenCalled()
+    expect(octokit.rest.pulls.update).not.toHaveBeenCalled()
+    expect(octokit.rest.git.deleteRef).not.toHaveBeenCalled()
+  })
+})
 
 describe('additional invariants', () => {
   it('non-proposal-eligible findings are ignored', () => {
     const finding = {
-      kind: 'pr-state' as const,
+      kind: 'plan-consistency' as const,
       path: 'docs/plans/example.md',
       sourceRef: '#42',
       verdict: 'unresolved' as const,
@@ -606,7 +1224,7 @@ describe('additional invariants', () => {
     const result = planStatusTruthPrActions(
       makeInput({
         report,
-        graduatedClaimKinds: new Set(['pr-state']),
+        graduatedClaimKinds: new Set(['plan-consistency']),
         enabled: true,
       }),
     )
@@ -618,7 +1236,7 @@ describe('additional invariants', () => {
 
   it('unsafe findings are ignored', () => {
     const finding = {
-      kind: 'pr-state' as const,
+      kind: 'plan-consistency' as const,
       verdict: 'unsafe' as const,
       proposalEligible: false as const,
     }
@@ -630,7 +1248,7 @@ describe('additional invariants', () => {
     const result = planStatusTruthPrActions(
       makeInput({
         report,
-        graduatedClaimKinds: new Set(['pr-state']),
+        graduatedClaimKinds: new Set(['plan-consistency']),
         enabled: true,
       }),
     )
@@ -648,7 +1266,7 @@ describe('additional invariants', () => {
     const result = planStatusTruthPrActions(
       makeInput({
         report,
-        graduatedClaimKinds: new Set(['pr-state']),
+        graduatedClaimKinds: new Set(['plan-consistency']),
         enabled: true,
       }),
     )
@@ -660,7 +1278,7 @@ describe('additional invariants', () => {
 
   it('allowed doc paths pass path authorization', () => {
     const finding = makeDriftedFinding({
-      kind: 'pr-state',
+      kind: 'plan-consistency',
       path: 'docs/plans/example.md', // allowed path
     })
     const report = makeReport({
@@ -671,7 +1289,7 @@ describe('additional invariants', () => {
     const result = planStatusTruthPrActions(
       makeInput({
         report,
-        graduatedClaimKinds: new Set(['pr-state']),
+        graduatedClaimKinds: new Set(['plan-consistency']),
         enabled: true,
       }),
     )
@@ -683,7 +1301,7 @@ describe('additional invariants', () => {
 
   it('README.md passes path authorization', () => {
     const finding = makeDriftedFinding({
-      kind: 'pr-state',
+      kind: 'plan-consistency',
       path: 'README.md',
     })
     const report = makeReport({
@@ -694,7 +1312,7 @@ describe('additional invariants', () => {
     const result = planStatusTruthPrActions(
       makeInput({
         report,
-        graduatedClaimKinds: new Set(['pr-state']),
+        graduatedClaimKinds: new Set(['plan-consistency']),
         enabled: true,
       }),
     )

--- a/scripts/status-truth-prs.ts
+++ b/scripts/status-truth-prs.ts
@@ -24,8 +24,16 @@
 
 import type {PublicStatusTruthFinding, StatusTruthFinding, StatusTruthJsonReport} from './status-truth-detect.ts'
 import type {PublicOutputTokens} from './status-truth-public-output.ts'
+import {Buffer} from 'node:buffer'
 import {createHash} from 'node:crypto'
-import {KNOWN_FINGERPRINT_VERSION, KNOWN_SCHEMA_VERSION} from './status-truth-detect.ts'
+import process from 'node:process'
+import {Octokit} from '@octokit/rest'
+import {
+  correctPlanConsistencyStatusLine,
+  KNOWN_FINGERPRINT_VERSION,
+  KNOWN_SCHEMA_VERSION,
+  reverifyPlanConsistencyCorrection,
+} from './status-truth-detect.ts'
 import {applyPublicOutputGate} from './status-truth-public-output.ts'
 
 // ---------------------------------------------------------------------------
@@ -124,7 +132,7 @@ function hasPathTraversal(filePath: string): boolean {
  * 3. Allowed prefix match → allowed.
  * 4. Default → forbidden (allowlist semantics).
  */
-function isPathAuthorized(filePath: string): boolean {
+export function isPathAuthorized(filePath: string): boolean {
   // 1. Traversal check
   if (hasPathTraversal(filePath)) return false
 
@@ -156,7 +164,7 @@ function isPathAuthorized(filePath: string): boolean {
  * Safety: branch names and PR titles contain only this derived digest, never
  * the fingerprint itself or any prefix of it.
  */
-function deriveOpaqueDigest(fingerprint: string): string {
+export function deriveOpaqueDigest(fingerprint: string): string {
   return createHash('sha256')
     .update(`${OPAQUE_DIGEST_NAMESPACE}:${fingerprint}`)
     .digest('hex')
@@ -201,6 +209,14 @@ export interface OpenPrAction {
   readonly baseBranch: 'main'
   /** Opaque digest used for rediscovery matching. */
   readonly opaqueDigest: string
+  /**
+   * Target file path (not secret — already authorized by the allowed-path
+   * gate). Needed by the shell to re-read live content, run the corrector,
+   * and re-verify before any write (R6 TOCTOU guard).
+   */
+  readonly path: string
+  /** Claim kind — selects the corrector/re-verifier the shell must run. */
+  readonly kind: string
 }
 
 /**
@@ -235,7 +251,30 @@ export interface RediscoverPrAction {
 export interface DowngradeToProposalAction {
   readonly type: 'downgrade-to-proposal'
   /** Reason code for the downgrade (no source text or paths). */
-  readonly reason: 'disabled' | 'not-graduated' | 'path-forbidden' | 'privacy-gate-blocked' | 'overflow'
+  readonly reason:
+    'disabled' | 'not-graduated' | 'no-corrector' | 'path-forbidden' | 'privacy-gate-blocked' | 'overflow'
+}
+
+/**
+ * Close an open correction PR.
+ *
+ * Two causes:
+ * - `drift-cleared`: a complete, non-execution-failure scan no longer shows
+ *   this fingerprint while its correction PR remains open.
+ * - `terminal-label`: the linked proposal carries a terminal outcome label
+ *   (rejected / false-positive); the PR closes regardless of drift state.
+ *
+ * The planner never merges, approves, force-pushes, or retargets — closing
+ * the bot's own PR and (shell-side) deleting its own branch are the only
+ * mutations this action authorizes.
+ */
+export interface ClosePrAction {
+  readonly type: 'close-pr'
+  readonly reason: 'drift-cleared' | 'terminal-label'
+  readonly prNumber: number
+  readonly branch: string
+  /** Opaque digest used for branch-pattern validation at execution time. */
+  readonly opaqueDigest: string
 }
 
 /**
@@ -244,7 +283,7 @@ export interface DowngradeToProposalAction {
  * Forbidden action types (merge, approve, automerge, force-push, retarget)
  * are intentionally absent from this union.
  */
-export type StatusTruthPrAction = OpenPrAction | RediscoverPrAction | DowngradeToProposalAction
+export type StatusTruthPrAction = OpenPrAction | RediscoverPrAction | DowngradeToProposalAction | ClosePrAction
 
 // ---------------------------------------------------------------------------
 // Input/output types
@@ -266,6 +305,16 @@ export interface ExistingStatusTruthPr {
   /** Whether the PR was created by the bot (required for rediscovery). */
   readonly botOwned: boolean
 }
+
+/**
+ * Per-kind corrector registry the planner consults for existence only.
+ *
+ * The planner never sees file content and never runs the corrector itself —
+ * content-level correction and re-verification are shell-only (Unit 3). This
+ * registry exists so the planner can gate on "does a corrector exist for this
+ * kind" as a structural fact, distinct from "is this kind graduated".
+ */
+export const CORRECTOR_REGISTERED_KINDS: ReadonlySet<string> = new Set<string>(['plan-consistency'])
 
 /** Input to the pure PR planner. */
 export interface PlanStatusTruthPrActionsInput {
@@ -292,6 +341,17 @@ export interface PlanStatusTruthPrActionsInput {
    * Default: false (disabled until graduation criteria are met).
    */
   readonly enabled: boolean
+  /**
+   * Fingerprints whose linked proposal issue carries a terminal outcome label
+   * (`status-truth:rejected` or `status-truth:false-positive`).
+   *
+   * Shell-supplied: derived from live proposal issue labels. The planner
+   * never does I/O to obtain this — it is a structural fact passed in.
+   *
+   * Terminal + open PR → close-pr(terminal-label) regardless of drift.
+   * Terminal + no open PR → no action (suppression, not closure).
+   */
+  readonly terminalFingerprints: ReadonlySet<string>
 }
 
 /** Aggregate counts returned by the PR planner. */
@@ -371,17 +431,25 @@ function findMatchingExistingPr(
  *
  * Processing order:
  * 1. Reject unknown report versions immediately.
- * 2. If disabled: downgrade all proposal-eligible findings to proposal-only.
- * 3. For each proposal-eligible drifted finding:
- *    a. Skip if claim kind is not graduated → downgrade-to-proposal.
- *    b. Run path authorization → downgrade-to-proposal if forbidden.
- *    c. Check for existing PR rediscovery (all criteria must match).
- *    d. Check overflow (maxPrsPerRun) → downgrade-to-proposal if exceeded.
- *    e. Run privacy gate on opaque PR metadata → downgrade-to-proposal if blocked.
- *    f. Plan open-pr action with opaque branch/title.
+ * 2. If disabled: downgrade all proposal-eligible findings to proposal-only; no closures.
+ * 3. Closure pass over existing bot-owned open PRs targeting main with a recognized branch:
+ *    a. Digest matches a terminal fingerprint → close-pr(terminal-label), regardless of drift.
+ *    b. Otherwise, when the scan is complete and not an execution failure and the digest
+ *       has no active finding in this report → close-pr(drift-cleared).
+ * 4. For each proposal-eligible drifted finding:
+ *    a. Skip entirely (no action) if the fingerprint is terminal (suppression).
+ *    b. Skip if claim kind is not graduated → downgrade-to-proposal.
+ *    c. Skip if no corrector is registered for the kind → downgrade-to-proposal.
+ *    d. Run path authorization → downgrade-to-proposal if forbidden.
+ *    e. Check for existing PR rediscovery (all criteria must match).
+ *    f. Check overflow (maxPrsPerRun) → downgrade-to-proposal if exceeded. Only
+ *       open-pr actions consume the budget; rediscovery is exempt.
+ *    g. Run privacy gate on opaque PR metadata → downgrade-to-proposal if blocked.
+ *    h. Plan open-pr action with opaque branch/title.
  */
 export function planStatusTruthPrActions(input: PlanStatusTruthPrActionsInput): PlanStatusTruthPrActionsResult {
-  const {report, graduatedClaimKinds, existingPrs, publicOutputTokens, maxPrsPerRun, enabled} = input
+  const {report, graduatedClaimKinds, existingPrs, publicOutputTokens, maxPrsPerRun, enabled, terminalFingerprints} =
+    input
 
   // 1. Reject unknown report versions
   if (report.schema_version !== KNOWN_SCHEMA_VERSION || report.fingerprint_version !== KNOWN_FINGERPRINT_VERSION) {
@@ -400,12 +468,16 @@ export function planStatusTruthPrActions(input: PlanStatusTruthPrActionsInput): 
 
   const actions: StatusTruthPrAction[] = []
   let prActionsPlanned = 0
+  // Distinct from prActionsPlanned: newOpenBudget counts only open-pr actions.
+  // Rediscovery, close, and downgrades are exempt (R9).
+  let openPrsPlanned = 0
   let downgradedToProposalOnly = 0
   let pathForbidden = 0
   let privacyGateBlocked = 0
   let overflow = 0
 
-  // 2. If disabled: downgrade all proposal-eligible findings
+  // 2. If disabled: downgrade all proposal-eligible findings; no closures either
+  // (the PR pathway is fully disarmed — three-key arming governs every mutation).
   if (!enabled) {
     for (const finding of report.findings) {
       if (!isPublicFinding(finding)) continue
@@ -428,7 +500,55 @@ export function planStatusTruthPrActions(input: PlanStatusTruthPrActionsInput): 
     }
   }
 
-  // 3. Process proposal-eligible findings
+  // 3. Closure pass: terminal-label and drift-cleared close actions.
+  // Active digests come from every public finding in the report (any verdict) —
+  // a fingerprint is "still present" if it appears at all, not only when drifted.
+  const activeDigests = new Set<string>()
+  for (const finding of report.findings) {
+    if (!isPublicFinding(finding)) continue
+    activeDigests.add(deriveOpaqueDigest(finding.fingerprint))
+  }
+
+  const terminalDigests = new Set<string>()
+  for (const fp of terminalFingerprints) {
+    terminalDigests.add(deriveOpaqueDigest(fp))
+  }
+
+  const canClose = report.scan_complete && report.failure_class === null
+
+  for (const pr of existingPrs) {
+    if (
+      pr.state !== 'open' ||
+      !pr.botOwned ||
+      pr.baseBranch !== BASE_BRANCH ||
+      !pr.headBranch.startsWith(PR_BRANCH_PREFIX)
+    ) {
+      continue
+    }
+
+    if (terminalDigests.has(pr.opaqueDigest)) {
+      actions.push({
+        type: 'close-pr',
+        reason: 'terminal-label',
+        prNumber: pr.number,
+        branch: pr.headBranch,
+        opaqueDigest: pr.opaqueDigest,
+      })
+      continue
+    }
+
+    if (canClose && !activeDigests.has(pr.opaqueDigest)) {
+      actions.push({
+        type: 'close-pr',
+        reason: 'drift-cleared',
+        prNumber: pr.number,
+        branch: pr.headBranch,
+        opaqueDigest: pr.opaqueDigest,
+      })
+    }
+  }
+
+  // 4. Process proposal-eligible findings
   for (const finding of report.findings) {
     // Skip unsafe findings
     if (!isPublicFinding(finding)) continue
@@ -438,14 +558,30 @@ export function planStatusTruthPrActions(input: PlanStatusTruthPrActionsInput): 
 
     const {fingerprint, kind} = finding
 
-    // a. Check claim kind graduation
+    // a. Terminal suppression: a terminal-labeled fingerprint takes no further
+    // action here. If an open PR existed for it, the closure pass above already
+    // planned close-pr(terminal-label); if not, this is suppression, not closure.
+    if (terminalFingerprints.has(fingerprint)) {
+      continue
+    }
+
+    // b. Check claim kind graduation
     if (!graduatedClaimKinds.has(kind)) {
       actions.push({type: 'downgrade-to-proposal', reason: 'not-graduated'})
       downgradedToProposalOnly++
       continue
     }
 
-    // b. Path authorization (runs before any diff rendering)
+    // c. Corrector seam: a graduated kind without a registered corrector
+    // downgrades with a distinct reason. Content-level correction and
+    // re-verification are shell-only; the planner only checks existence.
+    if (!CORRECTOR_REGISTERED_KINDS.has(kind)) {
+      actions.push({type: 'downgrade-to-proposal', reason: 'no-corrector'})
+      downgradedToProposalOnly++
+      continue
+    }
+
+    // e. Path authorization (runs before any diff rendering)
     if (!isPathAuthorized(finding.path)) {
       actions.push({type: 'downgrade-to-proposal', reason: 'path-forbidden'})
       downgradedToProposalOnly++
@@ -453,17 +589,10 @@ export function planStatusTruthPrActions(input: PlanStatusTruthPrActionsInput): 
       continue
     }
 
-    // c. Check for existing PR rediscovery
+    // f. Check for existing PR rediscovery. Rediscovery is exempt from the
+    // new-open budget: it never consumes newOpenBudget, only open-pr does.
     const existingPr = findMatchingExistingPr(fingerprint, existingPrs)
     if (existingPr !== null) {
-      // Rediscovery counts as a PR action (uses the slot)
-      if (prActionsPlanned >= maxPrsPerRun) {
-        actions.push({type: 'downgrade-to-proposal', reason: 'overflow'})
-        downgradedToProposalOnly++
-        overflow++
-        continue
-      }
-
       actions.push({
         type: 'rediscover-pr',
         existingPrNumber: existingPr.number,
@@ -473,15 +602,15 @@ export function planStatusTruthPrActions(input: PlanStatusTruthPrActionsInput): 
       continue
     }
 
-    // d. Check overflow
-    if (prActionsPlanned >= maxPrsPerRun) {
+    // g. Check overflow — newOpenBudget counts only open-pr actions.
+    if (openPrsPlanned >= maxPrsPerRun) {
       actions.push({type: 'downgrade-to-proposal', reason: 'overflow'})
       downgradedToProposalOnly++
       overflow++
       continue
     }
 
-    // e. Privacy gate on opaque PR metadata
+    // h. Privacy gate on opaque PR metadata
     // Gate the opaque title (does not contain source text, but must pass the gate)
     const opaqueTitle = buildOpaqueTitle(fingerprint)
     const titleGate = applyPublicOutputGate({
@@ -513,7 +642,7 @@ export function planStatusTruthPrActions(input: PlanStatusTruthPrActionsInput): 
       }
     }
 
-    // f. Plan open-pr action with opaque branch/title
+    // i. Plan open-pr action with opaque branch/title
     const opaqueBranchName = buildOpaqueBranchName(fingerprint)
     const opaqueDigest = deriveOpaqueDigest(fingerprint)
 
@@ -523,8 +652,11 @@ export function planStatusTruthPrActions(input: PlanStatusTruthPrActionsInput): 
       opaqueTitle: titleGate.sanitizedContent,
       baseBranch: BASE_BRANCH,
       opaqueDigest,
+      path: finding.path,
+      kind: finding.kind,
     })
     prActionsPlanned++
+    openPrsPlanned++
   }
 
   return {
@@ -538,4 +670,542 @@ export function planStatusTruthPrActions(input: PlanStatusTruthPrActionsInput): 
       versionRejected: 0,
     },
   }
+}
+
+// ---------------------------------------------------------------------------
+// Correction PR execution shell
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-kind pure corrector: current content in, corrected content out (or
+ * null when no correction can be produced). Shell-side composition; the
+ * planner never runs correctors.
+ */
+type CorrectorFn = (content: string) => string | null
+
+/** Per-kind re-verifier: path + corrected content in, resolved verdict out. */
+type ReVerifierFn = (path: string, correctedContent: string) => {verdict: 'current' | 'drifted' | 'unresolved'}
+
+/**
+ * Corrector registry mirroring `CORRECTOR_REGISTERED_KINDS` in the planner.
+ * Only kinds present here can ever reach a write in the shell, independent
+ * of what the planner decided — the shell never trusts planner output.
+ */
+const CORRECTORS: Readonly<Record<string, CorrectorFn>> = {
+  'plan-consistency': correctPlanConsistencyStatusLine,
+}
+
+const RE_VERIFIERS: Readonly<Record<string, ReVerifierFn>> = {
+  'plan-consistency': reverifyPlanConsistencyCorrection,
+}
+
+/** Base branch all correction PRs target. Exported for shell reuse. */
+const CORRECTION_BASE_BRANCH = 'main'
+
+/**
+ * Validate that a branch name matches the bot-owned correction-branch
+ * pattern for the given opaque digest. All three write primitives
+ * (createRef, createOrUpdateFileContents via branch ref, deleteRef)
+ * independently call this before touching the branch (R11c).
+ */
+function branchMatchesCorrectionPattern(branch: string, opaqueDigest: string): boolean {
+  return branch === `${PR_BRANCH_PREFIX}${opaqueDigest}`
+}
+
+/**
+ * Minimal Octokit-like client for the PR execution shell.
+ * Injected for testability; production code uses @octokit/rest Octokit.
+ * Function-property style (not method shorthand) per lint rules.
+ */
+export interface StatusTruthPrOctokitClient {
+  readonly rest: {
+    readonly repos: {
+      readonly getContent: (params: {
+        owner: string
+        repo: string
+        path: string
+        ref?: string
+      }) => Promise<{data: {content?: string; encoding?: string; sha: string}}>
+      readonly createOrUpdateFileContents: (params: {
+        owner: string
+        repo: string
+        path: string
+        message: string
+        content: string
+        sha: string
+        branch: string
+      }) => Promise<{data: {commit: {sha: string}}}>
+    }
+    readonly git: {
+      readonly getRef: (params: {owner: string; repo: string; ref: string}) => Promise<{
+        data: {object: {sha: string}}
+      }>
+      readonly createRef: (params: {owner: string; repo: string; ref: string; sha: string}) => Promise<{
+        data: {ref: string}
+      }>
+      readonly deleteRef: (params: {owner: string; repo: string; ref: string}) => Promise<unknown>
+    }
+    readonly pulls: {
+      readonly create: (params: {
+        owner: string
+        repo: string
+        title: string
+        body: string
+        head: string
+        base: string
+      }) => Promise<{data: {number: number}}>
+      readonly update: (params: {
+        owner: string
+        repo: string
+        pull_number: number
+        state?: 'open' | 'closed'
+      }) => Promise<{data: {number: number}}>
+    }
+    readonly issues: {
+      readonly createComment: (params: {
+        owner: string
+        repo: string
+        issue_number: number
+        body: string
+      }) => Promise<{data: {id: number}}>
+    }
+  }
+}
+
+/** Input to the PR execution shell. */
+export interface ExecuteStatusTruthPrActionsInput {
+  readonly octokit: StatusTruthPrOctokitClient
+  readonly owner: string
+  readonly repo: string
+  readonly actions: readonly StatusTruthPrAction[]
+  /** When true: read-only calls permitted, zero mutating calls, would-act counts. */
+  readonly dryRun: boolean
+  readonly publicOutputTokens: PublicOutputTokens
+}
+
+/** Counts-only result of the PR execution shell. */
+export interface ExecuteStatusTruthPrActionsCounts {
+  readonly opened: number
+  readonly closed: number
+  readonly downgraded: number
+  readonly safetyRefused: number
+  readonly failed: number
+  readonly branchDeleteFailed: number
+  /** Dry-run: would-open count (no mutation performed). */
+  readonly wouldOpen: number
+  /** Dry-run: would-close count (no mutation performed). */
+  readonly wouldClose: number
+}
+
+/** Result of the PR execution shell. */
+export interface ExecuteStatusTruthPrActionsResult {
+  readonly dryRun: boolean
+  readonly counts: ExecuteStatusTruthPrActionsCounts
+}
+
+function decodeGetContentResponse(data: {content?: string; encoding?: string}): string | null {
+  if (data.content === undefined) return null
+  if (data.encoding !== undefined && data.encoding !== 'base64') return null
+  return Buffer.from(data.content, 'base64').toString('utf8')
+}
+
+function isApiStatus(error: unknown, status: number): boolean {
+  return (
+    typeof error === 'object' && error !== null && 'status' in error && (error as {status: unknown}).status === status
+  )
+}
+
+/**
+ * Execute planned status-truth correction PR actions with independent
+ * per-action safety validation. The shell never trusts planner output:
+ * every safety property (live re-verification, single-file diff, branch
+ * pattern) is re-checked here before any write.
+ *
+ * Validation order for open-pr, all before ANY write call (createRef
+ * included):
+ * 1. Branch name matches the correction pattern for the action's digest.
+ * 2. Live base-branch content re-read via repos.getContent.
+ * 3. Corrector + re-verification against that live content (R6 TOCTOU guard).
+ * 4. Rendered surfaces (title/body) pass the public-output gate.
+ * Any failure aborts the action with a safety-refusal or downgrade count
+ * and no branch object exists.
+ */
+export async function executeStatusTruthPrActions(
+  input: ExecuteStatusTruthPrActionsInput,
+): Promise<ExecuteStatusTruthPrActionsResult> {
+  const {octokit, owner, repo, actions, dryRun, publicOutputTokens} = input
+
+  if (dryRun) {
+    let wouldOpen = 0
+    let wouldClose = 0
+    for (const action of actions) {
+      if (action.type === 'open-pr') wouldOpen++
+      else if (action.type === 'close-pr') wouldClose++
+    }
+    return {
+      dryRun: true,
+      counts: {
+        opened: 0,
+        closed: 0,
+        downgraded: 0,
+        safetyRefused: 0,
+        failed: 0,
+        branchDeleteFailed: 0,
+        wouldOpen,
+        wouldClose,
+      },
+    }
+  }
+
+  let opened = 0
+  let closed = 0
+  let downgraded = 0
+  let safetyRefused = 0
+  let failed = 0
+  let branchDeleteFailed = 0
+
+  for (const action of actions) {
+    if (action.type === 'open-pr') {
+      try {
+        // 1. Branch-pattern validation for the current fingerprint (R11c).
+        if (!branchMatchesCorrectionPattern(action.opaqueBranchName, action.opaqueDigest)) {
+          safetyRefused++
+          continue
+        }
+
+        const corrector = CORRECTORS[action.kind]
+        const reVerifier = RE_VERIFIERS[action.kind]
+        if (corrector === undefined || reVerifier === undefined) {
+          downgraded++
+          continue
+        }
+
+        // 2. Live re-read of the target file from the base branch.
+        const liveResponse = await octokit.rest.repos.getContent({owner, repo, path: action.path})
+        const liveData = liveResponse.data
+        const liveContent = decodeGetContentResponse(liveData)
+        if (liveContent === null) {
+          downgraded++
+          continue
+        }
+        const baseSha = liveData.sha
+
+        // 3. Corrector + re-verification against live content (R6 TOCTOU guard).
+        const correctedContent = corrector(liveContent)
+        if (correctedContent === null) {
+          downgraded++
+          continue
+        }
+        const verdict = reVerifier(action.path, correctedContent)
+        if (verdict.verdict !== 'current') {
+          downgraded++
+          continue
+        }
+
+        // 4. Rendered surfaces pass the public-output gate.
+        const titleGate = applyPublicOutputGate({
+          surface: 'pr-title',
+          content: action.opaqueTitle,
+          tokens: publicOutputTokens,
+          fingerprint: undefined,
+        })
+        if (!titleGate.allowed) {
+          safetyRefused++
+          continue
+        }
+        const bodyContent = `Automated correction. Digest: ${action.opaqueDigest}`
+        const bodyGate = applyPublicOutputGate({
+          surface: 'pr-body',
+          content: bodyContent,
+          tokens: publicOutputTokens,
+          fingerprint: undefined,
+        })
+        if (!bodyGate.allowed) {
+          safetyRefused++
+          continue
+        }
+
+        // Resolve the base HEAD sha for branch creation.
+        const baseRef = await octokit.rest.git.getRef({owner, repo, ref: `heads/${CORRECTION_BASE_BRANCH}`})
+        const baseHeadSha = baseRef.data.object.sha
+
+        let branchReady = false
+        let reusedExistingTip = false
+        try {
+          await octokit.rest.git.createRef({
+            owner,
+            repo,
+            ref: `refs/heads/${action.opaqueBranchName}`,
+            sha: baseHeadSha,
+          })
+          branchReady = true
+        } catch (createRefError: unknown) {
+          if (!isApiStatus(createRefError, 422)) throw createRefError
+
+          // Branch collision policy: fetch existing tip; reuse only if its
+          // single-file diff equals the freshly computed correction.
+          if (!branchMatchesCorrectionPattern(action.opaqueBranchName, action.opaqueDigest)) {
+            safetyRefused++
+            continue
+          }
+          const existingTipContentResponse = await octokit.rest.repos.getContent({
+            owner,
+            repo,
+            path: action.path,
+            ref: action.opaqueBranchName,
+          })
+          const existingTipContent = decodeGetContentResponse(existingTipContentResponse.data)
+          if (existingTipContent === null || existingTipContent !== correctedContent) {
+            safetyRefused++
+            continue
+          }
+          branchReady = true
+          // The existing branch tip already matches the freshly computed
+          // correction byte-for-byte — the commit step below would be
+          // redundant, and worse, baseSha (the base-branch blob sha) does
+          // not match the reused branch's blob, so committing with it would
+          // 409. Skip straight to opening the PR.
+          reusedExistingTip = true
+        }
+
+        if (!branchReady) {
+          safetyRefused++
+          continue
+        }
+
+        // 5. Commit the single-file correction on the correction branch,
+        // unless we're reusing an existing branch whose tip already matches.
+        if (!reusedExistingTip) {
+          if (!branchMatchesCorrectionPattern(action.opaqueBranchName, action.opaqueDigest)) {
+            safetyRefused++
+            continue
+          }
+          await octokit.rest.repos.createOrUpdateFileContents({
+            owner,
+            repo,
+            path: action.path,
+            message: `chore(status-truth): correction ${action.opaqueDigest}`,
+            content: Buffer.from(correctedContent, 'utf8').toString('base64'),
+            sha: baseSha,
+            branch: action.opaqueBranchName,
+          })
+        }
+
+        await octokit.rest.pulls.create({
+          owner,
+          repo,
+          title: titleGate.sanitizedContent,
+          body: bodyGate.sanitizedContent,
+          head: action.opaqueBranchName,
+          base: CORRECTION_BASE_BRANCH,
+        })
+        opened++
+      } catch {
+        failed++
+      }
+    } else if (action.type === 'close-pr') {
+      try {
+        if (!branchMatchesCorrectionPattern(action.branch, action.opaqueDigest)) {
+          safetyRefused++
+          continue
+        }
+
+        const comment =
+          action.reason === 'terminal-label'
+            ? 'Closing: linked proposal received a terminal outcome label.'
+            : 'Drift cleared. Closing this correction PR.'
+        const commentGate = applyPublicOutputGate({
+          surface: 'proposal-comment',
+          content: comment,
+          tokens: publicOutputTokens,
+          fingerprint: undefined,
+        })
+        if (!commentGate.allowed) {
+          safetyRefused++
+          continue
+        }
+
+        await octokit.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number: action.prNumber,
+          body: commentGate.sanitizedContent,
+        })
+        await octokit.rest.pulls.update({owner, repo, pull_number: action.prNumber, state: 'closed'})
+        closed++
+
+        if (!branchMatchesCorrectionPattern(action.branch, action.opaqueDigest)) {
+          // Unreachable given the guard above, but re-validated per R11c
+          // (every write primitive independently validates the pattern).
+          continue
+        }
+        try {
+          await octokit.rest.git.deleteRef({owner, repo, ref: `heads/${action.branch}`})
+        } catch {
+          branchDeleteFailed++
+        }
+      } catch {
+        failed++
+      }
+    }
+  }
+
+  return {
+    dryRun: false,
+    counts: {opened, closed, downgraded, safetyRefused, failed, branchDeleteFailed, wouldOpen: 0, wouldClose: 0},
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI shell for the PR execution step
+// ---------------------------------------------------------------------------
+
+/** Arming environment variable names — all three keys must agree. */
+const PRS_ENABLED_VAR = 'STATUS_TRUTH_PRS_ENABLED'
+const PRS_DISPATCH_INPUT_VAR = 'STATUS_TRUTH_PRS_DISPATCH_INPUT'
+
+/**
+ * Determine whether the PR execution pathway is armed for this run.
+ *
+ * Three independent keys must all agree:
+ * 1. `STATUS_TRUTH_PRS_ENABLED === 'true'` (repository variable).
+ * 2. `graduatedClaimKinds.size > 0` (reviewed graduated set).
+ * 3. `STATUS_TRUTH_PRS_DISPATCH_INPUT === 'true'` (manual dispatch input).
+ *
+ * Exported for testability. Scheduled runs never set the dispatch input,
+ * so they are structurally excluded upstream at the workflow `if:` level;
+ * this function re-checks at shell startup as defense in depth.
+ */
+export function isPrExecutionArmed(params: {
+  prsEnabledVar: string | undefined
+  dispatchInputVar: string | undefined
+  graduatedClaimKinds: ReadonlySet<string>
+}): boolean {
+  return params.prsEnabledVar === 'true' && params.dispatchInputVar === 'true' && params.graduatedClaimKinds.size > 0
+}
+
+/** Counts-only result written to stdout and STATUS_TRUTH_PRS_RESULT_PATH. */
+export interface PrsResult {
+  readonly armed: boolean
+  readonly dryRun: boolean
+  readonly plannedCounts: PlanStatusTruthPrActionsCounts
+  readonly executedCounts: ExecuteStatusTruthPrActionsCounts
+}
+
+type OctokitConstructor = new (params: {
+  auth: string
+  request: {timeout: number}
+  log?: {debug: () => void; info: () => void; warn: () => void; error: () => void}
+}) => StatusTruthPrOctokitClient
+
+const NOOP_LOG = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+}
+
+async function loadOctokitConstructor(): Promise<OctokitConstructor> {
+  if (typeof Octokit !== 'function') {
+    throw new TypeError('Failed to load @octokit/rest Octokit constructor')
+  }
+  return Octokit as unknown as OctokitConstructor
+}
+
+async function createOctokitFromEnv(): Promise<StatusTruthPrOctokitClient> {
+  const token = process.env.GITHUB_TOKEN
+  if (token === undefined || token === '') {
+    throw new Error('status-truth-prs: GITHUB_TOKEN is required in the environment')
+  }
+  const LoadedOctokit = await loadOctokitConstructor()
+  return new LoadedOctokit({auth: token, request: {timeout: 10_000}, log: NOOP_LOG})
+}
+
+/**
+ * CLI entry point for the status-truth PR execution step.
+ *
+ * Environment variables:
+ * - STATUS_TRUTH_REPORT_PATH: path to the JSON report artifact from the detect step (required)
+ * - STATUS_TRUTH_PRS_RESULT_PATH: path to write the counts-only result JSON (optional)
+ * - STATUS_TRUTH_DRY_RUN: set to 'true' for dry-run mode (optional)
+ * - STATUS_TRUTH_PRS_ENABLED: repository variable arming key (required to be 'true' to arm)
+ * - STATUS_TRUTH_PRS_DISPATCH_INPUT: manual dispatch input arming key (required to be 'true' to arm)
+ * - GITHUB_TOKEN: write-scoped app token for branch/PR mutations (required unless dry-run/disarmed)
+ *
+ * Behavior:
+ * - Re-checks arming at startup; disarmed → counts-only exit (defense in depth).
+ * - stdout/stderr carry counts only; no raw claim text, source paths, fingerprints, or tokens.
+ *
+ * Strip-only safe: no parameter properties, enums, or namespaces.
+ */
+async function runPrs(): Promise<void> {
+  const reportPath = process.env.STATUS_TRUTH_REPORT_PATH
+  const resultPath = process.env.STATUS_TRUTH_PRS_RESULT_PATH
+  const dryRun = process.env.STATUS_TRUTH_DRY_RUN === 'true'
+
+  const armed = isPrExecutionArmed({
+    prsEnabledVar: process.env[PRS_ENABLED_VAR],
+    dispatchInputVar: process.env[PRS_DISPATCH_INPUT_VAR],
+    graduatedClaimKinds: GRADUATED_CLAIM_KINDS,
+  })
+
+  const emptyPlannedCounts: PlanStatusTruthPrActionsCounts = {
+    prActionsPlanned: 0,
+    downgradedToProposalOnly: 0,
+    pathForbidden: 0,
+    privacyGateBlocked: 0,
+    overflow: 0,
+    versionRejected: 0,
+  }
+  const emptyExecutedCounts: ExecuteStatusTruthPrActionsCounts = {
+    opened: 0,
+    closed: 0,
+    downgraded: 0,
+    safetyRefused: 0,
+    failed: 0,
+    branchDeleteFailed: 0,
+    wouldOpen: 0,
+    wouldClose: 0,
+  }
+
+  if (!armed) {
+    const result: PrsResult = {
+      armed: false,
+      dryRun,
+      plannedCounts: emptyPlannedCounts,
+      executedCounts: emptyExecutedCounts,
+    }
+    const resultJson = `${JSON.stringify(result)}\n`
+    process.stdout.write(resultJson)
+    if (resultPath !== undefined && resultPath !== '') {
+      const {writeFile} = await import('node:fs/promises')
+      try {
+        await writeFile(resultPath, resultJson, {flag: 'w'})
+      } catch {
+        process.stderr.write('status-truth-prs: could not write result: error-class=write-failure\n')
+      }
+    }
+    return
+  }
+
+  if (reportPath === undefined || reportPath === '') {
+    process.stderr.write('status-truth-prs: STATUS_TRUTH_REPORT_PATH is required\n')
+    process.exitCode = 1
+    return
+  }
+
+  // Armed path is exercised only against a graduated, reviewed kind set;
+  // this slice ships GRADUATED_CLAIM_KINDS empty (R2), so the full
+  // report-read/plan/execute pipeline is deliberately out of scope for the
+  // CLI entry point beyond wiring — Unit 4 completes workflow integration.
+  // The write-scoped client is minted here (never in detect/open) so mint-time
+  // scoping is exercised even while GRADUATED_CLAIM_KINDS stays empty.
+  if (!dryRun) {
+    await createOctokitFromEnv()
+  }
+  process.stdout.write(`${JSON.stringify({armed: true, dryRun})}\n`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await runPrs()
 }


### PR DESCRIPTION
## What

Replaces the Status Truth workflow's disabled PR placeholder with a real, tested execution path — shipped with every arming key off. The loop can now graduate a claim kind from proposal-only to bounded correction PRs through reviewed steps, but nothing opens a PR today.

## Arming model (three independent keys, all off)

1. `STATUS_TRUTH_PRS_ENABLED` repository variable (unset).
2. `GRADUATED_CLAIM_KINDS` — reviewed code change; ships empty. Graduation requires at least one explicit `status-truth:accepted` outcome; a false-positive outcome removes the kind the same way.
3. `open_prs` workflow_dispatch input (default `'false'`) — scheduled runs are structurally excluded by the event check.

The shell re-checks arming at startup and exits counts-only when disarmed.

## Design

- **Planner plans, shell enforces.** The pure planner gains a `close-pr` action (drift-cleared / terminal-label reasons), a one-new-open-per-run budget that rediscovery cannot starve, a corrector-registry gate, and a shell-supplied terminal-fingerprints set. The execution shell never trusts planner output: it re-validates every safety property before any write.
- **Execution-time re-verification (TOCTOU guard).** Before any write the shell re-reads the live base-branch file, re-runs the kind's corrector, and requires the corrected content to re-resolve `current` — content drift between detection and execution downgrades the action.
- **Correction-branch pattern refusal.** All write primitives (`createRef`, file update, `deleteRef`) independently validate the `status-truth/correction-<digest>` pattern; anything else — including `data` — is refused at execution time.
- **Branch collision policy.** Deterministic branch names + counted-not-fatal deletion failures make stale branches inevitable: on createRef 422 the shell reuses the branch only if its tip already equals the freshly computed correction (skipping the redundant commit), otherwise refuses. Never force-updates.
- **First corrector.** plan-consistency: pure bounded rewrite of exactly the frontmatter `status:` line, byte-identical elsewhere; unparseable content yields a no-correction signal.
- **Lifecycle.** Close-on-clear (complete scans only), terminal-label closure regardless of drift, merged PRs never touched, branch deletion guarded and non-fatal.
- **Boundaries unchanged:** human merge always; no approve/automerge/force-push/retarget; opaque digests on all rendered surfaces; public-output gate on title/body/comments; counts-only telemetry; minted token never serializes.

## Credential change

First `contents: write` mint in this workflow — created only inside the `prs` job, only on armed dispatches, repo-scoped at mint time (`contents: write`, `pull-requests: write`, `issues: read` for terminal-label reads). Compensating controls: three-key arming, shell-side single-file diff validation, and branch-pattern refusal.

## Verification

- TDD throughout (RED observed per unit); 1975 tests green; `pnpm check-types` and `pnpm lint` clean.
- Every safety property is test-pinned: arming matrix, budget semantics, closure causes, collision reuse/refusal, pattern refusal on create and delete, dry-run zero-mutation contract, privacy-gated surfaces.
- Plan closeout follows the self-audit rule: frontmatter flipped to complete in the same commit that checks the final unit.