### PR TITLE
feat: surface proposal outcomes by claim kind

### DIFF
--- a/.github/workflows/status-truth.yaml
+++ b/.github/workflows/status-truth.yaml
@@ -287,6 +287,21 @@ jobs:
                   | "| \(.key) | \(.value.opened // 0) | \(.value.updated // 0) | \(.value.reopened // 0) | \(.value.closed // 0) | \(.value.suppressed // 0) |"
                 ' "$result"
               fi
+
+              # Proposal outcomes by claim kind (read-model; counts-only, no paths or fingerprints)
+              outcome_kind_count=$(jq '.outcomeCountsByKind | length' "$result" 2>/dev/null || echo 0)
+              if [[ "$outcome_kind_count" -gt 0 ]]; then
+                echo ""
+                echo "### Proposal outcomes by claim kind"
+                echo ""
+                echo "| Kind | Pending | Accepted | Rejected | False positive | Resolved | Superseded | Needs outcome | Conflicting | Malformed |"
+                echo "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |"
+                jq -r '
+                  .outcomeCountsByKind
+                  | to_entries[]
+                  | "| \(.key) | \(.value.proposedPending // 0) | \(.value.explicitAccepted // 0) | \(.value.explicitRejected // 0) | \(.value.falsePositive // 0) | \(.value.resolvedPositive // 0) | \(.value.superseded // 0) | \(.value.needsOutcome // 0) | \(.value.conflictingLabels // 0) | \(.value.malformedOutcome // 0) |"
+                ' "$result"
+              fi
             else
               echo "| Status | (open result unavailable) |"
             fi

