### PR TITLE
docs: refresh privacy-gate learnings against current code

### DIFF
--- a/docs/solutions/best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md
+++ b/docs/solutions/best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md
@@ -1,7 +1,7 @@
 ---
 title: Privacy Gate Design for Data→Main Promotion Leak Prevention
 date: 2026-06-04
-last_updated: 2026-06-24
+last_updated: 2026-07-04
 verified: 2026-06-04
 category: best-practices
 module: github-workflows
@@ -29,6 +29,11 @@ tags:
 ---
 
 # Privacy Gate Design for Data→Main Promotion Leak Prevention
+
+This doc covers the promotion chokepoint specifically — the `data → main` gate below. It is
+no longer the earliest gate a wiki write passes through: `scripts/wiki-repair.ts` now runs
+`detectPrivateWikiLeaks` as a pre-commit gate (`gateWikiRepairs`) against current-tip authority
+metadata before repaired pages ever reach the `data` branch. See "Related" for that gate's doc.
 
 ## Context
 

--- a/docs/solutions/best-practices/pure-core-privacy-gates-shared-module-2026-06-22.md
+++ b/docs/solutions/best-practices/pure-core-privacy-gates-shared-module-2026-06-22.md
@@ -1,7 +1,7 @@
 ---
 title: Pure-Core Privacy Gates with a Shared Module and Mutation-Proof Tests
 date: 2026-06-22
-last_updated: 2026-06-22
+last_updated: 2026-07-04
 problem_type: best_practice
 category: best-practices
 component: development_workflow
@@ -37,9 +37,13 @@ pure core**, before enriched content enters the digest, with a second independen
 authored body as a backstop.
 
 Two separate gate call sites create a divergence risk: if each builds its own token set from
