### PR TITLE
docs: refresh reconcile and doc-drift learnings

### DIFF
--- a/docs/solutions/best-practices/github-issues-api-same-run-eventual-consistency-2026-05-20.md
+++ b/docs/solutions/best-practices/github-issues-api-same-run-eventual-consistency-2026-05-20.md
@@ -1,7 +1,7 @@
 ---
 title: GitHub Issues API same-run eventual consistency requires an in-memory created-ID set
 date: 2026-05-20
-last_updated: 2026-05-20
+last_updated: 2026-07-04
 verified: 2026-05-20
 category: best-practices
 module: scripts/reconcile-repos.ts
@@ -92,6 +92,15 @@ A regression test must reproduce the race shape: mock `issues.listForRepo` to re
 - **GitHub's write→read consistency window is asymmetric and load-dependent.** Writes are reflected in the SAME call's response within ~1s, but visible to a subsequent list call only after several seconds — sometimes longer under platform load.
 - **"Just sleep a few seconds" is not a fix.** It inflates run wall-clock, is unreliable (the consistency window varies), and does not compose if stages stack.
 - **The pattern recurs across the GitHub API.** Same shape applies to PRs, labels, comments, deployments, and check runs. The dedup-via-Set pattern is the universal answer when the stages live in the same process.
+
+## Verified: two call sites now use this pattern
+
+As of 2026-07-04, this pattern guards two independent call sites in `scripts/reconcile-repos.ts`, not just the rollup path:
+
+- **Per-owner rollups** — `currentRunRollupOwners` (built ~line 1665, passed into `selfHealRollups` at line 1668) is checked against `existingRollupOwners` inside `selfHealRollups` (function starts ~line 3106; the same-run check is at lines 3158-3166, separate from the `listForRepo`-derived set built at lines 3130-3153).
+- **Visibility-transition alerts** — `runIssueQueue` (function starts ~line 2680) declares its own same-run `attemptedTransitionNodeIds` Set at line 2708 and checks it at lines 2727-2739, independently of the `listForRepo`-based duplicate check earlier in the same loop.
+
+Both sites follow the identical shape: a `listForRepo`-derived set for cross-run/pre-existing dedup, unioned or checked alongside an in-memory same-run Set that is authoritative for anything created earlier in the current process. Different resource within the same run (rollup issues vs. visibility-transition alerts), same eventual-consistency fix.
 
 ## When to Apply
 

--- a/docs/solutions/documentation-gaps/doc-drift-cleanup-pattern-2026-04-18.md
+++ b/docs/solutions/documentation-gaps/doc-drift-cleanup-pattern-2026-04-18.md
@@ -6,8 +6,8 @@ component: documentation
 resolution_type: process_improvement
 severity: medium
 date: 2026-04-18
-last_updated: 2026-04-18
-module: README.md, SECURITY.md, .github/copilot-instructions.md, metadata/README.md
+last_updated: 2026-07-04
+module: README.md, .github/copilot-instructions.md, metadata/README.md, docs/solutions/, .agents/skills/generating-project-docs
 tags:
   [documentation, drift, readme, security-policy, copilot-instructions, agent-skills, inventory, pr-sequencing]
 verified: 2026-04-18
@@ -15,9 +15,9 @@ verified: 2026-04-18
 
 ## Context
 
-The root-level community-health and AI-guidance docs (`README.md`, `SECURITY.md`, `.github/copilot-instructions.md`,
-and subdirectory READMEs) describe a live control plane whose surface keeps changing — workflows, scripts, metadata
-schemas, wiki pages, and persona assets land regularly. Without a disciplined refresh process, the docs drift: counts
+The canonical docs — `README.md`, `.github/copilot-instructions.md`, `metadata/README.md`, `docs/solutions/`, and the
+repo-scoped skill `.agents/skills/generating-project-docs` — describe a live control plane whose surface keeps
+changing — workflows, scripts, metadata schemas, wiki pages, and persona assets land regularly. Without a disciplined refresh process, the docs drift: counts
 go stale, runtime claims contradict the live repo, tree diagrams list files that were deleted, and AI-assistant
 guidance keeps pointing at obsolete files.
 
