### PR TITLE
docs: refresh wiki and integration learnings against current code

### DIFF
--- a/docs/solutions/best-practices/wiki-page-structured-attribution-2026-06-04.md
+++ b/docs/solutions/best-practices/wiki-page-structured-attribution-2026-06-04.md
@@ -1,7 +1,7 @@
 ---
 title: Structured-First Attribution for Public-Allowlist Privacy Gates
 date: 2026-06-04
-last_updated: 2026-06-04
+last_updated: 2026-07-04
 verified: 2026-06-04
 category: best-practices
 module: github-workflows
@@ -146,6 +146,10 @@ if (structuredSources !== null) {
   fail-closed-on-unknown predicate this attribution model extends.
 - `docs/solutions/security-issues/survey-workflow-side-privacy-gate-2026-05-16.md` — verifying
   privacy inside the trusted workflow before a public side effect.
+- `docs/solutions/best-practices/status-truth-synthetic-self-audit-claim-kinds-2026-07-03.md` —
+  cites this doc's structured-provenance-over-body-text pattern.
+- `docs/solutions/best-practices/closed-vocabulary-telemetry-keys-from-public-bodies-2026-07-03.md`
+  — cites this doc's structured-metadata-over-body-text pattern.
 - Issues: #3419 (this refresh), #3408 (operator-actionable blocked output), #3418 (self-asserted
   provenance residual — a page lying about its own `sources` is bounded by agent identity + data
   sole-writer, not closeable at this attribution layer).

--- a/docs/solutions/integration-issues/bootstrap-data-branch-before-autonomous-writes-2026-05-09.md
+++ b/docs/solutions/integration-issues/bootstrap-data-branch-before-autonomous-writes-2026-05-09.md
@@ -6,7 +6,7 @@ module: data-branch-bootstrap
 problem_type: integration_issue
 component: tooling
 severity: high
-last_updated: 2026-05-09
+last_updated: 2026-07-04
 verified: 2026-05-09
 symptoms:
   - GitHub deleted the data source branch after a data-to-main promotion PR was squash-merged.
