### PR TITLE
feat: add wiki authority repair loop

### DIFF
--- a/.github/workflows/wiki-lint.yaml
+++ b/.github/workflows/wiki-lint.yaml
@@ -5,6 +5,15 @@ on:
   schedule:
     - cron: '0 20 * * 0' # Every Sunday at 20:00 UTC
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry-run mode: run the repair pipeline but commit nothing'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
 
 permissions:
   contents: read
@@ -18,6 +27,9 @@ jobs:
     name: Lint authoritative wiki snapshot
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      repairable: ${{ steps.repairable.outputs.repairable }}
+      snapshot_sha: ${{ steps.repairable.outputs.snapshot_sha }}
     steps:
       - name: ⤵ Checkout Branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -47,6 +59,26 @@ jobs:
           WIKI_LINT_JSON_PATH: wiki-lint-report.json
           WIKI_LINT_SNAPSHOT_SHA: ${{ steps.restore-wiki.outputs.data_sha }}
         run: node scripts/wiki-lint.ts
+
+      - name: Compute repairable output
+        id: repairable
+        if: always()
+        run: |
+          set -euo pipefail
+          report=wiki-lint-report.json
+          if [[ -s "$report" ]]; then
+            repairable=$(jq -r '
+              (.scan_complete == true and .failure_class == null and
+                ([.findings[]? | select(.kind == "index-drift" or .kind == "orphan-page" or .kind == "missing-frontmatter" or .kind == "invalid-frontmatter")] | length) > 0
+              )
+            ' "$report")
+            snapshot_sha=$(jq -r '.snapshot_sha // ""' "$report")
+          else
+            repairable=false
+            snapshot_sha=""
+          fi
+          echo "repairable=${repairable}" >> "$GITHUB_OUTPUT"
+          echo "snapshot_sha=${snapshot_sha}" >> "$GITHUB_OUTPUT"
 
       - name: Report restore failure
         if: steps.restore-wiki.outcome == 'failure'
@@ -103,3 +135,98 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           WIKI_LINT_JSON_PATH: wiki-lint-report.json
         run: node scripts/wiki-lint-issues.ts
+
+  # ---------------------------------------------------------------------------
+  # Repair job: runs only when the lint job's dedicated repairable-classes
+  # output is true (deterministic findings only — index-drift, orphan-page,
+  # missing/invalid-frontmatter). Re-derives repairable findings by linting the
+  # tree it loads (the lint report is the trigger, not the source of truth) and
+  # mints its own least-privilege write token, scoped to this job only.
+  # ---------------------------------------------------------------------------
+  wiki-repair:
+    name: Repair wiki integrity findings
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: wiki-lint
+    if: needs.wiki-lint.outputs.repairable == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: ⤵ Checkout Branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      # Grandfather main's knowledge/wiki/repos BEFORE restoring data — mirrors
+      # merge-data.yaml's dual-tree wiring. main content never overwrites data
+      # content in the repair computation; it is a read-only privacy-gate input.
+      - name: 📦 Grandfather main's wiki repos
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/grandfather-wiki-repos"
+          if [[ -d knowledge/wiki/repos ]]; then
+            cp -R knowledge/wiki/repos/. "${RUNNER_TEMP}/grandfather-wiki-repos/"
+          fi
+
+      - name: 📦 Setup
+        uses: ./.github/actions/setup
+
+      - name: Restore data snapshot
+        id: restore-data
+        run: |
+          set -euo pipefail
+          git fetch --depth=1 origin data
+          git restore --source FETCH_HEAD --worktree -- knowledge metadata/repos.yaml
+          echo "data_sha=$(git rev-parse FETCH_HEAD)" >> "$GITHUB_OUTPUT"
+
+      # Least-privilege write token, minted only in this job, skipped entirely
+      # on dry-run dispatches (no write credential exists on a run that cannot write).
+      - name: 🔑 Mint write token
+        id: app-token
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+
+      - name: 🛠 Run wiki repair
+        id: repair
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          GRANDFATHER_WIKI_REPOS_DIR: ${{ runner.temp }}/grandfather-wiki-repos
+          WIKI_REPAIR_RESULT_PATH: ${{ runner.temp }}/wiki-repair-result.json
+          # Scheduled runs carry no inputs, so a schedule run is always live (not dry-run).
+          WIKI_REPAIR_DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          WIKI_REPAIR_DATA_TIP_SHA: ${{ steps.restore-data.outputs.data_sha }}
+        run: node scripts/wiki-repair.ts
+
+      - name: 📋 Write repair summary
+        if: always()
+        env:
+          WIKI_REPAIR_RESULT_PATH: ${{ runner.temp }}/wiki-repair-result.json
+        run: |
+          set -euo pipefail
+          result="$WIKI_REPAIR_RESULT_PATH"
+
+          {
+            echo "## Wiki Repair Summary"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+
+            if [[ -s "$result" ]]; then
+              echo "| Dry run | $(jq -r 'if .dry_run then "true" else "false" end' "$result") |"
+              echo "| Repairable seen | $(jq '.repairable_seen // 0' "$result") |"
+              echo "| Repaired | $(jq '.repaired // 0' "$result") |"
+              echo "| Aborted | $(jq '.aborted // 0' "$result") |"
+              echo "| Out of scope | $(jq '.out_of_scope // 0' "$result") |"
+              echo "| Privacy blocked | $(jq '.privacy_blocked // 0' "$result") |"
+              echo "| Path refused | $(jq '.path_refused // 0' "$result") |"
+              echo "| Conflict retries | $(jq '.conflict_retries // 0' "$result") |"
+              echo "| No-op | $(jq '.noop // 0' "$result") |"
+            else
+              echo "| Status | (repair result unavailable) |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/wiki-lint.yaml
+++ b/.github/workflows/wiki-lint.yaml
@@ -200,6 +200,8 @@ jobs:
           # Scheduled runs carry no inputs, so a schedule run is always live (not dry-run).
           WIKI_REPAIR_DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
           WIKI_REPAIR_DATA_TIP_SHA: ${{ steps.restore-data.outputs.data_sha }}
+          WIKI_REPAIR_OWNER: ${{ github.repository_owner }}
+          WIKI_REPAIR_REPO: ${{ github.event.repository.name }}
         run: node scripts/wiki-repair.ts
 
       - name: 📋 Write repair summary

--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ Runtime state lives in version-controlled YAML under [`metadata/`](metadata/) (a
 
 Fro Bot maintains a [Karpathy-style LLM wiki](knowledge/) (`schema.md`, `index.md`, `log.md`, plus `wiki/{repos,topics,entities,comparisons}/`) that compounds cross-repo knowledge. The **Survey Repo** workflow ingests repositories into the wiki; **Reconcile Repos** schedules those surveys; **Wiki Lint** validates the authoritative snapshot restored from `origin/data` before reporting findings.
 
+When a completed scan reports a purely mechanical finding, **Wiki Lint**'s `wiki-repair` job self-heals it in the same run: `index-drift` and `orphan-page` regenerate the wiki index, and `missing-frontmatter`/`invalid-frontmatter` get a per-page frontmatter repair limited to two derivable fields — `type` (from the page's directory) and `title` (copied verbatim from an existing H1). Every other finding, including any other frontmatter field, requires judgment and stays on the issue-only lifecycle (open/update/reopen/close via `wiki-lint-issue-sync`). Repairs commit to the `data` branch through the existing atomic-commit envelope and ride the normal `data → main` promotion path (auto-merge when the promoted diff is knowledge/metadata-only); they never touch `main` directly. Repair commit messages are a fixed, counts-free template — never page slugs, titles, or repo names. Issue closure for a repaired finding still runs through the next **Wiki Lint** scan's close-on-clear behavior, not the repair job itself.
+
 To manually re-survey a repo, pass its GitHub GraphQL `node_id` as the dispatch input:
 
 ```bash

--- a/docs/brainstorms/2026-07-03-wiki-authority-repair-loop-requirements.md
+++ b/docs/brainstorms/2026-07-03-wiki-authority-repair-loop-requirements.md
@@ -1,0 +1,268 @@
+---
+date: 2026-07-03
+topic: wiki-authority-repair-loop
+title: Wiki authority repair loop
+---
+
+# Wiki authority repair loop
+
+## Summary
+
+Close the detect→issue→wait-for-human gap for the knowledge wiki's deterministic failure
+classes. When a completed wiki-lint scan reports repairable findings, a repair job regenerates
+the affected surfaces — index regeneration and strictly mechanical frontmatter fixes —
+verifies the repair clears the finding, and commits it to the `data` branch through the existing
+atomic-commit envelope. The promotion pipeline carries it to `main`; wiki-lint's close-on-clear
+confirms the fix on the next scan. No new write authority is created.
+
+---
+
+## Problem Frame
+
+Wiki-lint detects seven failure classes and turns the deterministic ones into fingerprinted
+issues with a full lifecycle — but repairs zero of them. Index drift and orphan pages are fixed
+by regenerating `knowledge/index.md` and `knowledge/log.md` from the wiki pages, an operation the
+bot already performs autonomously on every ingest and that `rebuild-wiki-index.ts` exposes as a
+manual healer. The gap is purely a trigger: the same regeneration the bot runs ungated during
+writes sits behind a human when lint finds drift.
+
+The A2 portfolio named metadata/wiki authority repair as the deferred second surface after
+status truth. Status truth built the proposal-first posture for judgment claims; this slice is
+the complementary case — repairs that are deterministic regenerations need no proposal gate,
+they need the existing operation wired to the existing detector.
+
+---
+
+## Actors
+
+- A1. Marcus: reviews the weekly promotion PR (or the auto-merged knowledge-only PR), handles
+  judgment-class lint issues, and can dispatch on-demand healing.
+- A2. Fro Bot: detects via wiki-lint, repairs deterministic findings, commits to `data`, and
+  closes lint issues via the existing close-on-clear when the fix lands.
+- A3. Promotion pipeline: existing `data → main` gates (private-presence, private-leak,
+  merge PR with knowledge-only auto-merge) — unchanged, load-bearing.
+
+---
+
+## Key Flows
+
+- F1. Post-lint auto-repair
+  - **Trigger:** A completed wiki-lint scan reports at least one repairable deterministic
+    finding.
+  - **Actors:** A2, A3
+  - **Steps:** The repair job regenerates the affected surfaces, re-lints locally to verify the
+    findings clear, commits once to `data` through the atomic-commit path, and records
+    counts-only telemetry. The next scheduled lint scan closes the corresponding issues via
+    close-on-clear.
+  - **Outcome:** Deterministic wiki drift heals without operator action; issue lifecycle
+    confirms it.
+  - **Covered by:** R1, R2, R3, R5, R6, R7, R8, R9
+- F2. Manual healing dispatch
+  - **Trigger:** Marcus dispatches the repair workflow on demand.
+  - **Actors:** A1, A2
+  - **Steps:** Same repair path as F1, same bounds, same verification.
+  - **Outcome:** On-demand healing without shell access or local scripts.
+  - **Covered by:** R4
+- F3. Non-repairable finding
+  - **Trigger:** Lint reports a judgment-class finding (broken wikilink, stale claim, missing
+    cross-reference, knowledge gap) or a frontmatter defect outside the mechanical allowlist.
+  - **Actors:** A2
+  - **Steps:** The finding follows the existing issue lifecycle untouched; the repair job counts
+    it as out-of-scope and does not modify the page.
+  - **Outcome:** Judgment work stays human-owned; the repair loop cannot creep into prose.
+  - **Covered by:** R2, R10
+
+---
+
+## Requirements
+
+**Repair classes and bounds**
+
+- R1. The repair loop owns exactly two repair operations in v1: (a) regeneration of
+  `knowledge/index.md` from the wiki pages (covering index-drift and orphan-page findings) via
+  the existing `rebuildWikiIndex` logic, and (b) mechanical frontmatter repair on wiki pages.
+  `knowledge/log.md` is not regenerated from pages — it is an append-only log with a separate
+  merge-heal operation — and is out of scope for v1 repair.
+- R2. Mechanical frontmatter repair is bounded by an explicit field allowlist: a field is
+  repairable only when its correct value is computable from the page's filename or existing
+  content alone, per the schema in `knowledge/schema.md`. The v1 allowlist is `type` (derived
+  from the page's directory) and `title` only when the page carries a canonical H1 to copy;
+  `created`, `updated`, `sources`, `tags`, `aliases`, and `related` are explicitly excluded. Any
+  field requiring judgment is out of scope and follows the existing issue lifecycle. Planning
+  validates the allowlist against the live corpus and may shrink — never grow — it.
+- R3. The repair job runs as part of the wiki-lint workflow after a completed scan reporting
+  repairable findings, and produces at most one repair commit per run covering all repairable
+  findings from that scan.
+- R4. A manual dispatch path runs the identical repair pipeline with identical bounds.
+
+**Verification and fail-closed behavior**
+
+- R5. Before committing, the repair job re-runs wiki-lint against the repaired working tree and
+  requires every targeted finding to clear; if any targeted finding persists, the job aborts
+  without committing and reports the abort as a distinct count. Verification and commit key off
+  the same tree: the repair job loads the current `data` tip, re-derives repairable findings by
+  linting that tree (the report is the trigger, not the source of truth), repairs, verifies, and
+  commits with that tip as parent — a repair never verifies against one tree and commits onto
+  another. Verification also fails if the repaired tree introduces any new deterministic finding
+  absent from the pre-repair tree.
+- R5b. Before any `data` commit, the repaired tree passes the same private-presence checks the
+  promotion pipeline enforces, using the authority metadata (`metadata/repos.yaml`) from the
+  current `data` tip — never a stale snapshot — so a redaction that landed after detection still
+  gates the repair. Any would-be introduction or resurrection of a private repo identifier on
+  the public branch aborts with a counted failure. The `data` branch is publicly readable —
+  promotion-time gating alone is too late.
+- R6. Repairs never run against an incomplete or failed lint scan; scan-execution failures
+  produce no repair activity.
+- R7. A repair that would modify any path outside `knowledge/` is refused at execution time;
+  `metadata/*.yaml` and all non-knowledge surfaces are structurally out of scope.
+
+**Write path and authority**
+
+- R8. Repair commits go exclusively to the `data` branch through the existing atomic-commit
+  envelope (`wiki-ingest`-style Git data API commit), and reach `main` only via the existing
+  promotion pipeline. The repair loop never pushes to `main` or any other branch. The lint
+  workflow's current mint is read-only for contents, so the repair step mints its own
+  least-privilege token (`contents: write`, repo-scoped) inside the repair job only; issue-sync
+  and detection jobs never hold write credentials, and the workflow's schedule/dispatch-only
+  trigger model is a stated precondition for hosting a writer.
+- R8b. Repair commit messages use a fixed template that may carry at most aggregate counts and
+  the fixed operation name — never page slugs, filenames, titles, or repo names. A constant
+  message satisfies this. Commit messages on `data` are public surfaces.
+- R9. On a data-branch ref conflict (concurrent ingest), the repair job re-fetches the new tip,
+  recomputes the regeneration against it, re-verifies, and retries; it never blind-retries a
+  stale computation. If recomputation finds the targeted findings already cleared by the
+  intervening commit, the job exits as a counted no-op without committing. Retry exhaustion
+  aborts with a counted failure.
+
+**Telemetry and lifecycle**
+
+- R10. Telemetry is counts-only: repairable findings seen, repairs applied, aborts,
+  out-of-scope findings, conflict retries — no paths, slugs, fingerprints, or page titles in
+  workflow summaries or logs.
+- R11. The repair loop does not open, close, or comment on lint issues directly; issue closure
+  happens exclusively through wiki-lint's existing close-on-clear on the next completed scan.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R3, R5, R8.** Given a completed lint scan reporting index-drift, when the
+  repair job runs, it regenerates the index from the pages, verifies the finding clears, and
+  lands exactly one commit on `data`; the next scan closes the issue.
+- AE2. **Covers R2.** Given a wiki page whose frontmatter slug field is missing but derivable
+  from its filename, when the repair job runs, the field is restored; given a page with a
+  missing title requiring judgment, the page is untouched and the finding stays issue-only.
+- AE3. **Covers R5.** Given a repair whose re-lint still reports the targeted finding, when
+  verification runs, no commit is created and the abort is counted.
+- AE4. **Covers R6.** Given a lint scan that failed or is incomplete, when the workflow
+  evaluates the repair job, no repair activity occurs.
+- AE5. **Covers R7.** Given a hypothetical repair computation that touches a path outside
+  `knowledge/`, when the job validates its changeset, the write is refused and counted.
+- AE6. **Covers R9.** Given an ingest commit lands on `data` between the repair's read and
+  write, when the commit conflicts, the job recomputes against the new tip and retries; the
+  final commit reflects the post-ingest state.
+- AE7. **Covers R10, R8b.** Given any repair run, when its summary and commit message render,
+  they contain only counts and fixed template text.
+- AE8. **Covers R11.** Given a repair run that fixes a finding with an open lint issue, when the
+  run completes, the issue is untouched — no comment, no close — and closes only via the next
+  completed scan's close-on-clear.
+- AE9. **Covers R5b.** Given a regeneration whose output would reintroduce a redacted private
+  slug into `knowledge/index.md`, when the pre-commit privacy check runs, no commit is created
+  and the abort is counted.
+
+---
+
+## Success Criteria
+
+- Index-drift and orphan-page lint issues stop requiring operator action: they open, a repair
+  lands, and close-on-clear resolves them within one lint cycle when the promotion diff is
+  knowledge/metadata-only (auto-merge); when unrelated code changes sit on `data`, the repair
+  still lands but promotion — and therefore closure — waits for the human-reviewed promotion PR,
+  which is accepted latency, not failure.
+- The mechanical-frontmatter allowlist produces zero judgment edits — no repair commit ever
+  changes prose, titles, or topics.
+- Every repair commit rides the existing promotion pipeline unchanged, auto-merging when
+  knowledge-only.
+- A dispatch-run rehearsal on a fixture-drifted wiki demonstrates regenerate → verify → commit →
+  close-on-clear end to end.
+
+---
+
+## Scope Boundaries
+
+- No repair of judgment classes: broken-wikilink, stale-claim, missing-cross-reference,
+  knowledge-gap.
+- No `metadata/*.yaml` writes — reconcile-repos owns metadata drift.
+- No changes to wiki-lint detection, the issue lifecycle, promotion gates, or ingest.
+- No proposal-issue machinery for repairs — deterministic regenerations ride the existing
+  write envelope; judgment repairs (if ever) would be a separate graduated slice.
+- No new schedules; detection cadence is repair cadence.
+- No LLM/generative content in any repair — regeneration and derivation only.
+
+---
+
+## Key Decisions
+
+- **Repair rides the existing envelope:** the bot already regenerates index/log ungated during
+  ingest; wiring the same operation to the lint trigger creates no new authority, so the
+  proposal-first posture status truth needed for judgment claims would be pure ceremony here.
+- **Verify-before-commit is the safety primitive:** re-linting the repaired tree and requiring
+  the targeted findings to clear turns "the repair worked" into a precondition instead of a
+  hope.
+- **Mechanical means computable:** the frontmatter allowlist is defined by derivability from
+  filename/content, drawn from `knowledge/schema.md` — a bright line that keeps the loop out of
+  prose.
+- **Issue lifecycle stays owned by lint:** the repair loop writes pages, never issue state;
+  close-on-clear remains the single source of issue truth and doubles as end-to-end
+  verification.
+- **One commit per run:** bounded blast radius, reviewable promotion diffs, deterministic
+  telemetry.
+
+---
+
+## Dependencies / Assumptions
+
+- `rebuildWikiIndex` (exported from `wiki-ingest.ts`; `rebuild-wiki-index.ts` is its CLI
+  wrapper) and `wiki-ingest.ts`'s atomic Git-data commit path (with conflict retry) are the
+  reuse seams.
+- Wiki-lint runs against files on disk and already records `snapshot_sha` from `origin/data`,
+  so working-tree re-lint verification and snapshot pinning are supported; the workflow's
+  current checkout/restore step is the place the repair job inherits its tree.
+- The lint workflow triggers are schedule and manual dispatch only (no PR-triggered runs) — a
+  precondition for hosting a write-capable repair job.
+- The promotion pipeline's knowledge-only auto-merge continues to treat repair commits like
+  ingest commits.
+- Assumption (labeled): wiki-lint's finding classification is precise enough that "repairable"
+  can be computed from the report JSON alone; if repairability needs page inspection, the
+  repair job derives it locally without widening lint.
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- [Affects R2][Technical] The exact mechanical-frontmatter field allowlist from
+  `knowledge/schema.md` — which fields are derivable in practice on the current corpus?
+
+### Deferred to Planning
+
+- [Affects R3][Technical] Whether the repair job is a new job in the wiki-lint workflow or a
+  called reusable workflow.
+- [Affects R8][Technical] Extract regeneration from `rebuild-wiki-index.ts`/`wiki-ingest.ts`
+  into a shared module vs invoke as-is.
+- [Affects R10][Technical] Result JSON shape and summary rendering, mirroring the status-truth
+  counts pattern.
+
+---
+
+## Sources / Research
+
+- A2 portfolio requirements: `docs/brainstorms/2026-06-26-a2-self-maintenance-portfolio-requirements.md`
+- Detection and lifecycle: `scripts/wiki-lint.ts`, `scripts/wiki-lint-issues.ts`
+- Regeneration and write primitives: `scripts/rebuild-wiki-index.ts`, `scripts/wiki-ingest.ts`,
+  `scripts/commit-metadata.ts`
+- Authority model: `scripts/check-wiki-authority.ts`, `.github/workflows/merge-data.yaml`,
+  `metadata/README.md`
+- Related learnings: `docs/solutions/integration-issues/wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md`,
+  `docs/solutions/best-practices/status-truth-synthetic-self-audit-claim-kinds-2026-07-03.md`

--- a/docs/plans/2026-07-03-002-feat-wiki-authority-repair-loop-plan.md
+++ b/docs/plans/2026-07-03-002-feat-wiki-authority-repair-loop-plan.md
@@ -1,0 +1,371 @@
+---
+title: 'feat: Wiki authority repair loop'
+type: feat
+status: complete
+completed: 2026-07-03
+date: 2026-07-03
+origin: docs/brainstorms/2026-07-03-wiki-authority-repair-loop-requirements.md
+---
+
+# feat: Wiki authority repair loop
+
+## Overview
+
+Close the detect→issue→wait-for-human gap for the knowledge wiki's deterministic failure
+classes. A new repair module regenerates `knowledge/index.md` (index-drift, orphan-page) and
+applies a two-field mechanical frontmatter allowlist (`type` from directory, `title` from
+canonical H1), verifies against the same tree it commits onto — the current `data` tip — with a
+no-new-findings rule, gates the repaired tree through the private-presence check using
+current-tip authority metadata, and commits once to `data` through the existing atomic-commit
+envelope. Issue closure stays owned by wiki-lint's close-on-clear.
+
+## Problem Frame
+
+Wiki-lint detects seven failure classes and repairs none. Index regeneration is an operation the
+bot already performs ungated during every ingest; `rebuild-wiki-index.ts` exposes it manually.
+The gap is a trigger, not an authority: deterministic drift sits behind a human for no safety
+gain (see origin: `docs/brainstorms/2026-07-03-wiki-authority-repair-loop-requirements.md`).
+
+## Requirements Trace
+
+From the origin document: R1 (index regeneration only; log out of scope), R2 (frontmatter
+allowlist: `type`, `title`-from-H1; shrink-only), R3–R4 (post-lint auto + manual dispatch, one
+commit per run), R5/R5b (verify-and-commit on the same current-tip tree, no-new-findings rule;
+pre-commit private-presence gate with current-tip repos.yaml), R6 (no repair on incomplete
+scans), R7 (knowledge/-only writes, refusal at execution time), R8/R8b (data-branch-only atomic
+commit, repair-job-only write mint, fixed identity-free commit message), R9
+(recompute-on-conflict, no-op semantics), R10 (counts-only telemetry), R11 (no issue-state
+writes).
+
+## Scope Boundaries
+
+- No repair of judgment classes: broken-wikilink, stale-claim, missing-cross-reference,
+  knowledge-gap.
+- `knowledge/log.md` is not regenerated (append-only; separate merge-heal op, out of v1).
+- No `metadata/*.yaml` writes; no changes to wiki-lint detection, issue lifecycle, promotion
+  gates, or ingest.
+- No proposal machinery; no new schedules; no LLM/generative content in repairs.
+
+### Deferred to Separate Tasks
+
+- Log merge-heal automation (the `--merge-logs` operation) if conflict damage recurs.
+- Any allowlist growth beyond `type`/`title` — requires a new reviewed requirements pass.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/wiki-lint.ts` — report contract: `WikiLintJsonReport` (`scan_complete`,
+  `snapshot_sha`, `repair_eligible`, `failure_class`, findings with
+  `kind/severity/path/target/message/fingerprint`). `orphan-page`: path=page, target=null;
+  `index-drift`: path=`knowledge/index.md`, target=missing slug. `splitFrontmatter` +
+  required-field checks produce `missing-frontmatter`/`invalid-frontmatter`.
+- `scripts/wiki-ingest.ts` — reuse seams: `rebuildWikiIndex({existingIndex?, wikiFiles})` →
+  new index string, in-memory, preserves header/footer prose; `commitWikiChanges({owner?, repo?,
+  branch?, message, files, octokit?, maxRetries?})` — atomic blob/tree/commit + ref update with
+  conflict retry and `CONFLICT_EXHAUSTED`; `parseFrontmatter` (strict); `pageTypeFromPath`
+  (directory → type derivation).
+- `scripts/check-wiki-private-presence.ts` — `detectPrivateWikiLeaks({dataWikiPages,
+  publicSlugMap, grandfatherPages})` is a pure exported detector; the promotion workflow feeds
+  it `metadata/repos.yaml`, the data checkout's `knowledge/wiki/repos`, and a grandfather dir
+  from the main checkout (`merge-data.yaml`).
+- `.github/workflows/wiki-lint.yaml` — schedule + dispatch only; job `wiki-lint` (contents:
+  read) restores `knowledge/` from `origin/data` via `git restore --source FETCH_HEAD`, runs
+  lint with `WIKI_LINT_REPORT_PATH`/`WIKI_LINT_JSON_PATH`/`WIKI_LINT_SNAPSHOT_SHA`, uploads
+  `wiki-lint-report` artifact; job `wiki-lint-issue-sync` downloads it and mints
+  `permission-issues: write` + `permission-contents: read`.
+- `scripts/merge-data-pr.ts` `selectLabel()` — auto-merge only when every changed file is under
+  `knowledge/` or `metadata/`.
+- Test patterns: `wiki-lint.test.ts` `buildPage()`/`buildIndex()`/`buildCleanFiles()` file-map
+  fixtures; `wiki-ingest.test.ts` `createWikiPage()`/`createOctokitMock()`;
+  `rebuild-wiki-index.test.ts` `wikiPage()` tuples.
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md`:
+  lint findings must be tied to the authoritative data snapshot — the repair loop pins the same
+  `snapshot_sha`.
+- `docs/solutions/best-practices/status-truth-synthetic-self-audit-claim-kinds-2026-07-03.md`:
+  planner/shell independence, sentinel handling of untrusted file text.
+- `docs/solutions/best-practices/credential-mint-time-permission-scoping-2026-06-22.md`: the
+  write mint lives only in the job that writes.
+- `docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md`: commit messages
+  on a public branch are a public surface (R8b).
+- `docs/solutions/best-practices/pure-core-privacy-gates-shared-module-2026-06-22.md`: pure
+  repair core, I/O shell.
+
+## Key Technical Decisions
+
+- **Pure core / thin shell, one new module:** `scripts/wiki-repair.ts` hosts a pure repair
+  pipeline — `planWikiRepairs(report, wikiFiles)` → repair actions + repaired file map →
+  `verifyWikiRepairs` (re-lint via the exported lint core against the repaired map) →
+  `gateWikiRepairs` (`detectPrivateWikiLeaks` against the repaired map) — and a thin
+  `runWikiRepair()` shell that loads the working tree, calls the pipeline, and commits via
+  `commitWikiChanges`. No planner/shell trust: the shell re-checks the knowledge/-only path
+  bound (R7) on the final file map before commit.
+- **Report is trigger, tree is truth:** the lint report gates whether the repair job runs, but
+  the job re-derives repairable findings by linting the tree it actually loads. This avoids
+  betting correctness on report/tree lineage agreement. Repairable classes: `index-drift` and
+  `orphan-page` map to one index regeneration; `missing-frontmatter`/`invalid-frontmatter` map
+  to per-page frontmatter repair attempts that succeed only within the allowlist. Judgment
+  classes count as out-of-scope. The workflow gate must key on deterministic repairable classes
+  — the report's existing `repair_eligible` means only "complete scan with findings" and is too
+  broad; the detect job computes a dedicated repairable-classes output.
+- **Current-tip model (verify what you commit onto):** the shell fetches the current `data` tip,
+  loads `knowledge/**` and `metadata/repos.yaml` from that tip, lints it (pre-repair baseline),
+  repairs, re-lints (verification), gates, and commits with that tip as parent.
+  `commitWikiChanges` reads `heads/data` at commit time; the shell compares the commit-time tip
+  against the tip it verified and treats any movement as the R9 conflict path (full-pipeline
+  recompute), so the job never silently commits onto unseen state even when no ref conflict
+  fires.
+- **No-new-findings verification:** verification fails not only when a targeted finding
+  survives, but when the repaired tree contains any deterministic finding absent from the
+  pre-repair baseline — a repair may not make the wiki worse. Partial frontmatter repairs whose
+  page-level finding cannot fully clear (e.g. `created` still missing after `type` is fixed)
+  make that page out-of-scope for this run: the page is reverted from the repair set and counted
+  rather than aborting the whole run; the index regeneration and other pages proceed. Abort is
+  reserved for repairs that fail verification, not for pages that were never fully repairable.
+- **Frontmatter repair is parse-preserving:** repairs operate on the frontmatter block via the
+  existing split/parse helpers; `type` derives from `pageTypeFromPath`; `title` copies the first
+  `# ` heading verbatim (new bounded extractor) and repairs nothing when absent. Unparseable
+  YAML that cannot be round-tripped safely is out of scope for v1 (counted, issue lifecycle
+  unchanged) — rewriting broken YAML wholesale is judgment, not mechanics.
+- **Pre-commit privacy gate uses current-tip authority:** the repair job wires
+  `detectPrivateWikiLeaks` with repos.yaml from the current `data` tip (never a stale snapshot —
+  a redaction landing after detection must still gate), repaired wiki pages, and grandfather
+  pages from the main checkout (read-only input; main content never overwrites data content in
+  the repair computation). Any leak → abort, counted (AE9).
+- **Fixed commit message:** `chore(knowledge): repair wiki integrity findings` — constant
+  string, nothing derived from page identity; counts live in the result JSON/summary. Satisfies
+  R8b's at-most-counts-and-operation-name template.
+- **Workflow: third job, own mint, mint-after-decision:** `wiki-repair` job in
+  `wiki-lint.yaml`, `needs: wiki-lint`, `if:` gate on the detect job's dedicated
+  repairable-classes output; dual checkout (main + current-data restore);
+  `create-github-app-token` mint with `permission-contents: write` repo-scoped inside this job
+  only, and the mint step itself is skipped on dry-run dispatches (least privilege: no write
+  token exists on a run that cannot write). Manual dispatch reuses the same job via the
+  existing workflow_dispatch trigger.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Lint core invocable against a working tree: yes — `lintWikiSnapshot` is exported and operates
+  on a file map; the repair module lints baseline and repaired maps in-memory, no second
+  checkout. Finding identity for baseline/verification comparison uses the same
+  kind/path/target fingerprint inputs the report generator uses.
+- The report's `repair_eligible` means only "complete scan with findings" — too broad for the
+  job gate; the detect job computes a dedicated output from the deterministic repairable
+  classes instead.
+- Export surface: `splitFrontmatter` (wiki-lint) and `parseFrontmatter`/`pageTypeFromPath`
+  (wiki-ingest) are currently unexported — exporting them (or narrowly re-hosting them in the
+  repair module) is in-scope Unit 1 work.
+- Write mint: new `permission-contents: write` mint inside the repair job only, skipped on
+  dry-run — the brainstorm's R8 as amended.
+
+### Deferred to Implementation
+
+- Exact result JSON field names (mirror the status-truth counts pattern).
+- Whether the H1 extractor tolerates leading HTML comments/blank lines before the first heading
+  (characterize corpus; strictest viable rule wins).
+
+## Implementation Units
+
+- [x] **Unit 1: Pure repair core — planning, repair computation, verification, privacy gate**
+
+**Goal:** The complete repair pipeline as pure functions over a report + file map.
+
+**Requirements:** R1, R2, R5, R5b, R6, R7, R9 (no-op semantics), R10 (count classes)
+
+**Dependencies:** None
+
+**Files:**
+- Create: `scripts/wiki-repair.ts`
+- Create: `scripts/wiki-repair.test.ts`
+- Modify: `scripts/wiki-ingest.ts` (export seams only, if any helper needs exporting)
+
+**Approach:**
+- `planWikiRepairs({baselineFindings, wikiFiles})`: takes the pre-repair lint result of the
+  loaded tree (the shell lints the tree it loaded; the report artifact only gated job startup);
+  partitions findings into repairable (index-drift, orphan-page → one index regeneration;
+  missing/invalid-frontmatter → per-page allowlist attempts) and out-of-scope; computes the
+  repaired file map via `rebuildWikiIndex` and the frontmatter repairers; pages whose finding
+  cannot fully clear within the allowlist are reverted from the repair set and counted
+  out-of-scope; every repaired path must be under `knowledge/` (refusal otherwise).
+- Frontmatter repairers: `type` via `pageTypeFromPath`; `title` via a new strict first-`# `
+  heading extractor (verbatim copy; absent → no repair). Unparseable YAML → out-of-scope count.
+- `verifyWikiRepairs`: re-runs the lint core against the repaired map; every targeted finding
+  must clear AND no deterministic finding absent from the baseline may appear; any survivor or
+  regression → abort result (no partial commits).
+- `gateWikiRepairs`: `detectPrivateWikiLeaks` over the repaired pages with snapshot repos.yaml +
+  grandfather pages; any leak → abort result.
+- No-op detection: if planning yields zero repairable findings or the repaired map equals the
+  input map, return a counted no-op.
+
+**Execution note:** Test-first; every drift matrix cell and count class is table-testable with
+the existing file-map fixture patterns.
+
+**Test scenarios:**
+- Index-drift fixture → regenerated index clears the finding; verification passes (AE1 shape).
+- Orphan-page fixture → same regeneration covers it.
+- Missing `type` → derived from directory; missing `title` with H1 → copied verbatim; missing
+  `title` without H1 → untouched, counted out-of-scope (AE2).
+- `created`/`updated`/`tags` defects → never repaired regardless of derivability.
+- Verification survivor (repair that doesn't clear its finding) → abort, no output map (AE3).
+- Repair that clears its targets but introduces a new deterministic finding → abort (no-worse
+  rule).
+- Page missing `type` AND `created`: `type` fixed but finding can't clear → page reverted,
+  counted out-of-scope; index regeneration still proceeds.
+- Incomplete scan / failure_class set → no repair activity (AE4).
+- Hypothetical repaired path outside `knowledge/` → refusal, counted (AE5).
+- Privacy gate: repaired index reintroducing a redacted slug → abort, counted (AE9).
+- Judgment-class findings → out-of-scope counts only, pages untouched (F3).
+- Unparseable frontmatter YAML → out-of-scope, file byte-identical.
+
+**Verification:**
+- Module imports nothing from Octokit; pure functions only. `pnpm vitest run
+  scripts/wiki-repair.test.ts` green.
+
+- [x] **Unit 2: Repair shell — snapshot load, conflict retry, atomic commit, result JSON**
+
+**Goal:** `runWikiRepair()` executes the pipeline against the real tree and commits to `data`.
+
+**Requirements:** R3 (one commit per run), R8, R8b, R9, R10, R11
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `scripts/wiki-repair.ts`
+- Modify: `scripts/wiki-repair.test.ts`
+
+**Approach:**
+- Load `knowledge/**` and `metadata/repos.yaml` from the current `data` tip (the workflow's
+  restore step fetches origin/data at job start; the shell records the tip SHA it loaded);
+  grandfather pages from the main checkout. Lint the loaded tree for the baseline.
+- Run the pure pipeline; before committing, re-read `heads/data` and require it to equal the
+  loaded tip — movement → conflict path. Commit once via `commitWikiChanges({branch: DATA_BRANCH
+  (constant), message: FIXED_MESSAGE, files: repairedChangedFiles})` — changed files only, all
+  under `knowledge/`; the branch is a module constant, never an input.
+- Conflict path (tip moved or ref-update conflict): re-fetch the new data tip, reload the tree,
+  re-run the FULL pipeline (baseline lint, plan, verify, gate), retry bounded times; recompute
+  finding nothing to fix → counted no-op exit (AE6). Retry exhaustion → counted abort.
+- Result JSON to `WIKI_REPAIR_RESULT_PATH`: counts only (repairable_seen, repaired, aborted,
+  out_of_scope, privacy_blocked, conflict_retries, noop) + `dry_run` marker; stdout mirrors it.
+  `WIKI_REPAIR_DRY_RUN=true` runs the full pipeline with zero mutating calls.
+- No issue API calls anywhere in the module (R11).
+
+**Test scenarios:**
+- Happy path: mocked Octokit receives exactly one commit with the fixed message and only
+  changed knowledge/ files.
+- Dry-run: pipeline runs, zero Octokit mutations, result carries dry-run marker.
+- Conflict retry: first commit 409s; reload returns a tree where findings persist → recompute →
+  second commit succeeds; result counts one retry (AE6).
+- Conflict-then-cleared: reload returns a tree where ingest already fixed the drift → no-op
+  exit, no commit.
+- Commit message is byte-identical to the constant across all scenarios (AE7).
+- Result JSON contains no paths/slugs/fingerprints (AE7); no `issues.*` mock is ever called
+  (AE8).
+
+**Verification:**
+- Full repo gate green; mocked-shell tests assert call shapes like the status-truth shell tests.
+
+- [x] **Unit 3: Workflow wiring — repair job with scoped mint**
+
+**Goal:** `wiki-lint.yaml` gains the gated repair job; manual dispatch works.
+
+**Requirements:** R3, R4, R6 (job-level gate), R8 (mint boundary)
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `.github/workflows/wiki-lint.yaml`
+
+**Approach:**
+- `wiki-lint` job exposes a dedicated repairable-classes output (computed from the JSON report
+  while it is still on disk in that job) — true only when the completed scan contains
+  deterministic repairable findings (index-drift, orphan-page, missing/invalid-frontmatter).
+- New `wiki-repair` job: `needs: wiki-lint`, `if:` gate on that output; checkout main; keep a
+  grandfather copy of main's `knowledge/wiki/repos` before restoring; fetch origin/data and
+  restore `knowledge/` + `metadata/repos.yaml` from the current data tip (mirroring
+  `merge-data.yaml`'s dual-tree wiring — note the existing lint restore only covers
+  `knowledge/`, so the repos.yaml restore is new plumbing); mint `create-github-app-token` with
+  `permission-contents: write` repo-scoped (this job only, step skipped when the dispatch is
+  dry-run); run `node scripts/wiki-repair.ts`; append counts-only summary from the result JSON.
+- Issue-sync job unchanged; detection job permissions unchanged (contents: read).
+
+**Test scenarios:**
+- Test expectation: none — workflow YAML; verified by YAML lint, `Check Workflows` CI, and the
+  live rehearsal below.
+
+**Verification:**
+- YAML parses; eslint yml rules pass; a dispatch on a clean wiki produces a skipped or no-op
+  repair job with counts-only summary.
+
+- [x] **Unit 4: Operator documentation**
+
+**Goal:** Document the repair loop's bounds and lifecycle.
+
+**Requirements:** R1, R2, R11 (documented boundaries)
+
+**Dependencies:** Units 1–3
+
+**Files:**
+- Modify: `metadata/README.md` (wiki/authority section) or `README.md` — match where the wiki
+  lint lifecycle is documented today; smallest accurate diff.
+
+**Approach:**
+- Document: which classes auto-repair vs stay issue-only, the two-field frontmatter allowlist
+  and its shrink-only rule, the data-branch write path and promotion latency semantics, and
+  that issue closure remains lint-owned.
+
+**Test scenarios:**
+- Test expectation: none — docs-only; markdown lint.
+
+**Verification:**
+- A reader can predict, for each of the seven lint classes, whether a finding self-heals or
+  waits for a human.
+
+## System-Wide Impact
+
+- **Interaction graph:** lint detection and issue lifecycle unchanged; promotion pipeline
+  unchanged (repair commits look like ingest commits); ingest unchanged. New edge: lint report →
+  repair job → data commit → (next scan) close-on-clear.
+- **Error propagation:** every abort class (verification survivor, privacy block, path refusal,
+  conflict exhaustion) exits without committing and is a distinct count; the lint workflow's
+  detection job cannot be failed by the repair job (separate job, `needs` only).
+- **State lifecycle risks:** repeated identical repairs across runs are bounded by no-op
+  detection (repaired map == input map after the prior repair landed); close-on-clear latency
+  when promotion waits on human review is accepted and documented.
+- **Unchanged invariants:** `main` protection, data-branch sole-writer authority model,
+  promotion gates, issue fingerprint lifecycle, counts-only telemetry, `metadata/*.yaml`
+  untouched by repair.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Write credential in the lint workflow | Mint only inside the repair job; schedule/dispatch-only triggers; detection/issue-sync jobs keep read-only contents. |
+| Repair resurrects private content on public `data` | Pre-commit `detectPrivateWikiLeaks` gate with promotion-identical inputs; abort on any leak (AE9). |
+| Verify/commit tree divergence | Snapshot-lineage pinning + full-pipeline recompute on conflict; no blind retry. |
+| Repair oscillation across runs | No-op detection + verify-before-commit; close-on-clear remains the single issue-state owner. |
+| Frontmatter repair judgment creep | Two-field allowlist, shrink-only; unparseable YAML out of scope; verbatim-only title copy. |
+| Log damage unaddressed in v1 | Documented deferral; `--merge-logs` healer remains the manual path. |
+
+## Documentation / Operational Notes
+
+- Rehearsal after merge: dispatch `wiki-lint.yaml` on the clean wiki — expect repair job
+  skipped (no repairable findings) or counts-only no-op. A live drift rehearsal requires a
+  fro-bot-authored drift commit on `data` (check-wiki-authority blocks manual staging); use an
+  agent-workflow write or accept waiting for organic drift.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-07-03-wiki-authority-repair-loop-requirements.md](../brainstorms/2026-07-03-wiki-authority-repair-loop-requirements.md)
+- Related code: `scripts/wiki-lint.ts`, `scripts/wiki-lint-issues.ts`, `scripts/wiki-ingest.ts`,
+  `scripts/rebuild-wiki-index.ts`, `scripts/check-wiki-private-presence.ts`,
+  `.github/workflows/wiki-lint.yaml`, `.github/workflows/merge-data.yaml`,
+  `scripts/merge-data-pr.ts`
+- Prior plans: [docs/plans/2026-07-03-001-feat-bounded-correction-pr-execution-plan.md](2026-07-03-001-feat-bounded-correction-pr-execution-plan.md)
+- Related learnings: `docs/solutions/integration-issues/wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md`,
+  `docs/solutions/best-practices/credential-mint-time-permission-scoping-2026-06-22.md`,
+  `docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md`

--- a/scripts/wiki-ingest.ts
+++ b/scripts/wiki-ingest.ts
@@ -637,7 +637,7 @@ function assertWikiPagePath(path: string): void {
   }
 }
 
-function pageTypeFromPath(path: string): WikiPageType {
+export function pageTypeFromPath(path: string): WikiPageType {
   if (path.includes('/repos/')) return 'repo'
   if (path.includes('/topics/')) return 'topic'
   if (path.includes('/entities/')) return 'entity'

--- a/scripts/wiki-lint.ts
+++ b/scripts/wiki-lint.ts
@@ -531,7 +531,11 @@ function collectWikilinks(content: string): string[] {
   return Array.from(matches, match => match[1]).filter((value): value is string => value !== undefined && value !== '')
 }
 
-function splitFrontmatter(content: string): {frontmatter: Record<string, unknown>; body: string; error?: string} {
+export function splitFrontmatter(content: string): {
+  frontmatter: Record<string, unknown>
+  body: string
+  error?: string
+} {
   const match = /^---\n([\s\S]+?)\n---\n?/u.exec(content)
   if (match === null) {
     return {frontmatter: {}, body: content.trim()}

--- a/scripts/wiki-repair.test.ts
+++ b/scripts/wiki-repair.test.ts
@@ -1,0 +1,869 @@
+import type {RepoEntry} from './schemas.ts'
+import type {CommitWikiChangesParams} from './wiki-ingest.ts'
+import {createHash} from 'node:crypto'
+
+import {describe, expect, it, vi} from 'vitest'
+
+import {buildPublicSlugMap} from './check-wiki-private-presence.ts'
+import {lintWikiSnapshot} from './wiki-lint.ts'
+import {
+  gateWikiRepairs,
+  planAndVerifyWikiRepairs,
+  planWikiRepairs,
+  runWikiRepair,
+  verifyWikiRepairs,
+  WIKI_REPAIR_COMMIT_MESSAGE,
+  WIKI_REPAIR_DATA_BRANCH,
+} from './wiki-repair.ts'
+
+function buildPage(params: {
+  path: string
+  type?: string
+  title?: string
+  created?: string
+  updated?: string
+  bodyLines?: string[]
+  extraFrontmatter?: string[]
+}): [string, string] {
+  const frontLines = ['---']
+  if (params.type !== undefined) frontLines.push(`type: ${params.type}`)
+  if (params.title !== undefined) frontLines.push(`title: ${params.title}`)
+  frontLines.push(`created: ${params.created ?? '2026-04-16'}`)
+  frontLines.push(`updated: ${params.updated ?? '2026-04-16'}`)
+  if (params.extraFrontmatter !== undefined) frontLines.push(...params.extraFrontmatter)
+  frontLines.push('---')
+
+  return [params.path, [...frontLines, '', ...(params.bodyLines ?? ['Body text.']), ''].join('\n')]
+}
+
+function buildIndex(lines: string[]): string {
+  return [
+    '# Wiki Index',
+    '',
+    'Master catalog of all wiki pages, organized by type.',
+    '',
+    ...lines,
+    '',
+    '---',
+    '',
+    '_Footer._',
+    '',
+  ].join('\n')
+}
+
+function buildCleanFiles(): Record<string, string> {
+  return Object.fromEntries([
+    [
+      'knowledge/index.md',
+      buildIndex([
+        '## Repos',
+        '',
+        '- [[fro-bot--github]] — Fro Bot .github',
+        '',
+        '## Topics',
+        '',
+        '- [[github-actions-ci]] — GitHub Actions CI',
+        '',
+        '## Entities',
+        '',
+        '_No entity pages yet._',
+        '',
+        '## Comparisons',
+        '',
+        '_No comparison pages yet._',
+      ]),
+    ],
+    buildPage({
+      path: 'knowledge/wiki/repos/fro-bot--github.md',
+      type: 'repo',
+      title: 'Fro Bot .github',
+      bodyLines: ['See [[github-actions-ci]] for workflow conventions.'],
+    }),
+    buildPage({
+      path: 'knowledge/wiki/topics/github-actions-ci.md',
+      type: 'topic',
+      title: 'GitHub Actions CI',
+      bodyLines: ['See [[fro-bot--github]] for control-plane workflow patterns.'],
+    }),
+  ])
+}
+
+function emptyGateInputs() {
+  return {publicSlugMap: new Map<string, readonly RepoEntry[]>(), grandfatherPages: []}
+}
+
+/**
+ * Grandfather the repo page(s) already present in `files` by content-identity hash,
+ * so tests focused on index/frontmatter repair aren't incidentally blocked by the
+ * privacy gate's fail-closed default for unattributable pages.
+ */
+function passingGateInputs(files: Record<string, string>) {
+  const grandfatherPages = Object.entries(files)
+    .filter(([path]) => path.startsWith('knowledge/wiki/repos/') && path.endsWith('.md'))
+    .map(([path, content]) => {
+      const filename = path.slice('knowledge/wiki/repos/'.length)
+      return {
+        filename,
+        stem: filename.replace(/\.md$/iu, '').toLowerCase(),
+        hash: createHash('sha256').update(content).digest('hex'),
+        content,
+      }
+    })
+  return {publicSlugMap: new Map<string, readonly RepoEntry[]>(), grandfatherPages}
+}
+
+describe('planWikiRepairs', () => {
+  it('regenerates the index for an index-drift finding and clears it (AE1)', () => {
+    const files = buildCleanFiles()
+    // Index references a slug that doesn't exist on disk.
+    files['knowledge/index.md'] = buildIndex([
+      '## Repos',
+      '',
+      '- [[fro-bot--github]] — Fro Bot .github',
+      '- [[ghost--repo]] — Ghost Repo',
+      '',
+      '## Topics',
+      '',
+      '- [[github-actions-ci]] — GitHub Actions CI',
+      '',
+      '## Entities',
+      '',
+      '_No entity pages yet._',
+      '',
+      '## Comparisons',
+      '',
+      '_No comparison pages yet._',
+    ])
+
+    const baseline = lintWikiSnapshot({files}).deterministicFindings
+    expect(baseline.some(f => f.kind === 'index-drift')).toBe(true)
+
+    const plan = planWikiRepairs({baselineFindings: baseline, wikiFiles: files})
+
+    expect(plan.noop).toBe(false)
+    expect(plan.repairedFiles['knowledge/index.md']).not.toContain('ghost--repo')
+    expect(plan.counts.repaired).toBe(0)
+    expect(plan.targetedFindings.some(f => f.kind === 'index-drift')).toBe(true)
+
+    const verify = verifyWikiRepairs({
+      baselineFindings: baseline,
+      targetedFindings: plan.targetedFindings,
+      repairedFiles: plan.repairedFiles,
+    })
+    expect(verify.ok).toBe(true)
+  })
+
+  it('regenerates the index for an orphan-page finding', () => {
+    const files = buildCleanFiles()
+    files['knowledge/wiki/repos/orphan--page.md'] = buildPage({
+      path: 'knowledge/wiki/repos/orphan--page.md',
+      type: 'repo',
+      title: 'Orphan Page',
+    })[1]
+
+    const baseline = lintWikiSnapshot({files}).deterministicFindings
+    expect(baseline.some(f => f.kind === 'orphan-page')).toBe(true)
+
+    const plan = planWikiRepairs({baselineFindings: baseline, wikiFiles: files})
+    expect(plan.repairedFiles['knowledge/index.md']).toContain('orphan--page')
+
+    const verify = verifyWikiRepairs({
+      baselineFindings: baseline,
+      targetedFindings: plan.targetedFindings,
+      repairedFiles: plan.repairedFiles,
+    })
+    expect(verify.ok).toBe(true)
+  })
+
+  it('derives missing type from directory and copies missing title from H1 (AE2)', () => {
+    const files = buildCleanFiles()
+    const path = 'knowledge/wiki/repos/fro-bot--widget.md'
+    files[path] = [
+      '---',
+      'created: 2026-04-16',
+      'updated: 2026-04-16',
+      '---',
+      '',
+      '# Fro Bot Widget',
+      '',
+      'Body text.',
+      '',
+    ].join('\n')
+    files['knowledge/index.md'] = buildIndex([
+      '## Repos',
+      '',
+      '- [[fro-bot--github]] — Fro Bot .github',
+      '- [[fro-bot--widget]] — Fro Bot Widget',
+      '',
+      '## Topics',
+      '',
+      '- [[github-actions-ci]] — GitHub Actions CI',
+      '',
+      '## Entities',
+      '',
+      '_No entity pages yet._',
+      '',
+      '## Comparisons',
+      '',
+      '_No comparison pages yet._',
+    ])
+
+    const baseline = lintWikiSnapshot({files}).deterministicFindings
+    const plan = planWikiRepairs({baselineFindings: baseline, wikiFiles: files})
+
+    expect(plan.repairedFiles[path]).toContain('type: repo')
+    expect(plan.repairedFiles[path]).toContain('title: Fro Bot Widget')
+    expect(plan.counts.repaired).toBeGreaterThan(0)
+  })
+
+  it('leaves a missing title without an H1 untouched and out-of-scope (AE2)', () => {
+    const files = buildCleanFiles()
+    const path = 'knowledge/wiki/repos/fro-bot--widget.md'
+    const originalContent = [
+      '---',
+      'type: repo',
+      'created: 2026-04-16',
+      'updated: 2026-04-16',
+      '---',
+      '',
+      'No heading here, just prose.',
+      '',
+    ].join('\n')
+    files[path] = originalContent
+
+    const baseline = lintWikiSnapshot({files}).deterministicFindings
+    expect(baseline.some(f => f.kind === 'missing-frontmatter' && f.path === path)).toBe(true)
+
+    const plan = planWikiRepairs({baselineFindings: baseline, wikiFiles: files})
+
+    expect(plan.repairedFiles[path]).toBe(originalContent)
+    expect(plan.counts.outOfScope).toBeGreaterThan(0)
+  })
+
+  it('never repairs created, updated, sources, tags, aliases, related', () => {
+    const files = buildCleanFiles()
+    const path = 'knowledge/wiki/repos/fro-bot--widget.md'
+    // Missing type (repairable) but also missing created/updated (never repairable).
+    files[path] = ['---', 'title: Fro Bot Widget', '---', '', '# Fro Bot Widget', '', 'Body.', ''].join('\n')
+
+    const baseline = lintWikiSnapshot({files}).deterministicFindings
+    const plan = planWikiRepairs({baselineFindings: baseline, wikiFiles: files})
+
+    // type gets fixed but created/updated remain missing, so the finding cannot fully
+    // clear — page is reverted from the repair set entirely (byte-identical revert).
+    expect(plan.repairedFiles[path]).toBe(files[path])
+    expect(plan.counts.outOfScope).toBeGreaterThan(0)
+  })
+
+  it('reverts a page whose type is fixed but created is still missing (partial-page revert)', () => {
+    const files = buildCleanFiles()
+    const path = 'knowledge/wiki/repos/fro-bot--widget.md'
+    const original = ['---', 'title: Fro Bot Widget', 'updated: 2026-04-16', '---', '', 'Body.', ''].join('\n')
+    files[path] = original
+    files['knowledge/index.md'] = buildIndex([
+      '## Repos',
+      '',
+      '- [[fro-bot--github]] — Fro Bot .github',
+      '- [[fro-bot--widget]] — Fro Bot Widget',
+      '',
+      '## Topics',
+      '',
+      '- [[github-actions-ci]] — GitHub Actions CI',
+      '',
+      '## Entities',
+      '',
+      '_No entity pages yet._',
+      '',
+      '## Comparisons',
+      '',
+      '_No comparison pages yet._',
+    ])
+
+    const baseline = lintWikiSnapshot({files}).deterministicFindings
+    const plan = planWikiRepairs({baselineFindings: baseline, wikiFiles: files})
+
+    // Page reverted: still missing created, so finding can't fully clear.
+    expect(plan.repairedFiles[path]).toBe(original)
+    expect(plan.counts.outOfScope).toBeGreaterThan(0)
+  })
+
+  it('counts judgment-class findings as out-of-scope without touching pages (F3)', () => {
+    const files = buildCleanFiles()
+    const baseline = [
+      {
+        kind: 'broken-wikilink' as const,
+        path: 'knowledge/wiki/repos/fro-bot--github.md',
+        target: 'missing-page',
+        message: 'broken',
+      },
+      {kind: 'stale-claim' as const, path: 'knowledge/wiki/repos/fro-bot--github.md', message: 'stale'},
+    ]
+
+    const plan = planWikiRepairs({baselineFindings: baseline, wikiFiles: files})
+
+    expect(plan.counts.outOfScope).toBe(2)
+    expect(plan.repairedFiles['knowledge/wiki/repos/fro-bot--github.md']).toBe(
+      files['knowledge/wiki/repos/fro-bot--github.md'],
+    )
+  })
+
+  it('treats unparseable frontmatter YAML as out-of-scope, file byte-identical', () => {
+    const files = buildCleanFiles()
+    const path = 'knowledge/wiki/repos/fro-bot--broken.md'
+    const original = ['---', 'type: [unterminated', '---', '', 'Body.', ''].join('\n')
+    files[path] = original
+
+    const baseline = lintWikiSnapshot({files}).deterministicFindings
+    expect(baseline.some(f => f.kind === 'invalid-frontmatter' && f.path === path)).toBe(true)
+
+    const plan = planWikiRepairs({baselineFindings: baseline, wikiFiles: files})
+
+    expect(plan.repairedFiles[path]).toBe(original)
+    expect(plan.counts.outOfScope).toBeGreaterThan(0)
+  })
+
+  it('refuses a repair whose path is outside knowledge/ (AE5)', () => {
+    const files = buildCleanFiles()
+    const baseline = [{kind: 'missing-frontmatter' as const, path: 'metadata/repos.yaml', message: 'missing fields'}]
+
+    const plan = planWikiRepairs({baselineFindings: baseline, wikiFiles: files})
+
+    expect(plan.counts.pathRefused).toBe(1)
+  })
+
+  it('returns a counted no-op when there is nothing repairable', () => {
+    const files = buildCleanFiles()
+    const baseline = lintWikiSnapshot({files}).deterministicFindings
+    expect(baseline).toEqual([])
+
+    const plan = planWikiRepairs({baselineFindings: baseline, wikiFiles: files})
+
+    expect(plan.noop).toBe(true)
+    expect(plan.counts.repaired).toBe(0)
+  })
+})
+
+describe('verifyWikiRepairs', () => {
+  it('aborts when a targeted finding survives verification (AE3)', () => {
+    const files = buildCleanFiles()
+    const baseline = [{kind: 'index-drift' as const, path: 'knowledge/index.md', target: 'ghost--repo', message: 'x'}]
+
+    // Repaired map does NOT actually clear the drift (simulating a bad repair).
+    const originalIndex = files['knowledge/index.md'] ?? ''
+    const verify = verifyWikiRepairs({
+      baselineFindings: baseline,
+      targetedFindings: baseline,
+      repairedFiles: {
+        ...files,
+        'knowledge/index.md': originalIndex.replace(
+          '- [[fro-bot--github]]',
+          '- [[ghost--repo]] — Ghost\n- [[fro-bot--github]]',
+        ),
+      },
+    })
+
+    expect(verify.ok).toBe(false)
+    expect(verify.survivingFindings.length).toBeGreaterThan(0)
+  })
+
+  it('aborts when the repaired tree introduces a new deterministic finding (no-worse rule)', () => {
+    const files = buildCleanFiles()
+    const baseline = lintWikiSnapshot({files}).deterministicFindings
+    expect(baseline).toEqual([])
+
+    // Introduce a brand-new orphan page not present in the baseline.
+    const repairedFiles = {
+      ...files,
+      'knowledge/wiki/repos/new--orphan.md': buildPage({
+        path: 'knowledge/wiki/repos/new--orphan.md',
+        type: 'repo',
+        title: 'New Orphan',
+      })[1],
+    }
+
+    const verify = verifyWikiRepairs({baselineFindings: baseline, targetedFindings: [], repairedFiles})
+
+    expect(verify.ok).toBe(false)
+    expect(verify.newFindings.length).toBeGreaterThan(0)
+  })
+})
+
+describe('gateWikiRepairs', () => {
+  it('passes when no repo pages are unattributable', () => {
+    const result = gateWikiRepairs({
+      repairedWikiFiles: buildCleanFiles(),
+      ...emptyGateInputs(),
+    })
+    // fro-bot--github isn't in publicSlugMap or grandfatherPages, so it's flagged —
+    // this exercises the fail-closed path directly.
+    expect(result.ok).toBe(false)
+    expect(result.leaks.length).toBeGreaterThan(0)
+  })
+
+  it('passes when the repo page matches a public slug entry with attribution (AE9 clean case)', () => {
+    const repos: RepoEntry[] = [
+      {
+        owner: 'fro-bot',
+        name: 'github',
+        added: '2026-01-01',
+        onboarding_status: 'onboarded',
+        last_survey_at: null,
+        last_survey_status: null,
+        has_fro_bot_workflow: true,
+        has_renovate: false,
+        private: false,
+      },
+    ]
+    const files = buildCleanFiles()
+    files['knowledge/wiki/repos/fro-bot--github.md'] = [
+      '---',
+      'type: repo',
+      'title: Fro Bot .github',
+      'created: 2026-04-16',
+      'updated: 2026-04-16',
+      '---',
+      '',
+      'https://github.com/fro-bot/github',
+      '',
+    ].join('\n')
+
+    const result = gateWikiRepairs({
+      repairedWikiFiles: files,
+      publicSlugMap: buildPublicSlugMap(repos),
+      grandfatherPages: [],
+    })
+
+    expect(result.ok).toBe(true)
+  })
+
+  it('aborts when the repair would reintroduce a redacted private slug (AE9)', () => {
+    const repos: RepoEntry[] = [
+      {
+        owner: 'acme',
+        name: 'widget',
+        added: '2026-01-01',
+        onboarding_status: 'onboarded',
+        last_survey_at: null,
+        last_survey_status: null,
+        has_fro_bot_workflow: true,
+        has_renovate: false,
+        private: false,
+      },
+      {
+        owner: 'ACME',
+        name: 'WIDGET',
+        added: '2026-01-01',
+        onboarding_status: 'onboarded',
+        last_survey_at: null,
+        last_survey_status: null,
+        has_fro_bot_workflow: true,
+        has_renovate: false,
+        private: false,
+      },
+    ]
+
+    const files: Record<string, string> = {
+      'knowledge/wiki/repos/acme--widget.md': [
+        '---',
+        'type: repo',
+        'title: Widget',
+        'created: 2026-04-16',
+        'updated: 2026-04-16',
+        '---',
+        '',
+        'Body.',
+        '',
+      ].join('\n'),
+    }
+
+    const result = gateWikiRepairs({
+      repairedWikiFiles: files,
+      publicSlugMap: buildPublicSlugMap(repos),
+      grandfatherPages: [],
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.leaks.some(l => l.reason === 'ambiguous-public-slug')).toBe(true)
+  })
+})
+
+describe('planAndVerifyWikiRepairs', () => {
+  it('returns a repaired result for a clean AE1 index-drift fixture', () => {
+    const files = buildCleanFiles()
+    files['knowledge/index.md'] = buildIndex([
+      '## Repos',
+      '',
+      '- [[fro-bot--github]] — Fro Bot .github',
+      '- [[ghost--repo]] — Ghost Repo',
+      '',
+      '## Topics',
+      '',
+      '- [[github-actions-ci]] — GitHub Actions CI',
+      '',
+      '## Entities',
+      '',
+      '_No entity pages yet._',
+      '',
+      '## Comparisons',
+      '',
+      '_No comparison pages yet._',
+    ])
+    const baseline = lintWikiSnapshot({files}).deterministicFindings
+
+    const result = planAndVerifyWikiRepairs({
+      baselineFindings: baseline,
+      wikiFiles: files,
+      ...passingGateInputs(files),
+    })
+
+    expect(result.status).toBe('repaired')
+    expect(result.repairedFiles['knowledge/index.md']).not.toContain('ghost--repo')
+  })
+
+  it('does not repair anything on an incomplete/failed scan (no baseline findings supplied) (AE4)', () => {
+    const files = buildCleanFiles()
+    const result = planAndVerifyWikiRepairs({
+      baselineFindings: [],
+      wikiFiles: files,
+      ...emptyGateInputs(),
+    })
+
+    expect(result.status).toBe('noop')
+  })
+})
+
+function makeTree(files: Record<string, string>, tipSha = 'tip-1') {
+  return {
+    tipSha,
+    wikiFiles: files,
+    ...passingGateInputs(files),
+  }
+}
+
+describe('runWikiRepair', () => {
+  it('happy path: exactly one commit with the fixed message and only changed knowledge/ files', async () => {
+    const files = buildCleanFiles()
+    files['knowledge/index.md'] = buildIndex([
+      '## Repos',
+      '',
+      '- [[fro-bot--github]] — Fro Bot .github',
+      '- [[ghost--repo]] — Ghost Repo',
+      '',
+      '## Topics',
+      '',
+      '- [[github-actions-ci]] — GitHub Actions CI',
+      '',
+      '## Entities',
+      '',
+      '_No entity pages yet._',
+      '',
+      '## Comparisons',
+      '',
+      '_No comparison pages yet._',
+    ])
+
+    const commitWikiChangesMock = vi.fn(async (_p: CommitWikiChangesParams) => ({
+      committed: true,
+      commitSha: 'sha-1',
+      attempts: 1,
+    }))
+    const loadTree = vi.fn(async () => makeTree(files))
+    const getCurrentDataTipSha = vi.fn(async () => 'tip-1')
+
+    const result = await runWikiRepair({loadTree, getCurrentDataTipSha, commitWikiChanges: commitWikiChangesMock})
+
+    expect(result.repaired).toBeGreaterThanOrEqual(0)
+    expect(result.aborted).toBe(0)
+    expect(commitWikiChangesMock).toHaveBeenCalledTimes(1)
+    const callArgs = commitWikiChangesMock.mock.calls[0]?.[0]
+    expect(callArgs?.branch).toBe(WIKI_REPAIR_DATA_BRANCH)
+    expect(callArgs?.message).toBe(WIKI_REPAIR_COMMIT_MESSAGE)
+    expect(Object.keys(callArgs?.files ?? {})).toEqual(['knowledge/index.md'])
+  })
+
+  it('dry-run: pipeline runs, zero commit calls, result carries dry-run marker', async () => {
+    const files = buildCleanFiles()
+    files['knowledge/index.md'] = buildIndex([
+      '## Repos',
+      '',
+      '- [[fro-bot--github]] — Fro Bot .github',
+      '- [[ghost--repo]] — Ghost Repo',
+      '',
+      '## Topics',
+      '',
+      '- [[github-actions-ci]] — GitHub Actions CI',
+      '',
+      '## Entities',
+      '',
+      '_No entity pages yet._',
+      '',
+      '## Comparisons',
+      '',
+      '_No comparison pages yet._',
+    ])
+
+    const commitWikiChangesMock = vi.fn(async () => ({committed: true, commitSha: 'sha-1', attempts: 1}))
+    const loadTree = vi.fn(async () => makeTree(files))
+    const getCurrentDataTipSha = vi.fn(async () => 'tip-1')
+
+    const result = await runWikiRepair({
+      loadTree,
+      getCurrentDataTipSha,
+      commitWikiChanges: commitWikiChangesMock,
+      dryRun: true,
+    })
+
+    expect(result.dry_run).toBe(true)
+    expect(commitWikiChangesMock).not.toHaveBeenCalled()
+    expect(getCurrentDataTipSha).not.toHaveBeenCalled()
+  })
+
+  it('conflict retry: tip moved before commit → reload and recompute; persisted findings retry commit (AE6)', async () => {
+    const files1 = buildCleanFiles()
+    files1['knowledge/index.md'] = buildIndex([
+      '## Repos',
+      '',
+      '- [[fro-bot--github]] — Fro Bot .github',
+      '- [[ghost--repo]] — Ghost Repo',
+      '',
+      '## Topics',
+      '',
+      '- [[github-actions-ci]] — GitHub Actions CI',
+      '',
+      '## Entities',
+      '',
+      '_No entity pages yet._',
+      '',
+      '## Comparisons',
+      '',
+      '_No comparison pages yet._',
+    ])
+    const files2 = {...files1} // Findings persist in the reloaded tree too.
+
+    const commitWikiChangesMock = vi.fn(async () => ({committed: true, commitSha: 'sha-2', attempts: 1}))
+    const loadTree = vi
+      .fn()
+      .mockResolvedValueOnce(makeTree(files1, 'tip-1'))
+      .mockResolvedValueOnce(makeTree(files2, 'tip-2'))
+    const getCurrentDataTipSha = vi.fn(async () => 'tip-2') // Moved before the pre-commit check.
+
+    const result = await runWikiRepair({loadTree, getCurrentDataTipSha, commitWikiChanges: commitWikiChangesMock})
+
+    expect(result.conflict_retries).toBe(1)
+    expect(commitWikiChangesMock).toHaveBeenCalledTimes(1)
+    expect(loadTree).toHaveBeenCalledTimes(2)
+  })
+
+  it('conflict-then-cleared: reload shows findings already fixed → no-op exit, no commit', async () => {
+    const driftFiles = buildCleanFiles()
+    driftFiles['knowledge/index.md'] = buildIndex([
+      '## Repos',
+      '',
+      '- [[fro-bot--github]] — Fro Bot .github',
+      '- [[ghost--repo]] — Ghost Repo',
+      '',
+      '## Topics',
+      '',
+      '- [[github-actions-ci]] — GitHub Actions CI',
+      '',
+      '## Entities',
+      '',
+      '_No entity pages yet._',
+      '',
+      '## Comparisons',
+      '',
+      '_No comparison pages yet._',
+    ])
+    const cleanFiles = buildCleanFiles()
+
+    const commitWikiChangesMock = vi.fn(async () => ({committed: true, commitSha: 'sha-3', attempts: 1}))
+    const loadTree = vi
+      .fn()
+      .mockResolvedValueOnce(makeTree(driftFiles, 'tip-1'))
+      .mockResolvedValueOnce(makeTree(cleanFiles, 'tip-2'))
+    const getCurrentDataTipSha = vi.fn(async () => 'tip-2')
+
+    const result = await runWikiRepair({loadTree, getCurrentDataTipSha, commitWikiChanges: commitWikiChangesMock})
+
+    expect(result.noop).toBe(1)
+    expect(commitWikiChangesMock).not.toHaveBeenCalled()
+  })
+
+  it('tip-moved-before-commit triggers the conflict path even without a ref-update error', async () => {
+    const files = buildCleanFiles()
+    files['knowledge/index.md'] = buildIndex([
+      '## Repos',
+      '',
+      '- [[fro-bot--github]] — Fro Bot .github',
+      '- [[ghost--repo]] — Ghost Repo',
+      '',
+      '## Topics',
+      '',
+      '- [[github-actions-ci]] — GitHub Actions CI',
+      '',
+      '## Entities',
+      '',
+      '_No entity pages yet._',
+      '',
+      '## Comparisons',
+      '',
+      '_No comparison pages yet._',
+    ])
+
+    const commitWikiChangesMock = vi.fn(async () => ({committed: true, commitSha: 'sha-4', attempts: 1}))
+    const loadTree = vi.fn(async () => makeTree(files, 'tip-1'))
+    const getCurrentDataTipSha = vi.fn().mockResolvedValueOnce('tip-2').mockResolvedValueOnce('tip-1')
+
+    const result = await runWikiRepair({loadTree, getCurrentDataTipSha, commitWikiChanges: commitWikiChangesMock})
+
+    expect(result.conflict_retries).toBe(1)
+    expect(loadTree).toHaveBeenCalledTimes(2)
+  })
+
+  it('commit message is byte-identical to the constant across scenarios and result JSON carries no paths/slugs (AE7)', async () => {
+    const files = buildCleanFiles()
+    files['knowledge/index.md'] = buildIndex([
+      '## Repos',
+      '',
+      '- [[fro-bot--github]] — Fro Bot .github',
+      '- [[ghost--repo]] — Ghost Repo',
+      '',
+      '## Topics',
+      '',
+      '- [[github-actions-ci]] — GitHub Actions CI',
+      '',
+      '## Entities',
+      '',
+      '_No entity pages yet._',
+      '',
+      '## Comparisons',
+      '',
+      '_No comparison pages yet._',
+    ])
+
+    const commitWikiChangesMock = vi.fn(async (_p: CommitWikiChangesParams) => ({
+      committed: true,
+      commitSha: 'sha-5',
+      attempts: 1,
+    }))
+    const loadTree = vi.fn(async () => makeTree(files))
+    const getCurrentDataTipSha = vi.fn(async () => 'tip-1')
+
+    const result = await runWikiRepair({loadTree, getCurrentDataTipSha, commitWikiChanges: commitWikiChangesMock})
+
+    const callArgs = commitWikiChangesMock.mock.calls[0]?.[0]
+    expect(callArgs?.message).toBe(WIKI_REPAIR_COMMIT_MESSAGE)
+
+    const resultJson = JSON.stringify(result)
+    expect(resultJson).not.toContain('knowledge/')
+    expect(resultJson).not.toContain('ghost--repo')
+    expect(resultJson).not.toContain('fro-bot')
+  })
+
+  it('never calls any issues.* API surface (AE8)', async () => {
+    const files = buildCleanFiles()
+    files['knowledge/index.md'] = buildIndex([
+      '## Repos',
+      '',
+      '- [[fro-bot--github]] — Fro Bot .github',
+      '- [[ghost--repo]] — Ghost Repo',
+      '',
+      '## Topics',
+      '',
+      '- [[github-actions-ci]] — GitHub Actions CI',
+      '',
+      '## Entities',
+      '',
+      '_No entity pages yet._',
+      '',
+      '## Comparisons',
+      '',
+      '_No comparison pages yet._',
+    ])
+
+    const issuesApi = {create: vi.fn(), update: vi.fn(), createComment: vi.fn()}
+    const commitWikiChangesMock = vi.fn(async () => ({committed: true, commitSha: 'sha-6', attempts: 1}))
+    const loadTree = vi.fn(async () => makeTree(files))
+    const getCurrentDataTipSha = vi.fn(async () => 'tip-1')
+
+    await runWikiRepair({loadTree, getCurrentDataTipSha, commitWikiChanges: commitWikiChangesMock})
+
+    expect(issuesApi.create).not.toHaveBeenCalled()
+    expect(issuesApi.update).not.toHaveBeenCalled()
+    expect(issuesApi.createComment).not.toHaveBeenCalled()
+  })
+
+  it('privacy abort: gate blocks the repaired map, counted as privacy_blocked and aborted (AE9)', async () => {
+    const repos: RepoEntry[] = [
+      {
+        owner: 'acme',
+        name: 'widget',
+        added: '2026-01-01',
+        onboarding_status: 'onboarded',
+        last_survey_at: null,
+        last_survey_status: null,
+        has_fro_bot_workflow: true,
+        has_renovate: false,
+        private: false,
+      },
+      {
+        owner: 'other',
+        name: 'widget',
+        added: '2026-01-01',
+        onboarding_status: 'onboarded',
+        last_survey_at: null,
+        last_survey_status: null,
+        has_fro_bot_workflow: true,
+        has_renovate: false,
+        private: false,
+      },
+    ]
+
+    const files: Record<string, string> = {
+      'knowledge/index.md': buildIndex([
+        '## Repos',
+        '',
+        '- [[acme--widget]] — Widget',
+        '- [[ghost--repo]] — Ghost Repo',
+        '',
+        '## Topics',
+        '',
+        '_No topic pages yet._',
+        '',
+        '## Entities',
+        '',
+        '_No entity pages yet._',
+        '',
+        '## Comparisons',
+        '',
+        '_No comparison pages yet._',
+      ]),
+      'knowledge/wiki/repos/acme--widget.md': [
+        '---',
+        'type: repo',
+        'title: Widget',
+        'created: 2026-04-16',
+        'updated: 2026-04-16',
+        '---',
+        '',
+        'Body.',
+        '',
+      ].join('\n'),
+    }
+
+    const commitWikiChangesMock = vi.fn(async () => ({committed: true, commitSha: 'sha-7', attempts: 1}))
+    const loadTree = vi.fn(async () => ({
+      tipSha: 'tip-1',
+      wikiFiles: files,
+      publicSlugMap: buildPublicSlugMap(repos),
+      grandfatherPages: [],
+    }))
+    const getCurrentDataTipSha = vi.fn(async () => 'tip-1')
+
+    const result = await runWikiRepair({loadTree, getCurrentDataTipSha, commitWikiChanges: commitWikiChangesMock})
+
+    expect(result.aborted).toBe(1)
+    expect(result.privacy_blocked).toBe(1)
+    expect(commitWikiChangesMock).not.toHaveBeenCalled()
+  })
+})

--- a/scripts/wiki-repair.test.ts
+++ b/scripts/wiki-repair.test.ts
@@ -1,10 +1,10 @@
 import type {RepoEntry} from './schemas.ts'
 import type {CommitWikiChangesParams} from './wiki-ingest.ts'
 import {createHash} from 'node:crypto'
-
 import {describe, expect, it, vi} from 'vitest'
 
 import {buildPublicSlugMap} from './check-wiki-private-presence.ts'
+import {rebuildWikiIndex} from './wiki-ingest.ts'
 import {lintWikiSnapshot} from './wiki-lint.ts'
 import {
   gateWikiRepairs,
@@ -329,6 +329,22 @@ describe('planWikiRepairs', () => {
     const plan = planWikiRepairs({baselineFindings: baseline, wikiFiles: files})
 
     expect(plan.counts.pathRefused).toBe(1)
+  })
+
+  it('counts a stale index-drift finding as out-of-scope when regeneration is byte-identical', () => {
+    const files = buildCleanFiles()
+    // Regenerate the index once up front so `files['knowledge/index.md']` is
+    // already byte-identical to what rebuildWikiIndex would produce again —
+    // simulating a stale/false index-drift finding that regeneration cannot clear.
+    files['knowledge/index.md'] = rebuildWikiIndex({existingIndex: files['knowledge/index.md'], wikiFiles: files})
+    const baseline = [{kind: 'index-drift' as const, path: 'knowledge/index.md', target: 'ghost--repo', message: 'x'}]
+
+    const plan = planWikiRepairs({baselineFindings: baseline, wikiFiles: files})
+
+    expect(plan.counts.repaired).toBe(0)
+    expect(plan.counts.outOfScope).toBe(1)
+    expect(plan.targetedFindings.some(f => f.kind === 'index-drift')).toBe(false)
+    expect(plan.counts.repairableSeen).toBe(plan.counts.repaired + plan.counts.outOfScope + plan.counts.pathRefused)
   })
 
   it('returns a counted no-op when there is nothing repairable', () => {

--- a/scripts/wiki-repair.ts
+++ b/scripts/wiki-repair.ts
@@ -1,0 +1,643 @@
+import type {PrivateWikiLeak, WikiPageSnapshot} from './check-wiki-private-presence.ts'
+import type {RepoEntry} from './schemas.ts'
+import type {CommitWikiChangesParams, CommitWikiChangesResult, OctokitClient} from './wiki-ingest.ts'
+import type {WikiLintFinding} from './wiki-lint.ts'
+import {createHash} from 'node:crypto'
+import {readdir, readFile, writeFile} from 'node:fs/promises'
+import {join} from 'node:path'
+import process from 'node:process'
+
+import YAML from 'yaml'
+import {
+  buildPublicSlugMap,
+  detectPrivateWikiLeaks,
+  loadWikiPages,
+  requireGrandfatherDir,
+} from './check-wiki-private-presence.ts'
+import {assertReposFile} from './schemas.ts'
+import {commitWikiChanges, pageTypeFromPath, rebuildWikiIndex, WikiIngestError} from './wiki-ingest.ts'
+import {lintWikiSnapshot, splitFrontmatter} from './wiki-lint.ts'
+
+// ---------------------------------------------------------------------------
+// Unit 1: pure repair core
+// ---------------------------------------------------------------------------
+
+const KNOWLEDGE_PREFIX = 'knowledge/'
+const INDEX_PATH = 'knowledge/index.md'
+const INDEX_KINDS = new Set<WikiLintFinding['kind']>(['index-drift', 'orphan-page'])
+const FRONTMATTER_KINDS = new Set<WikiLintFinding['kind']>(['missing-frontmatter', 'invalid-frontmatter'])
+const JUDGMENT_KINDS = new Set<WikiLintFinding['kind']>([
+  'broken-wikilink',
+  'stale-claim',
+  'missing-cross-reference',
+  'knowledge-gap',
+])
+
+export interface PlanWikiRepairsParams {
+  readonly baselineFindings: readonly WikiLintFinding[]
+  readonly wikiFiles: Record<string, string>
+}
+
+export interface WikiRepairPlanCounts {
+  readonly repairableSeen: number
+  readonly repaired: number
+  readonly outOfScope: number
+  readonly pathRefused: number
+}
+
+export interface WikiRepairPlanResult {
+  readonly repairedFiles: Record<string, string>
+  readonly targetedFindings: readonly WikiLintFinding[]
+  readonly counts: WikiRepairPlanCounts
+  readonly noop: boolean
+}
+
+function hasNonEmptyString(value: unknown): boolean {
+  return typeof value === 'string' && value.trim() !== ''
+}
+
+/**
+ * Extract the page's canonical title from its first body line.
+ *
+ * Strict rule: the FIRST line of the (already-trimmed) body must match `^# `.
+ * Anything else — no heading, a different heading level, leading prose —
+ * yields no title. Verbatim text after `# ` is copied unmodified.
+ */
+function extractCanonicalTitle(body: string): string | undefined {
+  const firstLine = body.split('\n', 1)[0] ?? ''
+  return firstLine.startsWith('# ') ? firstLine.slice(2) : undefined
+}
+
+/**
+ * Apply the two-field mechanical frontmatter allowlist to a single page's content.
+ *
+ * Returns `undefined` when the page has unparseable frontmatter or when neither
+ * allowlisted field is repairable (nothing changed). `created`, `updated`,
+ * `sources`, `tags`, `aliases`, and `related` are never touched.
+ */
+function repairPageFrontmatter(path: string, content: string): string | undefined {
+  const {frontmatter, body, error} = splitFrontmatter(content)
+  if (error !== undefined) {
+    return undefined
+  }
+
+  const next: Record<string, unknown> = {...frontmatter}
+  let changed = false
+
+  if (!hasNonEmptyString(next.type)) {
+    next.type = pageTypeFromPath(path)
+    changed = true
+  }
+
+  if (!hasNonEmptyString(next.title)) {
+    const title = extractCanonicalTitle(body)
+    if (title !== undefined) {
+      next.title = title
+      changed = true
+    }
+  }
+
+  if (!changed) {
+    return undefined
+  }
+
+  const yamlText = YAML.stringify(next).trimEnd()
+  return `---\n${yamlText}\n---\n\n${body}\n`
+}
+
+/**
+ * Partition baseline lint findings into repairable actions and compute the
+ * repaired file map. Index regeneration (index-drift, orphan-page) is one
+ * operation; frontmatter repair is per-page and shrink-only. Pages whose
+ * finding cannot fully clear within the allowlist are reverted and counted
+ * out-of-scope rather than aborting the whole run.
+ */
+export function planWikiRepairs(params: PlanWikiRepairsParams): WikiRepairPlanResult {
+  const {baselineFindings, wikiFiles} = params
+
+  let repaired = 0
+  let outOfScope = 0
+  let pathRefused = 0
+
+  const repairedFiles: Record<string, string> = {...wikiFiles}
+  const targetedFindings: WikiLintFinding[] = []
+
+  const hasIndexRepair = baselineFindings.some(f => INDEX_KINDS.has(f.kind))
+  if (hasIndexRepair) {
+    // rebuildWikiIndex parses every wiki page's frontmatter strictly and throws on
+    // pages that are missing required fields — a page with an unrelated frontmatter
+    // defect must not crash index regeneration for the rest of the tree.
+    let newIndex: string | undefined
+    try {
+      newIndex = rebuildWikiIndex({existingIndex: wikiFiles[INDEX_PATH], wikiFiles})
+    } catch {
+      newIndex = undefined
+    }
+
+    if (newIndex !== undefined && newIndex !== wikiFiles[INDEX_PATH]) {
+      repairedFiles[INDEX_PATH] = newIndex
+      for (const finding of baselineFindings) {
+        if (INDEX_KINDS.has(finding.kind)) {
+          targetedFindings.push(finding)
+        }
+      }
+    }
+  }
+
+  const frontmatterFindingsByPath = new Map<string, WikiLintFinding>()
+  for (const finding of baselineFindings) {
+    if (FRONTMATTER_KINDS.has(finding.kind) && !frontmatterFindingsByPath.has(finding.path)) {
+      frontmatterFindingsByPath.set(finding.path, finding)
+    }
+  }
+
+  const attemptedPaths: string[] = []
+
+  for (const [path, finding] of frontmatterFindingsByPath) {
+    if (!path.startsWith(KNOWLEDGE_PREFIX)) {
+      pathRefused += 1
+      continue
+    }
+
+    if (finding.kind === 'invalid-frontmatter') {
+      outOfScope += 1
+      continue
+    }
+
+    const content = wikiFiles[path]
+    if (content === undefined) {
+      outOfScope += 1
+      continue
+    }
+
+    const candidate = repairPageFrontmatter(path, content)
+    if (candidate === undefined) {
+      outOfScope += 1
+      continue
+    }
+
+    repairedFiles[path] = candidate
+    attemptedPaths.push(path)
+  }
+
+  if (attemptedPaths.length > 0) {
+    const relint = lintWikiSnapshot({files: repairedFiles})
+    const stillFailing = new Set(
+      relint.deterministicFindings
+        .filter(f => f.kind === 'missing-frontmatter' || f.kind === 'invalid-frontmatter')
+        .map(f => f.path),
+    )
+
+    for (const path of attemptedPaths) {
+      if (stillFailing.has(path)) {
+        const original = wikiFiles[path]
+        if (original !== undefined) {
+          repairedFiles[path] = original
+        }
+        outOfScope += 1
+      } else {
+        repaired += 1
+        const finding = frontmatterFindingsByPath.get(path)
+        if (finding !== undefined) {
+          targetedFindings.push(finding)
+        }
+      }
+    }
+  }
+
+  outOfScope += baselineFindings.filter(f => JUDGMENT_KINDS.has(f.kind)).length
+
+  const repairableSeen = baselineFindings.filter(f => INDEX_KINDS.has(f.kind) || FRONTMATTER_KINDS.has(f.kind)).length
+
+  const noop = Object.entries(repairedFiles).every(([path, content]) => wikiFiles[path] === content)
+
+  return {
+    repairedFiles,
+    targetedFindings,
+    counts: {repairableSeen, repaired, outOfScope, pathRefused},
+    noop,
+  }
+}
+
+export interface VerifyWikiRepairsParams {
+  readonly baselineFindings: readonly WikiLintFinding[]
+  readonly targetedFindings: readonly WikiLintFinding[]
+  readonly repairedFiles: Record<string, string>
+}
+
+export interface VerifyWikiRepairsResult {
+  readonly ok: boolean
+  readonly survivingFindings: readonly WikiLintFinding[]
+  readonly newFindings: readonly WikiLintFinding[]
+}
+
+function findingIdentity(finding: WikiLintFinding): string {
+  return `${finding.kind}\u0000${finding.path}\u0000${finding.target ?? ''}`
+}
+
+/**
+ * Re-lint the repaired file map and require every targeted finding to clear,
+ * with a no-worse rule: any deterministic finding absent from the baseline
+ * that appears in the repaired tree is a regression and aborts the run.
+ */
+export function verifyWikiRepairs(params: VerifyWikiRepairsParams): VerifyWikiRepairsResult {
+  const relint = lintWikiSnapshot({files: params.repairedFiles})
+  const baselineIds = new Set(params.baselineFindings.map(findingIdentity))
+  const newIds = new Set(relint.deterministicFindings.map(findingIdentity))
+
+  const survivingFindings = params.targetedFindings.filter(f => newIds.has(findingIdentity(f)))
+  const newFindings = relint.deterministicFindings.filter(f => !baselineIds.has(findingIdentity(f)))
+
+  return {
+    ok: survivingFindings.length === 0 && newFindings.length === 0,
+    survivingFindings,
+    newFindings,
+  }
+}
+
+export interface GateWikiRepairsParams {
+  readonly repairedWikiFiles: Record<string, string>
+  readonly publicSlugMap: ReadonlyMap<string, readonly RepoEntry[]>
+  readonly grandfatherPages: readonly WikiPageSnapshot[]
+}
+
+export interface GateWikiRepairsResult {
+  readonly ok: boolean
+  readonly leaks: readonly PrivateWikiLeak[]
+}
+
+const REPO_PAGE_PREFIX = 'knowledge/wiki/repos/'
+
+/**
+ * Pre-commit private-presence gate: reruns the promotion pipeline's leak
+ * detector over the repaired repo wiki pages using current-tip authority
+ * metadata. Any leak aborts the run.
+ */
+export function gateWikiRepairs(params: GateWikiRepairsParams): GateWikiRepairsResult {
+  const dataWikiPages: WikiPageSnapshot[] = Object.entries(params.repairedWikiFiles)
+    .filter(([path]) => path.startsWith(REPO_PAGE_PREFIX) && path.endsWith('.md'))
+    .map(([path, content]) => {
+      const filename = path.slice(REPO_PAGE_PREFIX.length)
+      return {
+        filename,
+        stem: filename.replace(/\.md$/iu, '').toLowerCase(),
+        hash: createHash('sha256').update(content).digest('hex'),
+        content,
+      }
+    })
+
+  const leaks = detectPrivateWikiLeaks({
+    dataWikiPages,
+    publicSlugMap: params.publicSlugMap,
+    grandfatherPages: params.grandfatherPages,
+  })
+
+  return {ok: leaks.length === 0, leaks}
+}
+
+export type WikiRepairAbortReason = 'verification-survivor' | 'verification-regression' | 'privacy-leak'
+
+export interface PlanAndVerifyWikiRepairsParams {
+  readonly baselineFindings: readonly WikiLintFinding[]
+  readonly wikiFiles: Record<string, string>
+  readonly publicSlugMap: ReadonlyMap<string, readonly RepoEntry[]>
+  readonly grandfatherPages: readonly WikiPageSnapshot[]
+}
+
+export interface WikiRepairPipelineResult {
+  readonly status: 'noop' | 'repaired' | 'aborted'
+  readonly abortReason?: WikiRepairAbortReason
+  readonly repairedFiles: Record<string, string>
+  readonly counts: WikiRepairPlanCounts
+}
+
+/**
+ * Compose plan → verify → gate into a single pure pipeline result. The shell
+ * calls this once per attempt (including conflict-recompute retries).
+ */
+export function planAndVerifyWikiRepairs(params: PlanAndVerifyWikiRepairsParams): WikiRepairPipelineResult {
+  const plan = planWikiRepairs({baselineFindings: params.baselineFindings, wikiFiles: params.wikiFiles})
+
+  if (plan.noop) {
+    return {status: 'noop', repairedFiles: params.wikiFiles, counts: plan.counts}
+  }
+
+  const verify = verifyWikiRepairs({
+    baselineFindings: params.baselineFindings,
+    targetedFindings: plan.targetedFindings,
+    repairedFiles: plan.repairedFiles,
+  })
+
+  if (!verify.ok) {
+    const abortReason: WikiRepairAbortReason =
+      verify.survivingFindings.length > 0 ? 'verification-survivor' : 'verification-regression'
+    return {status: 'aborted', abortReason, repairedFiles: params.wikiFiles, counts: plan.counts}
+  }
+
+  const gate = gateWikiRepairs({
+    repairedWikiFiles: plan.repairedFiles,
+    publicSlugMap: params.publicSlugMap,
+    grandfatherPages: params.grandfatherPages,
+  })
+
+  if (!gate.ok) {
+    return {status: 'aborted', abortReason: 'privacy-leak', repairedFiles: params.wikiFiles, counts: plan.counts}
+  }
+
+  return {status: 'repaired', repairedFiles: plan.repairedFiles, counts: plan.counts}
+}
+
+// ---------------------------------------------------------------------------
+// Unit 2: repair shell — snapshot load, conflict retry, atomic commit
+// ---------------------------------------------------------------------------
+
+export const WIKI_REPAIR_DATA_BRANCH = 'data'
+export const WIKI_REPAIR_COMMIT_MESSAGE = 'chore(knowledge): repair wiki integrity findings'
+const DEFAULT_MAX_RETRIES = 3
+
+export interface WikiRepairTreeSnapshot {
+  readonly tipSha: string
+  readonly wikiFiles: Record<string, string>
+  readonly publicSlugMap: ReadonlyMap<string, readonly RepoEntry[]>
+  readonly grandfatherPages: readonly WikiPageSnapshot[]
+}
+
+export interface RunWikiRepairParams {
+  readonly loadTree: () => Promise<WikiRepairTreeSnapshot>
+  readonly getCurrentDataTipSha: () => Promise<string>
+  readonly commitWikiChanges: (commitParams: CommitWikiChangesParams) => Promise<CommitWikiChangesResult>
+  readonly maxRetries?: number
+  readonly dryRun?: boolean
+}
+
+export interface WikiRepairResultCounts {
+  readonly repairable_seen: number
+  readonly repaired: number
+  readonly aborted: number
+  readonly out_of_scope: number
+  readonly privacy_blocked: number
+  readonly path_refused: number
+  readonly conflict_retries: number
+  readonly noop: number
+  readonly dry_run: boolean
+}
+
+function emptyResultCounts(dryRun: boolean): WikiRepairResultCounts {
+  return {
+    repairable_seen: 0,
+    repaired: 0,
+    aborted: 0,
+    out_of_scope: 0,
+    privacy_blocked: 0,
+    path_refused: 0,
+    conflict_retries: 0,
+    noop: 0,
+    dry_run: dryRun,
+  }
+}
+
+function diffChangedFiles(before: Record<string, string>, after: Record<string, string>): Record<string, string> {
+  const changed: Record<string, string> = {}
+  for (const [path, content] of Object.entries(after)) {
+    if (before[path] !== content) {
+      changed[path] = content
+    }
+  }
+  return changed
+}
+
+/**
+ * Load the working tree, run the repair pipeline against the current-tip
+ * baseline, and commit exactly once to `data` — or recompute on conflict.
+ *
+ * Environment variables (see `main()` below): `WIKI_REPAIR_RESULT_PATH`,
+ * `WIKI_REPAIR_DRY_RUN`, `WIKI_REPAIR_DATA_TIP_SHA`, `GRANDFATHER_WIKI_REPOS_DIR`,
+ * `GITHUB_TOKEN`.
+ */
+export async function runWikiRepair(params: RunWikiRepairParams): Promise<WikiRepairResultCounts> {
+  const maxRetries = params.maxRetries ?? DEFAULT_MAX_RETRIES
+  const dryRun = params.dryRun ?? false
+
+  let tree = await params.loadTree()
+  let conflictRetries = 0
+
+  for (let attempt = 1; attempt <= maxRetries; attempt += 1) {
+    const baseline = lintWikiSnapshot({files: tree.wikiFiles}).deterministicFindings
+
+    if (baseline.length === 0) {
+      return {...emptyResultCounts(dryRun), noop: 1, conflict_retries: conflictRetries}
+    }
+
+    const pipeline = planAndVerifyWikiRepairs({
+      baselineFindings: baseline,
+      wikiFiles: tree.wikiFiles,
+      publicSlugMap: tree.publicSlugMap,
+      grandfatherPages: tree.grandfatherPages,
+    })
+
+    if (pipeline.status === 'noop') {
+      return {
+        repairable_seen: pipeline.counts.repairableSeen,
+        repaired: 0,
+        aborted: 0,
+        out_of_scope: pipeline.counts.outOfScope,
+        privacy_blocked: 0,
+        path_refused: pipeline.counts.pathRefused,
+        conflict_retries: conflictRetries,
+        noop: 1,
+        dry_run: dryRun,
+      }
+    }
+
+    if (pipeline.status === 'aborted') {
+      return {
+        repairable_seen: pipeline.counts.repairableSeen,
+        repaired: 0,
+        aborted: 1,
+        out_of_scope: pipeline.counts.outOfScope,
+        privacy_blocked: pipeline.abortReason === 'privacy-leak' ? 1 : 0,
+        path_refused: pipeline.counts.pathRefused,
+        conflict_retries: conflictRetries,
+        noop: 0,
+        dry_run: dryRun,
+      }
+    }
+
+    const changedFiles = diffChangedFiles(tree.wikiFiles, pipeline.repairedFiles)
+
+    if (dryRun) {
+      return {
+        repairable_seen: pipeline.counts.repairableSeen,
+        repaired: pipeline.counts.repaired,
+        aborted: 0,
+        out_of_scope: pipeline.counts.outOfScope,
+        privacy_blocked: 0,
+        path_refused: pipeline.counts.pathRefused,
+        conflict_retries: conflictRetries,
+        noop: 0,
+        dry_run: true,
+      }
+    }
+
+    const currentTip = await params.getCurrentDataTipSha()
+    if (currentTip !== tree.tipSha) {
+      conflictRetries += 1
+      tree = await params.loadTree()
+      continue
+    }
+
+    try {
+      await params.commitWikiChanges({
+        branch: WIKI_REPAIR_DATA_BRANCH,
+        message: WIKI_REPAIR_COMMIT_MESSAGE,
+        files: changedFiles,
+        maxRetries: 1,
+      })
+    } catch (error: unknown) {
+      if (error instanceof WikiIngestError && error.code === 'CONFLICT_EXHAUSTED') {
+        conflictRetries += 1
+        tree = await params.loadTree()
+        continue
+      }
+      throw error
+    }
+
+    return {
+      repairable_seen: pipeline.counts.repairableSeen,
+      repaired: pipeline.counts.repaired,
+      aborted: 0,
+      out_of_scope: pipeline.counts.outOfScope,
+      privacy_blocked: 0,
+      path_refused: pipeline.counts.pathRefused,
+      conflict_retries: conflictRetries,
+      noop: 0,
+      dry_run: false,
+    }
+  }
+
+  return {...emptyResultCounts(dryRun), aborted: 1, conflict_retries: conflictRetries}
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+const WIKI_DIRECTORIES = ['repos', 'topics', 'entities', 'comparisons']
+
+async function loadWikiFilesFromDisk(rootDir: string): Promise<Record<string, string>> {
+  const files: Record<string, string> = {}
+  files[INDEX_PATH] = await readFile(join(rootDir, 'knowledge', 'index.md'), 'utf8')
+
+  for (const directory of WIKI_DIRECTORIES) {
+    const directoryPath = join(rootDir, 'knowledge', 'wiki', directory)
+    let entries
+
+    try {
+      entries = await readdir(directoryPath, {withFileTypes: true})
+    } catch (error: unknown) {
+      if (typeof error === 'object' && error !== null && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+        continue
+      }
+      throw error
+    }
+
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.md')) {
+        continue
+      }
+      const relativePath = `knowledge/wiki/${directory}/${entry.name}`
+      files[relativePath] = await readFile(join(directoryPath, entry.name), 'utf8')
+    }
+  }
+
+  return files
+}
+
+type OctokitConstructor = new (params: {auth: string}) => OctokitClient
+
+async function loadOctokitConstructor(): Promise<OctokitConstructor> {
+  const loaded: unknown = await import('@octokit/rest')
+  if (
+    typeof loaded !== 'object' ||
+    loaded === null ||
+    !('Octokit' in loaded) ||
+    typeof (loaded as {Octokit: unknown}).Octokit !== 'function'
+  ) {
+    throw new Error('wiki-repair: failed to load @octokit/rest Octokit constructor')
+  }
+  return (loaded as {Octokit: OctokitConstructor}).Octokit
+}
+
+async function createOctokitFromEnv(): Promise<OctokitClient> {
+  const token = process.env.GITHUB_TOKEN
+  if (token === undefined || token === '') {
+    throw new Error('wiki-repair: GITHUB_TOKEN is required in the environment')
+  }
+  const Octokit = await loadOctokitConstructor()
+  return new Octokit({auth: token})
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.env.WIKI_REPAIR_DRY_RUN === 'true'
+  const resultPath = process.env.WIKI_REPAIR_RESULT_PATH
+  const rootDir = process.cwd()
+  const owner = process.env.WIKI_REPAIR_OWNER
+  const repo = process.env.WIKI_REPAIR_REPO
+
+  const loadTree = async (): Promise<WikiRepairTreeSnapshot> => {
+    const tipSha = process.env.WIKI_REPAIR_DATA_TIP_SHA
+    if (tipSha === undefined || tipSha === '') {
+      throw new Error('wiki-repair: WIKI_REPAIR_DATA_TIP_SHA is required in the environment')
+    }
+
+    const wikiFiles = await loadWikiFilesFromDisk(rootDir)
+
+    const reposRaw = await readFile(join(rootDir, 'metadata', 'repos.yaml'), 'utf8')
+    const reposParsed: unknown = YAML.parse(reposRaw)
+    assertReposFile(reposParsed)
+    const publicSlugMap = buildPublicSlugMap(reposParsed.repos)
+
+    const grandfatherDir = requireGrandfatherDir(process.env.GRANDFATHER_WIKI_REPOS_DIR)
+    const grandfatherPages = await loadWikiPages(grandfatherDir)
+
+    return {tipSha, wikiFiles, publicSlugMap, grandfatherPages}
+  }
+
+  let octokitPromise: Promise<OctokitClient> | undefined
+  const getOctokit = async (): Promise<OctokitClient> => {
+    octokitPromise ??= createOctokitFromEnv()
+    return octokitPromise
+  }
+
+  const getCurrentDataTipSha = async (): Promise<string> => {
+    const octokit = await getOctokit()
+    const ref = await octokit.rest.git.getRef({
+      owner: owner ?? 'fro-bot',
+      repo: repo ?? '.github',
+      ref: `heads/${WIKI_REPAIR_DATA_BRANCH}`,
+    })
+    return ref.data.object.sha
+  }
+
+  const commitWikiChangesInjected = async (commitParams: CommitWikiChangesParams): Promise<CommitWikiChangesResult> => {
+    const octokit = await getOctokit()
+    return commitWikiChanges({...commitParams, owner, repo, octokit})
+  }
+
+  const result = await runWikiRepair({
+    loadTree,
+    getCurrentDataTipSha,
+    commitWikiChanges: commitWikiChangesInjected,
+    dryRun,
+  })
+
+  const json = `${JSON.stringify(result)}\n`
+  process.stdout.write(json)
+  if (resultPath !== undefined && resultPath !== '') {
+    await writeFile(resultPath, json, 'utf8')
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}

--- a/scripts/wiki-repair.ts
+++ b/scripts/wiki-repair.ts
@@ -141,6 +141,15 @@ export function planWikiRepairs(params: PlanWikiRepairsParams): WikiRepairPlanRe
           targetedFindings.push(finding)
         }
       }
+    } else {
+      // Regeneration either threw or produced byte-identical output — the
+      // index-drift/orphan-page findings cannot be cleared by this repair.
+      // Count them out-of-scope rather than letting them vanish from the ledger.
+      for (const finding of baselineFindings) {
+        if (INDEX_KINDS.has(finding.kind)) {
+          outOfScope += 1
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## What

Wiki-lint detects seven failure classes and repairs none — deterministic drift (index-drift, orphan-page, mechanical frontmatter defects) sits behind a human for no safety gain, since index regeneration is an operation the bot already performs ungated during every ingest. This closes the loop: a repair job in the wiki-lint workflow regenerates `knowledge/index.md` and applies a strict two-field frontmatter allowlist, then commits once to `data` through the existing atomic-commit envelope. Promotion and issue lifecycle are untouched: repairs ride the normal `data → main` pipeline (auto-merge when knowledge-only), and wiki-lint's close-on-clear remains the only writer of issue state.

## Design

- **Report is trigger, tree is truth.** The lint report only gates job startup (a dedicated `repairable` job output — the report's `repair_eligible` means "complete scan with findings" and is too broad). The shell re-derives findings by linting the tree it actually loads.
- **Verify what you commit onto.** The shell loads the current `data` tip (knowledge/ + `metadata/repos.yaml`), lints a baseline, repairs, re-lints, and requires tip equality immediately before the commit — movement triggers a full-pipeline recompute, never a blind retry. No-op exits when an intervening ingest already fixed the drift.
- **No-worse rule.** Verification fails if any targeted finding survives *or* any deterministic finding absent from the baseline appears. Pages that can't fully clear within the allowlist (e.g. `type` fixable but `created` missing) are reverted and counted out-of-scope rather than aborting the run.
- **Frontmatter allowlist, shrink-only:** `type` derived from the page directory; `title` copied verbatim from the first `# ` heading, else untouched. `created`/`updated`/`sources`/`tags`/`aliases`/`related` are never repaired; unparseable YAML stays byte-identical.
- **Pre-commit privacy gate.** The repaired pages pass `detectPrivateWikiLeaks` with **current-tip** authority metadata (a redaction landing after detection still gates) plus the main-checkout grandfather pages — the `data` branch is publicly readable, so promotion-time gating alone is too late.
- **Credential boundary.** The repair job mints its own repo-scoped `contents: write` token; the mint step is skipped entirely on dry-run dispatches; detection and issue-sync jobs keep read-only contents. Branch (`data`) and commit message are module constants — the message carries no page identity.

## Verification

- TDD throughout; 25 new tests (AE-mapped: drift matrix, no-worse rule, partial-page revert, privacy abort, conflict recompute, tip-moved path, dry-run zero-mutation, result-JSON leak check, no issues.* calls). Repo gate green: 2021 tests, check-types, lint.
- Workflow YAML eslint-clean; pinned action SHAs byte-identical to existing usages.
- Rehearsal after merge: dispatch `wiki-lint.yaml` — expect the repair job skipped (clean wiki) or a counts-only no-op.