### PR TITLE
fix: mint owner-aware dispatch tokens across two GitHub Apps

### DIFF
--- a/.github/workflows/cross-repo-dispatch.yaml
+++ b/.github/workflows/cross-repo-dispatch.yaml
@@ -57,29 +57,60 @@ jobs:
           fi
 
       # Mint AFTER the actor+label gate above — a refused event never mints a
-      # cross-repo token. The target set is data-driven from the bot marker at
-      # runtime, so this mint is scoped at the owner level (the App is only
-      # installed on fro-bot/marcusrbrown-owned repos, matching the registry's
-      # owner-only gate) rather than to a static per-target repo list. Narrowest
-      # permission that permits `createWorkflowDispatch` cross-repo: actions:write.
-      - name: 🔑 Mint dispatch token
-        id: app-token
+      # cross-repo token.
+      #
+      # Two credential ROLES, minted separately:
+      #   1. Control plane: scoped to this repo's owner (fro-bot), issues:write
+      #      only — reads/writes the marker comment, removes labels, closes
+      #      the coordination issue. Never used against target repos.
+      #   2. Per-owner dispatch tokens: fro-bot and marcusrbrown are SEPARATE
+      #      App installations, so one token can't span both — a token minted
+      #      for owner X 403s ("Resource not accessible by integration") when
+      #      createWorkflowDispatch targets owner Y's installation. The
+      #      eligible owner set (ELIGIBLE_OWNERS in cross-repo-dispatch.ts) is
+      #      a fixed two, so two explicit mint steps here is correct and
+      #      simplest — no dynamic loop over a data-driven target set.
+      - name: 🔑 Mint control-plane token
+        id: control-plane-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.APPLICATION_ID }}
           private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          permission-actions: write
+          repositories: ${{ github.event.repository.name }}
           permission-issues: write
+
+      - name: 🔑 Mint fro-bot dispatch token
+        id: dispatch-token-fro-bot
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          owner: fro-bot
+          permission-actions: write
+
+      # marcusrbrown is a separate App installation, so its token is minted
+      # from the mrbro-bot App credentials (the fro-bot App cannot mint
+      # tokens for marcusrbrown-owned repos).
+      - name: 🔑 Mint marcusrbrown dispatch token
+        id: dispatch-token-marcusrbrown
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.MRBRO_BOT_APPLICATION_ID }}
+          private-key: ${{ secrets.MRBRO_BOT_APPLICATION_PRIVATE_KEY }}
+          owner: marcusrbrown
+          permission-actions: write
 
       - name: 🚀 Dispatch approved goal items
         id: dispatch
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.control-plane-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
           CROSS_REPO_DISPATCH_APPROVE_LABEL: dispatch-approved
           CROSS_REPO_DISPATCH_RESULT_PATH: ${{ runner.temp }}/cross-repo-dispatch-result.json
+          CROSS_REPO_DISPATCH_TARGET_TOKENS: >-
+            {"fro-bot":"${{ steps.dispatch-token-fro-bot.outputs.token }}","marcusrbrown":"${{ steps.dispatch-token-marcusrbrown.outputs.token }}"}
         run: node scripts/cross-repo-dispatch.ts dispatch
 
       - name: 📋 Write dispatch summary
@@ -167,25 +198,52 @@ jobs:
             echo "data branch not yet established; skipping metadata overlay."
           fi
 
-      # Track needs read access to target-repo runs/PRs plus write access to
-      # this repo's coordination issues (marker writes, close-on-terminal).
-      - name: 🔑 Mint track token
-        id: app-token
+      # Same two-role split as the dispatch job: a control-plane token
+      # (issues:write, scoped to this repo's owner) for marker/close
+      # operations in fro-bot/.github, plus a per-owner target token (fro-bot,
+      # marcusrbrown — separate App installations) for listWorkflowRunsForRepo
+      # + PR lookups against each target repo.
+      - name: 🔑 Mint control-plane token
+        id: control-plane-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.APPLICATION_ID }}
           private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+
+      - name: 🔑 Mint fro-bot track token
+        id: track-token-fro-bot
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          owner: fro-bot
           permission-actions: read
           permission-pull-requests: read
-          permission-issues: write
+
+      # marcusrbrown is a separate App installation, so its token is minted
+      # from the mrbro-bot App credentials (the fro-bot App cannot mint
+      # tokens for marcusrbrown-owned repos).
+      - name: 🔑 Mint marcusrbrown track token
+        id: track-token-marcusrbrown
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.MRBRO_BOT_APPLICATION_ID }}
+          private-key: ${{ secrets.MRBRO_BOT_APPLICATION_PRIVATE_KEY }}
+          owner: marcusrbrown
+          permission-actions: read
+          permission-pull-requests: read
 
       - name: 📡 Track dispatched goal items
         id: track
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.control-plane-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           CROSS_REPO_DISPATCH_RESULT_PATH: ${{ runner.temp }}/cross-repo-dispatch-result.json
+          CROSS_REPO_DISPATCH_TARGET_TOKENS: >-
+            {"fro-bot":"${{ steps.track-token-fro-bot.outputs.token }}","marcusrbrown":"${{ steps.track-token-marcusrbrown.outputs.token }}"}
         run: node scripts/cross-repo-dispatch.ts track
 
       - name: 📋 Write track summary

