### PR TITLE
feat: add cross-repo goal planning and agent dispatch

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -44,3 +44,9 @@ labels:
   - name: learning-proposal
     color: '#0e8a16'
     description: Candidate learning proposed from a multi-round-review PR
+  - name: cross-repo-goal
+    color: '#1d76db'
+    description: Coordination issue describing a goal spanning multiple repos
+  - name: dispatch-approved
+    color: '#0e8a16'
+    description: Operator-applied approval that dispatches the proposed items

--- a/.github/workflows/cross-repo-dispatch.yaml
+++ b/.github/workflows/cross-repo-dispatch.yaml
@@ -1,0 +1,217 @@
+---
+name: Cross-Repo Dispatch
+
+on:
+  issues:
+    types: [labeled, reopened]
+  schedule:
+    - cron: '0 */6 * * *' # Every 6 hours
+  workflow_dispatch:
+
+# Default permissions: read-only. Each job mints its own scoped write token
+# after its own gate passes (least-privilege, mint-time scoping).
+permissions:
+  contents: read
+
+concurrency:
+  group: cross-repo-dispatch
+  cancel-in-progress: false
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Dispatch job: actor+label-bound control plane for approved goal
+  # decompositions. Gate is boolean-safe (string equality) and fail-closed —
+  # only the operator (`marcusrbrown`) applying the approve label triggers a mint + dispatch.
+  # The script re-checks sender.login independently (defense in depth).
+  # ---------------------------------------------------------------------------
+  dispatch:
+    name: Dispatch approved goal items
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: >-
+      github.event_name == 'issues' &&
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'dispatch-approved' &&
+      github.event.sender.login == 'marcusrbrown'
+    permissions:
+      contents: read
+    steps:
+      - name: ⤵ Checkout Branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: 📦 Setup
+        uses: ./.github/actions/setup
+
+      # Overlay metadata/repos.yaml from the data branch so the registry gate
+      # (owner-only, has_fro_bot_workflow, public) reads live state.
+      - name: ⤵ Overlay metadata from data branch
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code origin data >/dev/null 2>&1; then
+            git fetch --no-tags origin data
+            git checkout origin/data -- metadata/
+          else
+            echo "data branch not yet established; skipping metadata overlay."
+          fi
+
+      # Mint AFTER the actor+label gate above — a refused event never mints a
+      # cross-repo token. The target set is data-driven from the bot marker at
+      # runtime, so this mint is scoped at the owner level (the App is only
+      # installed on fro-bot/marcusrbrown-owned repos, matching the registry's
+      # owner-only gate) rather than to a static per-target repo list. Narrowest
+      # permission that permits `createWorkflowDispatch` cross-repo: actions:write.
+      - name: 🔑 Mint dispatch token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-actions: write
+          permission-issues: write
+
+      - name: 🚀 Dispatch approved goal items
+        id: dispatch
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          CROSS_REPO_DISPATCH_APPROVE_LABEL: dispatch-approved
+          CROSS_REPO_DISPATCH_RESULT_PATH: ${{ runner.temp }}/cross-repo-dispatch-result.json
+        run: node scripts/cross-repo-dispatch.ts dispatch
+
+      - name: 📋 Write dispatch summary
+        if: always()
+        env:
+          CROSS_REPO_DISPATCH_RESULT_PATH: ${{ runner.temp }}/cross-repo-dispatch-result.json
+        run: |
+          set -euo pipefail
+          result="$CROSS_REPO_DISPATCH_RESULT_PATH"
+
+          {
+            echo "## Cross-Repo Dispatch Summary"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+
+            if [[ -s "$result" ]]; then
+              echo "| Refused | $(jq '.counts.refused // 0' "$result") |"
+              echo "| Dispatched | $(jq '.counts.dispatched // 0' "$result") |"
+              echo "| Deferred | $(jq '.counts.deferred // 0' "$result") |"
+              echo "| Blocked | $(jq '.counts.blocked // 0' "$result") |"
+              echo "| Reconciled | $(jq '.counts.reconciled // 0' "$result") |"
+              echo "| Skipped unsafe prompt | $(jq '.counts.skippedUnsafePrompt // 0' "$result") |"
+              echo "| CAS deferred | $(jq '.counts.casDeferred // 0' "$result") |"
+            else
+              echo "| Status | (dispatch result unavailable) |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
+  # Reopen job: an issue reopened while still carrying the approve label
+  # produces no new `labeled` event, so recovery would stall. Removing the
+  # label here (and letting the marker's approval record go stale) forces
+  # the operator's re-approval to fire a fresh `labeled` event under a new
+  # fingerprint.
+  # ---------------------------------------------------------------------------
+  reopen:
+    name: Clear approval on reopen
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'issues' && github.event.action == 'reopened'
+    permissions:
+      issues: write
+    steps:
+      - name: 🧹 Remove approve label if present
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          APPROVE_LABEL: dispatch-approved
+        run: |
+          set -euo pipefail
+          if gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json labels \
+            --jq '.labels[].name' | grep -qxF "$APPROVE_LABEL"; then
+            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label "$APPROVE_LABEL"
+          fi
+
+  # ---------------------------------------------------------------------------
+  # Track job: periodic snapshot of dispatched goal items to terminal state,
+  # closing coordination issues once every item settles.
+  # ---------------------------------------------------------------------------
+  track:
+    name: Track dispatched goal items
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+    steps:
+      - name: ⤵ Checkout Branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: 📦 Setup
+        uses: ./.github/actions/setup
+
+      - name: ⤵ Overlay metadata from data branch
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code origin data >/dev/null 2>&1; then
+            git fetch --no-tags origin data
+            git checkout origin/data -- metadata/
+          else
+            echo "data branch not yet established; skipping metadata overlay."
+          fi
+
+      # Track needs read access to target-repo runs/PRs plus write access to
+      # this repo's coordination issues (marker writes, close-on-terminal).
+      - name: 🔑 Mint track token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-actions: read
+          permission-pull-requests: read
+          permission-issues: write
+
+      - name: 📡 Track dispatched goal items
+        id: track
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          CROSS_REPO_DISPATCH_RESULT_PATH: ${{ runner.temp }}/cross-repo-dispatch-result.json
+        run: node scripts/cross-repo-dispatch.ts track
+
+      - name: 📋 Write track summary
+        if: always()
+        env:
+          CROSS_REPO_DISPATCH_RESULT_PATH: ${{ runner.temp }}/cross-repo-dispatch-result.json
+        run: |
+          set -euo pipefail
+          result="$CROSS_REPO_DISPATCH_RESULT_PATH"
+
+          {
+            echo "## Cross-Repo Track Summary"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+
+            if [[ -s "$result" ]]; then
+              echo "| Goals processed | $(jq '.counts.goalsProcessed // 0' "$result") |"
+              echo "| Items completed | $(jq '.counts.itemsCompleted // 0' "$result") |"
+              echo "| Items failed | $(jq '.counts.itemsFailed // 0' "$result") |"
+              echo "| Items blocked | $(jq '.counts.itemsBlocked // 0' "$result") |"
+              echo "| Items still open | $(jq '.counts.itemsStillOpen // 0' "$result") |"
+              echo "| Goals closed | $(jq '.counts.goalsClosed // 0' "$result") |"
+              echo "| Idempotent no-op | $(jq '.counts.idempotentNoop // 0' "$result") |"
+              echo "| CAS deferred | $(jq '.counts.casDeferred // 0' "$result") |"
+            else
+              echo "| Status | (track result unavailable) |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -1,6 +1,13 @@
 ---
 name: Fro Bot
 
+# Optional correlation-id suffix lets a cross-repo-dispatch caller identify
+# this exact run by a unique token instead of coincidental epoch/actor
+# matching (see scripts/cross-repo-dispatch.ts). Empty by default — a purely
+# cosmetic, backward-compatible run-name change.
+run-name: >-
+  Fro Bot${{ github.event.inputs.correlation_id && format(' ({0})', github.event.inputs.correlation_id) || '' }}
+
 on:
   issue_comment:
     types: [created]
@@ -18,6 +25,10 @@ on:
     inputs:
       prompt:
         description: 'Custom prompt for the Fro Bot agent (leave empty to run the default daily oversight + autohealing pass)'
+        required: false
+        default: ''
+      correlation_id:
+        description: Optional opaque correlation id echoed into run-name (used by cross-repo-dispatch to identify this run)
         required: false
         default: ''
   workflow_call:
@@ -97,6 +108,30 @@ env:
     - Include every heading exactly once and in the order above.
     - Write "None" under headings with no findings.
     - Keep findings actionable: file path, impact, and concrete remediation.
+
+  GOAL_DECOMPOSITION_PROMPT: |
+    This issue carries the `cross-repo-goal` label: it describes a goal spanning
+    multiple owner repos (`fro-bot/*`, `marcusrbrown/*`). Propose a per-repo
+    work-item decomposition as a single comment on this issue. Do NOT dispatch,
+    trigger, or execute anything — this run has no dispatch capability and this
+    output is a proposal only, subject to the operator's edit and approval.
+
+    Read the goal description and the managed-repo registry
+    (`metadata/repos.yaml`) to identify eligible owner-repo targets.
+
+    Post exactly one checklist item per proposed work item, in this literal
+    format (each line independently parseable):
+    - [ ] <owner>/<name>: <prompt>
+
+    Rules:
+    - <owner>/<name> must be an owner-repo target (`fro-bot/*` or
+      `marcusrbrown/*`) present in `metadata/repos.yaml`.
+    - <prompt> is the exact task to hand to that repo's worker run — concise,
+      concrete, self-contained.
+    - Emit nothing else that looks like a checklist item; free text outside
+      the checklist is fine but must not be mistaken for an item.
+    - If the goal cannot be decomposed into owner-repo targets, say so plainly
+      instead of inventing items.
 
   SCHEDULE_PROMPT: |
     Run the daily Fro Bot pass for fro-bot/.github — the autonomous control
@@ -402,6 +437,7 @@ jobs:
               || inputs.prompt
               || ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && env.SCHEDULE_PROMPT)
               || (github.event_name == 'pull_request' && env.PR_REVIEW_PROMPT)
+              || (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'cross-repo-goal') && env.GOAL_DECOMPOSITION_PROMPT)
               || ''
             }}
         with:

--- a/README.md
+++ b/README.md
@@ -337,6 +337,18 @@ Any single key missing produces zero PR actions; eligible findings fall back to 
 - If a fingerprint's drift clears on a complete scan while its correction PR is still open, the bot closes its own PR with a brief comment and deletes the branch. If the linked proposal later gets a terminal label (`status-truth:rejected` or `status-truth:false-positive`), the same closure happens regardless of drift state. Merged PRs are never touched.
 - The bot never merges, approves, enables automerge, force-pushes, or retargets a correction PR — closing its own stale PRs and deleting its own branches are the only PR-state mutations it can make. A human always merges.
 
+### Cross-Repo Goal Dispatch
+
+Fro Bot coordinates a single goal across multiple owner repos (`fro-bot/*`, `marcusrbrown/*`) through an open → decompose → approve → dispatch → track lifecycle:
+
+1. **Open a goal issue.** Describe a multi-repo goal and mention `@fro-bot`. Label the issue `cross-repo-goal`.
+2. **Review the proposed decomposition.** The bot posts a per-repo work-item checklist as a comment. Edit it freely before approving — nothing dispatches yet.
+3. **Approve.** Applying the `dispatch-approved` label triggers dispatch. Only an approval applied by the repository owner (the operator) is honored; any other applier has the label removed and nothing runs.
+4. **Dispatch.** Each approved item runs as a worker agent in its target repo. Targets are restricted to owner repos already onboarded to Fro Bot's automation.
+5. **Track to completion.** A periodic tracker snapshots each item's run outcome to the issue. The issue closes automatically once every item reaches a terminal state (completed, failed, or blocked).
+
+If you need to re-approve after reopening a closed goal issue, reopening automatically clears the prior approval — reapply the `dispatch-approved` label to fire a fresh dispatch.
+
 ## Development
 
 ### Code Quality Standards

--- a/docs/brainstorms/2026-07-04-a3-cross-repo-dispatch-requirements.md
+++ b/docs/brainstorms/2026-07-04-a3-cross-repo-dispatch-requirements.md
@@ -1,0 +1,333 @@
+---
+date: 2026-07-04
+topic: a3-cross-repo-dispatch
+title: Cross-repo planning and agent dispatch (A3 v1)
+---
+
+# Cross-repo planning and agent dispatch (A3 v1)
+
+## Summary
+
+Give Fro Bot its first goal-level coordination surface: the operator states a goal that spans managed
+repos in a coordination issue; an agent run proposes a per-repo work-item decomposition into that
+issue; the operator approves; a dispatch loop launches one agent run per approved item in the target
+repos and tracks completion back on the issue until close. Planning is agent-proposed and
+human-approved; dispatch is registry-gated, sequential, and bounded. A3 composes existing
+surfaces — the reusable agent workflow, cross-repo `workflow_dispatch`, the managed-repo
+registry, and the tracker-snapshot pattern — and adds no new agent authority.
+
+---
+
+## Problem Frame
+
+Every transport primitive for cross-repo work already exists: the reusable `fro-bot.yaml`
+agent surface, owner-scoped App-token dispatch (reconcile, invitations), the registry of repos
+carrying the workflow, and snapshot bookkeeping over multi-repo state (rollout tracker). What
+does not exist is anything that takes a goal spanning repos, decomposes it into per-repo work,
+dispatches agents against those repos, and drives the items to completion. Today that
+coordination lives in the operator's head and gets re-typed into N separate prompts.
+
+The north-star names this A3 and rates it high-risk. The risk is concentrated in autonomy
+posture, not transport — so v1 climbs the same earned-autonomy ladder every prior loop used:
+propose → approve → act, with the human gate on dispatch.
+
+---
+
+## Actors
+
+(The slice is A3; actors are named to avoid colliding with that label.)
+
+- **Operator**: states goals, edits and approves decompositions, reviews the resulting PRs. The
+  sole approval authority.
+- **Planner** (Fro Bot planning run): proposes the per-repo work-item decomposition on the
+  coordination issue via the existing mention-triggered agent surface.
+- **Control loop** (deterministic control-plane script + its workflow): validates approval,
+  dispatches one agent run per item, snapshots completion state back to the issue.
+- **Worker** (Fro Bot per-repo runs): ordinary agent runs executing individual items — existing
+  surface, unchanged.
+
+---
+
+## Key Flows
+
+- F1. Goal → proposed decomposition
+  - **Trigger:** The operator opens a coordination issue (label `cross-repo-goal`) describing the goal and
+    mentions `@fro-bot`.
+  - **Actors:** A1, A2
+  - **Steps:** The mention-triggered agent run reads the goal, the managed-repo registry, and
+    relevant repo context, then posts a decomposition comment: a per-repo work-item checklist
+    (target repo + item prompt) plus a hidden state marker. It never dispatches anything.
+  - **Outcome:** A reviewable, editable plan artifact on the issue.
+  - **Covered by:** R1, R2, R3, R12
+- F2. Approval → dispatch
+  - **Trigger:** The operator applies the approval label. A dedicated control-plane workflow reacts to
+    the `issues.labeled` event.
+  - **Actors:** Operator, Control loop
+  - **Steps:** The control loop verifies the labeling actor is the operator, snapshots the approval
+    fingerprint (hash of the bot-authored decomposition marker at label time), validates every
+    target against the registry gate, then dispatches one agent run per item (sequential,
+    per-item marker persistence, bounded per run), and posts a counts-only summary.
+  - **Outcome:** Worker runs launched in target repos; the issue is the dispatch ledger.
+  - **Covered by:** R4, R5, R6, R7, R8, R13, R14, R15
+- F3. Tracking → completion
+  - **Trigger:** Scheduled snapshot (and manual dispatch). Scheduled runs only track — they
+    never dispatch new items.
+  - **Actors:** Control loop
+  - **Steps:** The loop resolves each dispatched item's terminal state by the precedence table
+    (R9), updates the checklist/marker idempotently, and when every item is terminal, closes the
+    issue with a summary comment.
+  - **Outcome:** Goal state is always visible on the issue; completion is machine-derived.
+  - **Covered by:** R9, R10, R11
+- F4. Post-approval edit
+  - **Trigger:** The checklist is edited after the approval label was applied.
+  - **Actors:** A1, A3
+  - **Steps:** The control loop detects the fingerprint mismatch, refuses to dispatch the
+    changed set, removes the approval label, and comments that re-approval is required.
+  - **Outcome:** Only the exact reviewed set is ever dispatched.
+  - **Covered by:** R5
+- F5. Failed-item recovery
+  - **Trigger:** After the goal issue closed with a failed/blocked item, the operator reopens the
+    issue, edits the checklist to correct the item, and re-applies the approval label.
+  - **Actors:** Operator, Control loop
+  - **Steps:** Reopening is required before re-approval; the corrected checklist yields a new
+    fingerprint, and the control loop dispatches only items not already terminal-succeeded under
+    the new fingerprint.
+  - **Outcome:** Recovery has a defined path; a closed issue never self-dispatches.
+  - **Covered by:** R10b
+
+---
+
+## Requirements
+
+**Planning (proposal-shaped)**
+
+- R1. Decomposition is produced by the existing mention-triggered agent surface on the
+  coordination issue; the planning run has no dispatch capability and no new permissions.
+- R2. The decomposition artifact is a per-repo work-item checklist in an issue comment: each
+  item names exactly one target repo and one item prompt, plus a hidden machine-readable
+  marker (item ids, targets, fingerprint) following the existing hidden-marker conventions.
+- R3. The operator can edit items freely before approval; the artifact is the review surface.
+
+**Dispatch (human-gated, registry-bounded)**
+
+- R4. Dispatch is triggered only by the `issues.labeled` event adding the approval label, and is
+  performed by a dedicated control-plane workflow + deterministic script (pure planner + serial
+  side effects), never by the planning agent run and never by a scheduled run. The control loop
+  verifies the labeling actor is `marcusrbrown`; an approval label applied by any other actor is
+  refused (label removed, counted) — the label alone is not authority.
+- R5. Dispatch binds to an immutable approval fingerprint: at label time the control loop hashes
+  the bot-authored decomposition marker and stores that hash as the approval record. It
+  dispatches exactly the item set matching that hash. Any post-approval edit to the checklist
+  produces a different current hash, so the mismatch invalidates approval (label removed,
+  re-approval required). The dispatch step re-reads and re-compares the stored hash immediately
+  before each item dispatch, so an edit mid-loop halts further dispatch.
+- R6. Every dispatch target must pass the registry gate: present in `metadata/repos.yaml` with
+  `has_fro_bot_workflow: true` and definitively public (private or indeterminate targets fail
+  closed and are counted). v1 is owner-repos-only (`fro-bot/*`, `marcusrbrown/*`); the contrib
+  allowlist path is explicitly out of v1. Targets failing the gate are marked blocked on the
+  checklist, never dispatched. A target that flips private between approval and dispatch fails
+  the gate re-checked at dispatch time and is blocked, not dispatched.
+- R7. Dispatches are sequential with a per-run cap; dispatched state is persisted to the marker
+  **per item, immediately after each successful dispatch**, so a crash-resume skips any item
+  already marked dispatched under the active fingerprint (each item dispatches at most once per
+  approval). No auto-retry in v1 — a failed item is terminal-failed until recovery (F5).
+- R8. Worker runs are ordinary per-repo agent runs via the existing reusable workflow with the
+  item prompt; A3 grants them no authority beyond what those runs already have. Item prompts are
+  bound by a v1 safety policy: bounded length, no embedded credential/secret patterns, no
+  private repo identifiers, and nothing dispatches whose target/prompt the control loop cannot
+  parse from the trusted marker. The human approval step is the primary injection mitigation;
+  the policy is defense-in-depth against a mistaken approval.
+- R14. The control loop mints a least-privilege token scoped at mint time to exactly the target
+  repo(s) of the approved set (`actions: write` for dispatch only), job-scoped lifetime, no
+  long-lived reusable credential. A per-goal mint bounds blast radius to the approved targets.
+
+**Tracking and lifecycle**
+
+- R9. Each item resolves to exactly one terminal state by a fixed precedence table, machine-
+  derived and recorded on the issue:
+  - `blocked` — failed the registry gate; never dispatched.
+  - `failed` — dispatched, worker run concluded failure, OR the run produced PRs that all closed
+    unmerged.
+  - `completed` — dispatched, worker run concluded success AND (produced no PR — a no-op success
+    where the agent decided no change was needed — OR produced at least one PR that merged). If a
+    run produces multiple PRs, the item is terminal only when all its PRs are terminal; it is
+    `completed` if at least one merged, else `failed`.
+  - `dispatched` (non-terminal) — awaiting run conclusion / PR resolution.
+  Precedence when signals conflict: gate-block > run-failure > PR-outcome > run-success.
+- R10. When all items are terminal (`completed`, `failed`, or `blocked`), the loop posts a
+  counts-only summary and closes the issue; a goal with any non-terminal item stays open.
+- R10b. A closed goal issue never self-dispatches. Recovery requires reopening the issue first
+  (F5); an approval label on a closed issue is inert until it is reopened. On reopen and
+  re-approval, the new fingerprint governs and items already `completed` under a prior
+  fingerprint are not re-dispatched.
+- R11. Snapshot updates are idempotent (marker-hash gated, tracker-snapshot pattern): unchanged
+  state produces no comment/edit churn.
+- R15. The control loop trusts only markers in comments authored by the bot/control-plane
+  identity (the `selectLatestMarkerCommentBody` author-filter pattern); user-authored comments
+  containing marker-like content are ignored for state, fingerprinting, and completion. A given
+  target repo is touched by at most one goal's dispatch at a time: overlapping approved goals
+  sharing a target serialize on it (the colliding item defers, counted), so two goals never
+  launch concurrent worker runs into the same repo.
+
+**Privacy and telemetry**
+
+- R12. Coordination issues, decomposition comments, and all A3 output live in this repo and are
+  public surfaces: no private repo identifiers ever appear in items, markers, comments, or
+  summaries. Private targets are structurally excluded by R6.
+- R13. Loop telemetry is counts-only (proposed, approved, dispatched, blocked, completed,
+  failed); workflow summaries carry no item prompts or repo lists beyond what the public issue
+  already shows.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1–R3.** Given a labeled goal issue mentioning the bot, when the planning run
+  completes, the issue has a decomposition comment with a per-repo checklist and hidden marker,
+  and nothing was dispatched.
+- AE2. **Covers R4–R6, R8.** Given the operator applies the approval label to a three-item plan whose
+  targets all pass the registry gate, when the dispatch loop runs, exactly three worker runs
+  are dispatched sequentially and the marker records all three as dispatched.
+- AE3. **Covers R5.** Given the checklist is edited after approval, when the dispatch loop
+  runs, nothing dispatches, the approval label is removed, and a re-approval comment is posted.
+- AE4. **Covers R6.** Given one item targets a repo without the Fro Bot workflow (or a private/
+  indeterminate one), when the loop runs, that item is marked blocked, the rest dispatch, and
+  the blocked count increments.
+- AE5. **Covers R7.** Given a dispatched item's worker run fails, when the snapshot runs, the
+  item shows terminal-failed and no automatic re-dispatch ever occurs for that fingerprint.
+- AE6. **Covers R9–R11.** Given all items reach terminal state, when the snapshot runs, the
+  issue closes with a counts-only summary; an identical follow-up snapshot produces no edits.
+- AE7. **Covers R12–R13.** Given any A3 run, when its outputs render (issue, marker, workflow
+  summary), no private repo identifier appears anywhere.
+- AE8. **Covers R4.** Given the approval label is applied by an actor other than the operator, when
+  the control loop runs, it dispatches nothing, removes the label, and counts the refusal.
+- AE9. **Covers R7 (crash resume).** Given the loop dispatched item 1 of 3 and crashed before
+  item 2, when it restarts on the same fingerprint, item 1 is skipped (already marked) and only
+  items 2–3 dispatch — no duplicate run for item 1.
+- AE10. **Covers R14.** Given a two-target approved set, when the control loop mints its token,
+  the token is scoped to exactly those two repos with `actions: write` only.
+- AE11. **Covers R15 (marker trust).** Given a non-bot comment contains a spoofed marker with a
+  different fingerprint, when the loop reads state, it ignores the spoofed marker and uses only
+  the bot-authored one.
+- AE12. **Covers R10b.** Given a closed goal with a corrected checklist, when the operator re-applies
+  the label without reopening, nothing dispatches; after reopening + re-approval, only the
+  non-completed items dispatch under the new fingerprint.
+- AE13. **Covers R15 (serialization).** Given two open goals both target the same repo, when
+  both are approved, the second goal's item for that repo defers until the first goal's item is
+  terminal — never concurrent.
+
+---
+
+## Success Criteria
+
+- One real multi-repo goal (e.g. a config or convention rollout across 3+ managed repos) goes
+  goal → proposal → approval → dispatch → tracked completion → issue close without the operator
+  hand-dispatching anything.
+- The approval gate provably binds: no dispatch has ever occurred without the label on the
+  exact fingerprinted set.
+- Worker-run outcomes are visible on the coordination issue without visiting the target repos.
+
+---
+
+## Scope Boundaries
+
+- No autonomous dispatch: the approval label (actor-bound to the operator) is the only trigger; no
+  graduation path is designed in v1 (that's a later slice with its own review, mirroring the
+  bounded-PR arc).
+- No cross-item dependency ordering: items are independent; sequential dispatch is an
+  implementation detail, not a DAG. Goals needing ordered phases use multiple goals.
+- No private-repo targets, and no contrib-org (non-owner) targets in v1 — owner repos only.
+- No retry/self-healing of failed worker runs.
+- No new agent permissions and no gateway involvement. Target-repo `fro-bot.yaml` may need a
+  small, reviewed `workflow_dispatch` input extension to accept a per-item prompt (deferred
+  question); if so, that extension is in scope, but no change to the agent action's authority.
+- No LLM in the dispatch loop: planning is the only model-touching step; the loop is
+  deterministic control-plane TypeScript.
+
+---
+
+## Threat Model (v1)
+
+- **Public, attacker-writable surface.** The goal issue and any comment are writable by anyone
+  who can comment. Mitigations: state is read only from bot-authored markers (R15); the planner
+  has no dispatch capability (R1); dispatch requires an operator-applied label (R4) bound to an
+  immutable fingerprint of the bot marker (R5).
+- **Prompt injection → cross-repo execution.** A hostile item prompt, if approved, would run an
+  agent with write authority in a target repo. Mitigations: human approval gate (R4), item-prompt
+  policy (R8), owner-repos-only targets (R6), least-privilege per-target mint (R14). Residual risk
+  (accepted, documented): the operator is a single high-trust reviewer; a careless approval is the
+  remaining hole, which is why v1 stays owner-repos-only and proposal-shaped.
+- **Label spoofing / self-approval.** Actor-bound approval (R4) rejects labels not applied by
+  the operator. Residual: anyone with triage can *apply* the label, but the actor check refuses it.
+
+## Key Decisions
+
+- **Propose → approve → act, again:** planning autonomy without dispatch autonomy. The agent
+  writes plans; only the operator's label moves the world. Matches the posture ladder of every
+  shipped loop (proposals → disarmed PR machinery → graduation-by-signal).
+- **Coordination issue as the artifact:** visible, editable, commentable, closeable — and the
+  tracker-snapshot pattern already proves issues work as machine-readable multi-repo ledgers.
+- **Fingerprint-bound approval:** approval attaches to bytes, not vibes — post-approval edits
+  structurally cannot ride an old approval (the TOCTOU lesson from the repair loop applied to
+  human gates).
+- **Registry as the blast-radius boundary:** dispatch eligibility is data (`repos.yaml`), not
+  code — growing A3's reach is a metadata change with existing review gates. v1 is
+  owner-repos-only; contrib-org targets are a later slice once the approval/dispatch chain is
+  battle-tested.
+- **Approval binds to bytes and to an actor:** the label is necessary but not sufficient — the
+  applying actor must be the operator, and the approval hashes the exact bot-authored marker, so
+  neither a spoofed label nor a post-approval edit can move the world.
+- **Composition over construction:** the only new machinery is the dispatch/tracking script and
+  its workflow; planner runs, worker runs, tokens, and the registry are all existing surfaces.
+
+---
+
+## Dependencies / Assumptions
+
+- The mention-triggered agent surface can be prompted (via persona/context wiring) to emit the
+  decomposition format reliably; malformed decompositions are a planning-quality issue the operator
+  catches at review, not a safety issue (nothing dispatches unapproved).
+- Cross-repo `workflow_dispatch` of target-repo `fro-bot.yaml` works with an owner-scoped App
+  token for owner repos (proven by reconcile/invitation dispatch); contrib-org targets may need
+  the allowlist probe pattern.
+- Worker-run → PR linkage for completion signals is derivable (run conclusion via Actions API;
+  PR linkage via branch/marker conventions) — exact mechanism is a planning-phase decision.
+- Assumption (labeled): per-item `workflow_dispatch` inputs (item prompt) fit the existing
+  target-repo workflow's dispatch contract; if target workflows only accept the standard
+  trigger set, the dispatch shape may need a small, reviewed extension to `fro-bot.yaml`
+  consumers — surfaced during planning, contradicting "no changes" only if proven necessary.
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- [Affects R9][Technical] Dispatch→run→PR correlation contract: the control loop writes a
+  dispatch-epoch + goal/item id into the `workflow_dispatch` inputs and correlates the resulting
+  run by `createdAt > epoch` (existing pattern); the run→PR link is by a marker the worker writes
+  into its PR body (or a head-branch convention). Pin the exact keys in planning — feasibility
+  confirmed the epoch pattern exists but the PR-link key is unproven.
+
+### Deferred to Planning
+
+- [Affects R2][Technical] Exact marker schema and checklist grammar (reuse rollout-tracker
+  marker conventions vs status-truth fingerprint style).
+- [Affects R8][Technical] Whether target-repo `fro-bot.yaml` accepts a per-item prompt via
+  `workflow_dispatch` as-is, or needs a small reviewed input extension (feasibility flagged the
+  bottom-of-doc assumption as load-bearing).
+- [Affects R13][Technical] Result JSON shape, mirroring the status-truth counts pattern.
+
+---
+
+## Sources / Research
+
+- North-star A3 definition: `docs/brainstorms/2026-06-15-fro-bot-personal-agent-north-star-requirements.md`
+- Transport primitives: `.github/workflows/fro-bot.yaml`, `scripts/reconcile-repos.ts`
+  (dispatch planner + gates), `scripts/handle-invitation.ts` (node_id-only dispatch),
+  `metadata/repos.yaml`, `metadata/allowlist.yaml`
+- Tracking pattern: `scripts/rollout-tracker-snapshot.ts`
+- Posture prior art: `docs/brainstorms/2026-06-26-a2-self-maintenance-portfolio-requirements.md`
+  (proposal-first ladder), `docs/brainstorms/2026-07-03-bounded-correction-pr-execution-requirements.md`
+  (arming/graduation model), `docs/brainstorms/2026-04-17-repo-reconciliation-requirements.md`
+  (commit-before-dispatch, sequential dispatch, trusted-owner gates)