@@ -119,11 +119,12 @@ if (shouldBootstrapDataBranch && isRecoverableDataBranchMissingError(error) && a
 }
 ```
 
-### Bootstrap and guard wiki ingest writes
+### Bootstrap and guard autonomous writes beyond metadata
 
-`commitWikiChanges()` now follows the same data-branch bootstrap pattern. It rejects literal `main`
-before bootstrap, and it checks branch protection before creating wiki blobs, trees, commits, or ref
-updates:
+This is not a metadata-only pattern. `scripts/wiki-ingest.ts`'s `commitWikiChanges()` follows the same
+data-branch bootstrap pattern: it rejects literal `main` before bootstrap, calls
+`bootstrapDataBranch()` when the target is the canonical `data` branch (`wiki-ingest.ts` ~188-196),
+and checks branch protection before creating wiki blobs, trees, commits, or ref updates:
 
 ```ts
 function rejectProtectedWikiBranchName(branch: string): void {
@@ -137,7 +138,14 @@ function rejectProtectedWikiBranchName(branch: string): void {
 }
 ```
 
-It retries when `data` disappears before reading the wiki head ref.
+It retries after re-bootstrapping on a recoverable 404 during the write loop (`wiki-ingest.ts`
+~241-258), the same shape as the metadata writer's retry-after-bootstrap loop.
+
+`scripts/data-branch-bootstrap.ts`'s `bootstrapDataBranch()` is the single shared primitive both
+writers call — it owns the `createRef` 422 race handling (re-read `data`; return the existing tip if
+present, otherwise raise) at `data-branch-bootstrap.ts` ~51-139. `scripts/wiki-repair.ts` also writes
+through `commitWikiChanges()`, so it inherits this bootstrap-then-retry behavior with no separate
+implementation.
 
 ## Why This Works
 

--- a/docs/solutions/integration-issues/normalize-redacted-yaml-quotes-2026-05-09.md
+++ b/docs/solutions/integration-issues/normalize-redacted-yaml-quotes-2026-05-09.md
@@ -6,7 +6,7 @@ module: commit-metadata
 problem_type: integration_issue
 component: tooling
 severity: medium
-last_updated: 2026-05-09
+last_updated: 2026-07-04
 verified: 2026-05-09
 symptoms:
   - Scheduled Reconcile Repos succeeded but wrote metadata/repos.yaml with double-quoted redacted owner values.
@@ -102,6 +102,23 @@ expect(serialized).toContain("owner: '[REDACTED]'")
 expect(serialized).not.toContain('owner: "[REDACTED]"')
 ```
 
+The quoting fix is one piece of a broader redacted-metadata serialization contract enforced by the
+shared metadata writer. `normalizeRepoEntryForStorage` (`scripts/repos-metadata.ts` ~82-137) is the
+single place that decides an entry's redacted shape: for a private entry it forces
+`owner: '[REDACTED]'` and writes `name` to the `node_id` value, short-circuiting to the same object
+by reference when the entry is already in that canonical form. `addRepoEntry` (~236-297) routes every
+new-entry write through it, so no caller can introduce a redacted entry with the wrong quoting or
+field layout.
+
+That canonical form has to survive reconcile, not just first-write. `scripts/reconcile-repos.ts`
+keeps `node_id` sticky across probe outcomes it can't trust — `transient`/`malformed` probe results
+and `still-accessible` disagreements with the access-list snapshot all return `...entry` unchanged
+rather than writing a fresh value, and lost-access transitions preserve the prior `node_id` when no
+fresh source is available. `database_id` is written onto redacted entries via
+`normalizeRepoEntryForStorage`'s `storageInputWithProbe` only when the probe returns a positive
+integer, and stays untouched otherwise (`reconcile-repos.ts` field-refresh block, ~966-1003) — it is
+a format-independent denylist anchor that must never regress once populated.
+
 ## Why This Works
 
 `[REDACTED]` requires quoting in YAML because of the brackets. Setting `singleQuote: true` makes
@@ -109,6 +126,10 @@ generated metadata match Prettier's enforced YAML style, including redaction sen
 
 The unchanged-parsed-metadata regression protects the delayed-failure path: a data file can be
 semantically correct but still promotion-blocking because its serialized form is not lintable.
+
+Routing every redacted-entry write through `normalizeRepoEntryForStorage` means the quoting fix and
+the sticky `node_id`/`database_id` contract are enforced at the same choke point — a caller cannot
+bypass one without bypassing the other.
 
 ## Prevention
 

--- a/docs/solutions/integration-issues/wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md
+++ b/docs/solutions/integration-issues/wiki-lint-authoritative-data-snapshot-reporting-2026-05-02.md
@@ -7,7 +7,7 @@ root_cause: missing_workflow_step
 resolution_type: workflow_improvement
 severity: medium
 date: 2026-05-02
-last_updated: 2026-05-02
+last_updated: 2026-07-04
 module: .github/workflows/wiki-lint.yaml + scripts/wiki-lint.ts
 related_components:
   - development_workflow
@@ -49,9 +49,9 @@ That also meant the failure path had to be explicit. If the workflow could not r
 
 ## Solution
 
-The implementation restores the authoritative snapshot, lints it, emits findings, uploads a report, and writes nothing back.
+The implementation restores the authoritative snapshot, lints it, emits findings, uploads a report artifact, and — as of the `wiki-repair` job — feeds deterministic findings into an automated repair path. Detection itself stays report-only; the `wiki-lint` job never writes.
 
-`.github/workflows/wiki-lint.yaml` restores `knowledge/` from `origin/data`, runs lint only on restore success, and routes restore failure through the same reporting surface:
+`.github/workflows/wiki-lint.yaml` restores `knowledge/` from `origin/data`, records the snapshot SHA, runs lint only on restore success, and routes restore failure through the same reporting surface:
 
 ```yaml
 - name: Restore wiki from data branch
@@ -59,8 +59,9 @@ The implementation restores the authoritative snapshot, lints it, emits findings
   continue-on-error: true
   run: |
     if git ls-remote --exit-code origin data >/dev/null 2>&1; then
-      git fetch origin data
+      git fetch --depth=1 origin data
       git restore --source FETCH_HEAD --worktree -- knowledge
+      echo "data_sha=$(git rev-parse FETCH_HEAD)" >> "$GITHUB_OUTPUT"
     else
       printf '%s\n' 'cannot lint wiki snapshot: origin/data is unavailable' >&2
       exit 1
@@ -70,15 +71,50 @@ The implementation restores the authoritative snapshot, lints it, emits findings
   if: steps.restore-wiki.outcome == 'success'
   env:
     WIKI_LINT_REPORT_PATH: wiki-lint-report.md
+    WIKI_LINT_JSON_PATH: wiki-lint-report.json
+    WIKI_LINT_SNAPSHOT_SHA: ${{ steps.restore-wiki.outputs.data_sha }}
   run: node scripts/wiki-lint.ts
+
+- name: Compute repairable output
+  id: repairable
+  if: always()
+  run: |
+    set -euo pipefail
+    report=wiki-lint-report.json
+    if [[ -s "$report" ]]; then
+      repairable=$(jq -r '
+        (.scan_complete == true and .failure_class == null and
+          ([.findings[]? | select(.kind == "index-drift" or .kind == "orphan-page" or .kind == "missing-frontmatter" or .kind == "invalid-frontmatter")] | length) > 0
+        )
+      ' "$report")
+      snapshot_sha=$(jq -r '.snapshot_sha // ""' "$report")
+    else
+      repairable=false
+      snapshot_sha=""
+    fi
+    echo "repairable=${repairable}" >> "$GITHUB_OUTPUT"
+    echo "snapshot_sha=${snapshot_sha}" >> "$GITHUB_OUTPUT"
 
 - name: Report restore failure
   if: steps.restore-wiki.outcome == 'failure'
   env:
     WIKI_LINT_REPORT_PATH: wiki-lint-report.md
+    WIKI_LINT_JSON_PATH: wiki-lint-report.json
     WIKI_LINT_FAILURE_MESSAGE: 'cannot lint wiki snapshot: origin/data is unavailable'
   run: node scripts/wiki-lint.ts
+
+- name: Upload wiki lint artifact
+  if: always()
+  uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+  with:
+    name: wiki-lint-report
+    path: |
+      wiki-lint-report.md
+      wiki-lint-report.json
+    retention-days: 7
 ```
+
+The `wiki-lint` job exposes `repairable` and `snapshot_sha` as job outputs. Two downstream jobs consume the uploaded artifact: `wiki-lint-issue-sync` (always runs; files issues for advisory and unaddressed findings) and `wiki-repair` (gated on `needs.wiki-lint.outputs.repairable == 'true'`). `wiki-repair` re-derives repairable findings itself via `scripts/wiki-repair.ts` rather than trusting the lint report as a write authority, mints its own least-privilege write token, and commits fixes for the deterministic finding classes (`index-drift`, `orphan-page`, `missing-frontmatter`, `invalid-frontmatter`) through `commitWikiChanges()`. Advisory/judgment findings (`stale-claim`, `missing-cross-reference`, `knowledge-gap`) remain issue-only — `wiki-repair` never touches them.
 
 `scripts/wiki-lint.ts` implements a detect/report-only engine around `lintWikiSnapshot()`, `writeWikiLintOutputs()`, `writeWikiLintFailureOutputs()`, and `runWikiLint()`.
 
@@ -121,16 +157,18 @@ The fix works because it matches the repo's `data`-branch wiki source and preser
 - **False positives are reduced:** alias-backed wikilinks resolve against both slugs and aliases.
 - **Page coverage is broader:** `missing-cross-reference` now applies to any page body with no wikilinks, not just repo pages.
 - **Failure is reported:** the workflow still routes restore failure through `writeWikiLintFailureOutputs()`, although the current workflow message is a fixed `origin/data is unavailable` string rather than a fully diagnosed restore error.
+- **Detection and repair stay separated:** `wiki-lint` never writes; `wiki-repair` only runs when the lint job's own `repairable` output says deterministic findings exist, and it re-derives those findings independently before committing.
 
 ## Prevention
 
 1. **Lint the authoritative snapshot, not checkout state.** Any future wiki health workflow should restore from `origin/data` first.
 2. **Keep the report artifact contract on script-handled paths.** Clean, findings, and `execution-failure` runs should keep producing the same markdown report surface.
 3. **Keep alias resolution and page-type coverage in tests.** If wiki schema or page types evolve, preserve regression coverage for aliases and non-repo `missing-cross-reference` behavior.
-4. **Do not smuggle remediation into v1.** Any future auto-fix or issue-escalation path should be an explicit follow-up, not a hidden side effect of linting.
+4. **Keep remediation an explicit, separately-gated job.** `wiki-repair` runs only when the lint job's own `repairable` output is true and re-derives findings independently — auto-fix must never become a hidden side effect of the detection step.
 
 ## Related Issues
 
 - Related issue: https://github.com/fro-bot/.github/issues/3148
 - Related learning: [`docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md`](../runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md)
+- Related learning: [`docs/solutions/best-practices/status-truth-synthetic-self-audit-claim-kinds-2026-07-03.md`](../best-practices/status-truth-synthetic-self-audit-claim-kinds-2026-07-03.md)
 - Updated plan unit: `docs/plans/2025-04-15-001-feat-frobot-control-plane-plan.md`


### PR DESCRIPTION
## What

Maintenance pass over the wiki + integration cluster of `docs/solutions/` (6 docs investigated against current code; 4 updated, 2 confirmed current without edits):

- **wiki-lint-authoritative-data-snapshot-reporting** — predated the repair loop; workflow example now shows the snapshot SHA capture, JSON report, `repairable` output, and the gated `wiki-repair` job. Detection-only framing corrected: deterministic findings auto-repair, judgment classes stay issue-only.
- **bootstrap-data-branch-before-autonomous-writes** — broadened from metadata-only: `commitWikiChanges` shares the bootstrap-then-retry pattern, `data-branch-bootstrap.ts` named as the shared primitive, wiki-repair inherits it.
- **normalize-redacted-yaml-quotes** — extended with the redacted-metadata serialization contract (canonical writers, sticky `node_id`/`database_id` through reconcile).
- **wiki-page-structured-attribution** — bidirectional Related links to its two structured-first descendant docs.

Reviewed without edits (still accurate against code): **autonomous-pipeline-silent-failures**, **merge-data-pr-github-422-race-recovery**.

## Verification

Every code line reference verified by reading the cited files; markdown lint clean; no private identifiers.