### PR TITLE
fix: tolerant decomposition parser + golden-path integration test

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -123,13 +123,21 @@ env:
     format (each line independently parseable):
     - [ ] <owner>/<name>: <prompt>
 
+    Wrap the checklist in a delimited region so the parser can find it
+    precisely even when you also write prose around it:
+
+    <!-- fro-bot:cross-repo-items:start -->
+    - [ ] <owner>/<name>: <prompt>
+    <!-- fro-bot:cross-repo-items:end -->
+
     Rules:
     - <owner>/<name> must be an owner-repo target (`fro-bot/*` or
       `marcusrbrown/*`) present in `metadata/repos.yaml`.
     - <prompt> is the exact task to hand to that repo's worker run — concise,
       concrete, self-contained.
-    - Emit nothing else that looks like a checklist item; free text outside
-      the checklist is fine but must not be mistaken for an item.
+    - Free text outside the delimited region is fine — an intro, an
+      explanation of why each target was chosen, a footer — as long as it
+      doesn't itself look like a checklist item.
     - If the goal cannot be decomposed into owner-repo targets, say so plainly
       instead of inventing items.
 

--- a/scripts/cross-repo-dispatch.test.ts
+++ b/scripts/cross-repo-dispatch.test.ts
@@ -16,6 +16,7 @@ import {
   buildMarkerComment,
   computeApprovalFingerprint,
   CROSS_REPO_GOAL_LABEL,
+  extractItemPrompts,
   extractMarker,
   findBotAuthoredPrs,
   findRunByCorrelationId,
@@ -223,6 +224,61 @@ describe('parseDecomposition', () => {
     const result = parseDecomposition('- [ ] not-a-valid-target-format do the thing')
     expect(result.ok).toBe(false)
     expect(result.items).toHaveLength(0)
+  })
+
+  it('accepts `*` and `+` task-list bullets identically to `-`', () => {
+    const body = [
+      'Some prose introducing the plan.',
+      '* [ ] marcusrbrown/sparkle: do thing',
+      'More prose in between items.',
+      '+ [ ] marcusrbrown/renovate-config: do thing',
+      'Trailing prose.',
+    ].join('\n')
+    const result = parseDecomposition(body)
+    expect(result.ok).toBe(true)
+    expect(result.items).toHaveLength(2)
+    expect(result.items[0]?.target).toEqual({owner: 'marcusrbrown', name: 'sparkle'})
+    expect(result.items[1]?.target).toEqual({owner: 'marcusrbrown', name: 'renovate-config'})
+  })
+})
+
+describe('extractItemPrompts', () => {
+  it('round-trips prompts for `*` and `+` bulleted items, matching parseDecomposition hashes', () => {
+    const body = [
+      'Some prose introducing the plan.',
+      '* [ ] marcusrbrown/sparkle: do thing',
+      'More prose in between items.',
+      '+ [ ] marcusrbrown/renovate-config: do thing',
+      'Trailing prose.',
+    ].join('\n')
+    const parsed = parseDecomposition(body)
+    expect(parsed.ok).toBe(true)
+    const prompts = extractItemPrompts(body)
+    for (const item of parsed.items) {
+      expect(prompts.get(item.promptHash)).toBeDefined()
+    }
+    expect(prompts.get(parsed.items[0]?.promptHash ?? '')).toBe('do thing')
+    expect(prompts.get(parsed.items[1]?.promptHash ?? '')).toBe('do thing')
+  })
+
+  it('agrees with parseDecomposition on a checklist-shaped but strictly invalid line: no prompts extracted', () => {
+    const body = '- [ ] bad-target-no-slash do thing'
+    const parsed = parseDecomposition(body)
+    expect(parsed.ok).toBe(false)
+    expect(parsed.reason).toBe('malformed')
+
+    const prompts = extractItemPrompts(body)
+    expect(prompts.size).toBe(0)
+  })
+
+  it('agrees with parseDecomposition when a valid item is mixed with a malformed item: neither is emitted', () => {
+    const body = ['- [ ] fro-bot/agent: do the thing', '- [ ] bad-target-no-slash do the other thing'].join('\n')
+    const parsed = parseDecomposition(body)
+    expect(parsed.ok).toBe(false)
+    expect(parsed.reason).toBe('malformed')
+
+    const prompts = extractItemPrompts(body)
+    expect(prompts.size).toBe(0)
   })
 })
 