--- a/docs/plans/2026-07-04-001-feat-cross-repo-dispatch-loop-plan.md
+++ b/docs/plans/2026-07-04-001-feat-cross-repo-dispatch-loop-plan.md
@@ -432,7 +432,7 @@ boolean-safe comparisons; mint steps sit after their gates.
 
 | Risk | Mitigation |
 |------|------------|
-| Cross-repo dispatch token over-broad | Per-target `repositories:` mint, narrowest scope, job-scoped, minted only after the actor gate (R14). |
+| Cross-repo dispatch token over-broad | Mint is owner-scoped (`owner: github.repository_owner`, no `repositories:` narrowing), not per-target: the approved target set is data-driven from the bot marker and unknown at YAML mint time, so a static per-target `repositories:` list isn't expressible at mint time. Effective blast radius is bounded instead by the owner-only registry gate (`ELIGIBLE_OWNERS` — only `fro-bot`/`marcusrbrown`-owned, public, onboarded repos ever receive a dispatch) plus the actor+label gate that must pass before mint. Job-scoped, minted only after the actor gate (R14). |
 | Label spoofing / self-approval | Actor-bound gate in BOTH workflow and script (`sender.login == marcusrbrown`), fail-closed label removal (R4). |
 | Prompt injection via public issue | Human approval + bot-marker-only trust + item-prompt policy + owner-only targets (R8/R15/R6). |
 | Duplicate worker runs on crash | Two-phase intent→confirm persistence + correlation-id reconciliation on resume (R7). |