--- a/scripts/status-truth-proposals.test.ts
+++ b/scripts/status-truth-proposals.test.ts
@@ -17,9 +17,11 @@ import type {PublicOutputTokens} from './status-truth-public-output.ts'
 import {describe, expect, it} from 'vitest'
 import {
   buildOutcomeCounts,
+  buildOutcomeCountsByKind,
   classifyProposalOutcome,
   executeStatusTruthProposalActions,
   extractProposalFingerprint,
+  extractProposalKind,
   extractRedactedCanonicalIds,
   fetchExistingProposalIssues,
   isWithinCooldown,
@@ -28,6 +30,7 @@ import {
   OUTCOME_LABELS,
   planStatusTruthProposalActions,
   PROPOSAL_LABEL,
+  recoverProposalKind,
   REQUIRED_LABELS,
 } from './status-truth-proposals.ts'
 import {applyPublicOutputGate, makePublicOutputTokens} from './status-truth-public-output.ts'
@@ -178,6 +181,86 @@ describe('extractProposalFingerprint', () => {
 })
 
 // ---------------------------------------------------------------------------
+// extractProposalKind / recoverProposalKind
+// ---------------------------------------------------------------------------
+
+describe('extractProposalKind', () => {
+  it('extracts kind from a valid hidden marker', () => {
+    const body = '<!-- status-truth:kind=pr-state -->\n\nBody text.'
+    expect(extractProposalKind(body)).toBe('pr-state')
+  })
+
+  it('returns null for body without marker', () => {
+    expect(extractProposalKind('No marker here.')).toBeNull()
+  })
+
+  it('returns null for null body', () => {
+    expect(extractProposalKind(null)).toBeNull()
+  })
+
+  it('returns null for undefined body', () => {
+    expect(extractProposalKind(undefined)).toBeNull()
+  })
+
+  it('returns null for empty body', () => {
+    expect(extractProposalKind('')).toBeNull()
+  })
+
+  it('returns null for malformed marker (missing value)', () => {
+    expect(extractProposalKind('<!-- status-truth:kind= -->')).toBeNull()
+  })
+})
+
+describe('recoverProposalKind — precedence and closed-vocabulary validation', () => {
+  it('prefers the hidden kind marker over the visible Kind body line', () => {
+    const body = '<!-- status-truth:kind=pr-state -->\n\n**Kind:** `issue-state`\n'
+    expect(recoverProposalKind(body)).toBe('pr-state')
+  })
+
+  it('falls back to the visible **Kind:** body line when the hidden marker is absent', () => {
+    const body = '**Kind:** `plan-consistency`\n\nSome other text.'
+    expect(recoverProposalKind(body)).toBe('plan-consistency')
+  })
+
+  it('returns unknown when neither the marker nor the body line is present', () => {
+    expect(recoverProposalKind('No kind information here.')).toBe('unknown')
+  })
+
+  it('returns unknown for a null body', () => {
+    expect(recoverProposalKind(null)).toBe('unknown')
+  })
+
+  it('returns unknown for an undefined body', () => {
+    expect(recoverProposalKind(undefined)).toBe('unknown')
+  })
+
+  it('buckets an unrecognized marker kind as unknown — closed vocabulary only', () => {
+    const body = '<!-- status-truth:kind=arbitrary-attacker-text -->\n\nBody.'
+    expect(recoverProposalKind(body)).toBe('unknown')
+  })
+
+  it('buckets an unrecognized visible Kind line as unknown — closed vocabulary only', () => {
+    const body = '**Kind:** `<script>alert(1)</script>`\n\nBody.'
+    expect(recoverProposalKind(body)).toBe('unknown')
+  })
+
+  it('recognizes every known ClaimKind value from the hidden marker', () => {
+    const knownKinds = [
+      'pr-state',
+      'issue-state',
+      'release-tag-state',
+      'plan-status',
+      'rollout-tracker-status',
+      'plan-consistency',
+    ]
+    for (const kind of knownKinds) {
+      const body = `<!-- status-truth:kind=${kind} -->\n\nBody.`
+      expect(recoverProposalKind(body)).toBe(kind)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
 // planStatusTruthProposalActions — happy paths
 // ---------------------------------------------------------------------------
 
@@ -200,6 +283,7 @@ describe('planStatusTruthProposalActions', () => {
         expect(openAction.fingerprint).toBe(finding.fingerprint)
         expect(openAction.title).toContain('pr-state')
         expect(openAction.body).toContain(`<!-- status-truth:fingerprint=${finding.fingerprint} -->`)
+        expect(openAction.body).toContain(`<!-- status-truth:kind=${finding.kind} -->`)
         expect(openAction.labels).toContain(PROPOSAL_LABEL)
       }
       expect(counts.opened).toBe(1)
@@ -3931,6 +4015,83 @@ describe('buildOutcomeCounts — outcome read-model counts separate from action 
 })
 
 // ---------------------------------------------------------------------------
+// buildOutcomeCountsByKind — per-kind outcome aggregation, single classification pass
+// ---------------------------------------------------------------------------
+
+describe('buildOutcomeCountsByKind', () => {
+  it('aggregates outcome counts per kind across open and closed issues with mixed kinds', () => {
+    const issues: ExistingProposalIssue[] = [
+      makeClosedIssue('fp1', [PROPOSAL_LABEL, OUTCOME_LABELS.accepted], {
+        body: `<!-- status-truth:fingerprint=fp1 -->\n<!-- status-truth:kind=pr-state -->\n\nBody.`,
+      }),
+      makeClosedIssue('fp2', [PROPOSAL_LABEL, OUTCOME_LABELS.rejected], {
+        body: `<!-- status-truth:fingerprint=fp2 -->\n<!-- status-truth:kind=issue-state -->\n\nBody.`,
+      }),
+      makeOpenIssue('fp3', {
+        body: `<!-- status-truth:fingerprint=fp3 -->\n<!-- status-truth:kind=pr-state -->\n\nBody.`,
+      }),
+    ]
+
+    const byKind = buildOutcomeCountsByKind(issues)
+
+    expect(byKind['pr-state']?.explicitAccepted).toBe(1)
+    expect(byKind['pr-state']?.proposedPending).toBe(1)
+    expect(byKind['issue-state']?.explicitRejected).toBe(1)
+  })
+
+  it('only includes kinds with at least one issue', () => {
+    const issues: ExistingProposalIssue[] = [
+      makeClosedIssue('fp1', [PROPOSAL_LABEL, OUTCOME_LABELS.accepted], {
+        body: `<!-- status-truth:fingerprint=fp1 -->\n<!-- status-truth:kind=pr-state -->\n\nBody.`,
+      }),
+    ]
+
+    const byKind = buildOutcomeCountsByKind(issues)
+
+    expect(Object.keys(byKind)).toEqual(['pr-state'])
+  })
+
+  it('buckets issues with unrecognized/missing kind info under unknown', () => {
+    const issues: ExistingProposalIssue[] = [
+      makeClosedIssue('fp1', [PROPOSAL_LABEL, OUTCOME_LABELS.accepted], {
+        body: `<!-- status-truth:fingerprint=fp1 -->\n\nNo kind info here.`,
+      }),
+    ]
+
+    const byKind = buildOutcomeCountsByKind(issues)
+
+    expect(byKind.unknown?.explicitAccepted).toBe(1)
+  })
+
+  it('returns an empty object for an empty issue list', () => {
+    expect(buildOutcomeCountsByKind([])).toEqual({})
+  })
+
+  it('output contains only numeric counts nested under kind keys — no raw body, title, or fingerprint', () => {
+    const issues: ExistingProposalIssue[] = [
+      makeClosedIssue('abc123def456abcd', [PROPOSAL_LABEL, OUTCOME_LABELS.accepted], {
+        title: 'Status truth: pr-state drift in docs/plans/secret-path.md',
+        body: `<!-- status-truth:fingerprint=abc123def456abcd -->\n<!-- status-truth:kind=pr-state -->\n\nSensitive body content.`,
+      }),
+    ]
+
+    const byKind = buildOutcomeCountsByKind(issues)
+    const json = JSON.stringify(byKind)
+
+    expect(json).not.toContain('secret-path')
+    expect(json).not.toContain('Sensitive body content')
+    expect(json).not.toContain('abc123def456abcd')
+    expect(json).not.toContain('Status truth:')
+
+    for (const counts of Object.values(byKind)) {
+      for (const value of Object.values(counts ?? {})) {
+        expect(typeof value).toBe('number')
+      }
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
 // conflictingLabels count in ProposalCounts
 // ---------------------------------------------------------------------------
 
@@ -4226,6 +4387,19 @@ describe('planStatusTruthProposalActions — outcomeCounts in result', () => {
     expect(result.counts.opened).toBe(0)
     // Outcome counts: one proposed-pending (the existing open issue)
     expect(result.outcomeCounts.proposedPending).toBe(1)
+  })
+
+  it('result includes outcomeCountsByKind, keyed by claim kind, derived from the same classification pass', () => {
+    const fingerprint = 'abc123def456abcd'
+    const openIssue = makeOpenIssue(fingerprint, {
+      body: `<!-- status-truth:fingerprint=${fingerprint} -->\n<!-- status-truth:kind=pr-state -->\n\nBody.`,
+    })
+
+    const result = planStatusTruthProposalActions(makePlanInput({existingIssues: [openIssue]})) as {
+      outcomeCountsByKind: Readonly<Record<string, OutcomeCounts>>
+    }
+
+    expect(result.outcomeCountsByKind['pr-state']?.proposedPending).toBe(1)
   })
 })
 
@@ -4752,6 +4926,38 @@ describe('plannedCounts assembly', () => {
     expect(plannedCounts.needsOutcomeCooldown).toBe(1)
     // No reopen during cooldown
     expect(planResult.counts.reopened).toBe(0)
+  })
+
+  it('outcomeCountsByKind from the planner is present in the OpenResult shape for dry-run and live paths', () => {
+    // Simulate the OpenResult assembly that runOpen() performs for both the
+    // dry-run and live execute paths — both reuse the same planResult.outcomeCountsByKind.
+    const fingerprint = 'abc123def456abcd'
+    const openIssue: ExistingProposalIssue = {
+      ...makeOpenIssue(fingerprint, {
+        body: `<!-- status-truth:fingerprint=${fingerprint} -->\n<!-- status-truth:kind=pr-state -->\n\nBody.`,
+      }),
+    }
+
+    const planResult = planStatusTruthProposalActions(makePlanInput({existingIssues: [openIssue]}))
+
+    // Assemble the OpenResult the same way runOpen() does for either dry-run or live.
+    const dryRunResult = {
+      dryRun: true,
+      outcomeCounts: planResult.outcomeCounts,
+      outcomeCountsByKind: planResult.outcomeCountsByKind,
+    }
+    const liveResult = {
+      dryRun: false,
+      outcomeCounts: planResult.outcomeCounts,
+      outcomeCountsByKind: planResult.outcomeCountsByKind,
+    }
+
+    expect(dryRunResult.outcomeCountsByKind['pr-state']?.proposedPending).toBe(1)
+    expect(liveResult.outcomeCountsByKind['pr-state']?.proposedPending).toBe(1)
+
+    const json = JSON.stringify(dryRunResult)
+    expect(json).not.toContain(fingerprint)
+    expect(json).not.toContain('docs/plans/example.md')
   })
 })
 

--- a/scripts/status-truth-proposals.ts
+++ b/scripts/status-truth-proposals.ts
@@ -187,6 +187,30 @@ const FINGERPRINT_MARKER_PATTERN = /<!-- status-truth:fingerprint=([a-f0-9]+) --
 /** Pattern to extract live-state from hidden marker. */
 const LIVE_STATE_MARKER_PATTERN = /<!-- status-truth:live-state=([\w-]+) -->/u
 
+/** Marker prefix for claim kind in issue body. */
+const KIND_MARKER_PREFIX = 'status-truth:kind='
+
+/** Pattern to extract claim kind from hidden marker. Claim kinds are lowercase words and hyphens only. */
+const KIND_MARKER_PATTERN = /<!-- status-truth:kind=([a-z-]+) -->/u
+
+/** Pattern to extract claim kind from the visible `**Kind:** \`<kind>\`` proposal body line. */
+const VISIBLE_KIND_LINE_PATTERN = /\*\*Kind:\*\* `([a-z-]+)`/u
+
+/**
+ * Closed vocabulary of recognized claim kinds for telemetry bucketing.
+ * Kept in sync with `ClaimKind` in status-truth-detect.ts. Any recovered kind
+ * text outside this set is bucketed as 'unknown' — telemetry keys must never
+ * carry arbitrary body text.
+ */
+const KNOWN_CLAIM_KINDS: ReadonlySet<string> = new Set<string>([
+  'pr-state',
+  'issue-state',
+  'release-tag-state',
+  'plan-status',
+  'rollout-tracker-status',
+  'plan-consistency',
+])
+
 // ---------------------------------------------------------------------------
 // Outcome classification read-model
 // ---------------------------------------------------------------------------
@@ -334,19 +358,70 @@ export interface OutcomeCounts {
  *   Used to distinguish resolved-positive (drift cleared) from needs-outcome (drift still active)
  *   for closed issues with no terminal/resolution label. Defaults to empty set (all drift cleared).
  */
+/** Mutable accumulator shape backing an {@link OutcomeCounts} bucket. */
+interface OutcomeCountsAccumulator {
+  proposedPending: number
+  explicitAccepted: number
+  explicitRejected: number
+  falsePositive: number
+  resolvedPositive: number
+  superseded: number
+  needsOutcome: number
+  conflictingLabels: number
+  malformedOutcome: number
+}
+
+function makeOutcomeCountsAccumulator(): OutcomeCountsAccumulator {
+  return {
+    proposedPending: 0,
+    explicitAccepted: 0,
+    explicitRejected: 0,
+    falsePositive: 0,
+    resolvedPositive: 0,
+    superseded: 0,
+    needsOutcome: 0,
+    conflictingLabels: 0,
+    malformedOutcome: 0,
+  }
+}
+
+function applyOutcomeState(acc: OutcomeCountsAccumulator, state: ProposalOutcomeState): void {
+  switch (state) {
+    case 'proposed-pending':
+      acc.proposedPending++
+      break
+    case 'explicit-accepted':
+      acc.explicitAccepted++
+      break
+    case 'explicit-rejected':
+      acc.explicitRejected++
+      break
+    case 'false-positive':
+      acc.falsePositive++
+      break
+    case 'resolved-positive':
+      acc.resolvedPositive++
+      break
+    case 'superseded':
+      acc.superseded++
+      break
+    case 'needs-outcome':
+      acc.needsOutcome++
+      break
+    case 'conflicting-labels':
+      acc.conflictingLabels++
+      break
+    case 'malformed-outcome':
+      acc.malformedOutcome++
+      break
+  }
+}
+
 export function buildOutcomeCounts(
   issues: readonly ExistingProposalIssue[],
   driftActiveFingerprints: ReadonlySet<string> = new Set<string>(),
 ): OutcomeCounts {
-  let proposedPending = 0
-  let explicitAccepted = 0
-  let explicitRejected = 0
-  let falsePositive = 0
-  let resolvedPositive = 0
-  let superseded = 0
-  let needsOutcome = 0
-  let conflictingLabels = 0
-  let malformedOutcome = 0
+  const acc = makeOutcomeCountsAccumulator()
 
   for (const issue of issues) {
     // Only classify issues that have the proposal label
@@ -357,49 +432,51 @@ export function buildOutcomeCounts(
     const fp = extractProposalFingerprint(issue.body)
     const driftActive = fp !== null && driftActiveFingerprints.has(fp)
 
-    const state = classifyProposalOutcome(issue, driftActive)
-    switch (state) {
-      case 'proposed-pending':
-        proposedPending++
-        break
-      case 'explicit-accepted':
-        explicitAccepted++
-        break
-      case 'explicit-rejected':
-        explicitRejected++
-        break
-      case 'false-positive':
-        falsePositive++
-        break
-      case 'resolved-positive':
-        resolvedPositive++
-        break
-      case 'superseded':
-        superseded++
-        break
-      case 'needs-outcome':
-        needsOutcome++
-        break
-      case 'conflicting-labels':
-        conflictingLabels++
-        break
-      case 'malformed-outcome':
-        malformedOutcome++
-        break
-    }
+    applyOutcomeState(acc, classifyProposalOutcome(issue, driftActive))
   }
 
-  return {
-    proposedPending,
-    explicitAccepted,
-    explicitRejected,
-    falsePositive,
-    resolvedPositive,
-    superseded,
-    needsOutcome,
-    conflictingLabels,
-    malformedOutcome,
+  return {...acc}
+}
+
+/**
+ * Build per-claim-kind outcome counts from a list of existing proposal issues.
+ *
+ * Pure function: no I/O, no side effects. Shares the same classification pass
+ * as {@link buildOutcomeCounts} (one `classifyProposalOutcome` call per issue) —
+ * it does not classify each issue twice.
+ *
+ * Kind is recovered via {@link recoverProposalKind}, which validates against the
+ * closed vocabulary of known claim kinds; unrecognized or missing kind info is
+ * bucketed under 'unknown'. Only kinds with at least one issue are included in
+ * the result — no zero-filled kind keys.
+ *
+ * Output is counts-only — no raw issue bodies, titles, or fingerprints.
+ */
+export function buildOutcomeCountsByKind(
+  issues: readonly ExistingProposalIssue[],
+  driftActiveFingerprints: ReadonlySet<string> = new Set<string>(),
+): Readonly<Record<string, OutcomeCounts>> {
+  const accByKind: Record<string, OutcomeCountsAccumulator> = {}
+
+  for (const issue of issues) {
+    if (!issue.labels.includes(PROPOSAL_LABEL)) continue
+
+    const fp = extractProposalFingerprint(issue.body)
+    const driftActive = fp !== null && driftActiveFingerprints.has(fp)
+    const state = classifyProposalOutcome(issue, driftActive)
+
+    const kind = recoverProposalKind(issue.body)
+    const existing = accByKind[kind]
+    const acc = existing ?? makeOutcomeCountsAccumulator()
+    if (existing === undefined) accByKind[kind] = acc
+    applyOutcomeState(acc, state)
   }
+
+  const result: Record<string, OutcomeCounts> = {}
+  for (const [kind, acc] of Object.entries(accByKind)) {
+    result[kind] = {...acc}
+  }
+  return result
 }
 
 // ---------------------------------------------------------------------------
@@ -575,6 +652,13 @@ export interface PlanStatusTruthProposalActionsResult {
    * proposal issues, not the actions taken in this run.
    */
   readonly outcomeCounts: OutcomeCounts
+  /**
+   * Per-claim-kind aggregate outcome counts from all existing proposal issues.
+   * Same read-model as `outcomeCounts`, bucketed by kind (closed vocabulary;
+   * unrecognized/missing kind info buckets as 'unknown'). Only kinds with at
+   * least one issue are present. Counts-only: no paths, titles, or fingerprints.
+   */
+  readonly outcomeCountsByKind: Readonly<Record<string, OutcomeCounts>>
 }
 
 // ---------------------------------------------------------------------------
@@ -622,6 +706,54 @@ function buildLiveStateMarker(liveState: string): string {
   return `<!-- ${LIVE_STATE_MARKER_PREFIX}${liveState} -->`
 }
 
+/**
+ * Extract the claim kind from a proposal issue body hidden marker.
+ * Returns null if the body is absent, empty, or the marker is malformed.
+ */
+export function extractProposalKind(body: string | null | undefined): string | null {
+  if (body === null || body === undefined || body === '') return null
+  const match = KIND_MARKER_PATTERN.exec(body)
+  if (match === null) return null
+  const value = match[1]
+  if (value === undefined || value === '') return null
+  return value
+}
+
+/**
+ * Build the hidden marker line for a claim kind.
+ */
+function buildKindMarker(kind: string): string {
+  return `<!-- ${KIND_MARKER_PREFIX}${kind} -->`
+}
+
+/**
+ * Recover the claim kind for a proposal issue, for telemetry bucketing only.
+ *
+ * Precedence:
+ * 1. Hidden `status-truth:kind=` marker (present on all proposals created after
+ *    this marker was introduced).
+ * 2. Visible `**Kind:** \`<kind>\`` body line (proposals created before the marker
+ *    existed).
+ * 3. 'unknown' when neither is present.
+ *
+ * Recovered text is validated against the closed vocabulary of known claim kinds
+ * (`KNOWN_CLAIM_KINDS`). Any unrecognized value — from a malicious or malformed
+ * body — is bucketed as 'unknown' rather than propagated into telemetry counts
+ * keys.
+ */
+export function recoverProposalKind(body: string | null | undefined): string {
+  const markerKind = extractProposalKind(body)
+  if (markerKind !== null && KNOWN_CLAIM_KINDS.has(markerKind)) return markerKind
+
+  if (body !== null && body !== undefined && body !== '') {
+    const visibleMatch = VISIBLE_KIND_LINE_PATTERN.exec(body)
+    const visibleKind = visibleMatch?.[1]
+    if (visibleKind !== undefined && KNOWN_CLAIM_KINDS.has(visibleKind)) return visibleKind
+  }
+
+  return 'unknown'
+}
+
 // ---------------------------------------------------------------------------
 // Cooldown helper
 // ---------------------------------------------------------------------------
@@ -658,6 +790,7 @@ function buildProposalBody(finding: PublicStatusTruthFinding, generatedAt: strin
 
   return [
     buildFingerprintMarker(finding.fingerprint),
+    buildKindMarker(finding.kind),
     liveStateMarker,
     '',
     `**Kind:** \`${finding.kind}\``,
@@ -755,6 +888,7 @@ export function planStatusTruthProposalActions(
       },
       countsByKind: {},
       outcomeCounts: buildOutcomeCounts(existingIssues),
+      outcomeCountsByKind: buildOutcomeCountsByKind(existingIssues),
     }
   }
 
@@ -789,6 +923,7 @@ export function planStatusTruthProposalActions(
       },
       countsByKind: {},
       outcomeCounts: buildOutcomeCounts(existingIssues),
+      outcomeCountsByKind: buildOutcomeCountsByKind(existingIssues),
     }
   }
 
@@ -1234,6 +1369,7 @@ export function planStatusTruthProposalActions(
     },
     countsByKind,
     outcomeCounts: buildOutcomeCounts(existingIssues, activeFingerprintsInReport),
+    outcomeCountsByKind: buildOutcomeCountsByKind(existingIssues, activeFingerprintsInReport),
   }
 }
 
@@ -1827,6 +1963,12 @@ interface OpenResult {
    * Counts-only: no raw issue bodies, titles, paths, or fingerprints.
    */
   outcomeCounts: OutcomeCounts
+  /**
+   * Per-claim-kind aggregate outcome counts from all existing proposal issues.
+   * Same read-model as `outcomeCounts`, bucketed by kind. Counts-only: no
+   * paths, titles, or fingerprints.
+   */
+  outcomeCountsByKind: Readonly<Record<string, OutcomeCounts>>
 }
 
 /**
@@ -1995,6 +2137,7 @@ async function runOpen(): Promise<void> {
       needsOutcomeCooldown: planResult.counts.needsOutcomeCooldown,
     },
     outcomeCounts: planResult.outcomeCounts,
+    outcomeCountsByKind: planResult.outcomeCountsByKind,
   }
 
   const resultJson = `${JSON.stringify(result)}\n`


### PR DESCRIPTION
## What

Graduation decisions need accepted-versus-rejected accuracy **per claim kind**, but proposal outcome counts were only aggregated globally. This adds the per-kind layer:

- Proposal bodies carry a hidden `status-truth:kind` marker (same pattern as the fingerprint and live-state markers); a visible `**Kind:**` body-line fallback recovers kind from proposals created before the marker existed.
- Outcome classification buckets per kind against a closed vocabulary (known claim kinds + `unknown`) — arbitrary body text can never mint a counts key.
- `outcomeCountsByKind` joins the open-job result JSON (single classification pass, shared with the existing global counts), and the workflow summary renders a per-kind outcome table after the global one.

Counts only — no paths, titles, or fingerprints — matching the existing telemetry contract.

## Verification

- TDD (RED observed per piece); 1996 tests green; `pnpm check-types` and `pnpm lint` clean.
- Covered: marker round-trip, recovery precedence (marker > body line > unknown), hostile-body-text bucketing, mixed-kind aggregation across open/closed issues, result shape in dry-run and live paths.