--- a/scripts/cross-repo-dispatch.test.ts
+++ b/scripts/cross-repo-dispatch.test.ts
@@ -130,11 +130,73 @@ describe('parseDecomposition', () => {
     expect(result.items[0]?.status).toBe('pending')
   })
 
-  it('returns a parse error on malformed input, no items', () => {
+  it('returns no-items for prose with no checklist-shaped lines (tolerant parser skips prose)', () => {
     const result = parseDecomposition('this is not a checklist line')
     expect(result.ok).toBe(false)
     expect(result.items).toHaveLength(0)
+    expect(result.reason).toBe('no-items')
     expect(result.error).toBeDefined()
+  })
+
+  it('returns malformed for a task-list-shaped line that fails the strict grammar', () => {
+    const result = parseDecomposition('- [ ] not-a-valid-target-format do the thing')
+    expect(result.ok).toBe(false)
+    expect(result.items).toHaveLength(0)
+    expect(result.reason).toBe('malformed')
+  })
+
+  it('tolerates surrounding prose, headers, and an HTML details block around a valid checklist', () => {
+    const body = [
+      'This is a clean cross-repo goal: confirm each target README opens with an H1.',
+      '',
+      '## Proposed per-repo work items',
+      '',
+      '- [ ] fro-bot/agent: do the thing',
+      '- [x] marcusrbrown/dotfiles: fix the config',
+      '',
+      '---',
+      '',
+      '<details>',
+      '<summary>Run Summary</summary>',
+      '',
+      '| Field | Value |',
+      '|-------|-------|',
+      '| Event | issues |',
+      '',
+      '</details>',
+    ].join('\n')
+    const result = parseDecomposition(body)
+    expect(result.ok).toBe(true)
+    expect(result.items).toHaveLength(2)
+    expect(result.items[0]?.id).toBe('item-1')
+    expect(result.items[1]?.id).toBe('item-2')
+  })
+
+  it('prefers the delimited region when present, ignoring prose-adjacent noise outside it', () => {
+    const body = [
+      'Prose intro that is not part of the checklist.',
+      '<!-- fro-bot:cross-repo-items:start -->',
+      '- [ ] fro-bot/agent: do the thing',
+      '<!-- fro-bot:cross-repo-items:end -->',
+      'Prose footer, also not part of the checklist.',
+    ].join('\n')
+    const result = parseDecomposition(body)
+    expect(result.ok).toBe(true)
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0]?.target).toEqual({owner: 'fro-bot', name: 'agent'})
+  })
+
+  it('assigns ids by ordinal among collected items, not source line index', () => {
+    const body = [
+      'Some prose above the first item.',
+      '- [ ] fro-bot/agent: first item',
+      'Some prose between items.',
+      '- [ ] fro-bot/wiki: second item',
+    ].join('\n')
+    const result = parseDecomposition(body)
+    expect(result.ok).toBe(true)
+    expect(result.items[0]?.id).toBe('item-1')
+    expect(result.items[1]?.id).toBe('item-2')
   })
 
   it('returns a parse error on empty body', () => {
@@ -671,6 +733,33 @@ describe('runDispatch — seeds marker from decomposition checklist', () => {
     const {octokit, comments} = mockOctokit()
     // Over-cap checklist, no existing state marker.
     comments.push({id: 1, body: decomposition, login: 'fro-bot'})
+
+    const createWorkflowDispatch = vi.fn(async (_params: unknown) => ({}))
+
+    const result = await runDispatch({
+      octokit,
+      event: makeLabeledEvent(),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      loadRegistry: async () => [],
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async () => false,
+      createWorkflowDispatch: async params => {
+        await createWorkflowDispatch(params)
+      },
+      nonceSource: () => 'nonce-1',
+    })
+
+    expect(result.counts.dispatched).toBe(0)
+    expect(result.counts.seedRejected).toBe(1)
+    expect(createWorkflowDispatch).not.toHaveBeenCalled()
+  })
+
+  it('bails with seedRejected:1 when the latest checklist-shaped comment fails the strict grammar', async () => {
+    const {octokit, comments} = mockOctokit()
+    // Task-list-shaped but the target/prompt grammar is invalid — a visible
+    // rejected seed, not a silent no-op indistinguishable from "no checklist".
+    comments.push({id: 1, body: '- [ ] not-a-valid-target-format do the thing', login: 'fro-bot'})
 
     const createWorkflowDispatch = vi.fn(async (_params: unknown) => ({}))
 
@@ -1490,6 +1579,185 @@ describe('CLI wiring — real collaborators, not stubs', () => {
       expect(listWorkflowRunsForRepo).toHaveBeenCalledWith(
         expect.objectContaining({owner: TARGET_A.owner, repo: TARGET_A.name}),
       )
+    } finally {
+      process.env = originalEnv
+    }
+  })
+})
+
+describe('golden path — real production composition (runDispatchCli then runTrackCli)', () => {
+  // Captured shape of a real planner comment: prose intro, a checklist, prose
+  // footer, and a `<details><summary>Run Summary</summary></details>` block.
+  // This is the exact structure that broke the strict line-by-line parser —
+  // this test drives the REAL production wiring (runDispatchCli/runTrackCli),
+  // not runDispatch with hand-picked collaborators, so a prompt/parser
+  // contract mismatch here can't hide behind a unit-tested island again.
+  const PLANNER_COMMENT = [
+    'This is a clean cross-repo goal: confirm each target README opens with an H1 ... (prose intro paragraph)',
+    '',
+    'Both targets resolve to valid owner-repo entries ... (second prose paragraph)',
+    '',
+    'Proposed per-repo work items:',
+    '',
+    '- [ ] marcusrbrown/sparkle: Read README.md at the repo root. If the first non-blank line is already a top-level # H1, make no change. If no H1 is present, insert a minimal one (# sparkle) as the first line. Open a PR titled docs: ensure README H1 heading; do not touch other content.',
+    '- [ ] marcusrbrown/renovate-config: Read README.md at the repo root. If absent, insert # renovate-config as the first line. Open a PR titled docs: ensure README H1 heading; do not touch other content.',
+    '',
+    'This is a proposal only—no dispatch happened and this run has no dispatch capability.',
+    '',
+    '---',
+    '',
+    '<!-- fro-bot-agent -->',
+    '<details>',
+    '<summary>Run Summary</summary>',
+    '',
+    '| Field | Value |',
+    '|-------|-------|',
+    '| Event | issues |',
+    '| Repository | fro-bot/.github |',
+    '| Run ID | 0000000000 |',
+    '| Cache | hit |',
+    '',
+    '</details>',
+  ].join('\n')
+
+  const GOLDEN_TARGETS: DispatchTarget[] = [
+    {owner: 'marcusrbrown', name: 'sparkle'},
+    {owner: 'marcusrbrown', name: 'renovate-config'},
+  ]
+
+  it('parses the real planner comment shape, seeds+gates+dispatches both items, then closes the issue on success', async () => {
+    const originalEnv = {...process.env}
+    const {writeFile, mkdtemp} = await import('node:fs/promises')
+    const {tmpdir} = await import('node:os')
+    const path = await import('node:path')
+    const dir = await mkdtemp(path.join(tmpdir(), 'cross-repo-dispatch-golden-'))
+    const eventPath = path.join(dir, 'event.json')
+    await writeFile(
+      eventPath,
+      JSON.stringify({
+        label: {name: 'dispatch-approved'},
+        sender: {login: REQUIRED_APPROVER},
+        issue: {number: 42},
+      }),
+    )
+
+    process.env.GITHUB_TOKEN = 'test-token'
+    process.env.GITHUB_REPOSITORY = 'fro-bot/.github'
+    process.env.GITHUB_EVENT_PATH = eventPath
+    process.env.CROSS_REPO_DISPATCH_RESULT_PATH = ''
+
+    try {
+      // ─── Phase 1: runDispatchCli against a fake octokit factory ──────────
+      const {octokit, comments} = mockOctokit()
+      comments.push({id: 1, body: PLANNER_COMMENT, login: 'fro-bot'})
+
+      const createComment = vi.fn(async (params: {owner: string; repo: string; issue_number: number; body: string}) => {
+        const comment = {id: comments.length + 1, body: params.body, login: 'fro-bot'}
+        comments.push(comment)
+        return {data: {id: comment.id}}
+      })
+      const updateComment = vi.fn(async (params: {comment_id: number; body: string}) => {
+        const existing = comments.find(c => c.id === params.comment_id)
+        if (existing !== undefined) existing.body = params.body
+        return {}
+      })
+      const createWorkflowDispatch = vi.fn(async (_params: unknown) => ({}))
+      const listForRepo = vi.fn(async () => ({data: [{number: 42}]}))
+
+      const dispatchOctokit = {
+        ...octokit,
+        rest: {
+          ...octokit.rest,
+          issues: {...octokit.rest.issues, createComment, updateComment, listForRepo},
+          actions: {...octokit.rest.actions, createWorkflowDispatch},
+        },
+      }
+
+      await runDispatchCli(async () => dispatchOctokit)
+
+      expect(createComment).toHaveBeenCalledOnce()
+      const seededBody = createComment.mock.calls[0]?.[0]?.body as string
+      expect(seededBody.startsWith(`<!-- ${MARKER_PREFIX}`)).toBe(true)
+
+      expect(createWorkflowDispatch).toHaveBeenCalledTimes(2)
+      for (const target of GOLDEN_TARGETS) {
+        const call = createWorkflowDispatch.mock.calls.find(
+          c =>
+            (c[0] as {owner: string; repo: string}).owner === target.owner &&
+            (c[0] as {repo: string}).repo === target.name,
+        )
+        expect(call).toBeDefined()
+      }
+      const sparkleCall = createWorkflowDispatch.mock.calls.find(
+        c => (c[0] as {repo: string}).repo === 'sparkle',
+      )?.[0] as {inputs: {prompt: string}} | undefined
+      expect(sparkleCall?.inputs.prompt).toContain('insert a minimal one (# sparkle)')
+
+      const renovateCall = createWorkflowDispatch.mock.calls.find(
+        c => (c[0] as {repo: string}).repo === 'renovate-config',
+      )?.[0] as {inputs: {prompt: string}} | undefined
+      expect(renovateCall?.inputs.prompt).toContain('insert # renovate-config')
+
+      // dispatch result is what runDispatchCli wrote via writeResult (stdout);
+      // re-derive counts from the marker state left on the issue instead.
+      const finalMarker = selectStateMarker(comments.map(c => ({author: {login: c.login}, body: c.body})))
+      expect(finalMarker).not.toBeNull()
+      const dispatchedItems = finalMarker?.state.items.filter(item => item.status === 'dispatched') ?? []
+      expect(dispatchedItems).toHaveLength(2)
+
+      // ─── Phase 2: runTrackCli against the seeded+dispatched marker ───────
+      const correlationIds = new Map(
+        (finalMarker?.state.items ?? []).map(item => [item.target.name, item.correlationId as string]),
+      )
+
+      const listWorkflowRunsForRepo = vi.fn(async (params: {repo: string}) => ({
+        data: {
+          workflow_runs: [
+            {
+              id: 1,
+              name: null,
+              display_title: `fro-bot (${correlationIds.get(params.repo)})`,
+              status: 'completed',
+              conclusion: 'success',
+            },
+          ],
+        },
+      }))
+      const issuesAndPullRequests = vi.fn(async (params: {q: string}) => {
+        const target = GOLDEN_TARGETS.find(t => params.q.includes(`repo:${t.owner}/${t.name}`))
+        if (target === undefined) return {data: {items: []}}
+        return {
+          data: {
+            items: [
+              {
+                number: 1,
+                state: 'closed',
+                user: {login: 'fro-bot'},
+                pull_request: {merged_at: '2026-07-01T00:00:00Z'},
+              },
+            ],
+          },
+        }
+      })
+      const update = vi.fn(async (_params: unknown) => ({data: {}}))
+
+      const trackListForRepo = vi.fn(async () => ({data: [{number: 42}]}))
+      const trackOctokit = {
+        ...octokit,
+        rest: {
+          ...octokit.rest,
+          issues: {...octokit.rest.issues, listForRepo: trackListForRepo, update},
+          actions: {...octokit.rest.actions, listWorkflowRunsForRepo},
+          search: {...octokit.rest.search, issuesAndPullRequests},
+        },
+      }
+
+      await runTrackCli(async () => trackOctokit)
+
+      expect(update).toHaveBeenCalledWith(expect.objectContaining({issue_number: 42, state: 'closed'}))
+
+      const closedMarker = selectStateMarker(comments.map(c => ({author: {login: c.login}, body: c.body})))
+      expect(closedMarker?.state.items.every(item => item.status === 'completed')).toBe(true)
     } finally {
       process.env = originalEnv
     }

--- a/scripts/cross-repo-dispatch.ts
+++ b/scripts/cross-repo-dispatch.ts
@@ -225,60 +225,116 @@ export function selectStateMarker(comments: TrackerComment[]): MarkerData | null
 
 const CHECKLIST_LINE = /^-\s*\[[ x]\]\s+([\w-]+)\/([\w.-]+): (.+)$/i
 
+/** Loose task-list shape check — anything matching this MUST also satisfy `CHECKLIST_LINE`. */
+const LOOSE_TASK_LIST_PREFIX = /^-\s*\[[ x]\]/i
+
+/** Delimited region the planner emits around its checklist (see `fro-bot.yaml`). Optional. */
+const ITEMS_REGION_START = '<!-- fro-bot:cross-repo-items:start -->'
+const ITEMS_REGION_END = '<!-- fro-bot:cross-repo-items:end -->'
+
 /**
- * Parse a planner checklist comment body into closed-vocabulary items.
- * Grammar: `- [ ] <owner>/<name>: <prompt>` per line. Unrecognized lines →
- * parse error (no items), never free-text passthrough into item fields.
+ * Extract the substring between the delimited region markers, if both are
+ * present in order. Returns null when the region is absent (caller falls
+ * back to scanning the whole body tolerantly).
  */
-export function parseDecomposition(commentBody: string): DecompositionResult {
-  const lines = commentBody
+function extractItemsRegion(body: string): string | null {
+  const startIndex = body.indexOf(ITEMS_REGION_START)
+  if (startIndex === -1) return null
+  const afterStart = startIndex + ITEMS_REGION_START.length
+  const endIndex = body.indexOf(ITEMS_REGION_END, afterStart)
+  if (endIndex === -1) return null
+  return body.slice(afterStart, endIndex)
+}
+
+interface ChecklistCollectResult {
+  ok: boolean
+  items: DispatchItem[]
+}
+
+/**
+ * Scan `scope` line by line: task-list-shaped lines must fully match
+ * `CHECKLIST_LINE` or the whole scan fails malformed; anything else
+ * (prose, headers, HTML, table rows, footers) is skipped. Item ids are
+ * assigned by ORDINAL among collected items, not source line index, so
+ * surrounding prose can shift without changing ids.
+ */
+function collectChecklistItems(scope: string): ChecklistCollectResult {
+  const lines = scope
     .split('\n')
     .map(line => line.trim())
     .filter(line => line.length > 0)
 
-  if (lines.length === 0) {
-    return {ok: false, items: [], error: 'empty decomposition', reason: 'no-items'}
-  }
-
   const items: DispatchItem[] = []
-  for (const [index, line] of lines.entries()) {
+  for (const line of lines) {
+    if (!LOOSE_TASK_LIST_PREFIX.test(line)) continue
+
     const match = CHECKLIST_LINE.exec(line)
-    if (match === null) {
-      return {ok: false, items: [], error: `unrecognized checklist line ${index + 1}: ${line}`, reason: 'malformed'}
-    }
+    if (match === null) return {ok: false, items: []}
     const [, owner, name, prompt] = match
-    if (owner === undefined || name === undefined || prompt === undefined) {
-      return {ok: false, items: [], error: `unrecognized checklist line ${index + 1}: ${line}`, reason: 'malformed'}
-    }
+    if (owner === undefined || name === undefined || prompt === undefined) return {ok: false, items: []}
+
     items.push({
-      id: `item-${index + 1}`,
+      id: `item-${items.length + 1}`,
       target: {owner, name},
       promptHash: createHash('sha256').update(prompt).digest('hex').slice(0, 16),
       status: 'pending',
     })
   }
 
-  if (items.length > MAX_ITEMS_PER_GOAL) {
-    return {
-      ok: false,
-      items: [],
-      error: `item count ${items.length} exceeds cap of ${MAX_ITEMS_PER_GOAL}`,
-      reason: 'too-many-items',
-    }
-  }
-
   return {ok: true, items}
 }
 
 /**
+ * Parse a planner checklist comment body into closed-vocabulary items.
+ * Grammar: `- [ ] <owner>/<name>: <prompt>` per line. Prefers the delimited
+ * `fro-bot:cross-repo-items` region when present; otherwise scans the whole
+ * body tolerantly, skipping non-checklist-shaped prose/HTML lines. A line
+ * that IS task-list-shaped but fails the strict grammar is still a parse
+ * error — never free-text passthrough into item fields.
+ */
+export function parseDecomposition(commentBody: string): DecompositionResult {
+  const region = extractItemsRegion(commentBody)
+  const scope = region ?? commentBody
+
+  const collected = collectChecklistItems(scope)
+  if (!collected.ok) {
+    return {
+      ok: false,
+      items: [],
+      error: 'checklist-shaped line failed to match the required grammar',
+      reason: 'malformed',
+    }
+  }
+
+  if (collected.items.length === 0) {
+    return {ok: false, items: [], error: 'empty decomposition', reason: 'no-items'}
+  }
+
+  if (collected.items.length > MAX_ITEMS_PER_GOAL) {
+    return {
+      ok: false,
+      items: [],
+      error: `item count ${collected.items.length} exceeds cap of ${MAX_ITEMS_PER_GOAL}`,
+      reason: 'too-many-items',
+    }
+  }
+
+  return {ok: true, items: collected.items}
+}
+
+/**
  * Extract a promptHash → raw prompt text map from a planner checklist body,
- * using the same closed-vocabulary grammar as `parseDecomposition`. Pure,
- * no I/O. Used by the dispatch shell to recover the item prompt text for a
- * `DispatchItem` (which stores only the hash) without trusting free text.
+ * using the same closed-vocabulary grammar and region preference as
+ * `parseDecomposition`. Pure, no I/O. Used by the dispatch shell to recover
+ * the item prompt text for a `DispatchItem` (which stores only the hash)
+ * without trusting free text.
  */
 export function extractItemPrompts(commentBody: string): Map<string, string> {
+  const region = extractItemsRegion(commentBody)
+  const scope = region ?? commentBody
+
   const prompts = new Map<string, string>()
-  const lines = commentBody
+  const lines = scope
     .split('\n')
     .map(line => line.trim())
     .filter(line => line.length > 0)
@@ -778,11 +834,12 @@ export async function runDispatch(input: RunDispatchInput): Promise<RunDispatchR
         break
       }
       // The latest bot comment that looks like a checklist but failed to
-      // parse as one (e.g. over the item cap) is a distinct outcome from
-      // "no checklist found at all" — surface it instead of silently
-      // falling through to older comments or bailing indistinguishably.
-      const looksLikeChecklist = comment.body.split('\n').some(line => CHECKLIST_LINE.test(line.trim()))
-      if (looksLikeChecklist && parsed.reason === 'too-many-items') {
+      // parse as one (over the item cap, or a task-list-shaped line that
+      // fails the strict grammar) is a distinct outcome from "no checklist
+      // found at all" — surface it instead of silently falling through to
+      // older comments or bailing indistinguishably.
+      const looksLikeChecklist = comment.body.split('\n').some(line => LOOSE_TASK_LIST_PREFIX.test(line.trim()))
+      if (looksLikeChecklist && (parsed.reason === 'too-many-items' || parsed.reason === 'malformed')) {
         counts.seedRejected = 1
         await writeResult(input.resultPath, {counts})
         return {counts}

--- a/scripts/cross-repo-dispatch.ts
+++ b/scripts/cross-repo-dispatch.ts
@@ -223,10 +223,10 @@ export function selectStateMarker(comments: TrackerComment[]): MarkerData | null
   return extractMarker(body)
 }
 
-const CHECKLIST_LINE = /^-\s*\[[ x]\]\s+([\w-]+)\/([\w.-]+): (.+)$/i
+const CHECKLIST_LINE = /^[-*+]\s*\[[ x]\]\s+([\w-]+)\/([\w.-]+): (.+)$/i
 
 /** Loose task-list shape check — anything matching this MUST also satisfy `CHECKLIST_LINE`. */
-const LOOSE_TASK_LIST_PREFIX = /^-\s*\[[ x]\]/i
+const LOOSE_TASK_LIST_PREFIX = /^[-*+]\s*\[[ x]\]/i
 
 /** Delimited region the planner emits around its checklist (see `fro-bot.yaml`). Optional. */
 const ITEMS_REGION_START = '<!-- fro-bot:cross-repo-items:start -->'
@@ -324,22 +324,32 @@ export function parseDecomposition(commentBody: string): DecompositionResult {
 
 /**
  * Extract a promptHash → raw prompt text map from a planner checklist body,
- * using the same closed-vocabulary grammar and region preference as
- * `parseDecomposition`. Pure, no I/O. Used by the dispatch shell to recover
- * the item prompt text for a `DispatchItem` (which stores only the hash)
- * without trusting free text.
+ * using the SAME `collectChecklistItems` helper (region preference + strict
+ * loose-then-strict line classification) as `parseDecomposition`. Pure, no
+ * I/O. If the scope is malformed (a task-list-shaped line fails the strict
+ * grammar), no items are collected and the map is empty — this deliberately
+ * mirrors `parseDecomposition`'s failure rather than silently emitting a
+ * partial map that hides the malformed line. Used by the dispatch shell to
+ * recover the item prompt text for a `DispatchItem` (which stores only the
+ * hash) without trusting free text.
  */
 export function extractItemPrompts(commentBody: string): Map<string, string> {
   const region = extractItemsRegion(commentBody)
   const scope = region ?? commentBody
 
+  const collected = collectChecklistItems(scope)
   const prompts = new Map<string, string>()
+  if (!collected.ok) return prompts
+
+  // Re-derive prompt text alongside the hash `collectChecklistItems` already
+  // computed, using the same line classification so both stay in lockstep.
   const lines = scope
     .split('\n')
     .map(line => line.trim())
     .filter(line => line.length > 0)
 
   for (const line of lines) {
+    if (!LOOSE_TASK_LIST_PREFIX.test(line)) continue
     const match = CHECKLIST_LINE.exec(line)
     if (match === null) continue
     const prompt = match[3]


### PR DESCRIPTION
## What

The cross-repo dispatch loop silently failed three times, each caught only by live testing after passing full unit tests + review. The current instance: the planner emits its work-item checklist wrapped in prose (intro, footer) and a `<details>` run-summary block, but `parseDecomposition` rejected the entire comment as `malformed` on the first non-checklist line — so approving a real goal dispatched nothing. The workflow prompt already told the planner free text around the checklist was fine; the parser disagreed.

## Root pattern

All three failures shared one signature: comprehensive unit tests around injected cores, no test across the real production seam. (1) CLI wiring shipped with stub collaborators; (2) the planner→marker bridge was never called; (3) the parser was only ever fed clean checklist-only fixtures. Each broke exactly where the tests didn't look.

## Fix

- **Tolerant parser:** skips prose/headers/HTML/tables/`---`, but still rejects a checklist-*shaped* line that fails the grammar (a typo'd item is still an error, not silent). Item fields come only from the strict regex capture — no free-text passthrough.
- **Delimited region:** prefers a `<!-- fro-bot:cross-repo-items:start/end -->` region when present; the planner now emits it. Kept optional so existing goals (with a bare checklist) still parse.
- **Ordinal item ids** so surrounding prose can't shift them; `extractItemPrompts` shares the same region + grammar so prompt hashes round-trip.
- **Golden-path integration test:** drives the real production composition — `runDispatchCli` → `runTrackCli` with a fake octokit and a realistic captured planner comment (prose + checklist + run-summary, no marker). It seeds the marker, dispatches exactly one run per item, and closes the issue. **It fails against the old parser and passes against the new one** — this is the standing contract test that would have caught all three failures.

## Verification

- Parser verified against the actual failing comment: `ok:true`, 2 items, ordinal ids, full prompt-hash round-trip.
- Repo gate green: 2104 tests, check-types, lint; workflow YAML lint clean.