--- a/docs/plans/2026-07-04-001-feat-cross-repo-dispatch-loop-plan.md
+++ b/docs/plans/2026-07-04-001-feat-cross-repo-dispatch-loop-plan.md
@@ -1,0 +1,460 @@
+---
+title: 'feat: Cross-repo planning and agent dispatch (A3 v1)'
+type: feat
+status: complete
+completed: 2026-07-04
+date: 2026-07-04
+origin: docs/brainstorms/2026-07-04-a3-cross-repo-dispatch-requirements.md
+---
+
+# feat: Cross-repo planning and agent dispatch (A3 v1)
+
+## Overview
+
+Give Fro Bot its first goal-level coordination surface. The operator opens a coordination issue
+describing a goal spanning owner repos and mentions the bot; a planning agent run proposes a
+per-repo work-item decomposition as a bot-authored marker comment; the operator approves by labeling;
+a dedicated `issues.labeled` control-plane workflow (actor-bound to the operator) dispatches one worker
+agent run per approved item into the target repos and tracks each item to a terminal state on the
+issue, closing it when all items settle. Planning is agent-proposed and human-approved; dispatch
+is registry-gated, fingerprint-bound, per-item-persisted, and owner-repos-only. A3 composes
+existing surfaces (reusable agent workflow, `workflow_dispatch`, the managed-repo registry, the
+tracker-snapshot pattern) and grants no new agent authority.
+
+## Problem Frame
+
+Every transport primitive for cross-repo work exists; no planning/coordination layer does. Today
+The operator re-types a multi-repo goal into N separate prompts and tracks completion by hand. The
+north-star names this A3 (high-risk). The risk is autonomy posture, not transport, so v1 climbs
+the same propose → approve → act ladder every prior loop used, with the human gate on dispatch.
+See origin: `docs/brainstorms/2026-07-04-a3-cross-repo-dispatch-requirements.md`.
+
+## Requirements Trace
+
+R1 (planner has no dispatch capability), R2 (bot-marker decomposition artifact), R3 (editable
+before approval), R4 (`issues.labeled`, actor-bound to the operator (`marcusrbrown`), control-plane script),
+R5 (immutable fingerprint of the bot marker, re-checked per dispatch), R6 (registry gate,
+owner-only, fail-closed), R7 (sequential, per-item persistence, no auto-retry), R8 (existing
+reusable workflow + item-prompt safety policy), R9 (terminal-state precedence table), R10/R10b
+(close-on-terminal; reopen-before-reapprove), R11 (idempotent snapshots), R12 (public-surface
+privacy), R13 (counts-only telemetry), R14 (least-privilege per-target mint), R15 (bot-marker
+trust + same-target serialization).
+
+## Scope Boundaries
+
+- Owner repos only (`fro-bot/*`, `marcusrbrown/*`); no private targets, no contrib-org targets.
+- No autonomous dispatch (label is the only trigger); no graduation path in v1.
+- No cross-item dependency ordering (independent items; sequential is an impl detail).
+- No retry/self-healing of failed worker runs.
+- No new agent permissions; no gateway involvement; no LLM in the control loop.
+
+### Deferred to Separate Tasks
+
+- Contrib-org targets (needs the allowlist path + its own review).
+- A graduation/arming path toward reduced approval friction.
+- Cross-item DAG ordering.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/rollout-tracker-snapshot.ts` — REUSE: marker `<!-- <prefix>:{json} -->`
+  (`MARKER_PREFIX`), `extractPreviousMarker(body)`, `selectLatestMarkerCommentBody(comments)`
+  (author-filter: `FROBOT_COMMENT_AUTHORS.has(login) && extractPreviousMarker !== null`,
+  `findLast`), and the hash idempotency gate (`decideComment` → `should_comment:false` when
+  `hash === previousMarker.hash`). Backs R2/R11/R15.
+- `scripts/wiki-lint-issues.ts` — REUSE: issue lifecycle octokit calls (`issues.create`,
+  `issues.createComment`, `issues.update{state}`), fingerprint marker, close-on-clear. Backs
+  the coordination-issue lifecycle (R10).
+- `scripts/reconcile-repos.ts` — REUSE: `createWorkflowDispatch({owner, repo, workflow_id,
+  ref, inputs})` (`:2591-2602`); the fail-closed public gate `accessPrivateForStorage` (`:1185`)
+  and `entry.private` semantics. Backs R6 dispatch + gate.
+- `scripts/handle-invitation.ts` — REUSE: `createWorkflowDispatch` with `node_id`-only inputs
+  (`:246`), privacy-refresh fail-closed. Pattern for the dispatch payload.
+- `scripts/schemas.ts` — `RepoEntry` shape: `has_fro_bot_workflow: boolean` (required),
+  `private?` (optional, fail-safe). Backs the registry read.
+- `.github/workflows/fro-bot.yaml:4-28` — CONFIRMED: target-repo workflow already accepts
+  `workflow_dispatch` with a `prompt` input. The item prompt dispatches through the existing
+  contract — no agent-surface change needed for owner repos (dissolves the origin's R8
+  "reviewed extension" assumption).
+- `.github/workflows/status-truth.yaml:205-216,368-378` — REUSE: repo-scoped App-token mint
+  (`repositories:` + `permission-*`) for R14 least-privilege dispatch mint.
+- `.github/workflows/reconcile-repos.yaml:26-36` — owner-installation mint (contrast; too broad
+  for R14, kept only where owner-wide is required).
+- Tests: `rollout-tracker-snapshot.test.ts` (marker fixtures, author-login accept/reject incl.
+  `marcusrbrown`), `wiki-lint-issues.test.ts` (octokit mock stubbing create/createComment/
+  update) — fixture patterns for the A3 suite.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/status-truth-synthetic-self-audit-claim-kinds-2026-07-03.md`:
+  planner/shell independence, never trust untrusted text — the control loop trusts only its own
+  bot marker (R15).
+- `docs/solutions/best-practices/credential-mint-time-permission-scoping-2026-06-22.md`: mint the
+  write token in the job that writes, scoped at mint time (R14).
+- `docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md`: enumerate every
+  public surface for identity leaks (R12/R13).
+- `docs/solutions/best-practices/closed-vocabulary-telemetry-keys-from-public-bodies-2026-07-03.md`:
+  recover machine state from markers, not free text, against a closed vocabulary.
+- `docs/solutions/workflow-issues/jq-falsy-coalesce-trap-in-shell-gates-2026-05-17.md`: the
+  `issues.labeled` gate compares booleans/strings correctly (numeric-vs-boolean lesson).
+
+### Known constraints (memory)
+
+- Cross-repo `create-github-app-token` must pass `owner` (or explicit `repositories`) or it only
+  sees the calling repo (memory 4815). R14 mint passes `repositories:` = approved targets.
+- `createWorkflowDispatch` requires the target ref to exist and the workflow to have a
+  `workflow_dispatch` trigger — satisfied by `fro-bot.yaml`.
+- Commit identity: the control loop writes issue comments as the bot App identity; no repo commits
+  in this feature (dispatch + issue I/O only).
+
+## Key Technical Decisions
+
+- **Run correlation by unique token, not epoch-alone.** Epoch+actor+workflow filtering
+  false-matches a coincidental non-A3 `fro-bot.yaml` run in the target repo. Instead the control
+  loop passes a unique `correlation-id` (goal+item+nonce) as a `workflow_dispatch` input; the
+  target run echoes it into its run-name (via the existing workflow's `run-name:` or an early
+  step that sets it), and `runTrack` identifies the exact run by that id — epoch is only a
+  coarse pre-filter. This requires the target `fro-bot.yaml` to surface the correlation id in a
+  queryable field; if it cannot today, that is the one reviewed target-workflow addition v1
+  needs (a `run-name` suffix), scoped in Unit 5.
+- **Completion = run-conclusion-primary, bot-authored-PR refinement.** v1's hard terminal signal
+  is the worker run's conclusion (identified by correlation-id above). The item prompt embeds the
+  same opaque id and instructs the worker to reference it in any PR it opens; the tracker refines
+  run-success into merged/closed-unmerged **only for a PR authored by the bot/worker identity**
+  carrying the id — a third party forging a PR with the token cannot spoof completion (author
+  check required). A run that concludes success with no bot-authored tagged PR resolves to
+  no-op-success = `completed` (R9). PR-tag linkage is best-effort refinement, never the sole
+  terminal gate.
+- **Pure core / thin shells, four modules.** `scripts/cross-repo-dispatch.ts` hosts the pure
+  planner (decomposition parse, registry gate, fingerprint, terminal-state resolver, snapshot
+  decision) + two thin shells (`runDispatch` for the labeled event, `runTrack` for the snapshot).
+  Planner never does I/O; shells never re-derive policy. Mirrors the status-truth split.
+- **Bot-marker as the only state source.** All state (item set, fingerprint, per-item dispatch
+  status, terminal states) lives in a single bot-authored marker comment on the coordination
+  issue, read via the `selectLatestMarkerCommentBody` author-filter. User comments are inert
+  (R15). The marker schema is a closed-vocabulary JSON (item ids, targets, prompts-hash,
+  fingerprint, per-item status) — never free text.
+- **Fingerprint = hash of the bot decomposition marker at label time.** `runDispatch` computes
+  the current marker hash on the labeled event, stores it as the approval record in the state
+  marker, and re-reads+re-compares before each item dispatch (R5). Any edit (which, being a
+  human edit of the bot comment, changes the bytes) mismatches → halt + label removal.
+- **Two-phase dispatch persistence (intent → confirm).** A dispatch-then-persist-fail window
+  duplicates runs. So the shell writes an `intent` record (item id + correlation-id + nonce)
+  to the marker **before** `createWorkflowDispatch`, then flips it to `dispatched` (+ epoch)
+  after. On resume: an item in `dispatched` is skipped; an item in `intent` is reconciled by
+  querying the target repo for a run carrying its correlation-id — if found, flip to
+  `dispatched` (no re-dispatch); if not found within a grace window, it is safe to dispatch
+  under the same nonce. This closes the split-brain window (R7, AE9). Serial, bounded per run.
+- **Actor-bound labeled trigger, gated in workflow AND script.** A new
+  `cross-repo-dispatch.yaml` triggers on `issues.labeled`; a first job step gates on
+  `github.event.label.name == '<approve-label>'` AND `github.event.sender.login ==
+  'marcusrbrown'` (boolean-safe comparison), removing the label + exiting counted otherwise.
+  The mint step runs only AFTER that gate passes — a refused event never mints a cross-repo
+  token. Defense-in-depth: `runDispatch` re-reads `sender.login` from the event payload and
+  refuses before any dispatch, so a workflow misedit/misfire cannot bypass the actor bind (R4,
+  AE8).
+- **Least-privilege per-target mint.** The dispatch job mints an App token with
+  `repositories:` = the approved target set and the narrowest scope that permits
+  `createWorkflowDispatch` (`actions: write`), job-scoped (R14, AE10). No owner-wide mint.
+- **Same-target serialization.** Before dispatching an item, the planner checks all other open
+  goal markers for an in-flight (`intent`/`dispatched`, non-terminal) item targeting the same
+  repo; if found, the colliding item defers (counted), never concurrent (R15, AE13).
+- **Single-writer marker discipline (compare-and-swap).** The labeled dispatch job and the
+  scheduled track job both write the same marker → lost-update risk. Every marker write
+  re-reads the latest bot marker immediately before writing and aborts+retries on hash mismatch
+  (optimistic CAS on the marker's own hash, the field the idempotency gate already computes).
+  Bounded retries; a persistent mismatch defers to the next run rather than clobbering. This is
+  the concurrency guard for both shells sharing one marker.
+- **Bounded marker size.** The marker stores only latest per-item state (status, epoch,
+  correlation-id) — never history; superseded epochs are overwritten, not appended. A hard
+  item-count cap per goal (checked at decomposition parse, Unit 1) keeps the serialized marker
+  well under GitHub's 65536-char comment limit; goals exceeding the cap are rejected at parse
+  with a comment asking the operator to split the goal.
+- **Owner-only registry gate, fail-closed.** Reuse `accessPrivateForStorage`/`entry.private`
+  semantics: a target dispatches only if it's in `repos.yaml`, `has_fro_bot_workflow: true`,
+  owner ∈ {`fro-bot`, `marcusrbrown`}, and definitively public; else `blocked`, counted (R6, AE4).
+  Re-checked at dispatch time (privacy-flip safety). `has_fro_bot_workflow: false` is a
+  first-class `blocked` reason distinct from a policy block, so the checklist tells the operator
+  "target not onboarded" vs "target ineligible" — several owner repos currently carry
+  `has_fro_bot_workflow: false` and must surface as an actionable rollout gap, not a silent drop.
+- **Reopen recovery forces a fresh label event.** Recovery (F5/R10b) needs an `issues.labeled`
+  event, but a reopened issue may still carry the approve label (no new event fires). The
+  control-plane workflow adds an `issues.reopened` handler that removes the approve label and
+  clears the approval record from the marker, so the operator's re-apply is guaranteed to emit a fresh
+  `labeled` event under a new fingerprint. A closed issue's label is inert until reopened.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Target `fro-bot.yaml` accepts a `prompt` `workflow_dispatch` input today → no agent-surface
+  change for owner repos except possibly a `run-name` suffix to surface the correlation-id.
+- Run correlation keys on a unique correlation-id echoed into the run-name (epoch is a
+  pre-filter only); PR linkage is a bot-authored-PR refinement, never a closure gate.
+- Marker/author-filter/hash-gate all reuse `rollout-tracker-snapshot.ts` primitives; every write
+  is compare-and-swap to serialize the two shells.
+- Track job needs `actions: read` + `pull-requests: read` on targets; dispatch job needs
+  `actions: write`; both minted after their gates.
+
+### Deferred to Implementation
+
+- Exact marker JSON field names, the correlation-id/nonce format, the item-count cap value, and
+  the approve/`cross-repo-goal` label strings (register in `.github/settings.yml`).
+- Result JSON shape for counts (mirror status-truth).
+- The precise `run-name` echo format if the target-workflow change is needed.
+
+## Implementation Units
+
+- [x] **Unit 1: Marker schema, decomposition parser, fingerprint — pure**
+
+**Goal:** The closed-vocabulary state marker and its parse/serialize/fingerprint core.
+
+**Requirements:** R2, R5, R12, R13, R15 (marker trust)
+
+**Dependencies:** None
+
+**Files:**
+- Create: `scripts/cross-repo-dispatch.ts`
+- Create: `scripts/cross-repo-dispatch.test.ts`
+
+**Approach:**
+- Define the marker: `<!-- cross-repo-dispatch:{json} -->` with a strict schema — goal id, items
+  (`{id, target, promptHash, status}`), approval fingerprint, per-item epochs. Reuse the
+  `MARKER_PREFIX` + `extractPreviousMarker` shape from `rollout-tracker-snapshot.ts`.
+- `parseDecomposition(commentBody)`: parse a planner-proposed checklist into items against the
+  closed vocabulary; unrecognized content → parse error (no items), never free-text passthrough.
+- `computeApprovalFingerprint(markerState)`: stable hash of the item set (targets + promptHash),
+  matching the rollout-tracker hash discipline.
+- `selectStateMarker(comments)`: author-filtered latest bot marker (reject non-bot authors incl.
+  `marcusrbrown`).
+- Privacy: item targets/prompts are owner-repo-only by construction; the marker carries no
+  private identifiers (nothing private can be a target, R6).
+
+**Test scenarios:** marker round-trip; author-filter rejects a spoofed non-bot marker (AE11);
+fingerprint stable under reorder-invariance decision (pin: order-sensitive or -insensitive —
+choose order-insensitive so cosmetic reordering doesn't invalidate approval); parse error on
+malformed checklist; no free text enters item fields.
+
+**Verification:** `pnpm vitest run scripts/cross-repo-dispatch.test.ts` green; pure (no octokit).
+
+- [x] **Unit 2: Planner — registry gate, terminal-state resolver, snapshot decision — pure**
+
+**Goal:** All dispatch/track policy as pure functions over marker state + inputs.
+
+**Requirements:** R6, R9, R10, R10b, R11, R15 (serialization)
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `scripts/cross-repo-dispatch.ts`, `scripts/cross-repo-dispatch.test.ts`
+
+**Approach:**
+- `gateTarget(entry)`: owner ∈ {fro-bot, marcusrbrown} AND `has_fro_bot_workflow` AND
+  definitively-public (reuse `accessPrivateForStorage`/`entry.private`); else `blocked`.
+- `resolveItemTerminalState({runConclusion, prs})`: the R9 precedence table
+  (gate-block > run-failure > PR-outcome > run-success), returning exactly one of
+  `blocked|failed|completed|dispatched`.
+- `planDispatch({markerState, fingerprint, otherOpenGoals})`: which items to dispatch now
+  (skip already-dispatched under fingerprint; defer same-target collisions), which are blocked.
+- `planSnapshot({markerState, signals})`: updated marker + whether all terminal (→ close) +
+  idempotency (no change → no write).
+
+**Test scenarios:** owner/non-owner/private/missing-workflow gating (AE4); every R9 precedence
+cell incl. no-op success=completed, multi-PR, closed-unmerged=failed; all-terminal → close;
+same-target collision defers (AE13); reopen-reapprove skips prior-completed (AE12); idempotent
+no-op snapshot (AE6).
+
+**Verification:** pure; full table coverage green.
+
+- [x] **Unit 3: Dispatch shell — actor/fingerprint gate, two-phase dispatch, CAS marker**
+
+**Goal:** `runDispatch()` executes an approved goal on the labeled event.
+
+**Requirements:** R4, R5, R7, R8, R14, R15 (serialization + CAS)
+
+**Dependencies:** Units 1–2
+
+**Files:**
+- Modify: `scripts/cross-repo-dispatch.ts`, `scripts/cross-repo-dispatch.test.ts`
+
+**Approach:**
+- Read event: label name + `sender.login`; refuse (remove label, count) unless `marcusrbrown` +
+  approve label — script-side re-check independent of the workflow gate (R4).
+- Compute current marker fingerprint; store as approval record. For each planned item
+  (sequential): re-read+re-compare fingerprint (halt on mismatch); write `intent` (item id +
+  correlation-id + nonce) via CAS; `createWorkflowDispatch` ({owner, repo, workflow_id:
+  'fro-bot.yaml', ref: default branch, inputs:{prompt: itemPrompt, correlation_id}}); flip to
+  `dispatched`+epoch via CAS. On resume, reconcile `intent` items by correlation-id lookup
+  before any re-dispatch.
+- Every marker write is compare-and-swap on the marker hash (abort+retry on mismatch, bounded).
+- Item-prompt safety policy (R8): length cap, reject credential/secret patterns, owner-target
+  only; unparseable item → skip, counted.
+- Result JSON: counts only (proposed/approved/dispatched/blocked/deferred/refused).
+
+**Test scenarios:** non-operator label → script refuses even if workflow gate bypassed (AE8);
+happy 3-item sequential dispatch (AE2); edit-after-approval mid-loop → halt (AE3); intent
+written before dispatch, crash between intent and confirm → resume reconciles by correlation-id,
+no duplicate (AE9); crash after confirm → item skipped; blocked target dispatches the rest
+(AE4); token mint scoped to targets asserted via injected mint (AE10); CAS mismatch → retry then
+defer; no `issues.*` state write beyond the marker comment.
+
+**Verification:** octokit-mocked shell tests (dispatch call shapes, intent-then-confirm marker
+writes, CAS retry); counts-only result asserted leak-free.
+
+- [x] **Unit 4: Tracking shell — run correlation, PR-tag refinement, close-on-terminal**
+
+**Goal:** `runTrack()` snapshots dispatched goals to terminal and closes completed issues.
+
+**Requirements:** R9, R10, R10b, R11, R12, R13
+
+**Dependencies:** Units 1–2
+
+**Files:**
+- Modify: `scripts/cross-repo-dispatch.ts`, `scripts/cross-repo-dispatch.test.ts`
+
+**Approach:**
+- For each open goal marker: identify each dispatched item's run by its `correlation-id`
+  (epoch is a coarse pre-filter; the id in the run-name is the unique key — never
+  epoch+actor+workflow alone); fetch run conclusion; refine via a **bot-authored** PR carrying
+  the id (author check defeats forged-PR completion spoofing).
+- Feed signals to `resolveItemTerminalState`; write the updated marker via CAS + idempotency
+  hash gate; when all terminal, post counts-only summary + close (R10). Reopen handled by the
+  workflow's `issues.reopened` step (clears approval), not here.
+- Token scope: the track job needs `actions: read` (list target runs) + `pull-requests: read`
+  (PR author/state) on the target repos, plus `issues: write` on this repo — minted accordingly.
+- Privacy: summary + marker counts-only; no target names beyond what the public issue already
+  shows; no private identifiers (structurally impossible — owner-only targets).
+
+**Test scenarios:** correct run picked by correlation-id when a coincidental run shares the
+epoch window; run-success-no-PR → completed; run-success + bot-merged PR → completed;
+forged non-bot PR with the id → ignored (no false completion); run-success + closed-unmerged →
+failed; run-failure → failed; partial → issue stays open; all terminal → close + summary (AE6);
+idempotent re-run no-op; CAS mismatch vs the dispatch job → retry/defer; counts-only leak check
+(AE7).
+
+**Verification:** octokit-mocked; terminal precedence + correlation-id disambiguation asserted.
+
+- [x] **Unit 5: Planner wiring + decomposition contract**
+
+**Goal:** The mention-triggered agent, on a `cross-repo-goal` issue, emits a valid decomposition marker
+and never dispatches.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** Units 1–2
+
+**Files:**
+- Modify: `.github/workflows/fro-bot.yaml` (planner-context wiring only)
+- Modify: persona/context assets as needed for the decomposition prompt
+
+**Approach:**
+- When the triggering issue carries the `cross-repo-goal` label, inject guidance so the agent reads the
+  goal + managed-repo registry and posts a decomposition comment in the exact marker schema from
+  Unit 1 (per-repo items, owner targets only). The planner run gets no new trigger, no new
+  permission, no dispatch capability (R1); its output is a proposal the operator edits/approves (R3).
+- The decomposition must be parseable by Unit 1's `parseDecomposition`; malformed output is a
+  planning-quality issue the operator catches at review (nothing dispatches unapproved).
+
+**Test scenarios:** none executable (prompt/context wiring) — validated by the rehearsal in
+Unit 6 and by Unit 1's parser accepting a representative decomposition fixture.
+
+**Verification:** a sample decomposition round-trips through `parseDecomposition`; no dispatch
+path exists in the planner run.
+
+- [x] **Unit 6: Control-plane workflows + labels**
+
+**Goal:** Wire the event surfaces, the approve label, and least-privilege mints.
+
+**Requirements:** R4, R10b, R11, R14
+
+**Dependencies:** Units 3–5
+
+**Files:**
+- Create: `.github/workflows/cross-repo-dispatch.yaml`
+- Modify: `.github/settings.yml` (register the `cross-repo-goal` + approve labels)
+- Modify (if correlation needs it): target `fro-bot.yaml` `run-name` to surface `correlation_id`
+
+**Approach:**
+- `dispatch` job on `issues.labeled`: actor+label gate step (boolean-safe, fail-closed, remove
+  label on refusal) → **only then** mint a token scoped `repositories:` = approved targets with
+  `actions: write` → `node scripts/cross-repo-dispatch.ts dispatch` → counts-only summary.
+- `reopen` job on `issues.reopened`: remove the approve label + clear the approval record so
+  recovery re-fires a fresh `labeled` event (R10b).
+- `track` job on `schedule` + `workflow_dispatch`: mint a token with `actions: read` +
+  `pull-requests: read` on target repos and `issues: write` on this repo → `runTrack` → counts-
+  only summary.
+- `settings.yml`: add the goal + approve labels (byte-exact strings the workflow gates on).
+- If `fro-bot.yaml` cannot surface `correlation_id` in a queryable field today, add a minimal
+  reviewed `run-name` suffix echoing the dispatch input — the one target-workflow change v1 may
+  need (KTD).
+
+**Test scenarios:** none (YAML) — verified by `Check Workflows` actionlint, eslint yml rules,
+pinned-SHA parity, and the post-merge rehearsal.
+
+**Verification:** YAML parses; eslint clean; action SHAs byte-identical; actor/label gate uses
+boolean-safe comparisons; mint steps sit after their gates.
+
+- [x] **Unit 7: Operator documentation**
+
+**Goal:** Document the goal → approve → track lifecycle and its bounds.
+
+**Requirements:** R4, R6, R12 (documented boundaries)
+
+**Dependencies:** Units 1–6
+
+**Files:**
+- Modify: `README.md` (or `metadata/README.md` — wherever automation lifecycle is documented)
+
+**Approach:**
+- Document: how to open a goal issue, what the decomposition looks like, that only an
+  operator-applied approve label dispatches, owner-repos-only, how items reach terminal state, and
+  that closure is machine-derived. No plan/unit/R-number references.
+
+**Verification:** markdown lint; a reader can run one goal end to end from the doc.
+
+## System-Wide Impact
+
+- **Interaction graph:** new edges — goal issue → planner run (existing agent surface) →
+  decomposition marker → labeled event → dispatch loop → target `fro-bot.yaml` runs → tracker
+  snapshot → issue close. No existing loop is modified; `fro-bot.yaml` gains only planner-context
+  wiring (no trigger/permission change).
+- **Error propagation:** every refusal/blocked/deferred path is counted and non-fatal; the
+  dispatch job cannot corrupt existing workflows (separate workflow). A worker run failure is an
+  item terminal state, never a control-loop failure.
+- **State lifecycle:** state lives only in the bot marker; idempotent snapshots prevent churn;
+  reopen-before-reapprove prevents closed-issue self-dispatch.
+- **Unchanged invariants:** `main` protection, data-branch model (untouched — A3 does no repo
+  commits), agent authority, privacy perimeter (owner-only targets make private leakage
+  structurally impossible), counts-only telemetry.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Cross-repo dispatch token over-broad | Per-target `repositories:` mint, narrowest scope, job-scoped, minted only after the actor gate (R14). |
+| Label spoofing / self-approval | Actor-bound gate in BOTH workflow and script (`sender.login == marcusrbrown`), fail-closed label removal (R4). |
+| Prompt injection via public issue | Human approval + bot-marker-only trust + item-prompt policy + owner-only targets (R8/R15/R6). |
+| Duplicate worker runs on crash | Two-phase intent→confirm persistence + correlation-id reconciliation on resume (R7). |
+| Wrong-run correlation (coincidental run) | Unique correlation-id in dispatch inputs echoed to run-name; epoch is only a pre-filter. |
+| Completion spoofing via forged PR | PR refinement requires a bot-authored PR carrying the id; run-conclusion is the hard gate. |
+| Concurrent marker writers (dispatch vs track) | Compare-and-swap on the marker hash, bounded retry, defer on persistent mismatch. |
+| Marker exceeds comment size limit | Latest-state-only marker (no history) + hard item-count cap at parse. |
+| Concurrent same-target runs | Same-target serialization defers colliding items (R15). |
+| Privacy leak on public issue | Owner-only targets (no private repo can be a target) + counts-only telemetry (R6/R12/R13). |
+| App private-key compromise | Residual (accepted): per-target mint bounds a leaked *run token*, but the App key + id can mint full install scope regardless (memory 6271); key storage/rotation stays the real control — documented, not solved here. |
+
+## Documentation / Operational Notes
+
+- Rehearsal after merge: open a low-stakes goal (e.g. a trivial doc-touch across 2 owner repos),
+  let the planner decompose, approve, watch two worker runs dispatch and the issue track to
+  close. Confirm a non-operator label application is refused.
+
+## Sources & References
+
+- **Origin:** [docs/brainstorms/2026-07-04-a3-cross-repo-dispatch-requirements.md](../brainstorms/2026-07-04-a3-cross-repo-dispatch-requirements.md)
+- Reuse: `scripts/rollout-tracker-snapshot.ts`, `scripts/wiki-lint-issues.ts`,
+  `scripts/reconcile-repos.ts`, `scripts/handle-invitation.ts`, `scripts/schemas.ts`,
+  `.github/workflows/fro-bot.yaml`, `.github/workflows/status-truth.yaml`
+- Prior plans: [docs/plans/2026-07-03-001-feat-bounded-correction-pr-execution-plan.md](2026-07-03-001-feat-bounded-correction-pr-execution-plan.md),
+  [docs/plans/2026-07-03-002-feat-wiki-authority-repair-loop-plan.md](2026-07-03-002-feat-wiki-authority-repair-loop-plan.md)

--- a/scripts/cross-repo-dispatch.test.ts
+++ b/scripts/cross-repo-dispatch.test.ts
@@ -1,0 +1,1162 @@
+import type {
+  CrossRepoDispatchOctokitClient,
+  DispatchItem,
+  DispatchTarget,
+  GateEntry,
+  GoalState,
+  LabeledEventPayload,
+  OpenGoalIssue,
+  PrLookupResult,
+  TrackerComment,
+} from './cross-repo-dispatch.ts'
+import {describe, expect, it, vi} from 'vitest'
+
+import {
+  buildMarkerComment,
+  computeApprovalFingerprint,
+  extractMarker,
+  gateTarget,
+  MARKER_PREFIX,
+  MAX_ITEMS_PER_GOAL,
+  parseDecomposition,
+  planDispatch,
+  planSnapshot,
+  REQUIRED_APPROVER,
+  resolveItemTerminalState,
+  runDispatch,
+  runTrack,
+  selectStateMarker,
+  serializeMarker,
+} from './cross-repo-dispatch.ts'
+
+function makeItem(overrides: Partial<DispatchItem> = {}): DispatchItem {
+  return {
+    id: 'item-1',
+    target: {owner: 'fro-bot', name: 'agent'},
+    promptHash: 'abc123abc123abcd',
+    status: 'pending',
+    ...overrides,
+  }
+}
+
+function makeState(overrides: Partial<GoalState> = {}): GoalState {
+  return {
+    goal: 'goal-1',
+    items: [makeItem()],
+    markerHash: '',
+    ...overrides,
+  }
+}
+
+describe('marker round-trip', () => {
+  it('serializes and extracts the same state', () => {
+    const state = makeState()
+    const comment = buildMarkerComment(state)
+    expect(comment.startsWith(`<!-- ${MARKER_PREFIX}`)).toBe(true)
+    const extracted = extractMarker(comment)
+    expect(extracted).not.toBeNull()
+    expect(extracted?.state.goal).toBe('goal-1')
+    expect(extracted?.state.items).toHaveLength(1)
+  })
+
+  it('returns null for absent marker', () => {
+    expect(extractMarker('just a regular comment')).toBeNull()
+  })
+
+  it('returns null for malformed marker JSON', () => {
+    expect(extractMarker(`<!-- ${MARKER_PREFIX}{not json} -->`)).toBeNull()
+  })
+
+  it('takes the last marker when multiple are present', () => {
+    const first = serializeMarker(makeState({goal: 'first'}))
+    const second = serializeMarker(makeState({goal: 'second'}))
+    const body = `<!-- ${MARKER_PREFIX}${JSON.stringify(first)} -->\n<!-- ${MARKER_PREFIX}${JSON.stringify(second)} -->`
+    expect(extractMarker(body)?.state.goal).toBe('second')
+  })
+})
+
+describe('selectStateMarker author filter', () => {
+  it('accepts fro-bot and fro-bot[bot]', () => {
+    const state = makeState()
+    const body = buildMarkerComment(state)
+    for (const login of ['fro-bot', 'fro-bot[bot]']) {
+      const comments: TrackerComment[] = [{author: {login}, body}]
+      expect(selectStateMarker(comments)?.state.goal).toBe('goal-1')
+    }
+  })
+
+  it('rejects a spoofed marker from marcusrbrown', () => {
+    const state = makeState({goal: 'spoofed'})
+    const body = buildMarkerComment(state)
+    const comments: TrackerComment[] = [{author: {login: 'marcusrbrown'}, body}]
+    expect(selectStateMarker(comments)).toBeNull()
+  })
+
+  it('rejects any other non-bot author', () => {
+    const state = makeState({goal: 'spoofed'})
+    const body = buildMarkerComment(state)
+    const comments: TrackerComment[] = [{author: {login: 'random-user'}, body}]
+    expect(selectStateMarker(comments)).toBeNull()
+  })
+
+  it('picks the latest bot marker via findLast semantics', () => {
+    const older = buildMarkerComment(makeState({goal: 'older'}))
+    const newer = buildMarkerComment(makeState({goal: 'newer'}))
+    const comments: TrackerComment[] = [
+      {author: {login: 'fro-bot'}, body: older},
+      {author: {login: 'marcusrbrown'}, body: buildMarkerComment(makeState({goal: 'ignored'}))},
+      {author: {login: 'fro-bot[bot]'}, body: newer},
+    ]
+    expect(selectStateMarker(comments)?.state.goal).toBe('newer')
+  })
+})
+
+describe('parseDecomposition', () => {
+  it('parses a valid checklist', () => {
+    const result = parseDecomposition('- [ ] fro-bot/agent: do the thing\n- [x] marcusrbrown/dotfiles: fix the config')
+    expect(result.ok).toBe(true)
+    expect(result.items).toHaveLength(2)
+    expect(result.items[0]?.target).toEqual({owner: 'fro-bot', name: 'agent'})
+    expect(result.items[0]?.status).toBe('pending')
+  })
+
+  it('returns a parse error on malformed input, no items', () => {
+    const result = parseDecomposition('this is not a checklist line')
+    expect(result.ok).toBe(false)
+    expect(result.items).toHaveLength(0)
+    expect(result.error).toBeDefined()
+  })
+
+  it('returns a parse error on empty body', () => {
+    const result = parseDecomposition('')
+    expect(result.ok).toBe(false)
+    expect(result.items).toHaveLength(0)
+  })
+
+  it('rejects when item count exceeds the cap', () => {
+    const lines = Array.from({length: MAX_ITEMS_PER_GOAL + 1}, (_, i) => `- [ ] fro-bot/repo-${i}: do thing ${i}`)
+    const result = parseDecomposition(lines.join('\n'))
+    expect(result.ok).toBe(false)
+    expect(result.items).toHaveLength(0)
+  })
+
+  it('accepts exactly the cap', () => {
+    const lines = Array.from({length: MAX_ITEMS_PER_GOAL}, (_, i) => `- [ ] fro-bot/repo-${i}: do thing ${i}`)
+    const result = parseDecomposition(lines.join('\n'))
+    expect(result.ok).toBe(true)
+    expect(result.items).toHaveLength(MAX_ITEMS_PER_GOAL)
+  })
+
+  it('never lets free text into item fields on partial match failure', () => {
+    const result = parseDecomposition('- [ ] not-a-valid-target-format do the thing')
+    expect(result.ok).toBe(false)
+    expect(result.items).toHaveLength(0)
+  })
+})
+
+describe('computeApprovalFingerprint', () => {
+  it('is stable under reordering', () => {
+    const a = makeItem({id: 'a', target: {owner: 'fro-bot', name: 'agent'}, promptHash: 'hash-a'})
+    const b = makeItem({id: 'b', target: {owner: 'marcusrbrown', name: 'dotfiles'}, promptHash: 'hash-b'})
+    expect(computeApprovalFingerprint([a, b])).toBe(computeApprovalFingerprint([b, a]))
+  })
+
+  it('changes when an item is added', () => {
+    const a = makeItem({id: 'a', target: {owner: 'fro-bot', name: 'agent'}, promptHash: 'hash-a'})
+    const b = makeItem({id: 'b', target: {owner: 'marcusrbrown', name: 'dotfiles'}, promptHash: 'hash-b'})
+    expect(computeApprovalFingerprint([a])).not.toBe(computeApprovalFingerprint([a, b]))
+  })
+
+  it('changes when an item is removed', () => {
+    const a = makeItem({id: 'a', target: {owner: 'fro-bot', name: 'agent'}, promptHash: 'hash-a'})
+    const b = makeItem({id: 'b', target: {owner: 'marcusrbrown', name: 'dotfiles'}, promptHash: 'hash-b'})
+    expect(computeApprovalFingerprint([a, b])).not.toBe(computeApprovalFingerprint([b]))
+  })
+
+  it('is unaffected by cosmetic id changes but changes on target/promptHash change', () => {
+    const a = makeItem({id: 'a', target: {owner: 'fro-bot', name: 'agent'}, promptHash: 'hash-a'})
+    const aRenamed = makeItem({id: 'z', target: {owner: 'fro-bot', name: 'agent'}, promptHash: 'hash-a'})
+    expect(computeApprovalFingerprint([a])).toBe(computeApprovalFingerprint([aRenamed]))
+  })
+})
+
+describe('gateTarget', () => {
+  const base: GateEntry = {owner: 'fro-bot', name: 'agent', has_fro_bot_workflow: true, private: false}
+
+  it('allows an owner repo with the workflow and definitively public', () => {
+    expect(gateTarget(base)).toBe('ok')
+  })
+
+  it('allows marcusrbrown-owned repos too', () => {
+    expect(gateTarget({...base, owner: 'marcusrbrown'})).toBe('ok')
+  })
+
+  it('blocks a non-owner repo as ineligible', () => {
+    expect(gateTarget({...base, owner: 'some-other-org'})).toBe('blocked-ineligible')
+  })
+
+  it('blocks a private repo as ineligible', () => {
+    expect(gateTarget({...base, private: true})).toBe('blocked-ineligible')
+  })
+
+  it('blocks an indeterminate-privacy repo (private undefined) as ineligible, fail-closed', () => {
+    expect(gateTarget({...base, private: undefined})).toBe('blocked-ineligible')
+  })
+
+  it('blocks missing has_fro_bot_workflow as not-onboarded', () => {
+    expect(gateTarget({...base, has_fro_bot_workflow: false})).toBe('blocked-not-onboarded')
+  })
+
+  it('blocks a missing registry entry as ineligible', () => {
+    expect(gateTarget(undefined)).toBe('blocked-ineligible')
+  })
+})
+
+describe('resolveItemTerminalState — precedence table', () => {
+  it('gate-block takes precedence over everything', () => {
+    expect(resolveItemTerminalState({gateBlocked: true, runConclusion: 'success'})).toBe('blocked')
+  })
+
+  it('run failure resolves to failed', () => {
+    expect(resolveItemTerminalState({runConclusion: 'failure'})).toBe('failed')
+  })
+
+  it('no run conclusion yet resolves to dispatched (non-terminal)', () => {
+    expect(resolveItemTerminalState({})).toBe('dispatched')
+  })
+
+  it('success with no PR (no-op success) resolves to completed', () => {
+    expect(resolveItemTerminalState({runConclusion: 'success', prs: []})).toBe('completed')
+  })
+
+  it('success with one merged bot PR resolves to completed', () => {
+    expect(
+      resolveItemTerminalState({
+        runConclusion: 'success',
+        prs: [{merged: true, closed: true, authorIsBot: true}],
+      }),
+    ).toBe('completed')
+  })
+
+  it('success with only closed-unmerged bot PRs resolves to failed', () => {
+    expect(
+      resolveItemTerminalState({
+        runConclusion: 'success',
+        prs: [{merged: false, closed: true, authorIsBot: true}],
+      }),
+    ).toBe('failed')
+  })
+
+  it('success with a still-open bot PR resolves to dispatched (non-terminal)', () => {
+    expect(
+      resolveItemTerminalState({
+        runConclusion: 'success',
+        prs: [{merged: false, closed: false, authorIsBot: true}],
+      }),
+    ).toBe('dispatched')
+  })
+
+  it('multi-PR: terminal only when all are terminal, completed if any merged', () => {
+    expect(
+      resolveItemTerminalState({
+        runConclusion: 'success',
+        prs: [
+          {merged: false, closed: true, authorIsBot: true},
+          {merged: true, closed: true, authorIsBot: true},
+        ],
+      }),
+    ).toBe('completed')
+  })
+
+  it('multi-PR: all closed-unmerged resolves to failed', () => {
+    expect(
+      resolveItemTerminalState({
+        runConclusion: 'success',
+        prs: [
+          {merged: false, closed: true, authorIsBot: true},
+          {merged: false, closed: true, authorIsBot: true},
+        ],
+      }),
+    ).toBe('failed')
+  })
+
+  it('a forged non-bot PR is ignored — no-op success completes', () => {
+    expect(
+      resolveItemTerminalState({
+        runConclusion: 'success',
+        prs: [{merged: true, closed: true, authorIsBot: false}],
+      }),
+    ).toBe('completed')
+  })
+})
+
+describe('planDispatch', () => {
+  it('skips already-dispatched and terminal items', () => {
+    const state = makeState({
+      items: [
+        makeItem({id: 'a', status: 'dispatched'}),
+        makeItem({id: 'b', status: 'completed'}),
+        makeItem({id: 'c', status: 'pending'}),
+      ],
+    })
+    const result = planDispatch({state, fingerprint: 'fp', otherOpenGoalMarkers: []})
+    expect(result.toDispatch.map(i => i.id)).toEqual(['c'])
+    expect(result.toDispatchCount).toBe(1)
+  })
+
+  it('defers items whose target has an in-flight item in another open goal', () => {
+    const target = {owner: 'fro-bot', name: 'agent'}
+    const state = makeState({items: [makeItem({id: 'a', target, status: 'pending'})]})
+    const otherGoal = makeState({
+      goal: 'other',
+      items: [makeItem({id: 'x', target, status: 'dispatched'})],
+    })
+    const result = planDispatch({state, fingerprint: 'fp', otherOpenGoalMarkers: [otherGoal]})
+    expect(result.toDispatch).toHaveLength(0)
+    expect(result.deferred.map(i => i.id)).toEqual(['a'])
+    expect(result.deferredCount).toBe(1)
+  })
+
+  it('does not defer when other goal item for same target is already terminal', () => {
+    const target = {owner: 'fro-bot', name: 'agent'}
+    const state = makeState({items: [makeItem({id: 'a', target, status: 'pending'})]})
+    const otherGoal = makeState({
+      goal: 'other',
+      items: [makeItem({id: 'x', target, status: 'completed'})],
+    })
+    const result = planDispatch({state, fingerprint: 'fp', otherOpenGoalMarkers: [otherGoal]})
+    expect(result.toDispatch.map(i => i.id)).toEqual(['a'])
+  })
+
+  it('counts blocked items separately from dispatch/defer', () => {
+    const state = makeState({items: [makeItem({id: 'a', status: 'blocked'})]})
+    const result = planDispatch({state, fingerprint: 'fp', otherOpenGoalMarkers: []})
+    expect(result.blocked.map(i => i.id)).toEqual(['a'])
+    expect(result.blockedCount).toBe(1)
+    expect(result.toDispatch).toHaveLength(0)
+  })
+})
+
+describe('planSnapshot', () => {
+  it('applies terminal resolution per dispatched item and flags allTerminal', () => {
+    const state = makeState({items: [makeItem({id: 'a', status: 'dispatched'})], markerHash: 'old'})
+    const result = planSnapshot({state, signals: {a: {runConclusion: 'success', prs: []}}})
+    expect(result.state.items[0]?.status).toBe('completed')
+    expect(result.allTerminal).toBe(true)
+    expect(result.shouldWrite).toBe(true)
+  })
+
+  it('stays open when not all items are terminal', () => {
+    const state = makeState({
+      items: [makeItem({id: 'a', status: 'dispatched'}), makeItem({id: 'b', status: 'dispatched'})],
+      markerHash: 'old',
+    })
+    const result = planSnapshot({state, signals: {a: {runConclusion: 'success', prs: []}}})
+    expect(result.allTerminal).toBe(false)
+  })
+
+  it('is idempotent — identical resulting hash yields shouldWrite false', () => {
+    const item = makeItem({id: 'a', status: 'completed'})
+    const state = makeState({items: [item]})
+    const marker = serializeMarker(state)
+    const stateWithHash = {...state, markerHash: marker.hash}
+    const result = planSnapshot({state: stateWithHash, signals: {}})
+    expect(result.shouldWrite).toBe(false)
+  })
+})
+
+// ─── Shell tests ──────────────────────────────────────────────────────────────
+
+interface MockComment {
+  id: number
+  body: string
+  login: string
+}
+
+function mockOctokit(
+  overrides: {
+    comments?: MockComment[]
+    createComment?: ReturnType<typeof vi.fn>
+    updateComment?: ReturnType<typeof vi.fn>
+    createWorkflowDispatch?: ReturnType<typeof vi.fn>
+    removeLabel?: ReturnType<typeof vi.fn>
+    update?: ReturnType<typeof vi.fn>
+  } = {},
+): {octokit: CrossRepoDispatchOctokitClient; comments: MockComment[]} {
+  const comments = overrides.comments ?? []
+  let nextId = comments.length + 1
+
+  const createComment =
+    overrides.createComment ??
+    vi.fn(async (params: {owner: string; repo: string; issue_number: number; body: string}) => {
+      const comment = {id: nextId, body: params.body, login: 'fro-bot'}
+      nextId += 1
+      comments.push(comment)
+      return {data: {id: comment.id}}
+    })
+
+  const updateComment =
+    overrides.updateComment ??
+    vi.fn(async (params: {comment_id: number; body: string}) => {
+      const existing = comments.find(c => c.id === params.comment_id)
+      if (existing !== undefined) existing.body = params.body
+      return {}
+    })
+
+  const octokit: CrossRepoDispatchOctokitClient = {
+    rest: {
+      issues: {
+        listComments: async () => ({
+          data: comments.map(c => ({id: c.id, body: c.body, user: {login: c.login}})),
+        }),
+        createComment: createComment as CrossRepoDispatchOctokitClient['rest']['issues']['createComment'],
+        updateComment: updateComment as CrossRepoDispatchOctokitClient['rest']['issues']['updateComment'],
+        update: (overrides.update ??
+          vi.fn(async () => ({data: {}}))) as CrossRepoDispatchOctokitClient['rest']['issues']['update'],
+        removeLabel: (overrides.removeLabel ??
+          vi.fn(async () => ({}))) as CrossRepoDispatchOctokitClient['rest']['issues']['removeLabel'],
+      },
+      actions: {
+        createWorkflowDispatch: (overrides.createWorkflowDispatch ??
+          vi.fn(async () => ({}))) as CrossRepoDispatchOctokitClient['rest']['actions']['createWorkflowDispatch'],
+      },
+    },
+  }
+
+  return {octokit, comments}
+}
+
+function seedMarkerComment(comments: MockComment[], state: GoalState): void {
+  comments.push({id: comments.length + 1, body: buildMarkerComment(state), login: 'fro-bot'})
+}
+
+function makeDecompositionBody(items: {owner: string; name: string; prompt: string}[]): string {
+  return items.map(item => `- [ ] ${item.owner}/${item.name}: ${item.prompt}`).join('\n')
+}
+
+function makeLabeledEvent(overrides: Partial<LabeledEventPayload> = {}): LabeledEventPayload {
+  return {
+    label: {name: 'dispatch-approved'},
+    sender: {login: REQUIRED_APPROVER},
+    issue: {number: 42},
+    ...overrides,
+  }
+}
+
+const REPO = {owner: 'fro-bot', repo: '.github'}
+const TARGET_A = {owner: 'fro-bot', name: 'agent'}
+
+function gateEntryFor(target: DispatchTarget): GateEntry {
+  return {owner: target.owner, name: target.name, has_fro_bot_workflow: true, private: false}
+}
+
+describe('runDispatch — actor gate', () => {
+  it('refuses and removes the label when sender is not marcusrbrown, even if workflow gate bypassed', async () => {
+    const removeLabel = vi.fn(async () => ({}))
+    const {octokit} = mockOctokit({removeLabel})
+    const createWorkflowDispatch = vi.fn(async (_params: unknown) => ({}))
+
+    const result = await runDispatch({
+      octokit,
+      event: makeLabeledEvent({sender: {login: 'some-attacker'}}),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      loadRegistry: async () => [],
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async () => false,
+      createWorkflowDispatch: async params => {
+        await createWorkflowDispatch(params)
+      },
+      nonceSource: () => 'nonce-1',
+    })
+
+    expect(result.counts.refused).toBe(1)
+    expect(removeLabel).toHaveBeenCalledOnce()
+    expect(createWorkflowDispatch).not.toHaveBeenCalled()
+  })
+
+  it('refuses when the label name does not match approveLabel', async () => {
+    const {octokit} = mockOctokit()
+    const result = await runDispatch({
+      octokit,
+      event: makeLabeledEvent({label: {name: 'wrong-label'}}),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      loadRegistry: async () => [],
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async () => false,
+      createWorkflowDispatch: async () => undefined,
+      nonceSource: () => 'nonce-1',
+    })
+    expect(result.counts.refused).toBe(1)
+  })
+})
+
+describe('runDispatch — happy sequential dispatch', () => {
+  it('dispatches 3 items sequentially with the correct createWorkflowDispatch shape', async () => {
+    const targets = [
+      {owner: 'fro-bot', name: 'agent'},
+      {owner: 'fro-bot', name: 'wiki'},
+      {owner: 'marcusrbrown', name: 'dotfiles'},
+    ]
+    const decomposition = makeDecompositionBody(targets.map(t => ({...t, prompt: `do work in ${t.name}`})))
+    const items: DispatchItem[] = targets.map((target, index) => ({
+      id: `item-${index + 1}`,
+      target,
+      promptHash: extractPromptHash(decomposition, target),
+      status: 'pending',
+    }))
+    const state: GoalState = {goal: 'goal-1', items, markerHash: ''}
+
+    const {octokit, comments} = mockOctokit()
+    comments.push({id: 1, body: decomposition, login: 'marcusrbrown'})
+    seedMarkerComment(comments, state)
+
+    const createWorkflowDispatch = vi.fn(
+      async (_params: {
+        owner: string
+        repo: string
+        workflow_id: string
+        ref: string
+        inputs: {prompt: string; correlation_id: string}
+      }) => ({}),
+    )
+
+    const result = await runDispatch({
+      octokit,
+      event: makeLabeledEvent(),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      loadRegistry: async () => targets.map(t => gateEntryFor(t)),
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async () => false,
+      createWorkflowDispatch: async params => {
+        await createWorkflowDispatch(params)
+      },
+      nonceSource: (() => {
+        let n = 0
+        return () => `nonce-${++n}`
+      })(),
+    })
+
+    expect(result.counts.dispatched).toBe(3)
+    expect(createWorkflowDispatch).toHaveBeenCalledTimes(3)
+    for (const [index, target] of targets.entries()) {
+      const call = createWorkflowDispatch.mock.calls[index]?.[0]
+      expect(call?.owner).toBe(target.owner)
+      expect(call?.repo).toBe(target.name)
+      expect(call?.workflow_id).toBe('fro-bot.yaml')
+      expect(call?.ref).toBe('main')
+      expect(call?.inputs.prompt).toBe(`do work in ${target.name}`)
+    }
+  })
+})
+
+describe('runDispatch — marker comment upsert (no comment spam)', () => {
+  it('writes exactly one marker comment (created once) and updates it in place thereafter', async () => {
+    const targets = [
+      {owner: 'fro-bot', name: 'agent'},
+      {owner: 'fro-bot', name: 'wiki'},
+      {owner: 'marcusrbrown', name: 'dotfiles'},
+    ]
+    const decomposition = makeDecompositionBody(targets.map(t => ({...t, prompt: `do work in ${t.name}`})))
+    const items: DispatchItem[] = targets.map((target, index) => ({
+      id: `item-${index + 1}`,
+      target,
+      promptHash: extractPromptHash(decomposition, target),
+      status: 'pending',
+    }))
+    const state: GoalState = {goal: 'goal-1', items, markerHash: ''}
+
+    // Marker comment already exists (decomposition committed it) — the seeded
+    // comment id is the single marker comment every subsequent write targets.
+    const {octokit, comments} = mockOctokit()
+    comments.push({id: 1, body: decomposition, login: 'marcusrbrown'})
+    seedMarkerComment(comments, state)
+    const markerCommentId = comments.at(-1)?.id
+
+    const createComment = vi.fn(async (params: {owner: string; repo: string; issue_number: number; body: string}) => {
+      const comment = {id: comments.length + 1, body: params.body, login: 'fro-bot'}
+      comments.push(comment)
+      return {data: {id: comment.id}}
+    })
+    const updateComment = vi.fn(async (params: {comment_id: number; body: string}) => {
+      const existing = comments.find(c => c.id === params.comment_id)
+      if (existing !== undefined) existing.body = params.body
+      return {}
+    })
+
+    const result = await runDispatch({
+      octokit: {
+        ...octokit,
+        rest: {...octokit.rest, issues: {...octokit.rest.issues, createComment, updateComment}},
+      },
+      event: makeLabeledEvent(),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      loadRegistry: async () => targets.map(t => gateEntryFor(t)),
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async () => false,
+      createWorkflowDispatch: async () => undefined,
+      nonceSource: (() => {
+        let n = 0
+        return () => `nonce-${++n}`
+      })(),
+    })
+
+    expect(result.counts.dispatched).toBe(3)
+    // The marker comment already existed, so no new marker comment is ever created.
+    expect(createComment).not.toHaveBeenCalled()
+    // Every state transition (approval + intent/confirm x 3 items = 7 writes)
+    // updates that same comment in place instead of appending a new one.
+    expect(updateComment).toHaveBeenCalledTimes(7)
+    for (const call of updateComment.mock.calls) {
+      expect(call[0]?.comment_id).toBe(markerCommentId)
+    }
+    // Only the single seeded marker comment exists on the issue — no spam.
+    const markerComments = comments.filter(c => c.login === 'fro-bot' && extractMarker(c.body) !== null)
+    expect(markerComments).toHaveLength(1)
+  })
+
+  it('creates the marker comment once on cold start (approval write, no prior bot marker), then updates it', async () => {
+    const decomposition = '- [ ] fro-bot/agent: do the thing'
+    const item: DispatchItem = {
+      id: 'item-1',
+      target: TARGET_A,
+      promptHash: extractPromptHash(decomposition, TARGET_A),
+      status: 'pending',
+    }
+    // Seed only a bare marker with no approvalFingerprint yet, authored by the bot,
+    // so runDispatch's very first CAS write (the approval record) is a cold-start
+    // create against this single comment id, then all following writes update it.
+    const state: GoalState = {goal: 'goal-1', items: [item], markerHash: ''}
+
+    const {octokit, comments} = mockOctokit()
+    comments.push({id: 1, body: decomposition, login: 'marcusrbrown'})
+    seedMarkerComment(comments, state)
+    const seededCommentId = comments.at(-1)?.id
+
+    const createComment = vi.fn(async (params: {owner: string; repo: string; issue_number: number; body: string}) => {
+      const comment = {id: comments.length + 1, body: params.body, login: 'fro-bot'}
+      comments.push(comment)
+      return {data: {id: comment.id}}
+    })
+    const updateComment = vi.fn(async (params: {comment_id: number; body: string}) => {
+      const existing = comments.find(c => c.id === params.comment_id)
+      if (existing !== undefined) existing.body = params.body
+      return {}
+    })
+
+    const result = await runDispatch({
+      octokit: {
+        ...octokit,
+        rest: {...octokit.rest, issues: {...octokit.rest.issues, createComment, updateComment}},
+      },
+      event: makeLabeledEvent(),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async () => false,
+      createWorkflowDispatch: async () => undefined,
+      nonceSource: () => 'nonce-1',
+    })
+
+    expect(result.counts.dispatched).toBe(1)
+    // A single bot marker comment already existed, so every write (approval,
+    // intent, confirm) updates it in place — no createComment at all.
+    expect(createComment).not.toHaveBeenCalled()
+    expect(updateComment).toHaveBeenCalledTimes(3)
+    for (const call of updateComment.mock.calls) {
+      expect(call[0]?.comment_id).toBe(seededCommentId)
+    }
+  })
+})
+
+function extractPromptHash(decompositionBody: string, target: DispatchTarget): string {
+  const parsed = parseDecomposition(decompositionBody)
+  const found = parsed.items.find(item => item.target.owner === target.owner && item.target.name === target.name)
+  if (found === undefined) throw new Error('fixture error: target not found in decomposition')
+  return found.promptHash
+}
+
+describe('runDispatch — fingerprint halt on mid-loop edit', () => {
+  it('halts remaining dispatch when the marker fingerprint mismatches mid-loop', async () => {
+    const targets = [TARGET_A, {owner: 'fro-bot', name: 'wiki'}]
+    const decomposition = makeDecompositionBody(targets.map(t => ({...t, prompt: `work-${t.name}`})))
+    const items: DispatchItem[] = targets.map((target, index) => ({
+      id: `item-${index + 1}`,
+      target,
+      promptHash: extractPromptHash(decomposition, target),
+      status: 'pending',
+    }))
+    const state: GoalState = {goal: 'goal-1', items, markerHash: ''}
+
+    const {octokit, comments} = mockOctokit()
+    comments.push({id: 1, body: decomposition, login: 'marcusrbrown'})
+    seedMarkerComment(comments, state)
+
+    // Simulate a human edit landing mid-loop: after item-1's own three marker
+    // writes (approval + intent + confirm) land, inject an edited marker with
+    // a different fingerprint before item-2's pre-check read. The marker
+    // comment already exists (seeded), so all three writes are in-place
+    // updates, not new comments.
+    let writeCount = 0
+    const baseUpdateComment = vi.fn(async (params: {comment_id: number; body: string}) => {
+      const existing = comments.find(c => c.id === params.comment_id)
+      if (existing !== undefined) existing.body = params.body
+      writeCount += 1
+      if (writeCount === 3) {
+        const editedState: GoalState = {
+          goal: 'goal-1',
+          items: [...items, {id: 'item-3', target: TARGET_A, promptHash: 'zzzz000011112222', status: 'pending'}],
+          markerHash: '',
+        }
+        comments.push({id: comments.length + 1, body: buildMarkerComment(editedState), login: 'fro-bot'})
+      }
+      return {}
+    })
+
+    const createWorkflowDispatch = vi.fn(async (_params: unknown) => ({}))
+
+    const result = await runDispatch({
+      octokit: {
+        ...octokit,
+        rest: {...octokit.rest, issues: {...octokit.rest.issues, updateComment: baseUpdateComment}},
+      },
+      event: makeLabeledEvent(),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      loadRegistry: async () => targets.map(t => gateEntryFor(t)),
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async () => false,
+      createWorkflowDispatch: async params => {
+        await createWorkflowDispatch(params)
+      },
+      nonceSource: (() => {
+        let n = 0
+        return () => `nonce-${++n}`
+      })(),
+    })
+
+    expect(result.counts.dispatched).toBe(1)
+    expect(createWorkflowDispatch).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('runDispatch — blocked target dispatches the rest', () => {
+  it('skips a blocked target and dispatches the eligible one', async () => {
+    const blockedTarget = {owner: 'some-other-org', name: 'private-thing'}
+    const okTarget = TARGET_A
+    const decomposition = makeDecompositionBody([
+      {...blockedTarget, prompt: 'blocked work'},
+      {...okTarget, prompt: 'ok work'},
+    ])
+    const items: DispatchItem[] = [
+      {
+        id: 'item-1',
+        target: blockedTarget,
+        promptHash: extractPromptHash(decomposition, blockedTarget),
+        status: 'pending',
+      },
+      {id: 'item-2', target: okTarget, promptHash: extractPromptHash(decomposition, okTarget), status: 'pending'},
+    ]
+    const state: GoalState = {goal: 'goal-1', items, markerHash: ''}
+
+    const {octokit, comments} = mockOctokit()
+    comments.push({id: 1, body: decomposition, login: 'marcusrbrown'})
+    seedMarkerComment(comments, state)
+
+    const createWorkflowDispatch = vi.fn(async (_params: unknown) => ({}))
+
+    const result = await runDispatch({
+      octokit,
+      event: makeLabeledEvent(),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      // blockedTarget is absent from the registry → blocked-ineligible.
+      loadRegistry: async () => [gateEntryFor(okTarget)],
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async () => false,
+      createWorkflowDispatch: async params => {
+        await createWorkflowDispatch(params)
+      },
+      nonceSource: () => 'nonce-1',
+    })
+
+    expect(result.counts.dispatched).toBe(1)
+    expect(result.counts.blocked).toBe(1)
+    expect(createWorkflowDispatch).toHaveBeenCalledOnce()
+    expect(createWorkflowDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({owner: okTarget.owner, repo: okTarget.name}),
+    )
+  })
+})
+
+describe('runDispatch — resume reconciliation by correlation-id', () => {
+  it('reconciles an intent item by correlation-id lookup without re-dispatching', async () => {
+    const item: DispatchItem = {
+      id: 'item-1',
+      target: TARGET_A,
+      promptHash: 'abcd1234abcd1234',
+      status: 'intent',
+      correlationId: 'corr-existing-1',
+      nonce: 'nonce-1',
+    }
+    const state: GoalState = {
+      goal: 'goal-1',
+      items: [item],
+      approvalFingerprint: computeApprovalFingerprint([item]),
+      markerHash: '',
+    }
+    const decomposition = '- [ ] fro-bot/agent: do the thing'
+
+    const {octokit, comments} = mockOctokit()
+    comments.push({id: 1, body: decomposition, login: 'marcusrbrown'})
+    seedMarkerComment(comments, state)
+
+    const createWorkflowDispatch = vi.fn(async (_params: unknown) => ({}))
+    const findRunByCorrelationId = vi.fn(async (_target: DispatchTarget, _correlationId: string) => true)
+
+    const result = await runDispatch({
+      octokit,
+      event: makeLabeledEvent(),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async (target, correlationId) => findRunByCorrelationId(target, correlationId),
+      createWorkflowDispatch: async params => {
+        await createWorkflowDispatch(params)
+      },
+      nonceSource: () => 'nonce-2',
+    })
+
+    expect(findRunByCorrelationId).toHaveBeenCalledWith(TARGET_A, 'corr-existing-1')
+    expect(createWorkflowDispatch).not.toHaveBeenCalled()
+    expect(result.counts.reconciled).toBe(1)
+  })
+})
+
+describe('runDispatch — CAS mismatch defers', () => {
+  it('defers when the marker changes underneath a concurrent write, after bounded retries', async () => {
+    const decomposition = '- [ ] fro-bot/agent: do the thing'
+    const item: DispatchItem = {
+      id: 'item-1',
+      target: TARGET_A,
+      promptHash: extractPromptHash(decomposition, TARGET_A),
+      status: 'pending',
+    }
+    const fingerprint = computeApprovalFingerprint([item])
+    const state: GoalState = {goal: 'goal-1', items: [item], approvalFingerprint: fingerprint, markerHash: ''}
+
+    const {octokit, comments} = mockOctokit()
+    comments.push({id: 1, body: decomposition, login: 'marcusrbrown'})
+    seedMarkerComment(comments, state)
+
+    // Every read returns a marker with a freshly rotated (unpredictable) hash,
+    // so the CAS write's expected-prior-hash never matches — simulating a
+    // marker that keeps changing underneath a concurrent writer.
+    let spin = 0
+    const rotatingListComments = async () => {
+      spin += 1
+      const spinning: GoalState = {
+        goal: 'goal-1',
+        items: [{...item, nonce: `spin-${spin}`}],
+        approvalFingerprint: fingerprint,
+        markerHash: '',
+      }
+      return {
+        data: [
+          {id: 1, body: decomposition, user: {login: 'marcusrbrown'}},
+          {id: 2, body: buildMarkerComment(spinning), user: {login: 'fro-bot'}},
+        ],
+      }
+    }
+
+    const result = await runDispatch({
+      octokit: {
+        ...octokit,
+        rest: {...octokit.rest, issues: {...octokit.rest.issues, listComments: rotatingListComments}},
+      },
+      event: makeLabeledEvent(),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async () => false,
+      createWorkflowDispatch: async () => undefined,
+      nonceSource: () => 'nonce-1',
+    })
+
+    expect(result.counts.casDeferred).toBeGreaterThan(0)
+  })
+})
+
+function makeOpenGoal(state: GoalState): OpenGoalIssue {
+  const marker = serializeMarker(state)
+  return {issueNumber: 7, marker: {hash: marker.hash, state: marker.state}}
+}
+
+function mockOctokitForGoal(goalIssue: OpenGoalIssue, overrides: Parameters<typeof mockOctokit>[0] = {}) {
+  return mockOctokit({
+    ...overrides,
+    comments: [
+      {
+        id: 1,
+        body: buildMarkerComment({...goalIssue.marker.state, markerHash: goalIssue.marker.hash}),
+        login: 'fro-bot',
+      },
+      ...(overrides.comments ?? []),
+    ],
+  })
+}
+
+describe('runTrack — terminal precedence and closure', () => {
+  it('picks the correct run by correlation-id when a coincidental run shares the epoch window', async () => {
+    const item: DispatchItem = {
+      id: 'item-1',
+      target: TARGET_A,
+      promptHash: 'abcd1234abcd1234',
+      status: 'dispatched',
+      correlationId: 'corr-real',
+      epoch: 1000,
+    }
+    const state: GoalState = {goal: 'goal-1', items: [item], markerHash: ''}
+    const goalIssue = makeOpenGoal(state)
+
+    const findRunConclusion = vi.fn(async (_target: DispatchTarget, correlationId: string) =>
+      correlationId === 'corr-real' ? ('success' as const) : ('failure' as const),
+    )
+
+    const {octokit} = mockOctokitForGoal(goalIssue)
+    const result = await runTrack({
+      octokit,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalIssue],
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      findRunConclusion,
+      findBotAuthoredPrs: async () => [],
+    })
+
+    expect(findRunConclusion).toHaveBeenCalledWith(TARGET_A, 'corr-real')
+    expect(result.counts.itemsCompleted).toBe(1)
+    expect(result.counts.goalsClosed).toBe(1)
+  })
+
+  it('run-success with no PR resolves to completed', async () => {
+    const item: DispatchItem = {
+      id: 'item-1',
+      target: TARGET_A,
+      promptHash: 'h',
+      status: 'dispatched',
+      correlationId: 'c1',
+    }
+    const goalIssue = makeOpenGoal({goal: 'g', items: [item], markerHash: ''})
+    const {octokit} = mockOctokitForGoal(goalIssue)
+    const result = await runTrack({
+      octokit,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalIssue],
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      findRunConclusion: async () => 'success',
+      findBotAuthoredPrs: async () => [],
+    })
+    expect(result.counts.itemsCompleted).toBe(1)
+  })
+
+  it('run-success with a bot-merged PR resolves to completed', async () => {
+    const item: DispatchItem = {
+      id: 'item-1',
+      target: TARGET_A,
+      promptHash: 'h',
+      status: 'dispatched',
+      correlationId: 'c1',
+    }
+    const goalIssue = makeOpenGoal({goal: 'g', items: [item], markerHash: ''})
+    const {octokit} = mockOctokitForGoal(goalIssue)
+    const result = await runTrack({
+      octokit,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalIssue],
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      findRunConclusion: async () => 'success',
+      findBotAuthoredPrs: async (): Promise<PrLookupResult[]> => [{merged: true, closed: true, authorIsBot: true}],
+    })
+    expect(result.counts.itemsCompleted).toBe(1)
+  })
+
+  it('a forged non-bot PR is ignored — no false completion signal from it alone', async () => {
+    const item: DispatchItem = {
+      id: 'item-1',
+      target: TARGET_A,
+      promptHash: 'h',
+      status: 'dispatched',
+      correlationId: 'c1',
+    }
+    const goalIssue = makeOpenGoal({goal: 'g', items: [item], markerHash: ''})
+    const {octokit} = mockOctokitForGoal(goalIssue)
+    const result = await runTrack({
+      octokit,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalIssue],
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      findRunConclusion: async () => 'success',
+      findBotAuthoredPrs: async (): Promise<PrLookupResult[]> => [{merged: true, closed: true, authorIsBot: false}],
+    })
+    // Forged PR is filtered out entirely -> no bot PRs -> no-op success -> completed,
+    // but crucially NOT because the forged PR's merged=true was trusted.
+    expect(result.counts.itemsCompleted).toBe(1)
+  })
+
+  it('run-success with closed-unmerged PR resolves to failed', async () => {
+    const item: DispatchItem = {
+      id: 'item-1',
+      target: TARGET_A,
+      promptHash: 'h',
+      status: 'dispatched',
+      correlationId: 'c1',
+    }
+    const goalIssue = makeOpenGoal({goal: 'g', items: [item], markerHash: ''})
+    const {octokit} = mockOctokitForGoal(goalIssue)
+    const result = await runTrack({
+      octokit,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalIssue],
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      findRunConclusion: async () => 'success',
+      findBotAuthoredPrs: async (): Promise<PrLookupResult[]> => [{merged: false, closed: true, authorIsBot: true}],
+    })
+    expect(result.counts.itemsFailed).toBe(1)
+  })
+
+  it('run-failure resolves to failed', async () => {
+    const item: DispatchItem = {
+      id: 'item-1',
+      target: TARGET_A,
+      promptHash: 'h',
+      status: 'dispatched',
+      correlationId: 'c1',
+    }
+    const goalIssue = makeOpenGoal({goal: 'g', items: [item], markerHash: ''})
+    const {octokit} = mockOctokitForGoal(goalIssue)
+    const result = await runTrack({
+      octokit,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalIssue],
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      findRunConclusion: async () => 'failure',
+      findBotAuthoredPrs: async () => [],
+    })
+    expect(result.counts.itemsFailed).toBe(1)
+  })
+
+  it('partial completion keeps the issue open (not all terminal)', async () => {
+    const items: DispatchItem[] = [
+      {id: 'item-1', target: TARGET_A, promptHash: 'h1', status: 'dispatched', correlationId: 'c1'},
+      {
+        id: 'item-2',
+        target: {owner: 'fro-bot', name: 'wiki'},
+        promptHash: 'h2',
+        status: 'dispatched',
+        correlationId: 'c2',
+      },
+    ]
+    const goalIssue = makeOpenGoal({goal: 'g', items, markerHash: ''})
+    const {octokit} = mockOctokitForGoal(goalIssue)
+    const result = await runTrack({
+      octokit,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalIssue],
+      loadRegistry: async () => [gateEntryFor(TARGET_A), gateEntryFor({owner: 'fro-bot', name: 'wiki'})],
+      findRunConclusion: async (_target, correlationId) => (correlationId === 'c1' ? 'success' : undefined),
+      findBotAuthoredPrs: async () => [],
+    })
+    expect(result.counts.itemsCompleted).toBe(1)
+    expect(result.counts.goalsClosed).toBe(0)
+    expect(result.counts.itemsStillOpen).toBe(1)
+  })
+
+  it('all-terminal closes the issue and posts a counts-only summary', async () => {
+    const items: DispatchItem[] = [
+      {id: 'item-1', target: TARGET_A, promptHash: 'h1', status: 'dispatched', correlationId: 'c1'},
+      {
+        id: 'item-2',
+        target: {owner: 'fro-bot', name: 'wiki'},
+        promptHash: 'h2',
+        status: 'dispatched',
+        correlationId: 'c2',
+      },
+    ]
+    const goalIssue = makeOpenGoal({goal: 'g', items, markerHash: ''})
+    const createComment = vi.fn(async (_params: {body: string}) => ({data: {id: 1}}))
+    const updateComment = vi.fn(async (_params: {comment_id: number; body: string}) => ({}))
+    const update = vi.fn(async (_params: unknown) => ({data: {}}))
+    const {octokit} = mockOctokitForGoal(goalIssue, {createComment, updateComment, update})
+    const result = await runTrack({
+      octokit,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalIssue],
+      loadRegistry: async () => [gateEntryFor(TARGET_A), gateEntryFor({owner: 'fro-bot', name: 'wiki'})],
+      findRunConclusion: async () => 'success',
+      findBotAuthoredPrs: async () => [],
+    })
+    expect(result.counts.goalsClosed).toBe(1)
+    // The marker comment already exists (seeded) so its update is in-place;
+    // only the closing summary uses createComment (a distinct human-facing artifact).
+    expect(updateComment).toHaveBeenCalledOnce()
+    expect(createComment).toHaveBeenCalledOnce()
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({state: 'closed'}))
+    const summaryBody = createComment.mock.calls[0]?.[0]?.body as string
+    expect(summaryBody).not.toContain('fro-bot/agent')
+    expect(summaryBody).not.toContain('fro-bot/wiki')
+  })
+
+  it('is idempotent — no signal change yields no write and no comment', async () => {
+    const item: DispatchItem = {id: 'item-1', target: TARGET_A, promptHash: 'h', status: 'completed'}
+    const state: GoalState = {goal: 'g', items: [item], markerHash: ''}
+    const marker = serializeMarker(state)
+    const goalIssue: OpenGoalIssue = {issueNumber: 7, marker: {hash: marker.hash, state: marker.state}}
+
+    const createComment = vi.fn(async () => ({data: {id: 1}}))
+    const {octokit} = mockOctokit({createComment})
+    const result = await runTrack({
+      octokit,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalIssue],
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      findRunConclusion: async () => 'success',
+      findBotAuthoredPrs: async () => [],
+    })
+    expect(result.counts.idempotentNoop).toBe(1)
+    expect(createComment).not.toHaveBeenCalled()
+  })
+})
+
+describe('counts-only leak check', () => {
+  it('runDispatch result contains no repo names or prompt text', async () => {
+    const item: DispatchItem = {id: 'item-1', target: TARGET_A, promptHash: 'abcd1234abcd1234', status: 'pending'}
+    const state: GoalState = {goal: 'goal-1', items: [item], markerHash: ''}
+    const decomposition = '- [ ] fro-bot/agent: super secret prompt text'
+
+    const {octokit, comments} = mockOctokit()
+    comments.push({id: 1, body: decomposition, login: 'marcusrbrown'})
+    seedMarkerComment(comments, state)
+
+    const result = await runDispatch({
+      octokit,
+      event: makeLabeledEvent(),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async () => false,
+      createWorkflowDispatch: async () => undefined,
+      nonceSource: () => 'nonce-1',
+    })
+
+    const serialized = JSON.stringify(result.counts)
+    expect(serialized).not.toContain('agent')
+    expect(serialized).not.toContain('secret')
+  })
+})

