### PR TITLE
fix: seed the dispatch marker from the planner decomposition

### DIFF
--- a/scripts/cross-repo-dispatch.test.ts
+++ b/scripts/cross-repo-dispatch.test.ts
@@ -577,6 +577,89 @@ describe('runDispatch — happy sequential dispatch', () => {
   })
 })
 
+describe('runDispatch — seeds marker from decomposition checklist', () => {
+  it('seeds a marker from the checklist, gates+dispatches items, and recovers prompts when no marker exists', async () => {
+    const targets = [
+      {owner: 'fro-bot', name: 'agent'},
+      {owner: 'fro-bot', name: 'wiki'},
+    ]
+    const decomposition = makeDecompositionBody(targets.map(t => ({...t, prompt: `do work in ${t.name}`})))
+
+    const {octokit, comments} = mockOctokit()
+    // Only the bot-authored decomposition checklist exists — no state marker yet.
+    comments.push({id: 1, body: decomposition, login: 'fro-bot'})
+
+    const createComment = vi.fn(async (params: {owner: string; repo: string; issue_number: number; body: string}) => {
+      const comment = {id: comments.length + 1, body: params.body, login: 'fro-bot'}
+      comments.push(comment)
+      return {data: {id: comment.id}}
+    })
+
+    const createWorkflowDispatch = vi.fn(
+      async (_params: {
+        owner: string
+        repo: string
+        workflow_id: string
+        ref: string
+        inputs: {prompt: string; correlation_id: string}
+      }) => ({}),
+    )
+
+    const result = await runDispatch({
+      octokit: {...octokit, rest: {...octokit.rest, issues: {...octokit.rest.issues, createComment}}},
+      event: makeLabeledEvent(),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      loadRegistry: async () => targets.map(t => gateEntryFor(t)),
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async () => false,
+      createWorkflowDispatch: async params => {
+        await createWorkflowDispatch(params)
+      },
+      nonceSource: (() => {
+        let n = 0
+        return () => `nonce-${++n}`
+      })(),
+    })
+
+    expect(result.counts.dispatched).toBe(2)
+    expect(createComment).toHaveBeenCalledOnce()
+    expect(createWorkflowDispatch).toHaveBeenCalledTimes(2)
+    for (const [index, target] of targets.entries()) {
+      const call = createWorkflowDispatch.mock.calls[index]?.[0]
+      expect(call?.owner).toBe(target.owner)
+      expect(call?.repo).toBe(target.name)
+      expect(call?.inputs.prompt).toBe(`do work in ${target.name}`)
+    }
+  })
+
+  it('bails without dispatching when no marker exists and no decomposition checklist is found', async () => {
+    const {octokit, comments} = mockOctokit()
+    // A bot comment exists but it is not a valid decomposition checklist.
+    comments.push({id: 1, body: 'just a status update, nothing structured here', login: 'fro-bot'})
+
+    const createWorkflowDispatch = vi.fn(async (_params: unknown) => ({}))
+
+    const result = await runDispatch({
+      octokit,
+      event: makeLabeledEvent(),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      loadRegistry: async () => [],
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async () => false,
+      createWorkflowDispatch: async params => {
+        await createWorkflowDispatch(params)
+      },
+      nonceSource: () => 'nonce-1',
+    })
+
+    expect(result.counts.dispatched).toBe(0)
+    expect(result.counts.refused).toBe(0)
+    expect(createWorkflowDispatch).not.toHaveBeenCalled()
+  })
+})
+
 describe('runDispatch — marker comment upsert (no comment spam)', () => {
   it('writes exactly one marker comment (created once) and updates it in place thereafter', async () => {
     const targets = [

--- a/scripts/cross-repo-dispatch.test.ts
+++ b/scripts/cross-repo-dispatch.test.ts
@@ -656,6 +656,40 @@ describe('runDispatch — seeds marker from decomposition checklist', () => {
 
     expect(result.counts.dispatched).toBe(0)
     expect(result.counts.refused).toBe(0)
+    expect(result.counts.seedRejected).toBe(0)
+    expect(createWorkflowDispatch).not.toHaveBeenCalled()
+  })
+
+  it('bails with seedRejected:1 when the latest checklist exceeds the item cap', async () => {
+    const targets = Array.from({length: MAX_ITEMS_PER_GOAL + 1}, (_, i) => ({
+      owner: 'fro-bot',
+      name: `repo-${i}`,
+      prompt: `do thing ${i}`,
+    }))
+    const decomposition = makeDecompositionBody(targets)
+
+    const {octokit, comments} = mockOctokit()
+    // Over-cap checklist, no existing state marker.
+    comments.push({id: 1, body: decomposition, login: 'fro-bot'})
+
+    const createWorkflowDispatch = vi.fn(async (_params: unknown) => ({}))
+
+    const result = await runDispatch({
+      octokit,
+      event: makeLabeledEvent(),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      loadRegistry: async () => [],
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async () => false,
+      createWorkflowDispatch: async params => {
+        await createWorkflowDispatch(params)
+      },
+      nonceSource: () => 'nonce-1',
+    })
+
+    expect(result.counts.dispatched).toBe(0)
+    expect(result.counts.seedRejected).toBe(1)
     expect(createWorkflowDispatch).not.toHaveBeenCalled()
   })
 })

--- a/scripts/cross-repo-dispatch.ts
+++ b/scripts/cross-repo-dispatch.ts
@@ -42,6 +42,8 @@ export interface DecompositionResult {
   ok: boolean
   items: DispatchItem[]
   error?: string
+  /** Machine-checkable failure discriminant, set only when `ok` is false. */
+  reason?: 'too-many-items' | 'no-items' | 'malformed'
 }
 
 export type GateResult = 'ok' | 'blocked-not-onboarded' | 'blocked-ineligible'
@@ -235,18 +237,18 @@ export function parseDecomposition(commentBody: string): DecompositionResult {
     .filter(line => line.length > 0)
 
   if (lines.length === 0) {
-    return {ok: false, items: [], error: 'empty decomposition'}
+    return {ok: false, items: [], error: 'empty decomposition', reason: 'no-items'}
   }
 
   const items: DispatchItem[] = []
   for (const [index, line] of lines.entries()) {
     const match = CHECKLIST_LINE.exec(line)
     if (match === null) {
-      return {ok: false, items: [], error: `unrecognized checklist line ${index + 1}: ${line}`}
+      return {ok: false, items: [], error: `unrecognized checklist line ${index + 1}: ${line}`, reason: 'malformed'}
     }
     const [, owner, name, prompt] = match
     if (owner === undefined || name === undefined || prompt === undefined) {
-      return {ok: false, items: [], error: `unrecognized checklist line ${index + 1}: ${line}`}
+      return {ok: false, items: [], error: `unrecognized checklist line ${index + 1}: ${line}`, reason: 'malformed'}
     }
     items.push({
       id: `item-${index + 1}`,
@@ -257,7 +259,12 @@ export function parseDecomposition(commentBody: string): DecompositionResult {
   }
 
   if (items.length > MAX_ITEMS_PER_GOAL) {
-    return {ok: false, items: [], error: `item count ${items.length} exceeds cap of ${MAX_ITEMS_PER_GOAL}`}
+    return {
+      ok: false,
+      items: [],
+      error: `item count ${items.length} exceeds cap of ${MAX_ITEMS_PER_GOAL}`,
+      reason: 'too-many-items',
+    }
   }
 
   return {ok: true, items}
@@ -698,6 +705,7 @@ export interface RunDispatchCounts {
   reconciled: number
   skippedUnsafePrompt: number
   casDeferred: number
+  seedRejected: number
 }
 
 export interface RunDispatchResult {
@@ -713,6 +721,7 @@ function emptyDispatchCounts(): RunDispatchCounts {
     reconciled: 0,
     skippedUnsafePrompt: 0,
     casDeferred: 0,
+    seedRejected: 0,
   }
 }
 
@@ -759,17 +768,27 @@ export async function runDispatch(input: RunDispatchInput): Promise<RunDispatchR
     // Cold start: no state marker exists yet. Seed one from the latest
     // bot-authored decomposition checklist so approving a goal actually
     // dispatches it instead of silently bailing.
-    const decompositionComment = comments.findLast(comment => {
-      if (!FROBOT_COMMENT_AUTHORS.has(comment.author.login)) return false
+    let decomposition: DecompositionResult | undefined
+    for (let i = comments.length - 1; i >= 0; i -= 1) {
+      const comment = comments[i]
+      if (comment === undefined || !FROBOT_COMMENT_AUTHORS.has(comment.author.login)) continue
       const parsed = parseDecomposition(comment.body)
-      return parsed.ok && parsed.items.length > 0
-    })
-    if (decompositionComment === undefined) {
-      await writeResult(input.resultPath, {counts})
-      return {counts}
+      if (parsed.ok && parsed.items.length > 0) {
+        decomposition = parsed
+        break
+      }
+      // The latest bot comment that looks like a checklist but failed to
+      // parse as one (e.g. over the item cap) is a distinct outcome from
+      // "no checklist found at all" — surface it instead of silently
+      // falling through to older comments or bailing indistinguishably.
+      const looksLikeChecklist = comment.body.split('\n').some(line => CHECKLIST_LINE.test(line.trim()))
+      if (looksLikeChecklist && parsed.reason === 'too-many-items') {
+        counts.seedRejected = 1
+        await writeResult(input.resultPath, {counts})
+        return {counts}
+      }
     }
-    const decomposition = parseDecomposition(decompositionComment.body)
-    if (!decomposition.ok) {
+    if (decomposition === undefined) {
       await writeResult(input.resultPath, {counts})
       return {counts}
     }

--- a/scripts/cross-repo-dispatch.ts
+++ b/scripts/cross-repo-dispatch.ts
@@ -754,10 +754,46 @@ export async function runDispatch(input: RunDispatchInput): Promise<RunDispatchR
     author: {login: comment.user?.login ?? ''},
     body: comment.body ?? '',
   }))
-  const marker = selectStateMarker(comments)
+  let marker = selectStateMarker(comments)
   if (marker === null) {
-    await writeResult(input.resultPath, {counts})
-    return {counts}
+    // Cold start: no state marker exists yet. Seed one from the latest
+    // bot-authored decomposition checklist so approving a goal actually
+    // dispatches it instead of silently bailing.
+    const decompositionComment = comments.findLast(comment => {
+      if (!FROBOT_COMMENT_AUTHORS.has(comment.author.login)) return false
+      const parsed = parseDecomposition(comment.body)
+      return parsed.ok && parsed.items.length > 0
+    })
+    if (decompositionComment === undefined) {
+      await writeResult(input.resultPath, {counts})
+      return {counts}
+    }
+    const decomposition = parseDecomposition(decompositionComment.body)
+    if (!decomposition.ok) {
+      await writeResult(input.resultPath, {counts})
+      return {counts}
+    }
+    const seedState: GoalState = {
+      goal: `issue-${issueNumber}`,
+      items: decomposition.items,
+      markerHash: '',
+    }
+    const serializedSeed = serializeMarker(seedState)
+    const seededState: GoalState = {...seedState, markerHash: serializedSeed.hash}
+    const seedCas = await casWriteMarker({
+      octokit: input.octokit,
+      owner: input.repo.owner,
+      repo: input.repo.repo,
+      issueNumber,
+      expectedPriorHash: undefined,
+      nextState: seededState,
+    })
+    if (!seedCas.ok) {
+      counts.casDeferred = 1
+      await writeResult(input.resultPath, {counts})
+      return {counts}
+    }
+    marker = serializedSeed
   }
 
   const prompts = extractItemPrompts(comments.map(comment => comment.body).join('\n'))


### PR DESCRIPTION
## What

The first live rehearsal of the cross-repo goal loop ([#3633](https://github.com/fro-bot/.github/issues/3633)) exposed a broken seam: the planner posts a human-readable work-item checklist, but the dispatch shell read **only** a hidden state marker and silently bailed when none existed. Approving a freshly proposed goal would have dispatched nothing — a silent no-op.

`parseDecomposition` was built for exactly this bridge but was never called outside tests (the unit tests inject pre-built markers, so they couldn't catch it — only the live planner→dispatch path does).

## Fix

On cold start (no existing marker), `runDispatch` now parses the latest bot-authored decomposition checklist into the initial state marker before gating and dispatch. The prompt-hash keying already matched between `parseDecomposition` and `extractItemPrompts`, so item prompts round-trip cleanly into the worker dispatch inputs. Malformed/absent checklist with no marker still bails (counted), unchanged.

## Verification

- TDD: new tests prove the seed path (checklist → seeded marker → gated dispatch → prompt recovery into `createWorkflowDispatch` inputs) and the bail-on-malformed path; all existing marker-present tests unchanged. Repo gate green: 2097 tests, check-types, lint.
- The rehearsal issue #3633 already carries a valid decomposition checklist, so the seed path can be exercised against it once this lands.