--- a/.github/workflows/cross-repo-dispatch.yaml
+++ b/.github/workflows/cross-repo-dispatch.yaml
@@ -109,6 +109,10 @@ jobs:
           GITHUB_EVENT_PATH: ${{ github.event_path }}
           CROSS_REPO_DISPATCH_APPROVE_LABEL: dispatch-approved
           CROSS_REPO_DISPATCH_RESULT_PATH: ${{ runner.temp }}/cross-repo-dispatch-result.json
+          # Safe to interpolate directly into inline JSON: App installation tokens are
+          # ghs_-prefixed with charset [A-Za-z0-9_], which cannot break JSON quoting or
+          # inject a key. Do not interpolate arbitrary/user-controlled values here without
+          # proper encoding.
           CROSS_REPO_DISPATCH_TARGET_TOKENS: >-
             {"fro-bot":"${{ steps.dispatch-token-fro-bot.outputs.token }}","marcusrbrown":"${{ steps.dispatch-token-marcusrbrown.outputs.token }}"}
         run: node scripts/cross-repo-dispatch.ts dispatch
@@ -242,6 +246,10 @@ jobs:
           GITHUB_TOKEN: ${{ steps.control-plane-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           CROSS_REPO_DISPATCH_RESULT_PATH: ${{ runner.temp }}/cross-repo-dispatch-result.json
+          # Safe to interpolate directly into inline JSON: App installation tokens are
+          # ghs_-prefixed with charset [A-Za-z0-9_], which cannot break JSON quoting or
+          # inject a key. Do not interpolate arbitrary/user-controlled values here without
+          # proper encoding.
           CROSS_REPO_DISPATCH_TARGET_TOKENS: >-
             {"fro-bot":"${{ steps.track-token-fro-bot.outputs.token }}","marcusrbrown":"${{ steps.track-token-marcusrbrown.outputs.token }}"}
         run: node scripts/cross-repo-dispatch.ts track

--- a/scripts/cross-repo-dispatch.test.ts
+++ b/scripts/cross-repo-dispatch.test.ts
@@ -15,6 +15,7 @@ import {describe, expect, it, vi} from 'vitest'
 import {
   buildMarkerComment,
   computeApprovalFingerprint,
+  createTargetClientResolver,
   CROSS_REPO_GOAL_LABEL,
   extractItemPrompts,
   extractMarker,
@@ -27,6 +28,7 @@ import {
   MARKER_PREFIX,
   MAX_ITEMS_PER_GOAL,
   parseDecomposition,
+  parseTargetTokens,
   planDispatch,
   planSnapshot,
   REQUIRED_APPROVER,
@@ -588,9 +590,25 @@ function makeLabeledEvent(overrides: Partial<LabeledEventPayload> = {}): Labeled
 
 const REPO = {owner: 'fro-bot', repo: '.github'}
 const TARGET_A = {owner: 'fro-bot', name: 'agent'}
+const TARGET_MARCUSRBROWN = {owner: 'marcusrbrown', name: 'sparkle'}
 
 function gateEntryFor(target: DispatchTarget): GateEntry {
   return {owner: target.owner, name: target.name, has_fro_bot_workflow: true, private: false}
+}
+
+/**
+ * Test-only single-client resolver: every owner routes to the SAME fake
+ * client — legacy single-client wiring adapted minimally so existing tests
+ * that don't care about owner routing keep passing.
+ */
+function singleOwnerResolver(client: CrossRepoDispatchOctokitClient) {
+  return async () =>
+    createTargetClientResolver(
+      new Map([
+        ['fro-bot', client],
+        ['marcusrbrown', client],
+      ]),
+    )
 }
 
 describe('runDispatch — actor gate', () => {
@@ -1573,6 +1591,348 @@ describe('findBotAuthoredPrs — anti-spoof', () => {
   })
 })
 
+describe('parseTargetTokens', () => {
+  it('parses a well-formed owner→token JSON map', () => {
+    expect(parseTargetTokens('{"fro-bot":"tok-a","marcusrbrown":"tok-b"}')).toEqual({
+      'fro-bot': 'tok-a',
+      marcusrbrown: 'tok-b',
+    })
+  })
+
+  it('returns an empty map for missing, empty, or malformed input', () => {
+    expect(parseTargetTokens(undefined)).toEqual({})
+    expect(parseTargetTokens('')).toEqual({})
+    expect(parseTargetTokens('not json')).toEqual({})
+    expect(parseTargetTokens('[]')).toEqual({})
+    expect(parseTargetTokens('null')).toEqual({})
+  })
+
+  it('drops non-string or empty-string token values', () => {
+    expect(parseTargetTokens('{"fro-bot":"","marcusrbrown":42,"good":"tok"}')).toEqual({good: 'tok'})
+  })
+
+  it('returns an empty map when every owner mint failed (both tokens empty)', () => {
+    // Mirrors the workflow's inline JSON when both per-owner mint steps
+    // continue-on-error past a failure (App not installed on either owner).
+    expect(parseTargetTokens('{"fro-bot":"","marcusrbrown":""}')).toEqual({})
+  })
+})
+
+describe('createTargetClientResolver — fail-closed owner routing', () => {
+  it('throws for an owner with no minted client', () => {
+    const {octokit} = mockOctokit()
+    const resolver = createTargetClientResolver(new Map([['fro-bot', octokit]]))
+    expect(resolver.hasTargetToken('fro-bot')).toBe(true)
+    expect(resolver.hasTargetToken('marcusrbrown')).toBe(false)
+    expect(() => resolver.targetClientFor('marcusrbrown')).toThrow(/no dispatch token minted/)
+  })
+})
+
+describe('owner-aware dispatch/track routing — fro-bot and marcusrbrown are separate App installations', () => {
+  it('routes a marcusrbrown target createWorkflowDispatch through the marcusrbrown client, not the control-plane client', async () => {
+    const originalEnv = {...process.env}
+    const {writeFile, mkdtemp} = await import('node:fs/promises')
+    const {tmpdir} = await import('node:os')
+    const path = await import('node:path')
+    const dir = await mkdtemp(path.join(tmpdir(), 'cross-repo-dispatch-owner-'))
+    const eventPath = path.join(dir, 'event.json')
+    await writeFile(eventPath, JSON.stringify(makeLabeledEvent()))
+
+    process.env.GITHUB_TOKEN = 'test-token'
+    process.env.GITHUB_REPOSITORY = 'fro-bot/.github'
+    process.env.GITHUB_EVENT_PATH = eventPath
+    process.env.CROSS_REPO_DISPATCH_RESULT_PATH = ''
+    try {
+      const decomposition = makeDecompositionBody([
+        {owner: 'marcusrbrown', name: 'sparkle', prompt: 'do the marcusrbrown thing'},
+      ])
+      const {octokit: controlPlaneOctokit} = mockOctokit({
+        comments: [{id: 1, body: decomposition, login: 'fro-bot'}],
+      })
+
+      const controlPlaneDispatch = vi.fn(async (_params: unknown) => ({}))
+      const marcusrbrownDispatch = vi.fn(async (_params: unknown) => ({}))
+
+      const controlPlane: CrossRepoDispatchOctokitClient = {
+        ...controlPlaneOctokit,
+        rest: {
+          ...controlPlaneOctokit.rest,
+          actions: {...controlPlaneOctokit.rest.actions, createWorkflowDispatch: controlPlaneDispatch},
+        },
+      }
+      const marcusrbrownClient: CrossRepoDispatchOctokitClient = {
+        ...controlPlaneOctokit,
+        rest: {
+          ...controlPlaneOctokit.rest,
+          actions: {...controlPlaneOctokit.rest.actions, createWorkflowDispatch: marcusrbrownDispatch},
+        },
+      }
+
+      await runDispatchCli(
+        async () => controlPlane,
+        async () =>
+          createTargetClientResolver(
+            new Map([
+              ['fro-bot', controlPlane],
+              ['marcusrbrown', marcusrbrownClient],
+            ]),
+          ),
+      )
+
+      expect(marcusrbrownDispatch).toHaveBeenCalledOnce()
+      expect(marcusrbrownDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({owner: 'marcusrbrown', repo: 'sparkle'}),
+      )
+      expect(controlPlaneDispatch).not.toHaveBeenCalled()
+    } finally {
+      process.env = originalEnv
+    }
+  })
+
+  it("dispatches a mixed goal (fro-bot + marcusrbrown targets) via each target owner's own client", async () => {
+    const originalEnv = {...process.env}
+    const {writeFile, mkdtemp} = await import('node:fs/promises')
+    const {tmpdir} = await import('node:os')
+    const path = await import('node:path')
+    const dir = await mkdtemp(path.join(tmpdir(), 'cross-repo-dispatch-mixed-'))
+    const eventPath = path.join(dir, 'event.json')
+    await writeFile(eventPath, JSON.stringify(makeLabeledEvent()))
+
+    process.env.GITHUB_TOKEN = 'test-token'
+    process.env.GITHUB_REPOSITORY = 'fro-bot/.github'
+    process.env.GITHUB_EVENT_PATH = eventPath
+    process.env.CROSS_REPO_DISPATCH_RESULT_PATH = ''
+    try {
+      const decomposition = makeDecompositionBody([
+        {owner: TARGET_A.owner, name: TARGET_A.name, prompt: 'do the fro-bot thing'},
+        {owner: TARGET_MARCUSRBROWN.owner, name: TARGET_MARCUSRBROWN.name, prompt: 'do the marcusrbrown thing'},
+      ])
+      const {octokit: controlPlaneOctokit} = mockOctokit({
+        comments: [{id: 1, body: decomposition, login: 'fro-bot'}],
+      })
+
+      const froBotDispatch = vi.fn(async (_params: unknown) => ({}))
+      const marcusrbrownDispatch = vi.fn(async (_params: unknown) => ({}))
+
+      const froBotClient: CrossRepoDispatchOctokitClient = {
+        ...controlPlaneOctokit,
+        rest: {
+          ...controlPlaneOctokit.rest,
+          actions: {...controlPlaneOctokit.rest.actions, createWorkflowDispatch: froBotDispatch},
+        },
+      }
+      const marcusrbrownClient: CrossRepoDispatchOctokitClient = {
+        ...controlPlaneOctokit,
+        rest: {
+          ...controlPlaneOctokit.rest,
+          actions: {...controlPlaneOctokit.rest.actions, createWorkflowDispatch: marcusrbrownDispatch},
+        },
+      }
+
+      await runDispatchCli(
+        async () => froBotClient,
+        async () =>
+          createTargetClientResolver(
+            new Map([
+              ['fro-bot', froBotClient],
+              ['marcusrbrown', marcusrbrownClient],
+            ]),
+          ),
+      )
+
+      expect(froBotDispatch).toHaveBeenCalledOnce()
+      expect(froBotDispatch).toHaveBeenCalledWith(expect.objectContaining({owner: TARGET_A.owner, repo: TARGET_A.name}))
+      expect(marcusrbrownDispatch).toHaveBeenCalledOnce()
+      expect(marcusrbrownDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({owner: TARGET_MARCUSRBROWN.owner, repo: TARGET_MARCUSRBROWN.name}),
+      )
+    } finally {
+      process.env = originalEnv
+    }
+  })
+
+  it('an eligible target owner with no minted token is blocked; other targets in the same goal still dispatch', async () => {
+    const item: DispatchItem = {
+      id: 'item-1',
+      target: TARGET_A,
+      promptHash: 'abcd1234abcd1234',
+      status: 'pending',
+    }
+    const missingTokenItem: DispatchItem = {
+      id: 'item-2',
+      target: TARGET_MARCUSRBROWN,
+      promptHash: 'ffff5678ffff5678',
+      status: 'pending',
+    }
+    const decomposition = makeDecompositionBody([
+      {owner: TARGET_A.owner, name: TARGET_A.name, prompt: 'do the fro-bot thing'},
+      {owner: TARGET_MARCUSRBROWN.owner, name: TARGET_MARCUSRBROWN.name, prompt: 'do the marcusrbrown thing'},
+    ])
+    const state: GoalState = {
+      goal: 'goal-mixed',
+      items: [
+        {...item, promptHash: extractPromptHash(decomposition, TARGET_A)},
+        {...missingTokenItem, promptHash: extractPromptHash(decomposition, TARGET_MARCUSRBROWN)},
+      ],
+      markerHash: '',
+    }
+    const {octokit, comments} = mockOctokit()
+    comments.push({id: 1, body: decomposition, login: 'marcusrbrown'})
+    seedMarkerComment(comments, state)
+
+    const createWorkflowDispatch = vi.fn(async (_params: unknown) => ({}))
+
+    const result = await runDispatch({
+      octokit,
+      event: makeLabeledEvent(),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      loadRegistry: async () => [gateEntryFor(TARGET_A), gateEntryFor(TARGET_MARCUSRBROWN)],
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async () => false,
+      createWorkflowDispatch: async params => {
+        await createWorkflowDispatch(params)
+      },
+      nonceSource: () => 'nonce-owner-gap',
+      // Only fro-bot has a minted token — marcusrbrown is eligible per the
+      // registry gate but ops forgot to mint its dispatch token.
+      hasTargetToken: owner => owner === 'fro-bot',
+    })
+
+    expect(createWorkflowDispatch).toHaveBeenCalledOnce()
+    expect(createWorkflowDispatch).toHaveBeenCalledWith(expect.objectContaining({owner: 'fro-bot', repo: 'agent'}))
+    expect(result.counts.dispatched).toBe(1)
+
+    const finalMarker = selectStateMarker(comments.map(c => ({author: {login: c.login}, body: c.body})))
+    const marcusrbrownItem = finalMarker?.state.items.find(candidate => candidate.id === 'item-2')
+    expect(marcusrbrownItem?.status).toBe('blocked')
+  })
+
+  it('all eligible targets blocked when the token map is empty (both owner mints failed); no crash, no dispatches', async () => {
+    const decomposition = makeDecompositionBody([
+      {owner: TARGET_A.owner, name: TARGET_A.name, prompt: 'do the fro-bot thing'},
+      {owner: TARGET_MARCUSRBROWN.owner, name: TARGET_MARCUSRBROWN.name, prompt: 'do the marcusrbrown thing'},
+    ])
+    const state: GoalState = {
+      goal: 'goal-all-blocked',
+      items: [
+        {id: 'item-1', target: TARGET_A, promptHash: extractPromptHash(decomposition, TARGET_A), status: 'pending'},
+        {
+          id: 'item-2',
+          target: TARGET_MARCUSRBROWN,
+          promptHash: extractPromptHash(decomposition, TARGET_MARCUSRBROWN),
+          status: 'pending',
+        },
+      ],
+      markerHash: '',
+    }
+
+    const {octokit, comments} = mockOctokit()
+    comments.push({id: 1, body: decomposition, login: 'marcusrbrown'})
+    seedMarkerComment(comments, state)
+
+    const createWorkflowDispatch = vi.fn(async (_params: unknown) => ({}))
+
+    const result = await runDispatch({
+      octokit,
+      event: makeLabeledEvent(),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      loadRegistry: async () => [gateEntryFor(TARGET_A), gateEntryFor(TARGET_MARCUSRBROWN)],
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async () => false,
+      createWorkflowDispatch: async params => {
+        await createWorkflowDispatch(params)
+      },
+      nonceSource: () => 'nonce-all-blocked',
+      // Simulates parseTargetTokens('{"fro-bot":"","marcusrbrown":""}') → {}
+      // → every owner lookup misses → every eligible item blocked.
+      hasTargetToken: () => false,
+    })
+
+    expect(createWorkflowDispatch).not.toHaveBeenCalled()
+    expect(result.counts.dispatched).toBe(0)
+    expect(result.counts.blocked).toBe(2)
+  })
+
+  it('track: listWorkflowRunsForRepo for a marcusrbrown target goes through the marcusrbrown client', async () => {
+    const item: DispatchItem = {
+      id: 'item-1',
+      target: TARGET_MARCUSRBROWN,
+      promptHash: 'abcd1234abcd1234',
+      status: 'dispatched',
+      correlationId: 'corr-track-owner-1',
+    }
+    const goalIssue: OpenGoalIssue = {
+      issueNumber: 77,
+      marker: serializeMarker({goal: 'goal-track', items: [item], markerHash: ''}),
+    }
+
+    const {octokit: controlPlaneOctokit} = mockOctokit()
+    const listForRepo = vi.fn(async () => ({data: [{number: 77}]}))
+    const controlPlaneListComments = vi.fn(async () => ({
+      data: [
+        {
+          id: 1,
+          body: buildMarkerComment({...goalIssue.marker.state, markerHash: goalIssue.marker.hash}),
+          user: {login: 'fro-bot'},
+        },
+      ],
+    }))
+    const controlPlane: CrossRepoDispatchOctokitClient = {
+      ...controlPlaneOctokit,
+      rest: {
+        ...controlPlaneOctokit.rest,
+        issues: {...controlPlaneOctokit.rest.issues, listForRepo, listComments: controlPlaneListComments},
+      },
+    }
+
+    const froBotListWorkflowRunsForRepo = vi.fn(async () => ({data: {workflow_runs: []}}))
+    const froBotClient: CrossRepoDispatchOctokitClient = {
+      ...controlPlaneOctokit,
+      rest: {
+        ...controlPlaneOctokit.rest,
+        actions: {...controlPlaneOctokit.rest.actions, listWorkflowRunsForRepo: froBotListWorkflowRunsForRepo},
+      },
+    }
+    const marcusrbrownListWorkflowRunsForRepo = vi.fn(async () => ({data: {workflow_runs: []}}))
+    const marcusrbrownClient: CrossRepoDispatchOctokitClient = {
+      ...controlPlaneOctokit,
+      rest: {
+        ...controlPlaneOctokit.rest,
+        actions: {
+          ...controlPlaneOctokit.rest.actions,
+          listWorkflowRunsForRepo: marcusrbrownListWorkflowRunsForRepo,
+        },
+      },
+    }
+
+    const originalEnv = {...process.env}
+    process.env.GITHUB_TOKEN = 'test-token'
+    process.env.GITHUB_REPOSITORY = 'fro-bot/.github'
+    process.env.CROSS_REPO_DISPATCH_RESULT_PATH = ''
+    try {
+      await runTrackCli(
+        async () => controlPlane,
+        async () =>
+          createTargetClientResolver(
+            new Map([
+              ['fro-bot', froBotClient],
+              ['marcusrbrown', marcusrbrownClient],
+            ]),
+          ),
+      )
+    } finally {
+      process.env = originalEnv
+    }
+
+    expect(marcusrbrownListWorkflowRunsForRepo).toHaveBeenCalledWith(
+      expect.objectContaining({owner: TARGET_MARCUSRBROWN.owner, repo: TARGET_MARCUSRBROWN.name}),
+    )
+    expect(froBotListWorkflowRunsForRepo).not.toHaveBeenCalled()
+  })
+})
+
 describe('CLI wiring — real collaborators, not stubs', () => {
   it('runTrackCli invokes octokit issue enumeration (wired loadOpenGoalIssues)', async () => {
     const originalEnv = {...process.env}
@@ -1582,7 +1942,7 @@ describe('CLI wiring — real collaborators, not stubs', () => {
     try {
       const listForRepo = vi.fn(async () => ({data: []}))
       const {octokit} = mockOctokit({listForRepo})
-      await runTrackCli(async () => octokit)
+      await runTrackCli(async () => octokit, singleOwnerResolver(octokit))
       expect(listForRepo).toHaveBeenCalled()
     } finally {
       process.env = originalEnv
@@ -1631,7 +1991,7 @@ describe('CLI wiring — real collaborators, not stubs', () => {
         rest: {...octokit.rest, actions: {...octokit.rest.actions, listWorkflowRunsForRepo}},
       }
 
-      await runDispatchCli(async () => patched)
+      await runDispatchCli(async () => patched, singleOwnerResolver(patched))
       expect(listWorkflowRunsForRepo).toHaveBeenCalledWith(
         expect.objectContaining({owner: TARGET_A.owner, repo: TARGET_A.name}),
       )
@@ -1729,7 +2089,7 @@ describe('golden path — real production composition (runDispatchCli then runTr
         },
       }
 
-      await runDispatchCli(async () => dispatchOctokit)
+      await runDispatchCli(async () => dispatchOctokit, singleOwnerResolver(dispatchOctokit))
 
       expect(createComment).toHaveBeenCalledOnce()
       const seededBody = createComment.mock.calls[0]?.[0]?.body as string
@@ -1808,7 +2168,7 @@ describe('golden path — real production composition (runDispatchCli then runTr
         },
       }
 
-      await runTrackCli(async () => trackOctokit)
+      await runTrackCli(async () => trackOctokit, singleOwnerResolver(trackOctokit))
 
       expect(update).toHaveBeenCalledWith(expect.objectContaining({issue_number: 42, state: 'closed'}))
 

--- a/scripts/cross-repo-dispatch.ts
+++ b/scripts/cross-repo-dispatch.ts
@@ -761,6 +761,15 @@ export interface RunDispatchInput {
   }) => Promise<void>
   nonceSource: () => string
   resultPath?: string
+  /**
+   * Owner-aware credential check. fro-bot and marcusrbrown are separate App
+   * installations, so a target's owner needs its OWN minted token — one
+   * token can't span both. When omitted, every owner is assumed reachable
+   * (single-client legacy wiring). Returning false fails an eligible target
+   * closed (counted `blocked`) instead of dispatching with the wrong owner's
+   * token and eating a 403.
+   */
+  hasTargetToken?: (owner: string) => boolean
 }
 
 export interface RunDispatchCounts {
@@ -896,8 +905,14 @@ export async function runDispatch(input: RunDispatchInput): Promise<RunDispatchR
   const gatedItems = state.items.map(item => {
     if (item.status !== 'pending') return item
     const gate = gateTarget(registryByKey.get(`${item.target.owner}/${item.target.name}`))
-    if (gate === 'ok') return item
-    return {...item, status: 'blocked' as ItemStatus}
+    if (gate !== 'ok') return {...item, status: 'blocked' as ItemStatus}
+    // An eligible target owner missing a minted dispatch token is an ops
+    // misconfiguration (App-installation mint didn't cover this owner) —
+    // fail this item closed rather than dispatch with the wrong token.
+    if (input.hasTargetToken !== undefined && !input.hasTargetToken(item.target.owner)) {
+      return {...item, status: 'blocked' as ItemStatus}
+    }
+    return item
   })
   state = {...state, items: gatedItems}
 
@@ -1075,6 +1090,8 @@ export interface RunTrackInput {
   findRunConclusion: (target: DispatchTarget, correlationId: string) => Promise<'success' | 'failure' | undefined>
   findBotAuthoredPrs: (target: DispatchTarget, correlationId: string) => Promise<PrLookupResult[]>
   resultPath?: string
+  /** Same owner-aware credential check as `RunDispatchInput.hasTargetToken`. */
+  hasTargetToken?: (owner: string) => boolean
 }
 
 export interface RunTrackCounts {
@@ -1132,6 +1149,10 @@ export async function runTrack(input: RunTrackInput): Promise<RunTrackResult> {
 
       const gate = gateTarget(registryByKey.get(`${item.target.owner}/${item.target.name}`))
       if (gate !== 'ok') {
+        signals[item.id] = {gateBlocked: true}
+        continue
+      }
+      if (input.hasTargetToken !== undefined && !input.hasTargetToken(item.target.owner)) {
         signals[item.id] = {gateBlocked: true}
         continue
       }
@@ -1353,13 +1374,87 @@ async function loadOctokitConstructor(): Promise<CrossRepoOctokitConstructor> {
   return Octokit as unknown as CrossRepoOctokitConstructor
 }
 
+async function createOctokitForToken(token: string): Promise<CrossRepoDispatchOctokitClient> {
+  const LoadedOctokit = await loadOctokitConstructor()
+  return new LoadedOctokit({auth: token, request: {timeout: 15_000}})
+}
+
 async function createOctokitFromEnv(): Promise<CrossRepoDispatchOctokitClient> {
   const token = process.env.GITHUB_TOKEN
   if (token === undefined || token === '') {
     throw new Error('cross-repo-dispatch: GITHUB_TOKEN is required in the environment')
   }
-  const LoadedOctokit = await loadOctokitConstructor()
-  return new LoadedOctokit({auth: token, request: {timeout: 15_000}})
+  return createOctokitForToken(token)
+}
+
+/** Env var carrying the owner→token JSON map minted per-owner in the workflow. */
+const TARGET_TOKENS_ENV_VAR = 'CROSS_REPO_DISPATCH_TARGET_TOKENS'
+
+/**
+ * Parse the owner→token JSON map. The App private key never enters this
+ * script — only already-minted per-owner tokens, one per eligible owner
+ * (fro-bot and marcusrbrown are separate App installations; one token can't
+ * span both). Malformed/absent input yields an empty map (fail-closed: every
+ * target owner is then treated as missing a token).
+ */
+export function parseTargetTokens(raw: string | undefined): Record<string, string> {
+  if (raw === undefined || raw === '') return {}
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+    const result: Record<string, string> = {}
+    for (const [owner, token] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof token === 'string' && token !== '') result[owner] = token
+    }
+    return result
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Per-owner target-repo client resolver. fro-bot and marcusrbrown are
+ * separate App installations — a token minted for one owner 403s against
+ * the other's repos, so every target-repo operation (dispatch,
+ * run-lookup, PR search) must go through the client for THAT target's
+ * owner, never the control-plane client.
+ */
+export interface TargetClientResolver {
+  targetClientFor: (owner: string) => CrossRepoDispatchOctokitClient
+  hasTargetToken: (owner: string) => boolean
+}
+
+/** Build a resolver from an owner→client map. Missing owner throws (fail-closed misconfiguration). */
+export function createTargetClientResolver(
+  clientsByOwner: ReadonlyMap<string, CrossRepoDispatchOctokitClient>,
+): TargetClientResolver {
+  return {
+    targetClientFor: owner => {
+      const client = clientsByOwner.get(owner)
+      if (client === undefined) {
+        throw new Error(`cross-repo-dispatch: no dispatch token minted for owner "${owner}"`)
+      }
+      return client
+    },
+    hasTargetToken: owner => clientsByOwner.has(owner),
+  }
+}
+
+/** Build the owner→client map from the parsed token map, reusing one client per distinct token. */
+async function buildTargetClients(
+  tokens: Record<string, string>,
+): Promise<Map<string, CrossRepoDispatchOctokitClient>> {
+  const clientsByToken = new Map<string, CrossRepoDispatchOctokitClient>()
+  const clientsByOwner = new Map<string, CrossRepoDispatchOctokitClient>()
+  for (const [owner, token] of Object.entries(tokens)) {
+    let client = clientsByToken.get(token)
+    if (client === undefined) {
+      client = await createOctokitForToken(token)
+      clientsByToken.set(token, client)
+    }
+    clientsByOwner.set(owner, client)
+  }
+  return clientsByOwner
 }
 
 async function loadRegistryFromDisk(): Promise<GateEntry[]> {
@@ -1387,8 +1482,15 @@ function parseRepository(raw: string | undefined): RepoRepository {
   return {owner, repo}
 }
 
+async function targetClientResolverFromEnv(): Promise<TargetClientResolver> {
+  const tokens = parseTargetTokens(process.env[TARGET_TOKENS_ENV_VAR])
+  const clientsByOwner = await buildTargetClients(tokens)
+  return createTargetClientResolver(clientsByOwner)
+}
+
 export async function runDispatchCli(
   createOctokit: () => Promise<CrossRepoDispatchOctokitClient> = createOctokitFromEnv,
+  createTargetClientResolverFn: () => Promise<TargetClientResolver> = targetClientResolverFromEnv,
 ): Promise<void> {
   const eventPath = process.env.GITHUB_EVENT_PATH
   const approveLabel = process.env.CROSS_REPO_DISPATCH_APPROVE_LABEL ?? 'dispatch-approved'
@@ -1404,6 +1506,7 @@ export async function runDispatchCli(
   const event = JSON.parse(await readFile(eventPath, 'utf8')) as LabeledEventPayload
   const repo = parseRepository(process.env.GITHUB_REPOSITORY)
   const octokit = await createOctokit()
+  const {targetClientFor, hasTargetToken} = await createTargetClientResolverFn()
 
   await runDispatch({
     octokit,
@@ -1412,30 +1515,37 @@ export async function runDispatchCli(
     approveLabel,
     loadRegistry: loadRegistryFromDisk,
     loadOtherOpenGoalMarkers: async () => loadOtherOpenGoalMarkers(octokit, repo, event.issue.number),
-    findRunByCorrelationId: findRunByCorrelationId(octokit),
+    findRunByCorrelationId: async (target, correlationId) =>
+      findRunByCorrelationId(targetClientFor(target.owner))(target, correlationId),
     createWorkflowDispatch: async params => {
-      await octokit.rest.actions.createWorkflowDispatch(params)
+      await targetClientFor(params.owner).rest.actions.createWorkflowDispatch(params)
     },
     nonceSource: () => createHash('sha256').update(`${Date.now()}:${Math.random()}`).digest('hex').slice(0, 12),
     resultPath,
+    hasTargetToken,
   })
 }
 
 export async function runTrackCli(
   createOctokit: () => Promise<CrossRepoDispatchOctokitClient> = createOctokitFromEnv,
+  createTargetClientResolverFn: () => Promise<TargetClientResolver> = targetClientResolverFromEnv,
 ): Promise<void> {
   const resultPath = process.env.CROSS_REPO_DISPATCH_RESULT_PATH
   const repo = parseRepository(process.env.GITHUB_REPOSITORY)
   const octokit = await createOctokit()
+  const {targetClientFor, hasTargetToken} = await createTargetClientResolverFn()
 
   await runTrack({
     octokit,
     repo,
     loadOpenGoalIssues: async () => loadOpenGoalIssues(octokit, repo),
     loadRegistry: loadRegistryFromDisk,
-    findRunConclusion: findRunConclusion(octokit),
-    findBotAuthoredPrs: findBotAuthoredPrs(octokit),
+    findRunConclusion: async (target, correlationId) =>
+      findRunConclusion(targetClientFor(target.owner))(target, correlationId),
+    findBotAuthoredPrs: async (target, correlationId) =>
+      findBotAuthoredPrs(targetClientFor(target.owner))(target, correlationId),
     resultPath,
+    hasTargetToken,
   })
 }
 

--- a/scripts/cross-repo-dispatch.ts
+++ b/scripts/cross-repo-dispatch.ts
@@ -1152,6 +1152,14 @@ export async function runTrack(input: RunTrackInput): Promise<RunTrackResult> {
         signals[item.id] = {gateBlocked: true}
         continue
       }
+      // Invariant: this token-gap branch is only safe because the workflow's per-owner
+      // mint steps are NOT continue-on-error — a failed mint fails the whole job, so by
+      // the time this script runs the token map is always fully populated for every
+      // eligible owner. If continue-on-error is ever re-added to the mints (or an owner
+      // is dropped from the mint set while remaining in ELIGIBLE_OWNERS), an
+      // already-dispatched item could be silently re-marked blocked on the next track
+      // pass, overwriting a real completed/failed conclusion. Do not soften the mints
+      // without addressing this.
       if (input.hasTargetToken !== undefined && !input.hasTargetToken(item.target.owner)) {
         signals[item.id] = {gateBlocked: true}
         continue


### PR DESCRIPTION
## What

The cross-repo dispatch loop 403'd when dispatching into a target owned by a different account (live run: `createWorkflowDispatch` into `marcusrbrown/sparkle` → 403 `Resource not accessible by integration`, `x-accepted-github-permissions: actions=write`). Root cause is **installation scope, not a missing permission**: the fro-bot App is private to `fro-bot` and cannot mint tokens for `marcusrbrown`-owned repos — those are covered by a separate App (`mrbro-bot`). One token can't span two installations, but the registry gate legitimately allows both owners.

## Fix (owner-aware, two-App)

- **Two credential roles.** A control-plane token (fro-bot App, repo-scoped to `.github`, `issues: write`) handles marker/CAS/label/close on the coordination issue. Per-owner **target** tokens handle cross-repo calls: `fro-bot` targets minted from the fro-bot App, `marcusrbrown` targets minted from the **mrbro-bot** App (new `MRBRO_BOT_APPLICATION_ID`/`_PRIVATE_KEY` secrets).
- **Owner-aware routing in the script.** `createWorkflowDispatch`, workflow-run lookup, and PR search route through `targetClientFor(target.owner)`; an eligible owner with no token fails closed to a `blocked` item, run continues. The App private keys never enter the script — only pre-minted per-owner tokens via an owner→token env map.
- **Fail loud on misconfig.** The per-owner mints are not `continue-on-error`: a missing/misconfigured App secret is broken infrastructure, not a runtime state to mask behind a blocked count (and in track it would terminally mis-mark dispatched items).
- Mints stay after the actor+label gate; control-plane token repo-narrowed.

## Verification

- Owner-routing is regression-locked: golden-path tests assert a `marcusrbrown` target dispatches through the mrbro-bot-token client and NOT the control-plane client; mixed-owner goals route each item via its own owner's client; an eligible owner without a token blocks that item while others dispatch.
- Repo gate green: 2118 tests, check-types, lint (incl. workflow YAML); action SHAs byte-identical.
- Designed with Oracle against the verified two-App topology.

## Note

This is the credential-scoping fix behind the cross-repo dispatch rehearsal (issue #3633). Once merged, resuming that rehearsal empirically confirms the mrbro-bot App reaches the marcusrbrown targets.