--- a/scripts/cross-repo-dispatch.test.ts
+++ b/scripts/cross-repo-dispatch.test.ts
@@ -9,13 +9,20 @@ import type {
   PrLookupResult,
   TrackerComment,
 } from './cross-repo-dispatch.ts'
+import process from 'node:process'
 import {describe, expect, it, vi} from 'vitest'
 
 import {
   buildMarkerComment,
   computeApprovalFingerprint,
+  CROSS_REPO_GOAL_LABEL,
   extractMarker,
+  findBotAuthoredPrs,
+  findRunByCorrelationId,
+  findRunConclusion,
   gateTarget,
+  loadOpenGoalIssues,
+  loadOtherOpenGoalMarkers,
   MARKER_PREFIX,
   MAX_ITEMS_PER_GOAL,
   parseDecomposition,
@@ -24,9 +31,12 @@ import {
   REQUIRED_APPROVER,
   resolveItemTerminalState,
   runDispatch,
+  runDispatchCli,
   runTrack,
+  runTrackCli,
   selectStateMarker,
   serializeMarker,
+  TARGET_WORKFLOW_ID,
 } from './cross-repo-dispatch.ts'
 
 function makeItem(overrides: Partial<DispatchItem> = {}): DispatchItem {
@@ -381,6 +391,9 @@ function mockOctokit(
     createWorkflowDispatch?: ReturnType<typeof vi.fn>
     removeLabel?: ReturnType<typeof vi.fn>
     update?: ReturnType<typeof vi.fn>
+    listForRepo?: ReturnType<typeof vi.fn>
+    listWorkflowRunsForRepo?: ReturnType<typeof vi.fn>
+    issuesAndPullRequests?: ReturnType<typeof vi.fn>
   } = {},
 ): {octokit: CrossRepoDispatchOctokitClient; comments: MockComment[]} {
   const comments = overrides.comments ?? []
@@ -415,10 +428,22 @@ function mockOctokit(
           vi.fn(async () => ({data: {}}))) as CrossRepoDispatchOctokitClient['rest']['issues']['update'],
         removeLabel: (overrides.removeLabel ??
           vi.fn(async () => ({}))) as CrossRepoDispatchOctokitClient['rest']['issues']['removeLabel'],
+        listForRepo: (overrides.listForRepo ??
+          vi.fn(async () => ({data: []}))) as CrossRepoDispatchOctokitClient['rest']['issues']['listForRepo'],
       },
       actions: {
         createWorkflowDispatch: (overrides.createWorkflowDispatch ??
           vi.fn(async () => ({}))) as CrossRepoDispatchOctokitClient['rest']['actions']['createWorkflowDispatch'],
+        listWorkflowRunsForRepo: (overrides.listWorkflowRunsForRepo ??
+          vi.fn(async () => ({
+            data: {workflow_runs: []},
+          }))) as CrossRepoDispatchOctokitClient['rest']['actions']['listWorkflowRunsForRepo'],
+      },
+      search: {
+        issuesAndPullRequests: (overrides.issuesAndPullRequests ??
+          vi.fn(async () => ({
+            data: {items: []},
+          }))) as CrossRepoDispatchOctokitClient['rest']['search']['issuesAndPullRequests'],
       },
     },
   }