@@ -128,7 +128,7 @@ Four PRs captured the pattern end-to-end:
 | PR                                                   | Scope                                                                              | Pattern Element  |
 | ---------------------------------------------------- | ---------------------------------------------------------------------------------- | ---------------- |
 | [#3129](https://github.com/fro-bot/.github/pull/3129) | Add `.agents/skills/generating-project-docs/SKILL.md`; exclude skill content from ESLint / markdownlint | Encode conventions first |
-| [#3130](https://github.com/fro-bot/.github/pull/3130) | `README.md` inventory refresh — Node 24 / pnpm 10.33.0, accurate tree, all 16 workflows, point AI guidance at `.github/copilot-instructions.md` | Slice 1: primary doc |
+| [#3130](https://github.com/fro-bot/.github/pull/3130) | `README.md` inventory refresh — Node 24 / pnpm 10.33.0, accurate tree, all current workflows (16 at the time — re-derive from `ls .github/workflows/`), point AI guidance at `.github/copilot-instructions.md` | Slice 1: primary doc |
 | [#3131](https://github.com/fro-bot/.github/pull/3131) | Delete `.cursorrules`; remove references in `.gitattributes`, `.github/copilot-instructions.md`, `.markdownlint-cli2.yaml`, `llms.txt` | Slice 2: removal |
 | [#3132](https://github.com/fro-bot/.github/pull/3132) | `SECURITY.md` refresh (main-branch model, drop npm contact form, add Automated Security Scanning); expand `.github/copilot-instructions.md` architecture + add Tests and Autonomous Commits subsections | Slice 3: adjacent polish |
 
@@ -142,13 +142,16 @@ PR alongside this compound doc.
 
 ### Inventory commands used
 
+Re-run these against the live repo for current counts — do not carry numbers forward from a previous refresh.
+The counts below are a point-in-time example from the 2026-04-18 session, not a target to match:
+
 ```bash
-ls .github/workflows/                      # 16 workflow files
-ls scripts/*.ts | grep -v test             # 12 production scripts
-ls scripts/*.test.ts                       # 11 test files
-pnpm test                                  # 186 tests
-ls metadata/*.yaml                         # 4 metadata files
-find knowledge/wiki -name '*.md' | wc -l   # 24 wiki pages
+ls .github/workflows/                      # workflow files (16 at time of writing)
+ls scripts/*.ts | grep -v test             # production scripts (12 at time of writing)
+ls scripts/*.test.ts                       # test files (11 at time of writing)
+pnpm test                                  # test count (186 at time of writing)
+ls metadata/*.yaml                         # metadata files (4 at time of writing)
+find knowledge/wiki -name '*.md' | wc -l   # wiki pages (24 at time of writing)
 git log --oneline -15                      # recent-change context
 ```
 

--- a/docs/solutions/documentation-gaps/doc-drift-cleanup-pattern-2026-04-18.md
+++ b/docs/solutions/documentation-gaps/doc-drift-cleanup-pattern-2026-04-18.md
@@ -7,7 +7,7 @@ resolution_type: process_improvement
 severity: medium
 date: 2026-04-18
 last_updated: 2026-07-04
-module: README.md, .github/copilot-instructions.md, metadata/README.md, docs/solutions/, .agents/skills/generating-project-docs
+module: README.md, SECURITY.md, .github/copilot-instructions.md, metadata/README.md, docs/solutions/, .agents/skills/generating-project-docs
 tags:
   [documentation, drift, readme, security-policy, copilot-instructions, agent-skills, inventory, pr-sequencing]
 verified: 2026-04-18
@@ -15,7 +15,7 @@ verified: 2026-04-18
 
 ## Context
 
-The canonical docs — `README.md`, `.github/copilot-instructions.md`, `metadata/README.md`, `docs/solutions/`, and the
+The canonical docs — `README.md`, `SECURITY.md`, `.github/copilot-instructions.md`, `metadata/README.md`, `docs/solutions/`, and the
 repo-scoped skill `.agents/skills/generating-project-docs` — describe a live control plane whose surface keeps
 changing — workflows, scripts, metadata schemas, wiki pages, and persona assets land regularly. Without a disciplined refresh process, the docs drift: counts
 go stale, runtime claims contradict the live repo, tree diagrams list files that were deleted, and AI-assistant


### PR DESCRIPTION
## What

Final cluster of the `docs/solutions/` maintenance sweep — 18 docs investigated in this pass (reconcile/gateway, metadata/runtime, workflow-contract clusters); 16 verified current with no edits needed, 2 updated:

- **github-issues-api-same-run-eventual-consistency** — the same-run Set dedup pattern now guards two call sites (`selfHealRollups` and visibility-transition alerts in `runIssueQueue`); the doc records both with verified line refs.
- **doc-drift-cleanup-pattern** — hardcoded 2026-04 inventory counts relabeled as point-in-time examples; canonical-docs list updated to the current set (including `docs/solutions/` and the repo-scoped docs skill).

Verified current without edits: minimum-progress-floor, observability-before-structural-change, private-repo-dispatch-visibility-gate, byte-exact-gateway-signing, node-strip-only-typescript, octokit-invitation-method-names, loose-then-tight-schema-migration, diagnostic-patches-observability, step-output-interpolation, required-github-token, quoted-status-check-context, consolidation-invariant-trace, superseded-workflow-removal, review-event-classification, rollout-tracker-workflow (+ 1 more from earlier batches).

Sweep complete: 34/34 docs reviewed across four PRs (#3626, #3627, this). 11 updated, 23 kept, 0 deleted/consolidated — the corpus was structurally healthy; drift was concentrated in the domains that changed this week.

## Verification

Every claim verified by reading cited files; markdown lint clean; no private identifiers.