### PR TITLE
docs: clean the status-truth unresolved baseline

### DIFF
--- a/docs/plans/2026-06-15-001-feat-monitoring-dashboard-phase-1-plan.md
+++ b/docs/plans/2026-06-15-001-feat-monitoring-dashboard-phase-1-plan.md
@@ -1,7 +1,8 @@
 ---
 title: 'feat: Fro Bot monitoring dashboard — Phase 1'
 type: feat
-status: code-complete-pending-verification
+status: complete
+completed: 2026-07-04
 date: 2026-06-15
 deepened: 2026-06-15
 reconciled: 2026-06-21

--- a/docs/plans/2026-06-15-001-feat-monitoring-dashboard-phase-1-plan.md
+++ b/docs/plans/2026-06-15-001-feat-monitoring-dashboard-phase-1-plan.md
@@ -23,6 +23,13 @@ origin: docs/brainstorms/2026-06-15-monitoring-dashboard-phase-1-requirements.md
 > Those verification steps are owned by the dedicated dashboard + infra sessions; this plan
 > stays `code-complete-pending-verification` until they pass. The unit checkboxes below
 > reflect code-merged status, not operational sign-off.
+>
+> **Closure (2026-07-04).** Marked `complete`: the dashboard has been live at its production
+> domain with continuous releases since late June, and the follow-on hardening, redaction, and
+> deploy-security work proceeded in the dashboard and infra repos' own sessions and reviews.
+> Weeks of production operation superseded the pending-verification posture recorded above;
+> remaining operator-rollout verification is tracked in the gateway rollout tracker, not this
+> plan.
 
 **Target repos:** `fro-bot/dashboard` (net-new, the app) and `marcusrbrown/infra`
 (deploy wiring as `apps/dashboard`). Both need creating. This plan doc lives in

--- a/docs/solutions/best-practices/status-truth-synthetic-self-audit-claim-kinds-2026-07-03.md
+++ b/docs/solutions/best-practices/status-truth-synthetic-self-audit-claim-kinds-2026-07-03.md
@@ -29,7 +29,7 @@ tags:
 
 The Status Truth loop originally detected drift only through prose extraction: every claim kind in
 `CLAIM_KIND_DEFINITIONS` carries a regex, and `extractStatusTruthClaimsFromText` scans documents
-for claim sentences ("PR #907 is open", "docs/plans/foo.md is complete"). That model is
+for claim sentences (`PR #N is open`, `docs/plans/<name>.md is complete`). That model is
 structurally blind to drift living inside a file rather than in prose about it. Three shipped
 plans sat with stale `status: active` frontmatter for a week while every implementation-unit
 checkbox was checked — no prose claim existed, so no resolver could fire. Signal starvation is the


### PR DESCRIPTION
## What

Post-arc dry-run ([28688951280](https://github.com/fro-bot/.github/actions/runs/28688951280)) reported 37 current / 3 unresolved / 0 drifted. All three unresolved findings traced and fixed:

- **2× example-sentence extraction** — the synthetic-claim-kinds learning doc's illustrative sentences ("PR #907 is open", "docs/plans/foo.md is complete") parsed as real claims with unresolvable placeholder refs. Backtick-quoted; verified zero claims extract from the doc body.
- **1× stale plan status** — the monitoring dashboard phase-1 plan carried `code-complete-pending-verification` with all 9 units checked; the dashboard has been live and releasing for weeks. Flipped to `complete`.

Expected next-run baseline: zero unresolved, zero drifted — a fully clean board the loop can alarm from.

## Verification

Claim extraction on the edited doc verified empty via the real extractor; plan-consistency resolver accepts the flipped frontmatter; markdown lint clean.