@@ -1158,5 +1183,198 @@ describe('counts-only leak check', () => {
     const serialized = JSON.stringify(result.counts)
     expect(serialized).not.toContain('agent')
     expect(serialized).not.toContain('secret')
+  })
+})
+
+// ─── Production collaborator tests ─────────────────────────────────────────────
+
+describe('findRunByCorrelationId / findRunConclusion', () => {
+  it('matches a run whose display_title contains the correlation id, ignoring a coincidental non-matching run', async () => {
+    const listWorkflowRunsForRepo = vi.fn(async () => ({
+      data: {
+        workflow_runs: [
+          {id: 1, display_title: 'Fro Bot (unrelated-id)', status: 'completed', conclusion: 'success'},
+          {id: 2, display_title: 'Fro Bot (corr-real)', status: 'completed', conclusion: 'success'},
+        ],
+      },
+    }))
+    const {octokit} = mockOctokit({listWorkflowRunsForRepo})
+
+    const found = await findRunByCorrelationId(octokit)(TARGET_A, 'corr-real')
+    expect(found).toBe(true)
+    expect(listWorkflowRunsForRepo).toHaveBeenCalledWith(
+      expect.objectContaining({owner: TARGET_A.owner, repo: TARGET_A.name, workflow_id: TARGET_WORKFLOW_ID}),
+    )
+  })
+
+  it('returns false when no run matches the correlation id', async () => {
+    const listWorkflowRunsForRepo = vi.fn(async () => ({
+      data: {workflow_runs: [{id: 1, display_title: 'Fro Bot (other-id)', status: 'completed', conclusion: 'success'}]},
+    }))
+    const {octokit} = mockOctokit({listWorkflowRunsForRepo})
+    expect(await findRunByCorrelationId(octokit)('corr-missing' as unknown as DispatchTarget, 'corr-missing')).toBe(
+      false,
+    )
+  })
+
+  it('findRunConclusion returns undefined while the matched run is not yet completed', async () => {
+    const listWorkflowRunsForRepo = vi.fn(async () => ({
+      data: {workflow_runs: [{id: 1, display_title: 'Fro Bot (corr-1)', status: 'in_progress', conclusion: null}]},
+    }))
+    const {octokit} = mockOctokit({listWorkflowRunsForRepo})
+    expect(await findRunConclusion(octokit)(TARGET_A, 'corr-1')).toBeUndefined()
+  })
+
+  it('findRunConclusion extracts conclusion once the run has completed', async () => {
+    const listWorkflowRunsForRepo = vi.fn(async () => ({
+      data: {workflow_runs: [{id: 1, display_title: 'Fro Bot (corr-1)', status: 'completed', conclusion: 'failure'}]},
+    }))
+    const {octokit} = mockOctokit({listWorkflowRunsForRepo})
+    expect(await findRunConclusion(octokit)(TARGET_A, 'corr-1')).toBe('failure')
+  })
+})
+
+describe('loadOpenGoalIssues', () => {
+  it('enumerates open cross-repo-goal issues and resolves each marker', async () => {
+    const state = makeState({goal: 'goal-a'})
+    const listForRepo = vi.fn(async () => ({data: [{number: 10}]}))
+    const listComments = vi.fn(async () => ({
+      data: [{id: 1, body: buildMarkerComment(state), user: {login: 'fro-bot'}}],
+    }))
+    const {octokit} = mockOctokit({listForRepo})
+    const patched = {...octokit, rest: {...octokit.rest, issues: {...octokit.rest.issues, listComments}}}
+
+    const result = await loadOpenGoalIssues(patched, REPO)
+    expect(listForRepo).toHaveBeenCalledWith(
+      expect.objectContaining({owner: REPO.owner, repo: REPO.repo, labels: CROSS_REPO_GOAL_LABEL, state: 'open'}),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.issueNumber).toBe(10)
+    expect(result[0]?.marker.state.goal).toBe('goal-a')
+  })
+
+  it('skips issues without a readable bot marker', async () => {
+    const listForRepo = vi.fn(async () => ({data: [{number: 11}]}))
+    const listComments = vi.fn(async () => ({data: [{id: 1, body: 'no marker here', user: {login: 'fro-bot'}}]}))
+    const {octokit} = mockOctokit({listForRepo})
+    const patched = {...octokit, rest: {...octokit.rest, issues: {...octokit.rest.issues, listComments}}}
+    expect(await loadOpenGoalIssues(patched, REPO)).toHaveLength(0)
+  })
+})
+
+describe('loadOtherOpenGoalMarkers', () => {
+  it('excludes the current issue and returns other open goal markers', async () => {
+    const stateOther = makeState({goal: 'goal-other'})
+    const listForRepo = vi.fn(async () => ({data: [{number: 42}, {number: 99}]}))
+    const listComments = vi.fn(async (params: {issue_number: number}) => ({
+      data:
+        params.issue_number === 99
+          ? [{id: 1, body: buildMarkerComment(stateOther), user: {login: 'fro-bot'}}]
+          : [{id: 2, body: buildMarkerComment(makeState({goal: 'current'})), user: {login: 'fro-bot'}}],
+    }))
+    const {octokit} = mockOctokit({listForRepo})
+    const patched = {octokit: {...octokit, rest: {...octokit.rest, issues: {...octokit.rest.issues, listComments}}}}
+
+    const result = await loadOtherOpenGoalMarkers(patched.octokit, REPO, 42)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.goal).toBe('goal-other')
+  })
+})
+
+describe('findBotAuthoredPrs — anti-spoof', () => {
+  it('includes a bot-authored PR carrying the correlation id', async () => {
+    const issuesAndPullRequests = vi.fn(async () => ({
+      data: {
+        items: [{number: 1, state: 'closed', user: {login: 'fro-bot'}, pull_request: {merged_at: '2026-01-01'}}],
+      },
+    }))
+    const {octokit} = mockOctokit({issuesAndPullRequests})
+    const result = await findBotAuthoredPrs(octokit)(TARGET_A, 'corr-1')
+    expect(issuesAndPullRequests).toHaveBeenCalledWith(
+      expect.objectContaining({q: expect.stringContaining('corr-1') as string}),
+    )
+    expect(result).toEqual([{merged: true, closed: true, authorIsBot: true}])
+  })
+
+  it('excludes a forged PR authored by a non-bot login carrying the same correlation id', async () => {
+    const issuesAndPullRequests = vi.fn(async () => ({
+      data: {
+        items: [
+          {number: 1, state: 'closed', user: {login: 'fro-bot'}, pull_request: {merged_at: '2026-01-01'}},
+          {number: 2, state: 'closed', user: {login: 'some-random-user'}, pull_request: {merged_at: '2026-01-01'}},
+        ],
+      },
+    }))
+    const {octokit} = mockOctokit({issuesAndPullRequests})
+    const result = await findBotAuthoredPrs(octokit)(TARGET_A, 'corr-1')
+    expect(result).toHaveLength(1)
+  })
+})
+
+describe('CLI wiring — real collaborators, not stubs', () => {
+  it('runTrackCli invokes octokit issue enumeration (wired loadOpenGoalIssues)', async () => {
+    const originalEnv = {...process.env}
+    process.env.GITHUB_TOKEN = 'test-token'
+    process.env.GITHUB_REPOSITORY = 'fro-bot/.github'
+    process.env.CROSS_REPO_DISPATCH_RESULT_PATH = ''
+    try {
+      const listForRepo = vi.fn(async () => ({data: []}))
+      const {octokit} = mockOctokit({listForRepo})
+      await runTrackCli(async () => octokit)
+      expect(listForRepo).toHaveBeenCalled()
+    } finally {
+      process.env = originalEnv
+    }
+  })
+
+  it('runDispatchCli wires a real findRunByCorrelationId consulted on an intent-resume path', async () => {
+    const originalEnv = {...process.env}
+    const {writeFile, mkdtemp} = await import('node:fs/promises')
+    const {tmpdir} = await import('node:os')
+    const path = await import('node:path')
+    const dir = await mkdtemp(path.join(tmpdir(), 'cross-repo-dispatch-'))
+    const eventPath = path.join(dir, 'event.json')
+    await writeFile(
+      eventPath,
+      JSON.stringify({label: {name: 'dispatch-approved'}, sender: {login: REQUIRED_APPROVER}, issue: {number: 42}}),
+    )
+
+    process.env.GITHUB_TOKEN = 'test-token'
+    process.env.GITHUB_REPOSITORY = 'fro-bot/.github'
+    process.env.GITHUB_EVENT_PATH = eventPath
+    process.env.CROSS_REPO_DISPATCH_RESULT_PATH = ''
+    try {
+      const item: DispatchItem = {
+        id: 'item-1',
+        target: TARGET_A,
+        promptHash: 'abcd1234abcd1234',
+        status: 'intent',
+        correlationId: 'corr-resume-1',
+        nonce: 'nonce-1',
+      }
+      const state: GoalState = {
+        goal: 'goal-1',
+        items: [item],
+        approvalFingerprint: computeApprovalFingerprint([item]),
+        markerHash: '',
+      }
+      const decomposition = '- [ ] fro-bot/agent: do the thing'
+      const {octokit, comments} = mockOctokit()
+      comments.push({id: 1, body: decomposition, login: 'marcusrbrown'})
+      seedMarkerComment(comments, state)
+
+      const listWorkflowRunsForRepo = vi.fn(async () => ({data: {workflow_runs: []}}))
+      const patched = {
+        ...octokit,
+        rest: {...octokit.rest, actions: {...octokit.rest.actions, listWorkflowRunsForRepo}},
+      }
+
+      await runDispatchCli(async () => patched)
+      expect(listWorkflowRunsForRepo).toHaveBeenCalledWith(
+        expect.objectContaining({owner: TARGET_A.owner, repo: TARGET_A.name}),
+      )
+    } finally {
+      process.env = originalEnv
+    }
   })
 })