-scratch, a future change to one path can silently leave the other stale. The fix is to extract
-the scan into a single shared module (e.g. `capture-learnings-privacy.ts`) that both call sites
-import. One module, two chokepoints — they cannot diverge.
+scratch, a future change to one path can silently leave the other stale. The fix splits the
+concern in two: the private-token-set **builder** (`buildPrivateTokenSet` /
+`buildPrivateNameTokens`) lives in `wiki-slug.ts` as the single source of truth for token
+shape, while `capture-learnings-privacy.ts` imports it and owns the **gate** itself —
+`learningBodyHasPrivateLeak` (the pure scan) and `loadPrivateTokensFromDisk` (the fail-closed
+disk loader). Both call sites import the gate module, and the gate module imports the builder.
+One builder, one gate, both chokepoints — they cannot diverge.
 
 A subtler correctness trap: the gate received a `Set<string>` of private tokens. An empty set
 (no private repos configured) is not the same as a failed load (the token set could not be
@@ -68,13 +72,18 @@ digest.push(reviewProse)
 ### 2. Extract one shared module so chokepoints can't diverge
 
 Two independent call sites that each build their own token set will eventually drift. Extract
-the scan logic and token-set construction into a single module. Both chokepoints import it.
-A change to the scan logic propagates to both automatically.
+the token-set builder into one module and the scan/load logic into another; both chokepoints
+import the gate module. A change to either propagates to both automatically.
 
 ```ts
-// capture-learnings-privacy.ts — one module, imported by both gate call sites
-export function buildPrivateTokenSet(repos: PrivateRepo[]): Set<string> { ... }
-export function scanForPrivateTokens(text: string, tokens: Set<string>): ScanResult { ... }
+// wiki-slug.ts — the single source of truth for token shape
+export function buildPrivateTokenSet(privateNames: string[]): Set<string> { ... }
+
+// capture-learnings-privacy.ts — imports the builder, owns the gate: both call
+// sites (open step, harvest step) import this module, not each other
+import {buildPrivateTokenSet} from './wiki-slug.ts'
+export function learningBodyHasPrivateLeak(body: string, privateTokens: Set<string>): boolean { ... }
+export async function loadPrivateTokensFromDisk(): Promise<Set<string>> { ... }
 ```
 
 ### 3. Handle empty-vs-absent in the I/O shell, not the pure core
@@ -122,3 +131,4 @@ it('mutation proof: digest assembly drops private prose', () => {
 - [Wiki page structured attribution](../best-practices/wiki-page-structured-attribution-2026-06-04.md) — the present-but-empty vs absent distinction recurs here; encode it as a habit. The three-state frontmatter read (absent / present-but-malformed / present-with-URLs) is the same discipline applied to structured provenance.
 - [Survey workflow-side privacy gate](../security-issues/survey-workflow-side-privacy-gate-2026-05-16.md) — verify privacy inside the trusted workflow before any public side effect.
 - [Private repo dispatch visibility gate](../security-issues/private-repo-dispatch-visibility-gate-2026-05-08.md) — the fail-closed predicate and opaque-identifier redaction this gate builds on.
+- `scripts/status-truth-public-output.ts` — a third chokepoint (`applyPublicOutputGate`) built on the same shared module: it wraps `learningBodyHasPrivateLeak` / `logDiffHasSecret` rather than forking privacy logic, and fails closed the same way — a token-load failure blocks all output.

--- a/docs/solutions/security-issues/survey-workflow-side-privacy-gate-2026-05-16.md
+++ b/docs/solutions/security-issues/survey-workflow-side-privacy-gate-2026-05-16.md
@@ -6,7 +6,7 @@ component: tooling
 module: .github/workflows/survey-repo.yaml
 severity: high
 date: 2026-05-16
-last_updated: 2026-05-23
+last_updated: 2026-07-04
 verified: 2026-05-16
 related_components:
   - development_workflow
@@ -36,6 +36,8 @@ symptoms:
 
 The `survey-repo` workflow trusted dispatch callers to pass `owner` and `repo` as inputs, making the privacy contract enforceable only outside the workflow. Any caller bug, operator misuse, or future regression could leak a canonical private-repo identity into public Actions surfaces (run name, concurrency key, log lines, step summaries, social broadcasts) before any privacy check ran. Even after the first version of the in-workflow gate landed, the recheck was scoped too narrowly: persistence and external-emit steps (metadata write, broadcast) ran on agent success regardless, leaving leak windows on no-op surveys.
 
+These leak channels are fixed. Current `.github/workflows/survey-repo.yaml` accepts only an opaque `node_id` input, uses a static `run-name`, and derives the `concurrency.group` from that same opaque input — none of the raw-input echo paths described below exist anymore. The privacy gate resolves and verifies before any other step runs, and the recheck now gates every persistence and external-emit step (wiki commit, metadata write, broadcast), not just the wiki commit. This doc is the record of the incident and the pattern that closed it — read on for the shape of the problem and why the fix generalizes.
+
 ## Symptoms
 
 - `workflow_dispatch` accepted any `{owner: string, repo: string}` from the caller with no validation.
@@ -50,7 +52,7 @@ The `survey-repo` workflow trusted dispatch callers to pass `owner` and `repo` a
 1. **Trusting the engine-side gate alone.** A separate doc (`docs/solutions/security-issues/private-repo-dispatch-visibility-gate-2026-05-08.md`) hardened the dispatch-planning engine to fail-closed on non-public entries. But if anything bypassed that gate — a future caller bug, manual `gh workflow run` from an operator, or a regression — the workflow itself had no fallback verification. A single privacy boundary outside the trust boundary it was protecting is not a boundary.
 2. **Trusting the invitation API payload's `node_id`.** The invitation handler originally used the `node_id` from the invitation payload directly. But invitations can be stale (repo deleted and recreated between invitation send and acceptance), so dispatching under that node_id could survey the wrong repository entirely.
 3. **Echoing raw input in failure messages.** Even a "failed" workflow run logs its input — `printf 'Aborting %s' "$NODE_ID"` is a leak channel. Aborting loudly with the bad value defeats the point of aborting.
-4. **Gating only the wiki-commit step on the recheck.** The first attempt at the recheck scoped its `if:` to `steps.wiki-changes.outputs.changed == 'true'`. That closed the wiki leak but left two larger ones: the `Record survey result` step kept its hardcoded `REPO_PRIVATE: 'false'` sourced from the initial resolve, and the `broadcast` job depended only on `needs.survey-repo.result == 'success'`. On a no-op survey where the agent ran but wrote no wiki changes, both paths emitted post-flip identity to public surfaces.
+4. **Gating only the wiki-commit step on the recheck.** The first attempt at the recheck scoped its `if:` to `steps.wiki-changes.outputs.changed == 'true'`. That closed the wiki leak but left two larger ones: the `Record survey result` step kept its hardcoded `REPO_PRIVATE: 'false'` sourced from the initial resolve, and the `broadcast` job depended only on `needs.survey-repo.result == 'success'`. On a no-op survey where the agent ran but wrote no wiki changes, both paths emitted post-flip identity to public surfaces. The recheck now covers both persistence (`Record survey result`, sourcing `REPO_PRIVATE` from `steps.recheck.outputs.private`, never hardcoded) and broadcast (`Announce survey to gateway` gated on `steps.recheck.conclusion == 'success'`) — not just the wiki commit.
 
 ## Solution
 

--- a/docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md
+++ b/docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md
@@ -1,7 +1,7 @@
 ---
 title: Verify the Whole Public Perimeter Before Declaring a Value Non-Leaking
 date: 2026-06-22
-last_updated: 2026-06-22
+last_updated: 2026-07-04
 problem_type: security_issue
 category: security-issues
 component: development_workflow
@@ -89,3 +89,4 @@ and verify the change against it, not against the author's description of what t
 - [Survey workflow-side privacy gate](../security-issues/survey-workflow-side-privacy-gate-2026-05-16.md) — the same fail-closed discipline applied to workflow-side privacy checks before any public side effect.
 - [Privacy-gate promotion leak prevention](../best-practices/privacy-gate-promotion-leak-prevention-2026-06-04.md) — scanning the full promotion diff (not just filenames) to catch in-body mentions of private identifiers.
 - [Byte-exact gateway signing and fail-soft telemetry](../best-practices/byte-exact-gateway-signing-and-fail-soft-telemetry-2026-06-04.md) — a related pattern of verifying exact values at a trust boundary rather than relying on prose descriptions.
+- `scripts/status-truth-public-output.ts` — a live example of whole-perimeter enforcement: every public output surface (proposal bodies, workflow summary rows, run display names) routes through one gate, and counts-only surfaces (`workflow-summary-row`, `workflow-step-summary`, `workflow-run-display-name`) are structurally forbidden from carrying a fingerprint or canonical-ID parameter — the gate blocks if one is provided.

--- a/docs/solutions/workflow-issues/jq-falsy-coalesce-trap-in-shell-gates-2026-05-17.md
+++ b/docs/solutions/workflow-issues/jq-falsy-coalesce-trap-in-shell-gates-2026-05-17.md
@@ -1,7 +1,7 @@
 ---
 title: 'jq // operator silently coalesces false to fallback in shell-driven gates'
 date: 2026-05-17
-last_updated: 2026-05-17
+last_updated: 2026-07-04
 problem_type: workflow_issue
 component: development_workflow
 module: github-actions-workflows
@@ -102,7 +102,10 @@ The fix is procedural, not just textual: when writing a shell-driven gate that c
 - Any `scripts/**/*.ts` shell-outs that parse GitHub API booleans (less common, but the same trap exists for any tool using `jq`'s `//`).
 - Any review of an existing workflow gate — `git grep -nE 'jq -r .+ // "(null|false|true)"'` is a fast audit for this exact pattern across the repo.
 
-The audit also catches non-boolean cases that *should* use `//` (string fallbacks for missing fields), so review each hit by intent: if the fallback intentionally distinguishes `present-but-falsy` from `missing`, the `//` is wrong.
+The audit distinction is numeric vs. boolean, not "does it use `//`":
+
+- **Numeric count defaults are fine.** Every summary-table `jq` call across `status-truth.yaml`, `wiki-lint.yaml`, `reconcile-repos.yaml`, and `capture-learnings.yaml` uses `.field // 0` to default a missing/absent counter to zero for display — that's the correct, intended use of `//`, since a count is never legitimately the boolean `false`.
+- **Boolean decision gates must never use string-fallback coalescing.** The two gates that decide control flow from a boolean — `survey-repo.yaml`'s resolve step (`jq -er '... | select(.isPrivate == false) | ...'`) and its recheck step (`jq -e '.data.node.isPrivate == false'`) — use `jq -e` assertions with `select()`/strict equality, never `// "fallback"`. Any future boolean gate should follow the same `jq -e` pattern; reach for `// 0` only when the field is a display-only count.
 
 ## Examples
 


### PR DESCRIPTION
## What

Second cluster of the `docs/solutions/` maintenance sweep — 5 privacy-gate docs investigated against current code, all updated:

- **pure-core-privacy-gates-shared-module** — corrected the drifted module architecture: the shared token builder lives in `scripts/wiki-slug.ts`; `capture-learnings-privacy.ts` is the load-and-scan gate helper importing it. Snippets fixed; status-truth public-output gate linked as the third chokepoint.
- **privacy-gate-promotion-leak-prevention** — scoped explicitly to the promotion chokepoint; notes `wiki-repair.ts` now runs `detectPrivateWikiLeaks` as an earlier pre-commit gate with current-tip authority.
- **verify-whole-public-perimeter** — links the status-truth public-output gate as a live whole-perimeter example.
- **survey-workflow-side-privacy-gate** — fixed leak channels (opaque `node_id`, static run-name, opaque concurrency key) moved to past tense; the recheck-gates-persistence-and-broadcast fix recorded.
- **jq-falsy-coalesce-trap** — audit guidance tightened to the numeric-default (`// 0` fine) vs boolean-decision-gate (never string-fallback) distinction, verified across current workflows.

Retrieval-value check: all five cover distinct sub-problems (module architecture / promotion ordering / perimeter discipline / workflow-side enforcement / jq semantics) — no consolidation warranted, no contradictions found.

## Verification

Every claim verified by reading the cited files; markdown lint clean; no private identifiers.