--- a/scripts/cross-repo-dispatch.ts
+++ b/scripts/cross-repo-dispatch.ts
@@ -476,6 +476,13 @@ export interface CrossRepoDispatchOctokitClient {
         issue_number: number
         name: string
       }) => Promise<unknown>
+      readonly listForRepo: (params: {
+        owner: string
+        repo: string
+        labels?: string
+        state?: 'open' | 'closed' | 'all'
+        per_page?: number
+      }) => Promise<{data: {number: number}[]}>
     }
     readonly actions: {
       readonly createWorkflowDispatch: (params: {
@@ -485,6 +492,34 @@ export interface CrossRepoDispatchOctokitClient {
         ref: string
         inputs?: Record<string, string>
       }) => Promise<unknown>
+      readonly listWorkflowRunsForRepo: (params: {
+        owner: string
+        repo: string
+        workflow_id: string
+        per_page?: number
+      }) => Promise<{
+        data: {
+          workflow_runs: {
+            id: number
+            name?: string | null
+            display_title?: string | null
+            status: string | null
+            conclusion: string | null
+          }[]
+        }
+      }>
+    }
+    readonly search: {
+      readonly issuesAndPullRequests: (params: {q: string; per_page?: number}) => Promise<{
+        data: {
+          items: {
+            number: number
+            state: string
+            user: {login: string} | null
+            pull_request?: {merged_at: string | null}
+          }[]
+        }
+      }>
     }
   }
 }
@@ -1041,6 +1076,137 @@ export async function runTrack(input: RunTrackInput): Promise<RunTrackResult> {
   return {counts}
 }
 
+// ─── Production collaborators ─────────────────────────────────────────────────
+
+/** Label marking a coordination issue as a cross-repo goal tracker. */
+export const CROSS_REPO_GOAL_LABEL = 'cross-repo-goal'
+
+/** Bounded page size for recent-run lookups — correlation ids are recent by construction. */
+const RUN_LOOKUP_PAGE_SIZE = 30
+
+/**
+ * Find the `fro-bot.yaml` run in `target` whose run-name/display_title
+ * contains `correlationId`. Matches the echo format in
+ * `.github/workflows/fro-bot.yaml`'s `run-name:` (` (correlationId)` suffix
+ * on manual dispatch runs). Bounded to the most recent runs — a correlation
+ * id is looked up shortly after the dispatch that minted it.
+ */
+export async function findWorkflowRunByCorrelationId(
+  octokit: CrossRepoDispatchOctokitClient,
+  target: DispatchTarget,
+  correlationId: string,
+): Promise<{id: number; status: string | null; conclusion: string | null} | null> {
+  const response = await octokit.rest.actions.listWorkflowRunsForRepo({
+    owner: target.owner,
+    repo: target.name,
+    workflow_id: TARGET_WORKFLOW_ID,
+    per_page: RUN_LOOKUP_PAGE_SIZE,
+  })
+  const match = response.data.workflow_runs.find(run => (run.display_title ?? run.name ?? '').includes(correlationId))
+  if (match === undefined) return null
+  return {id: match.id, status: match.status, conclusion: match.conclusion}
+}
+
+/** Factory: `findRunByCorrelationId` collaborator — run existence, any status. */
+export function findRunByCorrelationId(
+  octokit: CrossRepoDispatchOctokitClient,
+): (target: DispatchTarget, correlationId: string) => Promise<boolean> {
+  return async (target, correlationId) => {
+    const run = await findWorkflowRunByCorrelationId(octokit, target, correlationId)
+    return run !== null
+  }
+}
+
+/** Factory: `findRunConclusion` collaborator — conclusion only once the run has completed. */
+export function findRunConclusion(
+  octokit: CrossRepoDispatchOctokitClient,
+): (target: DispatchTarget, correlationId: string) => Promise<'success' | 'failure' | undefined> {
+  return async (target, correlationId) => {
+    const run = await findWorkflowRunByCorrelationId(octokit, target, correlationId)
+    if (run === null || run.status !== 'completed') return undefined
+    return run.conclusion === 'success' ? 'success' : 'failure'
+  }
+}
+
+/**
+ * Enumerate this repo's OPEN `cross-repo-goal`-labeled issues and resolve
+ * each one's latest bot-authored state marker. Issues without a readable
+ * marker are skipped (nothing to track yet).
+ */
+export async function loadOpenGoalIssues(
+  octokit: CrossRepoDispatchOctokitClient,
+  repo: RepoRepository,
+): Promise<OpenGoalIssue[]> {
+  const issuesResponse = await octokit.rest.issues.listForRepo({
+    owner: repo.owner,
+    repo: repo.repo,
+    labels: CROSS_REPO_GOAL_LABEL,
+    state: 'open',
+    per_page: 100,
+  })
+
+  const results: OpenGoalIssue[] = []
+  for (const issue of issuesResponse.data) {
+    const marker = await readLatestMarker(octokit, repo, issue.number)
+    if (marker === null) continue
+    results.push({issueNumber: issue.number, marker})
+  }
+  return results
+}
+
+/**
+ * Enumerate OTHER open `cross-repo-goal` issues' marker states (excluding
+ * `currentIssueNumber`) for same-target in-flight serialization in
+ * `planDispatch`.
+ */
+export async function loadOtherOpenGoalMarkers(
+  octokit: CrossRepoDispatchOctokitClient,
+  repo: RepoRepository,
+  currentIssueNumber: number,
+): Promise<GoalState[]> {
+  const issuesResponse = await octokit.rest.issues.listForRepo({
+    owner: repo.owner,
+    repo: repo.repo,
+    labels: CROSS_REPO_GOAL_LABEL,
+    state: 'open',
+    per_page: 100,
+  })
+
+  const results: GoalState[] = []
+  for (const issue of issuesResponse.data) {
+    if (issue.number === currentIssueNumber) continue
+    const marker = await readLatestMarker(octokit, repo, issue.number)
+    if (marker === null) continue
+    results.push({...marker.state, markerHash: marker.hash})
+  }
+  return results
+}
+
+/**
+ * Factory: `findBotAuthoredPrs` collaborator. Searches for PRs in `target`
+ * carrying `correlationId` via the GitHub search API, then keeps only
+ * PRs authored by a Fro Bot identity (`FROBOT_COMMENT_AUTHORS`) —
+ * the anti-spoofing check that stops a forged non-bot PR referencing the
+ * same correlation id from producing a false completion signal.
+ */
+export function findBotAuthoredPrs(
+  octokit: CrossRepoDispatchOctokitClient,
+): (target: DispatchTarget, correlationId: string) => Promise<PrLookupResult[]> {
+  return async (target, correlationId) => {
+    const response = await octokit.rest.search.issuesAndPullRequests({
+      q: `repo:${target.owner}/${target.name} type:pr ${correlationId}`,
+      per_page: 30,
+    })
+    return response.data.items
+      .filter(item => FROBOT_COMMENT_AUTHORS.has(item.user?.login ?? ''))
+      .map(item => ({
+        merged: item.pull_request?.merged_at !== null && item.pull_request?.merged_at !== undefined,
+        closed: item.state === 'closed',
+        authorIsBot: true,
+      }))
+  }
+}
+
 // ─── CLI shell ────────────────────────────────────────────────────────────────
 
 async function writeResult(resultPath: string | undefined, result: unknown): Promise<void> {
@@ -1099,7 +1265,9 @@ function parseRepository(raw: string | undefined): RepoRepository {
   return {owner, repo}
 }
 
-async function runDispatchCli(): Promise<void> {
+export async function runDispatchCli(
+  createOctokit: () => Promise<CrossRepoDispatchOctokitClient> = createOctokitFromEnv,
+): Promise<void> {
   const eventPath = process.env.GITHUB_EVENT_PATH
   const approveLabel = process.env.CROSS_REPO_DISPATCH_APPROVE_LABEL ?? 'dispatch-approved'
   const resultPath = process.env.CROSS_REPO_DISPATCH_RESULT_PATH
@@ -1113,7 +1281,7 @@ async function runDispatchCli(): Promise<void> {
   const {readFile} = await import('node:fs/promises')
   const event = JSON.parse(await readFile(eventPath, 'utf8')) as LabeledEventPayload
   const repo = parseRepository(process.env.GITHUB_REPOSITORY)
-  const octokit = await createOctokitFromEnv()
+  const octokit = await createOctokit()
 
   await runDispatch({
     octokit,
@@ -1121,8 +1289,8 @@ async function runDispatchCli(): Promise<void> {
     repo,
     approveLabel,
     loadRegistry: loadRegistryFromDisk,
-    loadOtherOpenGoalMarkers: async () => [],
-    findRunByCorrelationId: async () => false,
+    loadOtherOpenGoalMarkers: async () => loadOtherOpenGoalMarkers(octokit, repo, event.issue.number),
+    findRunByCorrelationId: findRunByCorrelationId(octokit),
     createWorkflowDispatch: async params => {
       await octokit.rest.actions.createWorkflowDispatch(params)
     },
@@ -1131,18 +1299,20 @@ async function runDispatchCli(): Promise<void> {
   })
 }
 
-async function runTrackCli(): Promise<void> {
+export async function runTrackCli(
+  createOctokit: () => Promise<CrossRepoDispatchOctokitClient> = createOctokitFromEnv,
+): Promise<void> {
   const resultPath = process.env.CROSS_REPO_DISPATCH_RESULT_PATH
   const repo = parseRepository(process.env.GITHUB_REPOSITORY)
-  const octokit = await createOctokitFromEnv()
+  const octokit = await createOctokit()
 
   await runTrack({
     octokit,
     repo,
-    loadOpenGoalIssues: async () => [],
+    loadOpenGoalIssues: async () => loadOpenGoalIssues(octokit, repo),
     loadRegistry: loadRegistryFromDisk,
-    findRunConclusion: async () => undefined,
-    findBotAuthoredPrs: async () => [],
+    findRunConclusion: findRunConclusion(octokit),
+    findBotAuthoredPrs: findBotAuthoredPrs(octokit),
     resultPath,
   })
 }

--- a/scripts/cross-repo-dispatch.ts
+++ b/scripts/cross-repo-dispatch.ts
@@ -1,0 +1,1164 @@
+import {createHash} from 'node:crypto'
+import process from 'node:process'
+import {assertReposFile} from './schemas.ts'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type ItemStatus = 'pending' | 'intent' | 'dispatched' | 'completed' | 'failed' | 'blocked' | 'deferred'
+
+export interface DispatchTarget {
+  owner: string
+  name: string
+}
+
+export interface DispatchItem {
+  id: string
+  target: DispatchTarget
+  promptHash: string
+  status: ItemStatus
+  correlationId?: string
+  epoch?: number
+  nonce?: string
+}
+
+export interface GoalState {
+  goal: string
+  items: DispatchItem[]
+  approvalFingerprint?: string
+  markerHash: string
+}
+
+export interface MarkerData {
+  hash: string
+  state: Omit<GoalState, 'markerHash'>
+}
+
+export interface TrackerComment {
+  author: {login: string}
+  body: string
+}
+
+export interface DecompositionResult {
+  ok: boolean
+  items: DispatchItem[]
+  error?: string
+}
+
+export type GateResult = 'ok' | 'blocked-not-onboarded' | 'blocked-ineligible'
+
+/** Minimal shape of a registry entry needed for the gate — mirrors `RepoEntry`. */
+export interface GateEntry {
+  owner: string
+  name: string
+  has_fro_bot_workflow: boolean
+  private?: boolean
+}
+
+export interface TerminalStateInput {
+  runConclusion?: 'success' | 'failure'
+  prs?: {merged: boolean; closed: boolean; authorIsBot: boolean}[]
+  gateBlocked?: boolean
+}
+
+export type TerminalState = 'blocked' | 'failed' | 'completed' | 'dispatched'
+
+export interface DispatchPlanInput {
+  state: GoalState
+  fingerprint: string
+  otherOpenGoalMarkers: GoalState[]
+}
+
+export interface DispatchPlanResult {
+  toDispatch: DispatchItem[]
+  deferred: DispatchItem[]
+  blocked: DispatchItem[]
+  toDispatchCount: number
+  deferredCount: number
+  blockedCount: number
+}
+
+export interface SnapshotSignals {
+  [itemId: string]: TerminalStateInput
+}
+
+export interface SnapshotPlanInput {
+  state: GoalState
+  signals: SnapshotSignals
+}
+
+export interface SnapshotPlanResult {
+  state: GoalState
+  allTerminal: boolean
+  shouldWrite: boolean
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** HTML marker prefix embedded in coordination-issue comments. */
+export const MARKER_PREFIX = 'cross-repo-dispatch:'
+
+/** Fro Bot identities permitted to author state marker comments. Mirrors rollout-tracker. */
+export const FROBOT_COMMENT_AUTHORS: ReadonlySet<string> = new Set(['fro-bot', 'fro-bot[bot]'])
+
+/** Owner repos eligible as dispatch targets — v1 is owner-repos-only. */
+export const ELIGIBLE_OWNERS: ReadonlySet<string> = new Set(['fro-bot', 'marcusrbrown'])
+
+/** Hard cap on items per goal, keeping the serialized marker well under GitHub's comment limit. */
+export const MAX_ITEMS_PER_GOAL = 20
+
+const ITEM_STATUSES: ReadonlySet<ItemStatus> = new Set([
+  'pending',
+  'intent',
+  'dispatched',
+  'completed',
+  'failed',
+  'blocked',
+  'deferred',
+])
+
+const TERMINAL_STATUSES: ReadonlySet<ItemStatus> = new Set(['completed', 'failed', 'blocked'])
+
+const IN_FLIGHT_STATUSES: ReadonlySet<ItemStatus> = new Set(['intent', 'dispatched'])
+
+// ─── Marker parse / serialize ────────────────────────────────────────────────
+
+function isDispatchTarget(value: unknown): value is DispatchTarget {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof (value as Record<string, unknown>).owner === 'string' &&
+    typeof (value as Record<string, unknown>).name === 'string'
+  )
+}
+
+function isDispatchItem(value: unknown): value is DispatchItem {
+  if (value === null || typeof value !== 'object') return false
+  const record = value as Record<string, unknown>
+  if (typeof record.id !== 'string') return false
+  if (!isDispatchTarget(record.target)) return false
+  if (typeof record.promptHash !== 'string') return false
+  if (typeof record.status !== 'string' || !ITEM_STATUSES.has(record.status as ItemStatus)) return false
+  if (record.correlationId !== undefined && typeof record.correlationId !== 'string') return false
+  if (record.epoch !== undefined && typeof record.epoch !== 'number') return false
+  if (record.nonce !== undefined && typeof record.nonce !== 'string') return false
+  return true
+}
+
+function isGoalStateBody(value: unknown): value is Omit<GoalState, 'markerHash'> {
+  if (value === null || typeof value !== 'object') return false
+  const record = value as Record<string, unknown>
+  if (typeof record.goal !== 'string') return false
+  if (!Array.isArray(record.items) || !record.items.every(isDispatchItem)) return false
+  if (record.approvalFingerprint !== undefined && typeof record.approvalFingerprint !== 'string') return false
+  return true
+}
+
+/**
+ * Produce a stable SHA-256 hex hash (16 chars) of the canonical goal state.
+ * Latest-state-only: no history arrays are ever hashed.
+ */
+export function hashState(state: Omit<GoalState, 'markerHash'>): string {
+  const stable = JSON.stringify(state, sortedReplacer)
+  return createHash('sha256').update(stable).digest('hex').slice(0, 16)
+}
+
+function sortedReplacer(_key: string, value: unknown): unknown {
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    const sorted: Record<string, unknown> = {}
+    for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+      sorted[k] = (value as Record<string, unknown>)[k]
+    }
+    return sorted
+  }
+  return value
+}
+
+/**
+ * Extract the marker JSON from a comment body. Returns null if absent or malformed.
+ * When multiple markers are present, the LAST one wins (latest state).
+ */
+export function extractMarker(body: string): MarkerData | null {
+  if (!body) return null
+
+  const markerRegex = /<!--\s*cross-repo-dispatch:([\s\S]*?)-->/g
+  let lastMatch: RegExpExecArray | null = null
+  for (;;) {
+    const match = markerRegex.exec(body)
+    if (match === null) break
+    lastMatch = match
+  }
+  if (lastMatch === null) return null
+
+  const jsonStr = lastMatch[1]
+  if (jsonStr === undefined) return null
+
+  try {
+    const parsed: unknown = JSON.parse(jsonStr)
+    if (
+      parsed === null ||
+      typeof parsed !== 'object' ||
+      Array.isArray(parsed) ||
+      typeof (parsed as Record<string, unknown>).hash !== 'string' ||
+      !isGoalStateBody((parsed as Record<string, unknown>).state)
+    ) {
+      return null
+    }
+    return parsed as MarkerData
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Author-filtered latest bot marker: rejects non-bot authors (including `marcusrbrown`).
+ * Uses `findLast` semantics — the latest bot-authored marker comment body wins.
+ */
+export function selectStateMarker(comments: TrackerComment[]): MarkerData | null {
+  const body =
+    comments.findLast(
+      comment => FROBOT_COMMENT_AUTHORS.has(comment.author.login) && extractMarker(comment.body) !== null,
+    )?.body ?? ''
+  return extractMarker(body)
+}
+
+const CHECKLIST_LINE = /^-\s*\[[ x]\]\s+([\w-]+)\/([\w.-]+): (.+)$/i
+
+/**
+ * Parse a planner checklist comment body into closed-vocabulary items.
+ * Grammar: `- [ ] <owner>/<name>: <prompt>` per line. Unrecognized lines →
+ * parse error (no items), never free-text passthrough into item fields.
+ */
+export function parseDecomposition(commentBody: string): DecompositionResult {
+  const lines = commentBody
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+
+  if (lines.length === 0) {
+    return {ok: false, items: [], error: 'empty decomposition'}
+  }
+
+  const items: DispatchItem[] = []
+  for (const [index, line] of lines.entries()) {
+    const match = CHECKLIST_LINE.exec(line)
+    if (match === null) {
+      return {ok: false, items: [], error: `unrecognized checklist line ${index + 1}: ${line}`}
+    }
+    const [, owner, name, prompt] = match
+    if (owner === undefined || name === undefined || prompt === undefined) {
+      return {ok: false, items: [], error: `unrecognized checklist line ${index + 1}: ${line}`}
+    }
+    items.push({
+      id: `item-${index + 1}`,
+      target: {owner, name},
+      promptHash: createHash('sha256').update(prompt).digest('hex').slice(0, 16),
+      status: 'pending',
+    })
+  }
+
+  if (items.length > MAX_ITEMS_PER_GOAL) {
+    return {ok: false, items: [], error: `item count ${items.length} exceeds cap of ${MAX_ITEMS_PER_GOAL}`}
+  }
+
+  return {ok: true, items}
+}
+
+/**
+ * Extract a promptHash → raw prompt text map from a planner checklist body,
+ * using the same closed-vocabulary grammar as `parseDecomposition`. Pure,
+ * no I/O. Used by the dispatch shell to recover the item prompt text for a
+ * `DispatchItem` (which stores only the hash) without trusting free text.
+ */
+export function extractItemPrompts(commentBody: string): Map<string, string> {
+  const prompts = new Map<string, string>()
+  const lines = commentBody
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+
+  for (const line of lines) {
+    const match = CHECKLIST_LINE.exec(line)
+    if (match === null) continue
+    const prompt = match[3]
+    if (prompt === undefined) continue
+    const hash = createHash('sha256').update(prompt).digest('hex').slice(0, 16)
+    prompts.set(hash, prompt)
+  }
+
+  return prompts
+}
+
+/**
+ * Stable, order-insensitive but membership-sensitive fingerprint: items are
+ * sorted by a canonical key of target+promptHash before hashing, so cosmetic
+ * reordering doesn't invalidate approval while adding/removing an item does.
+ */
+export function computeApprovalFingerprint(items: DispatchItem[]): string {
+  const canonicalKeys = items
+    .map(item => `${item.target.owner}/${item.target.name}:${item.promptHash}`)
+    .sort((a, b) => a.localeCompare(b))
+  return createHash('sha256').update(JSON.stringify(canonicalKeys)).digest('hex').slice(0, 16)
+}
+
+/** Serialize goal state (sans markerHash) into the canonical state used for hashing. */
+function canonicalStateBody(state: GoalState): Omit<GoalState, 'markerHash'> {
+  return {
+    goal: state.goal,
+    items: state.items,
+    ...(state.approvalFingerprint === undefined ? {} : {approvalFingerprint: state.approvalFingerprint}),
+  }
+}
+
+/** Compute the markerHash for a goal state over its canonical (latest-state-only) body. */
+export function serializeMarker(state: GoalState): MarkerData {
+  const body = canonicalStateBody(state)
+  return {hash: hashState(body), state: body}
+}
+
+/** Build the full comment body embedding the state marker. */
+export function buildMarkerComment(state: GoalState): string {
+  const marker = serializeMarker(state)
+  return `<!-- ${MARKER_PREFIX}${JSON.stringify(marker)} -->`
+}
+
+// ─── Planner: registry gate ──────────────────────────────────────────────────
+
+/**
+ * Owner-only, fail-closed registry gate.
+ * - `blocked-not-onboarded` when the entry lacks the Fro Bot workflow.
+ * - `blocked-ineligible` when the owner is not in the eligible set, the repo
+ *   is not definitively public, or the entry is missing from the registry.
+ */
+export function gateTarget(entry: GateEntry | undefined): GateResult {
+  if (entry === undefined) return 'blocked-ineligible'
+  if (!ELIGIBLE_OWNERS.has(entry.owner)) return 'blocked-ineligible'
+  if (entry.private !== false) return 'blocked-ineligible'
+  if (!entry.has_fro_bot_workflow) return 'blocked-not-onboarded'
+  return 'ok'
+}
+
+// ─── Planner: terminal-state resolver ────────────────────────────────────────
+
+/**
+ * Precedence: gate-block > run-failure > PR-outcome > run-success.
+ * Multi-PR: terminal only when the run has concluded; completed if >=1
+ * bot-authored PR merged, else failed if any PR is closed-unmerged, else
+ * (no PR) completed as a no-op success.
+ */
+export function resolveItemTerminalState(input: TerminalStateInput): TerminalState {
+  if (input.gateBlocked === true) return 'blocked'
+  if (input.runConclusion === 'failure') return 'failed'
+  if (input.runConclusion === undefined) return 'dispatched'
+
+  const prs = input.prs ?? []
+  const botPrs = prs.filter(pr => pr.authorIsBot)
+
+  if (botPrs.length === 0) return 'completed'
+
+  const anyMerged = botPrs.some(pr => pr.merged)
+  if (anyMerged) return 'completed'
+
+  const allTerminalPrs = botPrs.every(pr => pr.merged || pr.closed)
+  if (!allTerminalPrs) return 'dispatched'
+
+  return 'failed'
+}
+
+// ─── Planner: dispatch plan ──────────────────────────────────────────────────
+
+/**
+ * Which items to dispatch now. Skips items already intent/dispatched/terminal.
+ * Defers items whose target has an in-flight (intent/dispatched) item in any
+ * OTHER open goal marker — same-target serialization.
+ */
+export function planDispatch(input: DispatchPlanInput): DispatchPlanResult {
+  const inFlightTargets = new Set<string>()
+  for (const other of input.otherOpenGoalMarkers) {
+    for (const item of other.items) {
+      if (IN_FLIGHT_STATUSES.has(item.status)) {
+        inFlightTargets.add(`${item.target.owner}/${item.target.name}`)
+      }
+    }
+  }
+
+  const toDispatch: DispatchItem[] = []
+  const deferred: DispatchItem[] = []
+  const blocked: DispatchItem[] = []
+
+  for (const item of input.state.items) {
+    if (item.status === 'blocked') {
+      blocked.push(item)
+      continue
+    }
+    if (IN_FLIGHT_STATUSES.has(item.status) || TERMINAL_STATUSES.has(item.status)) continue
+
+    const targetKey = `${item.target.owner}/${item.target.name}`
+    if (inFlightTargets.has(targetKey)) {
+      deferred.push(item)
+      continue
+    }
+    toDispatch.push(item)
+  }
+
+  return {
+    toDispatch,
+    deferred,
+    blocked,
+    toDispatchCount: toDispatch.length,
+    deferredCount: deferred.length,
+    blockedCount: blocked.length,
+  }
+}
+
+// ─── Planner: snapshot decision ──────────────────────────────────────────────
+
+/**
+ * Apply resolveItemTerminalState per dispatched item, compute allTerminal
+ * (→ close), and idempotency (identical markerHash → no write).
+ */
+export function planSnapshot(input: SnapshotPlanInput): SnapshotPlanResult {
+  const updatedItems = input.state.items.map(item => {
+    const signal = input.signals[item.id]
+    if (signal === undefined) return item
+    if (TERMINAL_STATUSES.has(item.status)) return item
+
+    const resolved = resolveItemTerminalState(signal)
+    if (resolved === item.status) return item
+    return {...item, status: resolved}
+  })
+
+  const updatedState: GoalState = {
+    ...input.state,
+    items: updatedItems,
+  }
+  const marker = serializeMarker(updatedState)
+  const finalState: GoalState = {...updatedState, markerHash: marker.hash}
+
+  const allTerminal = updatedItems.every(item => TERMINAL_STATUSES.has(item.status))
+  const shouldWrite = marker.hash !== input.state.markerHash
+
+  return {state: finalState, allTerminal, shouldWrite}
+}
+
+// ─── Shells: shared octokit client shape ─────────────────────────────────────
+
+/** Minimal Octokit-like client shared by both shells. Injected for testability. */
+export interface CrossRepoDispatchOctokitClient {
+  readonly rest: {
+    readonly issues: {
+      readonly listComments: (params: {
+        owner: string
+        repo: string
+        issue_number: number
+      }) => Promise<{data: {id: number; body?: string | null; user: {login: string} | null}[]}>
+      readonly createComment: (params: {
+        owner: string
+        repo: string
+        issue_number: number
+        body: string
+      }) => Promise<{data: {id: number}}>
+      readonly updateComment: (params: {
+        owner: string
+        repo: string
+        comment_id: number
+        body: string
+      }) => Promise<unknown>
+      readonly update: (params: {
+        owner: string
+        repo: string
+        issue_number: number
+        state?: 'open' | 'closed'
+        labels?: string[]
+      }) => Promise<unknown>
+      readonly removeLabel: (params: {
+        owner: string
+        repo: string
+        issue_number: number
+        name: string
+      }) => Promise<unknown>
+    }
+    readonly actions: {
+      readonly createWorkflowDispatch: (params: {
+        owner: string
+        repo: string
+        workflow_id: string
+        ref: string
+        inputs?: Record<string, string>
+      }) => Promise<unknown>
+    }
+  }
+}
+
+/** Target workflow file dispatched into every approved item's target repo. */
+export const TARGET_WORKFLOW_ID = 'fro-bot.yaml'
+
+/** Default ref dispatched against in target repos. */
+export const TARGET_WORKFLOW_REF = 'main'
+
+/** Actor required to approve dispatch — script-side gate independent of the workflow gate. */
+export const REQUIRED_APPROVER = 'marcusrbrown'
+
+/** Bounded retry count for compare-and-swap marker writes. */
+export const CAS_MAX_RETRIES = 3
+
+/** Upper bound on item-prompt length accepted by the safety policy. */
+export const MAX_PROMPT_LENGTH = 4000
+
+/** Patterns rejected by the item-prompt safety policy — credential/secret-looking content. */
+const CREDENTIAL_PATTERNS: readonly RegExp[] = [
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+  /\bgh[pousr]_[A-Za-z0-9]{20,}\b/,
+  /\bAKIA[0-9A-Z]{16}\b/,
+  /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/,
+]
+
+/**
+ * Item-prompt safety policy: length-capped, no credential/secret-looking
+ * content, owner-target only (enforced by `gateTarget` upstream). Pure.
+ */
+export function isPromptSafe(prompt: string): boolean {
+  if (prompt.length === 0 || prompt.length > MAX_PROMPT_LENGTH) return false
+  return !CREDENTIAL_PATTERNS.some(pattern => pattern.test(prompt))
+}
+
+/** Compute a compact opaque correlation id: goal + item id + nonce, hashed. */
+export function computeCorrelationId(goal: string, itemId: string, nonce: string): string {
+  return createHash('sha256').update(`${goal}:${itemId}:${nonce}`).digest('hex').slice(0, 20)
+}
+
+/**
+ * Compare-and-swap a marker comment write. Re-reads the latest bot marker
+ * immediately before writing; aborts+retries on hash mismatch against the
+ * caller's expected prior hash. Bounded retries; persistent mismatch defers
+ * (returns `ok:false`) rather than clobbering (single-writer discipline).
+ */
+export interface CasWriteInput {
+  octokit: CrossRepoDispatchOctokitClient
+  owner: string
+  repo: string
+  issueNumber: number
+  expectedPriorHash: string | undefined
+  nextState: GoalState
+}
+
+export interface CasWriteResult {
+  ok: boolean
+  reason?: 'mismatch'
+}
+
+/**
+ * Read the latest bot-authored marker comment, including its comment id, so
+ * callers can update that same comment in place rather than appending a new
+ * one on every state transition (single-comment marker discipline).
+ */
+async function readLatestMarkerComment(
+  octokit: CrossRepoDispatchOctokitClient,
+  repo: RepoRepository,
+  issueNumber: number,
+): Promise<{marker: MarkerData; commentId: number} | null> {
+  const response = await octokit.rest.issues.listComments({
+    owner: repo.owner,
+    repo: repo.repo,
+    issue_number: issueNumber,
+  })
+  const commentId = response.data.findLast(
+    comment => FROBOT_COMMENT_AUTHORS.has(comment.user?.login ?? '') && extractMarker(comment.body ?? '') !== null,
+  )?.id
+  if (commentId === undefined) return null
+
+  const comments: TrackerComment[] = response.data.map(comment => ({
+    author: {login: comment.user?.login ?? ''},
+    body: comment.body ?? '',
+  }))
+  const marker = selectStateMarker(comments)
+  if (marker === null) return null
+  return {marker, commentId}
+}
+
+async function readLatestMarker(
+  octokit: CrossRepoDispatchOctokitClient,
+  repo: RepoRepository,
+  issueNumber: number,
+): Promise<MarkerData | null> {
+  const found = await readLatestMarkerComment(octokit, repo, issueNumber)
+  return found?.marker ?? null
+}
+
+async function casWriteMarker(input: CasWriteInput): Promise<CasWriteResult> {
+  for (let attempt = 0; attempt < CAS_MAX_RETRIES; attempt++) {
+    const found = await readLatestMarkerComment(
+      input.octokit,
+      {owner: input.owner, repo: input.repo},
+      input.issueNumber,
+    )
+    const currentHash = found?.marker.hash
+
+    if (currentHash !== input.expectedPriorHash) {
+      // Someone else wrote since we last read. Retry against the latest state
+      // only if our nextState was derived from a state that's still coherent;
+      // callers that cannot re-derive a plan safely should treat this as defer.
+      continue
+    }
+
+    const body = buildMarkerComment(input.nextState)
+    if (found === null) {
+      // Cold start: no bot marker comment exists yet.
+      await input.octokit.rest.issues.createComment({
+        owner: input.owner,
+        repo: input.repo,
+        issue_number: input.issueNumber,
+        body,
+      })
+    } else {
+      // Update the existing marker comment in place — never append a new one.
+      await input.octokit.rest.issues.updateComment({
+        owner: input.owner,
+        repo: input.repo,
+        comment_id: found.commentId,
+        body,
+      })
+    }
+    return {ok: true}
+  }
+  return {ok: false, reason: 'mismatch'}
+}
+
+// ─── Dispatch shell ───────────────────────────────────────────────────────────
+
+export interface LabeledEventPayload {
+  label: {name: string}
+  sender: {login: string}
+  issue: {number: number}
+}
+
+export interface RepoRepository {
+  owner: string
+  repo: string
+}
+
+export interface RunDispatchInput {
+  octokit: CrossRepoDispatchOctokitClient
+  event: LabeledEventPayload
+  repo: RepoRepository
+  approveLabel: string
+  loadRegistry: () => Promise<GateEntry[]>
+  loadOtherOpenGoalMarkers: () => Promise<GoalState[]>
+  findRunByCorrelationId: (target: DispatchTarget, correlationId: string) => Promise<boolean>
+  createWorkflowDispatch: (params: {
+    owner: string
+    repo: string
+    workflow_id: string
+    ref: string
+    inputs: {prompt: string; correlation_id: string}
+  }) => Promise<void>
+  nonceSource: () => string
+  resultPath?: string
+}
+
+export interface RunDispatchCounts {
+  refused: number
+  dispatched: number
+  deferred: number
+  blocked: number
+  reconciled: number
+  skippedUnsafePrompt: number
+  casDeferred: number
+}
+
+export interface RunDispatchResult {
+  counts: RunDispatchCounts
+}
+
+function emptyDispatchCounts(): RunDispatchCounts {
+  return {
+    refused: 0,
+    dispatched: 0,
+    deferred: 0,
+    blocked: 0,
+    reconciled: 0,
+    skippedUnsafePrompt: 0,
+    casDeferred: 0,
+  }
+}
+
+/**
+ * Dispatch shell: executes an approved goal on the `issues.labeled` event.
+ * Script-side actor gate, fingerprint CAS approval record, two-phase
+ * (intent → confirm) sequential per-item dispatch with correlation-id
+ * reconciliation on resume.
+ */
+export async function runDispatch(input: RunDispatchInput): Promise<RunDispatchResult> {
+  const counts = emptyDispatchCounts()
+
+  // 1. Script-side actor gate, independent of the workflow gate.
+  if (input.event.sender.login !== REQUIRED_APPROVER || input.event.label.name !== input.approveLabel) {
+    try {
+      await input.octokit.rest.issues.removeLabel({
+        owner: input.repo.owner,
+        repo: input.repo.repo,
+        issue_number: input.event.issue.number,
+        name: input.event.label.name,
+      })
+    } catch {
+      // Label removal is best-effort; the refusal is still counted.
+    }
+    counts.refused = 1
+    await writeResult(input.resultPath, {counts})
+    return {counts}
+  }
+
+  const issueNumber = input.event.issue.number
+
+  // 2. Read the issue's bot marker.
+  const commentsResponse = await input.octokit.rest.issues.listComments({
+    owner: input.repo.owner,
+    repo: input.repo.repo,
+    issue_number: issueNumber,
+  })
+  const comments: TrackerComment[] = commentsResponse.data.map(comment => ({
+    author: {login: comment.user?.login ?? ''},
+    body: comment.body ?? '',
+  }))
+  const marker = selectStateMarker(comments)
+  if (marker === null) {
+    await writeResult(input.resultPath, {counts})
+    return {counts}
+  }
+
+  const prompts = extractItemPrompts(comments.map(comment => comment.body).join('\n'))
+
+  const registry = await input.loadRegistry()
+  const registryByKey = new Map<string, GateEntry>()
+  for (const entry of registry) {
+    registryByKey.set(`${entry.owner}/${entry.name}`, entry)
+  }
+
+  // Apply the registry gate up front — items whose target is ineligible move
+  // to 'blocked' before dispatch planning, distinct from a not-onboarded gate.
+  let state: GoalState = {...marker.state, markerHash: marker.hash}
+  const gatedItems = state.items.map(item => {
+    if (item.status !== 'pending') return item
+    const gate = gateTarget(registryByKey.get(`${item.target.owner}/${item.target.name}`))
+    if (gate === 'ok') return item
+    return {...item, status: 'blocked' as ItemStatus}
+  })
+  state = {...state, items: gatedItems}
+
+  // 3. Compute current approval fingerprint; store as approval record via CAS.
+  const fingerprint = computeApprovalFingerprint(state.items)
+  const priorHash = marker.hash
+  if (state.approvalFingerprint !== fingerprint) {
+    const withApproval: GoalState = {...state, approvalFingerprint: fingerprint}
+    const serialized = serializeMarker(withApproval)
+    const approvalState: GoalState = {...withApproval, markerHash: serialized.hash}
+    const cas = await casWriteMarker({
+      octokit: input.octokit,
+      owner: input.repo.owner,
+      repo: input.repo.repo,
+      issueNumber,
+      expectedPriorHash: priorHash,
+      nextState: approvalState,
+    })
+    if (!cas.ok) {
+      counts.casDeferred = 1
+      await writeResult(input.resultPath, {counts})
+      return {counts}
+    }
+    state = approvalState
+  }
+
+  // Resume reconciliation pass: any pre-existing 'intent' item (from a prior
+  // crashed run) is reconciled by correlation-id lookup BEFORE any dispatch
+  // planning runs — `planDispatch` treats intent as in-flight and
+  // would never surface it as dispatchable, so this pass runs first.
+  for (const item of state.items) {
+    if (item.status !== 'intent' || item.correlationId === undefined) continue
+    const found = await input.findRunByCorrelationId(item.target, item.correlationId)
+    if (!found) continue
+
+    const latestMarkerForReconcile = await readLatestMarker(input.octokit, input.repo, issueNumber)
+    if (latestMarkerForReconcile === null) continue
+    const flipped = flipItemStatus(latestMarkerForReconcile, item.id, 'dispatched', item.epoch ?? Date.now())
+    const cas = await casWriteMarker({
+      octokit: input.octokit,
+      owner: input.repo.owner,
+      repo: input.repo.repo,
+      issueNumber,
+      expectedPriorHash: latestMarkerForReconcile.hash,
+      nextState: flipped,
+    })
+    if (cas.ok) {
+      counts.reconciled += 1
+      state = flipped
+    } else {
+      counts.casDeferred += 1
+    }
+  }
+
+  const otherOpenGoalMarkers = await input.loadOtherOpenGoalMarkers()
+  const plan = planDispatch({state, fingerprint, otherOpenGoalMarkers})
+  counts.deferred = plan.deferredCount
+  counts.blocked = plan.blockedCount
+
+  // 5/6. Sequential per-item dispatch with re-read+re-compare before each item.
+  for (const item of plan.toDispatch) {
+    // Re-read + re-compare fingerprint before each item — halt on mismatch.
+    const latestMarker = await readLatestMarker(input.octokit, input.repo, issueNumber)
+    if (latestMarker === null || latestMarker.state.approvalFingerprint !== fingerprint) {
+      break
+    }
+
+    const currentItem = latestMarker.state.items.find(candidate => candidate.id === item.id)
+    if (currentItem === undefined) continue
+    if (currentItem.status !== 'pending') continue
+
+    const prompt = prompts.get(currentItem.promptHash)
+    if (prompt === undefined || !isPromptSafe(prompt)) {
+      counts.skippedUnsafePrompt += 1
+      continue
+    }
+
+    const nonce = currentItem.nonce ?? input.nonceSource()
+    const correlationId = currentItem.correlationId ?? computeCorrelationId(state.goal, currentItem.id, nonce)
+
+    // Write 'intent' before dispatching (two-phase persistence).
+    const intentState = flipItemStatus(latestMarker, currentItem.id, 'intent', undefined, {
+      correlationId,
+      nonce,
+    })
+    const intentCas = await casWriteMarker({
+      octokit: input.octokit,
+      owner: input.repo.owner,
+      repo: input.repo.repo,
+      issueNumber,
+      expectedPriorHash: latestMarker.hash,
+      nextState: intentState,
+    })
+    if (!intentCas.ok) {
+      counts.casDeferred += 1
+      continue
+    }
+
+    await input.createWorkflowDispatch({
+      owner: currentItem.target.owner,
+      repo: currentItem.target.name,
+      workflow_id: TARGET_WORKFLOW_ID,
+      ref: TARGET_WORKFLOW_REF,
+      inputs: {prompt, correlation_id: correlationId},
+    })
+
+    // Flip to 'dispatched' + epoch via CAS.
+    const dispatchedState = flipItemStatus(
+      {hash: intentState.markerHash, state: intentState},
+      currentItem.id,
+      'dispatched',
+      Date.now(),
+    )
+    const confirmCas = await casWriteMarker({
+      octokit: input.octokit,
+      owner: input.repo.owner,
+      repo: input.repo.repo,
+      issueNumber,
+      expectedPriorHash: intentState.markerHash,
+      nextState: dispatchedState,
+    })
+    if (confirmCas.ok) {
+      counts.dispatched += 1
+    } else {
+      // Crash-after-confirm-write-failure: item stays 'intent'; a future
+      // resume reconciles it by correlation-id.
+      counts.casDeferred += 1
+    }
+  }
+
+  await writeResult(input.resultPath, {counts})
+  return {counts}
+}
+
+function flipItemStatus(
+  marker: MarkerData,
+  itemId: string,
+  status: ItemStatus,
+  epoch: number | undefined,
+  extra: {correlationId?: string; nonce?: string} = {},
+): GoalState {
+  const items = marker.state.items.map(item => {
+    if (item.id !== itemId) return item
+    return {
+      ...item,
+      status,
+      ...(epoch === undefined ? {} : {epoch}),
+      ...(extra.correlationId === undefined ? {} : {correlationId: extra.correlationId}),
+      ...(extra.nonce === undefined ? {} : {nonce: extra.nonce}),
+    }
+  })
+  const nextState: GoalState = {...marker.state, items, markerHash: ''}
+  const serialized = serializeMarker(nextState)
+  return {...nextState, markerHash: serialized.hash}
+}
+
+// ─── Tracking shell ─────────────────────────────────────────────────────────
+
+export interface OpenGoalIssue {
+  issueNumber: number
+  marker: MarkerData
+}
+
+export interface PrLookupResult {
+  merged: boolean
+  closed: boolean
+  authorIsBot: boolean
+}
+
+export interface RunTrackInput {
+  octokit: CrossRepoDispatchOctokitClient
+  repo: RepoRepository
+  loadOpenGoalIssues: () => Promise<OpenGoalIssue[]>
+  loadRegistry: () => Promise<GateEntry[]>
+  findRunConclusion: (target: DispatchTarget, correlationId: string) => Promise<'success' | 'failure' | undefined>
+  findBotAuthoredPrs: (target: DispatchTarget, correlationId: string) => Promise<PrLookupResult[]>
+  resultPath?: string
+}
+
+export interface RunTrackCounts {
+  goalsProcessed: number
+  itemsCompleted: number
+  itemsFailed: number
+  itemsBlocked: number
+  itemsStillOpen: number
+  goalsClosed: number
+  idempotentNoop: number
+  casDeferred: number
+}
+
+export interface RunTrackResult {
+  counts: RunTrackCounts
+}
+
+function emptyTrackCounts(): RunTrackCounts {
+  return {
+    goalsProcessed: 0,
+    itemsCompleted: 0,
+    itemsFailed: 0,
+    itemsBlocked: 0,
+    itemsStillOpen: 0,
+    goalsClosed: 0,
+    idempotentNoop: 0,
+    casDeferred: 0,
+  }
+}
+
+/**
+ * Tracking shell: snapshots dispatched goals to terminal, closing the
+ * coordination issue when every item is terminal. Run
+ * correlation is by correlation-id (never epoch+actor alone). Reopen is
+ * handled by the workflow's `issues.reopened` step, not here.
+ */
+export async function runTrack(input: RunTrackInput): Promise<RunTrackResult> {
+  const counts = emptyTrackCounts()
+
+  const registry = await input.loadRegistry()
+  const registryByKey = new Map<string, GateEntry>()
+  for (const entry of registry) {
+    registryByKey.set(`${entry.owner}/${entry.name}`, entry)
+  }
+
+  const openGoals = await input.loadOpenGoalIssues()
+
+  for (const goalIssue of openGoals) {
+    counts.goalsProcessed += 1
+    const state: GoalState = {...goalIssue.marker.state, markerHash: goalIssue.marker.hash}
+
+    const signals: SnapshotSignals = {}
+    for (const item of state.items) {
+      if (item.status !== 'dispatched') continue
+
+      const gate = gateTarget(registryByKey.get(`${item.target.owner}/${item.target.name}`))
+      if (gate !== 'ok') {
+        signals[item.id] = {gateBlocked: true}
+        continue
+      }
+
+      if (item.correlationId === undefined) continue
+
+      const runConclusion = await input.findRunConclusion(item.target, item.correlationId)
+      if (runConclusion === undefined) continue
+
+      const prs = await input.findBotAuthoredPrs(item.target, item.correlationId)
+      signals[item.id] = {runConclusion, prs}
+    }
+
+    const snapshot = planSnapshot({state, signals})
+
+    for (const item of snapshot.state.items) {
+      const previous = state.items.find(candidate => candidate.id === item.id)
+      if (previous === undefined || previous.status === item.status) continue
+      if (item.status === 'completed') counts.itemsCompleted += 1
+      else if (item.status === 'failed') counts.itemsFailed += 1
+      else if (item.status === 'blocked') counts.itemsBlocked += 1
+    }
+    counts.itemsStillOpen += snapshot.state.items.filter(item => item.status === 'dispatched').length
+
+    if (!snapshot.shouldWrite) {
+      counts.idempotentNoop += 1
+      continue
+    }
+
+    const cas = await casWriteMarker({
+      octokit: input.octokit,
+      owner: input.repo.owner,
+      repo: input.repo.repo,
+      issueNumber: goalIssue.issueNumber,
+      expectedPriorHash: goalIssue.marker.hash,
+      nextState: snapshot.state,
+    })
+    if (!cas.ok) {
+      counts.casDeferred += 1
+      continue
+    }
+
+    if (snapshot.allTerminal) {
+      const completed = snapshot.state.items.filter(item => item.status === 'completed').length
+      const failed = snapshot.state.items.filter(item => item.status === 'failed').length
+      const blocked = snapshot.state.items.filter(item => item.status === 'blocked').length
+      await input.octokit.rest.issues.createComment({
+        owner: input.repo.owner,
+        repo: input.repo.repo,
+        issue_number: goalIssue.issueNumber,
+        body: `Goal complete. completed=${completed} failed=${failed} blocked=${blocked}`,
+      })
+      await input.octokit.rest.issues.update({
+        owner: input.repo.owner,
+        repo: input.repo.repo,
+        issue_number: goalIssue.issueNumber,
+        state: 'closed',
+      })
+      counts.goalsClosed += 1
+    }
+  }
+
+  await writeResult(input.resultPath, {counts})
+  return {counts}
+}
+
+// ─── CLI shell ────────────────────────────────────────────────────────────────
+
+async function writeResult(resultPath: string | undefined, result: unknown): Promise<void> {
+  const json = `${JSON.stringify(result)}\n`
+  process.stdout.write(json)
+  if (resultPath === undefined || resultPath === '') return
+  const {writeFile} = await import('node:fs/promises')
+  try {
+    await writeFile(resultPath, json, {flag: 'w'})
+  } catch {
+    process.stderr.write('cross-repo-dispatch: could not write result: error-class=write-failure\n')
+  }
+}
+
+type CrossRepoOctokitConstructor = new (params: {
+  auth: string
+  request: {timeout: number}
+}) => CrossRepoDispatchOctokitClient
+
+async function loadOctokitConstructor(): Promise<CrossRepoOctokitConstructor> {
+  const {Octokit} = await import('@octokit/rest')
+  return Octokit as unknown as CrossRepoOctokitConstructor
+}
+
+async function createOctokitFromEnv(): Promise<CrossRepoDispatchOctokitClient> {
+  const token = process.env.GITHUB_TOKEN
+  if (token === undefined || token === '') {
+    throw new Error('cross-repo-dispatch: GITHUB_TOKEN is required in the environment')
+  }
+  const LoadedOctokit = await loadOctokitConstructor()
+  return new LoadedOctokit({auth: token, request: {timeout: 15_000}})
+}
+
+async function loadRegistryFromDisk(): Promise<GateEntry[]> {
+  const {readFile} = await import('node:fs/promises')
+  const {parse} = await import('yaml')
+  try {
+    const raw: unknown = parse(await readFile('metadata/repos.yaml', 'utf8'))
+    assertReposFile(raw, 'repos')
+    return raw.repos.map(entry => ({
+      owner: entry.owner,
+      name: entry.name,
+      has_fro_bot_workflow: entry.has_fro_bot_workflow,
+      private: entry.private,
+    }))
+  } catch {
+    return []
+  }
+}
+
+function parseRepository(raw: string | undefined): RepoRepository {
+  const [owner, repo] = (raw ?? '').split('/')
+  if (owner === undefined || repo === undefined || owner === '' || repo === '') {
+    throw new Error('cross-repo-dispatch: GITHUB_REPOSITORY must be in owner/repo format')
+  }
+  return {owner, repo}
+}
+
+async function runDispatchCli(): Promise<void> {
+  const eventPath = process.env.GITHUB_EVENT_PATH
+  const approveLabel = process.env.CROSS_REPO_DISPATCH_APPROVE_LABEL ?? 'dispatch-approved'
+  const resultPath = process.env.CROSS_REPO_DISPATCH_RESULT_PATH
+
+  if (eventPath === undefined || eventPath === '') {
+    process.stderr.write('cross-repo-dispatch: GITHUB_EVENT_PATH is required for dispatch mode\n')
+    process.exitCode = 1
+    return
+  }
+
+  const {readFile} = await import('node:fs/promises')
+  const event = JSON.parse(await readFile(eventPath, 'utf8')) as LabeledEventPayload
+  const repo = parseRepository(process.env.GITHUB_REPOSITORY)
+  const octokit = await createOctokitFromEnv()
+
+  await runDispatch({
+    octokit,
+    event,
+    repo,
+    approveLabel,
+    loadRegistry: loadRegistryFromDisk,
+    loadOtherOpenGoalMarkers: async () => [],
+    findRunByCorrelationId: async () => false,
+    createWorkflowDispatch: async params => {
+      await octokit.rest.actions.createWorkflowDispatch(params)
+    },
+    nonceSource: () => createHash('sha256').update(`${Date.now()}:${Math.random()}`).digest('hex').slice(0, 12),
+    resultPath,
+  })
+}
+
+async function runTrackCli(): Promise<void> {
+  const resultPath = process.env.CROSS_REPO_DISPATCH_RESULT_PATH
+  const repo = parseRepository(process.env.GITHUB_REPOSITORY)
+  const octokit = await createOctokitFromEnv()
+
+  await runTrack({
+    octokit,
+    repo,
+    loadOpenGoalIssues: async () => [],
+    loadRegistry: loadRegistryFromDisk,
+    findRunConclusion: async () => undefined,
+    findBotAuthoredPrs: async () => [],
+    resultPath,
+  })
+}
+
+async function main(): Promise<void> {
+  const mode = process.argv[2]
+  if (mode === 'dispatch') {
+    await runDispatchCli()
+  } else if (mode === 'track') {
+    await runTrackCli()
+  } else {
+    process.stderr.write('cross-repo-dispatch: expected argv[2] to be "dispatch" or "track"\n')
+    process.exitCode = 1
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}


### PR DESCRIPTION
## What

Fro Bot could dispatch agents into repos and track multi-repo state, but had no way to take a goal spanning repos, decompose it, and drive the pieces to completion — that coordination lived in the operator's head and got re-typed into N prompts. This adds the coordination surface.

**Lifecycle:** open an issue labeled `cross-repo-goal` describing a multi-repo goal and mention the bot → a planning run proposes a per-repo work-item decomposition as a bot-authored marker comment → apply the `dispatch-approved` label (only the operator's application triggers dispatch) → one worker run per approved item dispatches into the target repos → each item is tracked to a terminal state on the issue, which closes when all settle.

The control loop is deterministic TypeScript composing existing surfaces: the reusable agent workflow, cross-repo `workflow_dispatch`, the managed-repo registry, and the tracker-snapshot marker pattern. No new agent authority.

## Safety design

This adds a privileged `issues.labeled` trigger and a cross-repo `actions: write` mint, on a public (attacker-writable) issue surface. The mitigations:

- **Approval binds to actor AND bytes.** The label dispatches only when applied by the operator (`sender.login` gate in both the workflow `if:` and re-checked in the script), and the approval is pinned to an immutable fingerprint of the bot-authored decomposition marker — a post-approval edit invalidates it, re-checked before every item dispatch.
- **Two-phase dispatch (intent → confirm) with correlation-id resume.** A crash between dispatch and marker-write never duplicates a run; resume reconciles `intent` items by correlation-id.
- **Compare-and-swap marker writes** serialize the dispatch and track jobs (single mutable state comment, updated in place — no comment spam).
- **Owner-repos-only, fail-closed gate.** Targets must be in the registry, `has_fro_bot_workflow: true`, owner-owned, and definitively public; `not-onboarded` surfaces distinctly from `ineligible`. No private or contrib targets in v1.
- **Completion can't be spoofed.** Terminal state is run-conclusion-primary; PR refinement requires a bot-authored PR carrying the correlation-id, so a forged third-party PR can't mark an item complete.
- **Least-privilege mints after the gate.** Dispatch mints `actions: write`; track mints `actions: read` + `pull-requests: read` + `issues: write`; neither exists on a refused event. (Residual, documented: an App key + id can mint full install scope regardless of per-run narrowing — key storage/rotation remains the real control.)
- **Counts-only telemetry** everywhere; owner-only targets make private-identifier leakage structurally impossible.

## Verification

- TDD throughout; 61 module tests (marker round-trip, author-filter, fingerprint order-insensitivity/membership-sensitivity, full terminal-state precedence incl. forged-PR rejection, two-phase resume, CAS retry, actor gate, close-on-terminal). Repo gate green: 2084 tests, check-types, lint.
- Workflow YAML actionlint/eslint clean; action SHAs byte-identical to existing usages.
- Rehearsal after merge: a low-stakes goal across two owner repos, goal → decompose → approve → dispatch → track → close, plus confirming a non-operator label application is refused.