### PR TITLE
feat: track cross-repo dispatch completion via worker receipts

### DIFF
--- a/.github/workflows/cross-repo-dispatch.yaml
+++ b/.github/workflows/cross-repo-dispatch.yaml
@@ -205,8 +205,10 @@ jobs:
       # Same two-role split as the dispatch job: a control-plane token
       # (issues:write, scoped to this repo's owner) for marker/close
       # operations in fro-bot/.github, plus a per-owner target token (fro-bot,
-      # marcusrbrown — separate App installations) for listWorkflowRunsForRepo
-      # + PR lookups against each target repo.
+      # marcusrbrown — separate App installations) for listWorkflowRunsForRepo.
+      # Receipts are the sole completion oracle (R7/R8); run-lookup is a
+      # diagnostic-only annotator (Unit 5), so the target token needs only
+      # `actions: read` — no `pull-requests: read` (PR search is removed).
       - name: 🔑 Mint control-plane token
         id: control-plane-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -225,7 +227,6 @@ jobs:
           private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
           owner: fro-bot
           permission-actions: read
-          permission-pull-requests: read
 
       # marcusrbrown is a separate App installation, so its token is minted
       # from the mrbro-bot App credentials (the fro-bot App cannot mint
@@ -238,7 +239,6 @@ jobs:
           private-key: ${{ secrets.MRBRO_BOT_APPLICATION_PRIVATE_KEY }}
           owner: marcusrbrown
           permission-actions: read
-          permission-pull-requests: read
 
       - name: 📡 Track dispatched goal items
         id: track

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -141,6 +141,29 @@ env:
     - If the goal cannot be decomposed into owner-repo targets, say so plainly
       instead of inventing items.
 
+    Downstream, once an item is approved and dispatched, the target repo's
+    worker run receives a prompt carrying this item's work plus a receipt
+    contract. That contract is generated automatically — you do not need to
+    restate it in <prompt> — but it is documented here so the shape of the
+    full loop is clear:
+
+    A dispatched worker must, after doing the item's work, post a completion
+    receipt as a comment on THIS coordination issue, wrapped in its own
+    delimited region:
+
+    <!-- fro-bot:cross-repo-result:start -->
+    <!-- fro-bot:cross-repo-result {"correlation_id":"...","nonce":"...","status":"success","summary":"...","pr":"https://github.com/owner/repo/pull/123"} -->
+    <!-- fro-bot:cross-repo-result:end -->
+
+    Receipt rules the worker follows:
+    - `status` is exactly one of `success`, `noop`, or `failed` — nothing else.
+    - A receipt is MANDATORY even when the outcome is a no-op; a missing
+      receipt reads as a failure to report, not as success.
+    - Before finishing, the worker echoes the coordination issue it resolved
+      (owner/repo/number) and re-reads its own posted comment to confirm the
+      marker round-trips; if the marker is missing, it edits the comment to
+      add it before declaring the item done.
+
   SCHEDULE_PROMPT: |
     Run the daily Fro Bot pass for fro-bot/.github — the autonomous control
     center for the fro-bot GitHub account. This single run does BOTH proactive

--- a/README.md
+++ b/README.md
@@ -353,6 +353,26 @@ Each dispatch carries only the universal `prompt` input — no `correlation_id` 
 
 The nonce binds a receipt to its item: the coordination issue stores only `hash(nonce)`, and the raw nonce reaches the worker only through the prompt. One caveat worth stating plainly — a repo running Fro Bot with `OPENCODE_PROMPT_ARTIFACT` enabled publishes the rendered prompt (raw nonce included) as a downloadable Actions artifact. Where that's set on a target, item-level nonce isolation falls back to trusting the dispatched worker itself, which is the same trust boundary the loop already assumes: every worker is a Fro Bot agent.
 
+**Why push, not poll.** Tracking used to correlate a dispatched item to its worker run by matching a `correlation_id` against the run name — until target repos turned out to only guarantee a `prompt` input, and GitHub's dispatch API gives you a `204` with no run id back anyway. So the model flipped: the worker already knows how it went, and it already holds a credential that can write back to the coordination issue. The worker posts, a scheduled tracker reads. Tracking never polls PR state or the Actions API for completion; a `pr` URL in a receipt is operator-facing metadata, nothing more.
+
+**The receipt.** When a worker finishes an item — success, no-op, or failure — it posts a comment on the coordination issue containing a delimited region:
+
+```html
+<!-- fro-bot:cross-repo-result:start -->
+<!-- fro-bot:cross-repo-result {"correlation_id":"...","nonce":"...","status":"success","summary":"...","pr":"..."} -->
+<!-- fro-bot:cross-repo-result:end -->
+```
+
+`status` is exactly one of `success | noop | failed` — a no-op is a valid, mandatory receipt, not a missing one. The parser prefers the region but tolerates surrounding prose and a trailing run-summary block, same as the goal-decomposition checklist parser; a bot-authored comment that has a marker but botches the fields is `unparseable-receipt`, not silently accepted and not treated the same as no receipt at all.
+
+**Three gates before a receipt moves anything.** All of these have to hold: the comment is authored by `fro-bot`, its `correlation_id` matches a dispatched item, and `hash(nonce)` matches that item's stored `nonceHash`. Author alone isn't enough — every worker shares the same bot identity and correlation ids sit in plain sight on the issue — so a per-item nonce is the real lock. Its hash is the only thing that ever touches the public marker; the raw value only ever appears in that item's dispatch prompt. Reading the marker gets an attacker nothing to forge with. Whichever authentic receipt arrives first, by comment order, is the one that resolves the item, and a resolved item never flips again — which matters because the raw nonce becomes public the moment the real worker posts it, and a later replay of that now-public nonce still can't undo a completed or failed item.
+
+**24h SLA and the "did it even run" question.** An item with no authentic receipt within 24 hours of confirmed dispatch surfaces as `needs-attention` rather than sitting silently dispatched forever. It's reversible — a late, genuine receipt still resolves it — so a slow worker isn't punished for being slow. Because a missing receipt is the most likely failure mode (agents drift off prompt formats more often than you'd like), a diagnostic run-lookup kicks in at that point, purely for operator context: it checks whether the worker's run actually completed and tags the item "ran but didn't report" versus "never ran." That lookup never resolves state on its own — it's forensic signal, not a second completion oracle.
+
+**When an item gets stuck wrong.** First-authentic-receipt-wins is a deliberate anti-spoof choice, but it means a bad early receipt (or your own mistake) can lock an item somewhere you don't want it. There's no undo command for that yet — the fix is editing the coordination issue's state marker comment directly to correct the item's status.
+
+**What's still open.** Every worker authenticates as the same shared `FRO_BOT_PAT`, so this is a shared-trust-boundary design, not per-item authorization — a compromised PAT can still forge a receipt for any item whose nonce it can obtain. Scoping receipt tokens per dispatch, per coordination issue, is planned hardening, not yet shipped.
+
 ## Development
 
 ### Code Quality Standards

--- a/README.md
+++ b/README.md
@@ -349,6 +349,10 @@ Fro Bot coordinates a single goal across multiple owner repos (`fro-bot/*`, `mar
 
 If you need to re-approve after reopening a closed goal issue, reopening automatically clears the prior approval — reapply the `dispatch-approved` label to fire a fresh dispatch.
 
+Each dispatch carries only the universal `prompt` input — no `correlation_id` or other custom input, since target repos are autonomous and only guarantee `prompt`. The correlation id and a per-item nonce ride inside the prompt itself; the worker reports completion by posting a receipt comment on the coordination issue, which a periodic tracker verifies (author, correlation id, and `hash(nonce)`) before resolving the item.
+
+The nonce binds a receipt to its item: the coordination issue stores only `hash(nonce)`, and the raw nonce reaches the worker only through the prompt. One caveat worth stating plainly — a repo running Fro Bot with `OPENCODE_PROMPT_ARTIFACT` enabled publishes the rendered prompt (raw nonce included) as a downloadable Actions artifact. Where that's set on a target, item-level nonce isolation falls back to trusting the dispatched worker itself, which is the same trust boundary the loop already assumes: every worker is a Fro Bot agent.
+
 ## Development
 
 ### Code Quality Standards

--- a/docs/brainstorms/2026-07-04-cross-repo-dispatch-tracking-push-model-requirements.md
+++ b/docs/brainstorms/2026-07-04-cross-repo-dispatch-tracking-push-model-requirements.md
@@ -1,0 +1,277 @@
+---
+date: 2026-07-04
+topic: cross-repo-dispatch-tracking-push-model
+title: Cross-repo dispatch tracking — push-model completion receipts
+---
+
+# Cross-repo dispatch tracking — push-model completion receipts
+
+## Summary
+
+The cross-repo goal dispatch loop works end to end up to dispatch: it parses a goal decomposition,
+seeds state, gates targets, mints owner-aware tokens across two GitHub Apps, and triggers a worker
+run in each target repo. It cannot track those runs to completion. The current design correlated a
+dispatched item to its worker run by passing a `correlation_id` as a `workflow_dispatch` input and
+matching it in the run name — but target repos are autonomous, their `fro-bot.yaml` files are
+heterogeneous, and they only universally declare a `prompt` input, so GitHub rejects the dispatch
+with `422 Unexpected inputs provided: ["correlation_id"]`. GitHub also exposes no reliable
+dispatch-to-run-id primitive, so run correlation cannot be made robust without target-side changes
+the control plane does not own.
+
+This replaces pull-based run correlation with a push model. Dispatch sends only the universal
+`prompt`, carrying the correlation id and receipt contract inside it. The worker reports its own
+outcome as a mandatory, bot-authored completion receipt on the coordination issue. Tracking becomes
+a watchdog whose only writes are to the coordination issue: it reads receipts, resolves state,
+enforces an SLA, and closes the goal — it never dispatches and never polls target-repo PR state. No
+target repo's workflow changes.
+
+## Problem Frame
+
+The tracking half assumed one dispatch contract shared by all targets, extensible with a
+correlation input the run name echoes. That assumption is false: targets are independently managed
+repos whose only common `workflow_dispatch` input is `prompt`, and the control plane neither owns
+nor synchronizes their workflows. Polling GitHub's Actions API to infer an item's outcome is
+inferring intent from plumbing exhaust — the API returns `204 No Content` on dispatch (no run id)
+and never exposes dispatch inputs on a run. The worker already knows its own outcome and already
+holds a cross-repo-capable credential (`FRO_BOT_PAT`) that can write the coordination issue. Invert
+the flow: let the worker report, and let the control plane listen.
+
+## Actors
+
+- **Operator**: states goals, approves dispatch, resolves flagged items. Owns the goal issue.
+- **Control loop (dispatch)**: seeds state, gates targets, mints tokens, triggers worker runs with a
+  prompt-embedded correlation id and receipt contract.
+- **Worker**: an ordinary `fro-bot/agent` run in a target repo; performs the item's work and posts a
+  completion receipt back to the coordination issue.
+- **Control loop (track)**: watchdog; reads bot-authored receipts, resolves terminal state, enforces
+  the SLA, and closes the goal when every item is terminal. It never dispatches and never polls PR
+  state; its only writes are coordination-issue marker/summary/flag/close.
+
+## Key Flows
+
+- F1. Dispatch carries the receipt contract
+  - **Trigger:** an approved goal's item is dispatched.
+  - **Actors:** Control loop (dispatch), Worker
+  - **Steps:** dispatch calls the worker with only the `prompt` input; the prompt embeds the item's
+    correlation id, a reference to the coordination issue, the exact receipt marker format, and the
+    rule that a receipt is mandatory even when no change is made.
+  - **Outcome:** the worker has everything it needs to report back; no target workflow input beyond
+    `prompt` is used.
+  - **Covered by:** R1, R2, R7
+- F2. Worker reports completion
+  - **Trigger:** the worker finishes its item (including deciding no change is needed).
+  - **Actors:** Worker
+  - **Steps:** the worker posts a comment on the coordination issue containing the hidden receipt
+    marker with its correlation id, a status of `success`, `noop`, or `failed`, a short summary, and
+    an optional PR URL. It writes via `FRO_BOT_PAT`, so the comment is Fro Bot-authored.
+  - **Outcome:** the authoritative terminal signal exists on the shared issue.
+  - **Covered by:** R3, R4, R5
+- F3. Track resolves and closes
+  - **Trigger:** scheduled track pass (and manual dispatch).
+  - **Actors:** Control loop (track)
+  - **Steps:** track reads the coordination issue's comments, accepts only receipts that are
+    Fro Bot-authored and carry a correlation id matching a dispatched item, resolves each item's
+    terminal state, and — when every item is terminal — posts a counts-only summary and closes the
+    goal. Track performs no dispatch and no PR polling.
+  - **Outcome:** goal state is driven by receipts; closure is deterministic.
+  - **Covered by:** R6, R8, R9, R11
+- F4. Missing receipt → needs-attention
+  - **Trigger:** an item is dispatched but has no valid receipt past its SLA.
+  - **Actors:** Control loop (track), Operator
+  - **Steps:** track marks the item `needs-attention` (non-terminal), surfaces it on the goal issue
+    for the operator, and keeps the goal open. It never auto-re-dispatches and never treats the
+    absence as success.
+  - **Outcome:** a lost or crashed worker is visible, not silently counted done; the operator decides
+    how to resolve.
+  - **Covered by:** R9, R10, R11
+
+## Requirements
+
+**Dispatch contract**
+
+- R1. Dispatch passes only the `prompt` input to the target workflow — no `correlation_id` or any
+  other input beyond `prompt`. This removes the current `422` and requires no change to any target
+  repo's `fro-bot.yaml`.
+- R2. The dispatch prompt embeds: the item's correlation id, a reference to the coordination issue
+  (owner/repo/number), the exact receipt marker format, and the rule that a receipt is mandatory —
+  including on a no-op. The correlation id is the same per-item id the control plane already mints
+  into the seeded state marker; it is a join key that routes a receipt to its item, not a secret (it
+  becomes public once the receipt is posted), so it is never the security factor — see R6.
+
+**Completion receipt**
+
+- R3. Every dispatched worker MUST post a completion receipt to the coordination issue, even when it
+  makes no change. Emitting the receipt is part of the dispatch-eligible worker contract. A worker
+  should post exactly one; if more than one authentic receipt appears for an item, R6a governs which
+  wins, so correctness never depends on perfect single-post behavior.
+- R4. The receipt is a comment containing a hidden marker
+  `<!-- fro-bot:cross-repo-result {json} -->` whose JSON carries: `correlation_id`, `status` ∈
+  `{success, noop, failed}`, a short `summary`, and an optional `pr` URL. Human-readable prose may
+  surround the marker; only the marker is parsed. Parsing is tolerant of surrounding prose and
+  strict on the marker's fields (the same region-tolerant, field-strict discipline used for the
+  decomposition parser).
+- R5. The worker's status vocabulary is exactly `success | noop | failed`. There is no worker
+  `blocked` status: a worker that runs but cannot complete reports `failed` with an explanatory
+  summary. `blocked` remains reserved system-wide for the pre-dispatch registry-gate outcome.
+
+**Tracking and lifecycle**
+
+- R6. Track accepts a receipt only when both hold: the comment author is a Fro Bot identity (the
+  existing `FROBOT_COMMENT_AUTHORS` set) — this is the authorization gate, and a non-Fro Bot comment
+  can never move state — AND the receipt's `correlation_id` matches a currently dispatched item on
+  that goal — the join key that routes the receipt to its item, not a secret. A comment failing the
+  author check is ignored entirely; a Fro Bot-authored comment whose id matches no dispatched item is
+  ignored for state.
+- R6a. When more than one authentic receipt exists for the same item, the FIRST authentic receipt
+  (earliest comment) is authoritative and later duplicates are ignored; an item's state never flips
+  once resolved from a receipt.
+- R6b. A Fro Bot-authored comment that carries a `cross-repo-result` marker for a dispatched item but
+  whose marker fails to parse (invalid JSON, missing `correlation_id`, or `status` outside
+  `{success, noop, failed}`) is a receipt error, NOT an absent receipt: the worker reported but
+  botched the format. Track surfaces it distinctly (reason `unparseable-receipt`) rather than
+  collapsing it into silence — see R9.
+- R7. Terminal state resolves as: gate failure → `blocked` (pre-dispatch, unchanged); authentic
+  receipt `success` or `noop` → `completed`; authentic receipt `failed` → `failed`. The receipt is
+  the sole terminal completion signal.
+- R8. Track does not poll pull-request state. A receipt's `pr` URL is operator-facing metadata only;
+  the goal loop does not follow it to merged/closed. Whether a referenced PR merges is the
+  operator's normal review flow, outside the dispatch loop.
+- R9. An item dispatched with no authentic receipt past its SLA resolves to `needs-attention`, which
+  is NOT terminal: the goal issue stays open and track surfaces the item for the operator with a
+  reason (`no-receipt`, or `unparseable-receipt` per R6b). The SLA is the wall-clock age of the item
+  measured from its per-item dispatch `epoch` in the state marker against the track run's clock; the
+  default is 24 hours — the exact value is tunable in planning, but the clock rule is fixed.
+- R9a. `needs-attention` is REVERSIBLE: if an authentic, well-formed receipt later arrives for a
+  `needs-attention` item, it resolves to `completed` or `failed` per R7 and the operator flag is
+  cleared, so a late-report race never strands a goal open forever. A `needs-attention` item is
+  never counted as completed on its own.
+- R9b. Track performs no dispatch (no auto-re-dispatch); its only writes are to the coordination
+  issue — the state marker, the counts summary, the operator flag, and the close event. It never
+  writes to a target repo and never polls PR state.
+- R10. A goal issue closes only when every item is terminal (`completed`, `failed`, or `blocked`).
+  Any `needs-attention` or still-pending item keeps it open.
+- R11. Snapshot writes remain idempotent (no-op when state is unchanged) and telemetry remains
+  counts-only: no private repo identifiers, no receipt prose, no PR URLs in workflow summaries.
+
+## Acceptance Examples
+
+- AE1. **Covers R1.** Given an approved goal targeting a repo whose `fro-bot.yaml` declares only
+  `prompt`, when dispatch runs, `createWorkflowDispatch` succeeds (no `422`) and the worker run
+  starts.
+- AE2. **Covers R2, R3, R4.** Given a dispatched worker that makes a change, when it finishes, it
+  posts one receipt comment with a hidden marker whose status is `success`, its correlation id, a
+  summary, and the PR URL.
+- AE3. **Covers R3.** Given a dispatched worker that correctly decides no change is needed, when it
+  finishes, it still posts one receipt with status `noop` — not silence.
+- AE4. **Covers R6.** Given a third party posts a comment carrying a real-looking marker and a
+  guessed id, when track reads it, the comment is rejected (author is not a Fro Bot identity) and
+  does not affect state.
+- AE5. **Covers R6.** Given a Fro Bot-authored comment whose correlation id matches no dispatched
+  item, when track reads it, it is ignored for state.
+- AE6. **Covers R7.** Given authentic receipts of `success`, `noop`, and `failed` for three items,
+  when track resolves, they become `completed`, `completed`, and `failed` respectively.
+- AE7. **Covers R8.** Given a receipt carrying a `pr` URL for an unmerged PR, when track resolves,
+  the item is `completed` from the receipt and track never queries the PR's state.
+- AE8. **Covers R9, R10.** Given an item dispatched with no receipt past its SLA, when track runs,
+  the item is `needs-attention` with reason `no-receipt`, the goal stays open, and the operator is
+  flagged; an item that never received a receipt is never counted as completed.
+- AE9. **Covers R10.** Given all items terminal, when track runs, the goal issue closes with a
+  counts-only summary; given one `needs-attention` item, the goal stays open.
+- AE11. **Covers R6a.** Given two authentic receipts for the same item — an earlier `failed` and a
+  later `success` — when track resolves, the item is `failed` from the first receipt and the second
+  is ignored; the state does not flip.
+- AE12. **Covers R6b.** Given a Fro Bot-authored comment whose `cross-repo-result` marker has
+  malformed JSON (or a `status` outside the enum) for a dispatched item, when track runs before the
+  SLA, the item is surfaced as `unparseable-receipt`, distinct from `no-receipt`, rather than being
+  read as a valid outcome or as silence.
+- AE13. **Covers R9a.** Given an item already marked `needs-attention`, when an authentic
+  well-formed `success` receipt later arrives, the next track pass resolves it to `completed` and
+  clears the operator flag; the goal can then close.
+- AE10. **Covers R11.** Given any track run, when its summary renders, it contains only counts — no
+  repo identifiers, receipt prose, or PR URLs.
+
+## Success Criteria
+
+- A real multi-repo goal dispatches without a `422` and every item resolves from a worker receipt —
+  including a legitimate no-op — with the goal closing only after all items report.
+- No target repo's `fro-bot.yaml` is modified to make tracking work.
+- A worker that never reports is always visible as `needs-attention`, never silently completed.
+- A forged or mismatched comment never moves an item's state.
+
+## Scope Boundaries
+
+- No PR-merge tracking, no cross-repo PR polling, no bot-authored-PR search in the completion path.
+- No auto-re-dispatch or self-healing; track stays read-only apart from coordination-issue writes.
+- No target-repo workflow change; the receipt contract rides the `prompt` only.
+- No worker `blocked` status; `blocked` stays the pre-dispatch gate outcome.
+- Run-name/run-id correlation is not a correctness dependency in v1.
+
+### Deferred to Separate Tasks
+
+- Formalizing the receipt contract into the agent persona or a bundled skill (v1 keeps it in the
+  prompt).
+- Optional per-target `correlation_id` + run-name echo as richer run telemetry for repos that opt in.
+- Auto-re-dispatch of `needs-attention` items.
+
+## Key Decisions
+
+- **Push over pull.** The worker owns ground truth; the control plane listens. Polling the Actions
+  API inferred intent from plumbing that doesn't expose it. This matches the agent-native discipline
+  of explicit completion signals over heuristic detection.
+- **Mandatory receipt makes tracking deterministic.** Requiring a receipt even on no-op removes the
+  fatal ambiguity between "agent correctly did nothing" and "agent crashed." Absence past SLA is then
+  a real signal, not a guess.
+- **Receipt-only completion.** With a mandatory receipt that can name its own PR, independent PR
+  tracking adds surface without changing correctness; drop it. The operator's PR review stays their
+  normal flow.
+- **Reuse the anti-spoof and parse patterns already shipped.** Bot-author + correlation-id trust is
+  the existing marker-trust pattern; the hidden-marker + tolerant-region parse is the decomposition
+  parser's hardening applied to the receipt — the same lesson, not new machinery.
+- **needs-attention is non-terminal and track stays read-only.** A lost worker keeps the goal open
+  and visible; the operator resolves it. This preserves the dispatch/track separation the two-phase
+  design depends on.
+- **Prompt-only instruction channel.** The whole point of prompt-only dispatch: the receipt contract
+  travels in the one universal input, so autonomous target repos need no change.
+
+## Dependencies / Assumptions
+
+- `FRO_BOT_PAT` (the credential the target worker runs with) is the org-wide bot PAT and can write
+  `fro-bot/.github` issues — verified; a worker comment via it is authored `fro-bot` and passes the
+  author filter (the gateway rollout tracker already comments cross-repo this way). Planning should
+  re-confirm the authored identity string a dispatched worker's comment actually carries.
+- The correlation id the control plane mints per item lives in the seeded state marker, not the
+  human-visible checklist. It is a per-item join key, not a security boundary — it becomes public the
+  moment the worker posts a receipt — so authorization rests entirely on the Fro Bot author check
+  (R6), and the id only routes an authentic receipt to its item.
+- `fro-bot/agent` reliably follows a prompt instruction to post a structured comment; a worker that
+  ignores the instruction surfaces as `needs-attention` (fail-safe, not silent success).
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- None. Product decisions are settled; the remaining items are implementation choices for planning.
+
+### Deferred to Planning
+
+- The exact SLA duration (R9 fixes the clock rule — wall-clock age from the per-item `epoch` — and
+  defaults it to 24h; planning tunes the number).
+- Whether to delete the now-dead run-lookup / bot-authored-PR machinery and the track token's
+  `pull-requests: read` scope, or keep any of it as optional telemetry.
+- How the correlation id is surfaced into the prompt text (format/placement) and how track extracts
+  it back from the receipt marker.
+- Whether `needs-attention` (and its `no-receipt` vs `unparseable-receipt` reason) is surfaced as an
+  issue comment, a label, or both.
+
+## Sources / Research
+
+- Feature state and the five prior integration walls: project memory (cross-repo dispatch
+  architecture) and `docs/plans/2026-07-04-001-feat-cross-repo-dispatch-loop-plan.md`.
+- Origin requirements: `docs/brainstorms/2026-07-04-a3-cross-repo-dispatch-requirements.md`.
+- Live evidence: dispatch run `422 Unexpected inputs provided: ["correlation_id"]`; target
+  `fro-bot.yaml` files declare only `prompt` universally; `FRO_BOT_PAT` cross-repo write capability
+  (gateway-rollout-tracker precedent).
+- Correlation-design review: architecture advisor (push-model recommendation, no reliable
+  dispatch-to-run-id primitive).
+- Reused patterns: `scripts/cross-repo-dispatch.ts` (`FROBOT_COMMENT_AUTHORS` marker trust,
+  `extractMarker` tolerant parse, idempotent snapshot).

--- a/docs/plans/2026-07-04-002-feat-cross-repo-dispatch-push-tracking-plan.md
+++ b/docs/plans/2026-07-04-002-feat-cross-repo-dispatch-push-tracking-plan.md
@@ -1,0 +1,621 @@
+---
+title: "feat: Cross-repo dispatch push-model completion tracking"
+type: feat
+status: complete
+date: 2026-07-04
+origin: docs/brainstorms/2026-07-04-cross-repo-dispatch-tracking-push-model-requirements.md
+---
+
+# feat: Cross-repo dispatch push-model completion tracking
+
+## Overview
+
+The cross-repo goal dispatch loop works end to end up to the moment a worker run is triggered, then
+cannot track those runs to completion. It correlated a dispatched item to its worker run by passing a
+`correlation_id` as a `workflow_dispatch` input and matching it in the run name — but target repos
+are autonomous, their `fro-bot.yaml` files only universally declare a `prompt` input, so GitHub
+rejects the dispatch with `422 Unexpected inputs provided: ["correlation_id"]`.
+
+This replaces pull-based run correlation with a push model. Dispatch sends only the universal
+`prompt`, carrying the item's correlation id, a per-item nonce, and the receipt contract inside it.
+The worker posts a mandatory, bot-authored completion receipt (`success | noop | failed`) to the
+coordination issue. `track` becomes a watchdog whose only writes are to the coordination issue: it
+reads receipts, resolves terminal state, enforces a 24h SLA, and closes the goal when every item is
+terminal. No target repo's workflow changes.
+
+## Problem Frame
+
+The tracking half assumed one dispatch contract shared by all targets, extensible with a correlation
+input the run name echoes. That assumption is false: targets are independently managed repos whose
+only common `workflow_dispatch` input is `prompt`, and the control plane neither owns nor
+synchronizes their workflows. GitHub also exposes no reliable dispatch-to-run-id primitive
+(`createWorkflowDispatch` returns `204 No Content`; the runs API never exposes dispatch inputs), so
+run correlation cannot be made robust without target-side changes. The worker already knows its own
+outcome and already holds a cross-repo-capable credential (`FRO_BOT_PAT`) that can write the
+coordination issue. Invert the flow: the worker reports, the control plane listens.
+See origin: docs/brainstorms/2026-07-04-cross-repo-dispatch-tracking-push-model-requirements.md.
+
+## Requirements Trace
+
+- R1. Dispatch passes only the `prompt` input — no `correlation_id` or other input (origin R1).
+- R2. The prompt embeds the correlation id, the raw per-item nonce, a STRUCTURED coordination-issue
+  reference (owner, repo, number, canonical URL as distinct fields), a literal example receipt
+  (including a no-op example), the mandatory-receipt rule, and a self-validate step that echoes the
+  resolved receipt destination before posting (origin R2, hardened by research). The raw nonce is
+  delivered ONLY via the prompt and must NOT appear in the public marker NOR in any target-run public
+  surface (logs, run summaries, or a prompt artifact) before the worker's receipt — see R13.
+- R3. Every dispatched worker posts a completion receipt, even on no-op (origin R3).
+- R4. The receipt is a bot comment carrying a delimited region
+  `<!-- fro-bot:cross-repo-result:start --> … <!-- fro-bot:cross-repo-result:end -->` wrapping a
+  `<!-- fro-bot:cross-repo-result {json} -->` marker; parse prefers the region, tolerates prose,
+  strict on fields (origin R4, region convention added from wall-#3 evidence).
+- R5. Worker status vocabulary is exactly `success | noop | failed`; `blocked` stays the pre-dispatch
+  gate outcome (origin R5).
+- R6. Track accepts a receipt only when all three hold: author ∈ `FROBOT_COMMENT_AUTHORS`, the
+  receipt's `correlation_id` matches a dispatched item, AND `hash(receipt.nonce)` equals the item's
+  stored `nonceHash`. The public marker stores ONLY `nonceHash`; the raw nonce lives only in that
+  item's prompt. The nonce MUST be CSPRNG-generated with ≥128 bits of entropy (256 preferred);
+  `nonceHash` is a FULL SHA-256 hex digest (NOT the 64-bit-truncated `hashState`, and NOT a
+  `Date.now()+Math.random()` token). A plain SHA-256 is sufficient because the nonce is itself a
+  high-entropy secret (no HMAC/salt needed). Preimage resistance then means reading the public marker
+  reveals nothing forgeable, so a worker for item B cannot forge item A's receipt (origin R6; nonce
+  third gate from the security audit, hash-bound after plan review found a bare public nonce is not a
+  secret; entropy/hash spec set by Oracle verification).
+- R6c. The raw nonce becomes PUBLIC the instant the worker posts its receipt (it is in the receipt
+  body). This is safe ONLY because resolution is earliest-authentic-receipt-wins and terminal items
+  are never reconsidered: track resolves each item from the EARLIEST authentic receipt by comment
+  chronology — including when multiple receipts are first observed in the same track pass — and MUST
+  NOT use the marker path's `findLast`/latest-wins semantics. A later receipt (including one an
+  attacker posts after reading the now-public nonce) can never flip a resolved item.
+- R7. Terminal state: gate failure → `blocked`; authentic `success`/`noop` → `completed`; authentic
+  `failed` → `failed`; receipt is the sole terminal completion signal (origin R7).
+- R8. Track does not poll PR state; a receipt's `pr` URL is operator-facing metadata only (origin R8).
+- R9. No authentic receipt past the 24h SLA → `needs-attention` (non-terminal), surfaced with a
+  reason (`no-receipt` or `unparseable-receipt`); SLA clock is wall-age from the per-item `epoch`,
+  which is set at CONFIRMED-dispatch time only (never at intent), so an item that crashed between
+  intent and confirm never ages into a spurious `needs-attention` — pre-confirm failures are tracked
+  as dispatch failures, not SLA misses (origin R9, R6b).
+- R10. `needs-attention` is reversible by a later authentic receipt; an item goes terminal the first
+  time an authentic well-formed receipt resolves it, and never flips thereafter (origin R6a, R9a).
+- R11. A goal closes only when every item is terminal (`completed`/`failed`/`blocked`) (origin R10).
+- R12. Snapshot writes stay idempotent; telemetry stays counts-only — no repo identifiers, receipt
+  prose, PR URLs, or nonce material (raw nonce or hash) in workflow summaries or logs (origin R11).
+- R13. The raw nonce must not be exposed on any PUBLIC target-run surface before the worker's receipt.
+  `.github/workflows/fro-bot.yaml` sets `OPENCODE_PROMPT_ARTIFACT: 'true'` and passes the prompt into
+  the agent; Unit 3 must verify the dispatched prompt (carrying the raw nonce) is not published to a
+  world-readable artifact/log for a cross-repo-goal run, and disable/redact it if it is. If this
+  cannot be guaranteed, the plan states plainly that item isolation collapses to the shared-trust
+  boundary (any worker could read another item's nonce from the artifact).
+
+## Scope Boundaries
+
+- No PR-merge tracking, no cross-repo PR polling, no bot-authored-PR search in the completion path.
+- No auto-re-dispatch; `track` performs no dispatch — its only writes are coordination-issue
+  marker/summary/flag/close.
+- No target-repo workflow change; the receipt contract rides the `prompt` only.
+- No worker `blocked` status.
+- Run-name/run-id correlation is not a correctness dependency in v1.
+
+### Deferred to Separate Tasks
+
+- Confused-deputy hardening (HARD follow-up, not optional) — replacing `FRO_BOT_PAT` authorship with a
+  per-dispatch, coordination-issue-scoped receipt token so a compromised org-wide PAT can no longer
+  author receipts. Filed as a tracked fro-bot/.github issue + smart note BEFORE this ships. v1 accepts
+  the residual risk explicitly (shared-trust-boundary: all workers are `fro-bot` agents).
+- Worker-side receipt channel (drift mitigation) — a bundled skill or runtime receipt template in the
+  fro-bot/agent repo so the receipt is generated from structured data rather than prompt prose. This
+  is the real fix if live drift stays high after v1; tracked as a follow-up (its own brainstorm/plan,
+  cross-repo).
+- Optional per-target `correlation_id` + run-name echo as richer run telemetry for repos that opt in.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/cross-repo-dispatch.ts` — the whole feature. Reuse verbatim:
+  - `extractMarker` / `selectStateMarker` family (single-marker extraction with author filter +
+    `findLast` semantics) — the receipt parser mirrors this as a `cross-repo-result` variant.
+  - `FROBOT_COMMENT_AUTHORS` (`['fro-bot','fro-bot[bot]']`) — the R6 author gate.
+  - `parseDecomposition` / `collectChecklistItems` / `extractItemsRegion` — the region-preference +
+    loose-then-strict + "malformed vs absent" discipline the receipt parser reuses (region → body
+    scan → strict-on-marker-presence).
+  - CAS-write marker path + idempotent snapshot — track's state writes.
+  - The per-item marker already carries a per-item `epoch` and a `nonce` field (both present in the
+    `DispatchItem` schema). The SLA clock reuses `epoch`; the field currently stores a RAW nonce
+    minted from `Date.now()+Math.random()` — rename it to `nonceHash` and store a full SHA-256 hex
+    digest instead (do NOT reuse `hashState`, which truncates to 64 bits). Legacy in-flight markers
+    that store a raw `nonce` are incompatible with hash verification and must be reseeded (see
+    Operational Notes: #3633).
+  - `extractItemsRegion` is file-private; Unit 1's receipt parser lives in the same file and reuses
+    it directly (no export needed).
+  - `runDispatch` / `runTrack` and their injectable collaborator seams; `runDispatchCli` /
+    `runTrackCli` production wiring; the golden-path integration test pattern.
+- `.github/workflows/cross-repo-dispatch.yaml` — dispatch prompt construction (drop `correlation_id`
+  from `createWorkflowDispatch` inputs), track job. Track token's `pull-requests: read` scope becomes
+  removable.
+- `.github/workflows/fro-bot.yaml` — the `GOAL_DECOMPOSITION_PROMPT` block; the receipt instruction
+  + literal example + self-validate step live in the cross-repo-goal prompt guidance here, mirroring
+  the decomposition prompt's literal-example convention (its `:start`/`:end` region example).
+
+### Institutional Learnings
+
+- Wall-#3 forensics (PR #3635, commit `faa6e25`): the one existing LLM-emits-a-marker precedent (the
+  decomposition checklist) drifted from the prompt on day one — the agent emitted items in prose
+  without the delimited region, the strict parser rejected the whole comment, and approving a goal
+  dispatched nothing. Live issue #3633 shows the agent still omits the region even after the prompt
+  was updated. Lesson applied: the receipt inherits the delimited-region + tolerant-parse discipline
+  by design, the prompt carries a literal example, and the worker self-validates — do not rediscover
+  the drift.
+- `docs/solutions/best-practices/status-truth-synthetic-self-audit-claim-kinds-2026-07-03.md`:
+  "round-trip every marker contract; test the round-trip, not just the producer." The receipt marker
+  builder and parser must be round-trip tested.
+- Security audit findings (this session): the `fro-bot` author identity is broadly shared and every
+  item's correlation id is public on the issue, so author-check-alone permits cross-item receipt
+  forgery by a buggy/injected worker. Plan review then found that a bare nonce stored in the PUBLIC
+  marker is not a secret either (any worker reads it before the target posts). The gate is therefore
+  hash-bound: the public marker stores `hash(nonce)`; the raw nonce is delivered only via the prompt;
+  track verifies `hash(receipt.nonce)`. Preimage resistance closes the forgery within v1's trust
+  boundary.
+
+### External References
+
+- None required — GitHub dispatch/runs API behavior (`204`, no dispatch inputs on runs) is already
+  established in the origin doc and confirmed by the live `422`.
+
+## Key Technical Decisions
+
+- **Push over pull.** The worker owns ground truth; `track` listens. Polling the Actions API inferred
+  intent from plumbing that does not expose it.
+- **Hash-bound per-item nonce as a third trust gate.** Author check is necessary but not sufficient —
+  all workers share the `fro-bot` identity and correlation ids are public. The gate is an unguessable
+  per-item nonce whose HASH is stored in the public state marker while the raw nonce is delivered
+  ONLY in that item's prompt (a dispatch input, never public). Track accepts a receipt only if
+  `hash(receipt.nonce)` matches the item's stored `nonceHash`. Because the marker is public the
+  instant it is written, storing the raw nonce there would make it forgeable by any other worker —
+  hashing is what makes the third gate real. Neither the raw nonce nor the hash is emitted in
+  telemetry/logs (R12).
+- **Receipt reuses the delimited-region + tolerant-parse pattern.** Symmetry with decomposition, and
+  the wall-#3 evidence says a bare marker will drift. Region preferred, body-scan fallback, strict on
+  marker presence; a bot-authored comment with a malformed marker is `unparseable-receipt`, distinct
+  from absent (mirrors the dispatch path's `seedRejected` vs "no checklist").
+- **Receipt-only completion; run-lookup demoted to diagnostic, not deleted.** The receipt is the SOLE
+  completion oracle — run-lookup and bot-authored-PR search no longer resolve terminal state. But
+  rather than delete them, demote run-lookup to a NON-AUTHORITATIVE diagnostic: when an item has no
+  authentic receipt, "the worker's run exists and concluded" is real forensic signal that makes
+  `needs-attention` actionable ("ran but didn't report" vs "never ran") and preserves a crash-recovery
+  path. This directly answers the drift risk (some workers will fail to post a well-formed receipt)
+  and the recovery concern in one move. Bot-authored-PR search, which is not needed for either
+  completion or diagnosis, is removed. The track token keeps `actions: read` for the diagnostic run
+  lookup and drops `pull-requests: read`.
+- **Earliest-authentic-receipt-wins, needs-attention reversible — no conflict.** An item goes terminal
+  from the EARLIEST authentic receipt by comment chronology (including when several are first seen in
+  one track pass) and never flips — this is what makes the post-receipt public nonce replay-safe
+  (R6c): a later attacker receipt cannot flip a resolved item. This must NOT reuse the marker path's
+  `findLast`/latest-wins. `needs-attention` only ever applies to an item with no terminal receipt
+  yet, so a late receipt resolving it is consistent. An operator manual-override path (edit the state
+  marker) covers a wrongly-locked `failed`.
+- **Prompt-only instruction channel.** The receipt contract rides the one universal `prompt` input;
+  autonomous target repos need no change.
+- **Drift is expected, not assumed away.** The one LLM-emits-a-marker precedent drifted on day one and
+  still drifts on live #3633. The plan treats prompt-only formatting as best-effort: delimited region
+  + literal example + self-validate reduce drift; the diagnostic run-lookup makes the residual drift
+  actionable rather than silent; and a drifted-but-present marker surfaces as `unparseable-receipt`,
+  never as success. Prompt formatting is an optimization, not a correctness guarantee.
+- **Structured, resolvable receipt destination.** The worker receives the coordination issue as
+  distinct owner/repo/number + canonical URL fields (not prose), and self-checks the resolved
+  destination before posting, so a worker in a target repo posts to the right issue deterministically.
+- **Early-receipt tolerance.** A fast worker may post its receipt before the two-phase
+  intent→confirm dispatch has durably persisted the item as confirmed. Track correlates receipts
+  against the item set tolerantly: an authentic receipt whose item is not yet confirmed is retained
+  and re-evaluated on the next pass rather than dropped, so no real completion is lost to the race.
+
+## Open Questions
+
+### Resolved During Planning
+
+- SLA duration → 24h default; wall-age from the per-item `epoch`, which is set at confirmed-dispatch
+  only (tunable constant).
+- Run-lookup / bot-authored-PR machinery → run-lookup DEMOTED to non-authoritative diagnostic (not
+  deleted); bot-authored-PR search removed. Receipts are the sole completion oracle.
+- Nonce approach → hash-bound: `hash(nonce)` in the public marker, raw nonce only in the prompt,
+  `hash(receipt.nonce)` verified by track (third gate).
+- `first-wins` × `needs-attention` interaction → first-terminal-wins; `needs-attention` is the
+  pre-terminal state, reversible by a later authentic receipt.
+- Early-receipt race → track retains an authentic receipt for a not-yet-confirmed item and
+  re-evaluates next pass (no drop).
+
+**Glossary (state/reason terms):** `blocked` = pre-dispatch registry-gate refusal (never dispatched).
+`completed`/`failed` = terminal, from an authentic receipt. `needs-attention` = non-terminal, no
+authentic terminal receipt yet; reason `no-receipt` (none present past SLA) or `unparseable-receipt`
+(a bot-authored receipt marker present but malformed). "authentic" = passes all three R6 gates.
+
+### Deferred to Implementation
+
+- Exact nonce encoding (e.g. 32 CSPRNG bytes as base64url or hex) within the R6 spec: CSPRNG,
+  ≥128-bit (256 preferred), full SHA-256 hex digest.
+- Exact prompt phrasing/placement of the correlation id, nonce, and literal example receipt.
+- Whether `needs-attention` is surfaced as an issue comment, a label, or both, and the exact operator
+  manual-override note.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation
+> specification. The implementing agent should treat it as context, not code to reproduce.*
+
+Dispatch (per item, at CONFIRMED-dispatch time):
+
+    nonce      = CSPRNG randomBytes(≥16B)         # raw, in-memory only; high-entropy secret
+    item = { id, target, correlationId, nonceHash: sha256hex(nonce), epoch: confirmedAt, status }
+    marker(state) written via CAS  ── carries FULL-sha256 nonceHash (NOT raw nonce, NOT hashState)
+    prompt = build(correlationId, rawNonce, {owner,repo,number,url}, literalExampleReceipt, rules)
+    createWorkflowDispatch(target, workflow=fro-bot.yaml, inputs={ prompt })   # prompt only
+    # epoch is set only on confirm; an item that crashes intent→confirm is a dispatch failure, not SLA
+
+Worker (in target repo, general fro-bot/agent run):
+
+    do the item's work
+    post comment on the coordination issue {owner,repo,number} resolved from the prompt:
+        <!-- fro-bot:cross-repo-result:start -->
+        <!-- fro-bot:cross-repo-result {"correlation_id","nonce"(raw),"status","summary","pr"} -->
+        <!-- fro-bot:cross-repo-result:end -->
+    echo the resolved destination, then re-read the posted comment;
+    if the marker is absent, edit to add it before declaring done
+
+Track (watchdog, scheduled + manual):
+
+    for each comment on the coordination issue:
+        receipt = parseReceipt(region-preferred, tolerant)      # reuse extractMarker discipline
+        accept iff author ∈ FROBOT_COMMENT_AUTHORS
+                 and receipt.correlation_id ∈ dispatched items
+                 and hash(receipt.nonce) == item.nonceHash       # third gate (hash-bound)
+    receipt for a not-yet-confirmed item → retain, re-evaluate next pass (early-receipt tolerance)
+    resolve item:
+        authentic success|noop → completed   (first terminal wins, never flips)
+        authentic failed        → failed
+        bot marker present but malformed → unparseable-receipt (non-terminal)
+        no authentic receipt and age(now, item.epoch) > SLA(24h) → needs-attention (non-terminal)
+            diagnostic: run-lookup answers "ran but didn't report" vs "never ran" (non-authoritative)
+    close goal iff every item terminal (completed|failed|blocked)
+    writes: coordination-issue marker/summary/flag/close only.  No dispatch. No PR polling.
+
+## Implementation Units
+
+- [x] **Unit 1: Receipt marker schema, builder, and tolerant parser (pure core)**
+
+**Goal:** Add the completion-receipt contract to the pure core: a typed receipt, a marker builder
+that emits the delimited region, and a region-preferring tolerant parser that is strict on fields.
+
+**Requirements:** R4, R5, R6 (parse+field validation portion), R10, R12 (nonce never in telemetry).
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `scripts/cross-repo-dispatch.ts`
+- Test: `scripts/cross-repo-dispatch.test.ts`
+
+**Approach:**
+- Define a `CrossRepoResult` receipt type: `correlationId`, `nonce` (raw, as posted by the worker),
+  `status ∈ {success,noop,failed}`, `summary`, optional `pr`.
+- Add `buildResultMarker(receipt)` emitting the `:start`/`:end` region wrapping the JSON marker,
+  mirroring the decomposition region constants.
+- Add `parseResult(body)` reusing the file-private `extractItemsRegion` region-preference (Unit 1 lives
+  in the same file, so no export is needed) and the loose-then-strict discipline: prefer the region,
+  tolerate surrounding prose, strict on the JSON fields; classify a region/marker-present-but-invalid
+  body as a distinct `malformed` outcome (feeds `unparseable-receipt`), distinct from "no receipt
+  marker present".
+- Status strictly one of the three; anything else → malformed. The parser returns the raw nonce; the
+  hash comparison happens in Unit 4 (the parser never sees the stored `nonceHash`).
+
+**Patterns to follow:** `extractMarker`/`extractItemsRegion`/`collectChecklistItems`,
+`parseDecomposition`'s `{ok, reason}` result shape, the decomposition region constants.
+
+**Test scenarios:**
+- Happy path: a receipt comment (region + marker + surrounding prose) parses to the typed receipt for
+  each of `success`, `noop`, `failed`, with round-trip against `buildResultMarker` (build→parse
+  identity).
+- Edge case: region present, marker inside a code fence or with adjacent prose → still parses.
+- Edge case: bare marker without the region → parses via body-scan fallback (backward tolerant).
+- Error path: marker with malformed JSON, missing `nonce`, missing `correlation_id`, or `status`
+  outside the enum → `malformed` (not a valid receipt, not "absent").
+- Error path: comment with no receipt marker at all → "absent" outcome, distinct from `malformed`.
+- Edge case: nonce/summary containing characters that could break JSON quoting → round-trips safely.
+
+**Verification:** Build→parse round-trips for all three statuses; malformed and absent are distinct
+outcomes; no parser path returns a partial receipt.
+
+- [x] **Unit 2: Mint per-item nonce and build the receipt-carrying prompt (dispatch core)**
+
+**Goal:** At confirmed-dispatch, mint an unguessable per-item nonce, store only its HASH in the state
+marker, and construct the prompt carrying the RAW nonce, correlation id, a structured
+coordination-issue reference, a literal example receipt, the mandatory-receipt rule, and the
+self-validate step.
+
+**Requirements:** R2, R6 (nonce mint side), R9 (epoch-at-confirm), R12.
+
+**Dependencies:** Unit 1 (receipt shape for the literal example).
+
+**Files:**
+- Modify: `scripts/cross-repo-dispatch.ts`
+- Test: `scripts/cross-repo-dispatch.test.ts`
+
+**Approach:**
+- Rename the existing item `nonce` field to `nonceHash`. Mint a RAW nonce in-memory with a CSPRNG
+  (`node:crypto` `randomBytes`, ≥128-bit — 256 preferred — as base64url/hex); store its FULL SHA-256
+  hex digest in the CAS marker — never the raw nonce, and never via `hashState` (64-bit) or
+  `Date.now()+Math.random()`. Two-phase precision: mint the raw nonce, persist only the hash with the
+  intent write, and set `epoch` only on confirmed dispatch.
+- Add a prompt builder composing: item prompt text + a machine-contract block containing the
+  correlation id, the RAW nonce, the coordination issue as distinct `owner`/`repo`/`number` + a
+  canonical URL, a literal example receipt (including a no-op example), the "receipt mandatory even on
+  no-op" rule, and a self-validate instruction ("echo the resolved destination; re-read your posted
+  comment; if the marker is absent, edit to add it").
+- Ensure neither the raw nonce nor `nonceHash` is emitted on any counts/telemetry surface.
+
+**Patterns to follow:** existing correlation-id/`epoch` minting and the `nonce` field already in
+`DispatchItem` (renamed to `nonceHash`); `node:crypto` for CSPRNG + SHA-256; the decomposition
+prompt's literal-example convention in `fro-bot.yaml`.
+
+**Test scenarios:**
+- Happy path: dispatching an item stores a full-SHA-256 `nonceHash` in the marker and the built prompt
+  contains the correlation id, the RAW nonce, the structured issue reference (owner/repo/number/url),
+  and a literal receipt example.
+- Security: the raw nonce does NOT appear anywhere in the written marker (only its full-length hash);
+  the stored hash is not the 64-bit `hashState` truncation.
+- Edge case: two items in one goal get distinct nonces and distinct hashes.
+- Integration: `hash(rawNonce in prompt)` equals the `nonceHash` stored in the marker (mint↔prompt
+  consistency — the property Unit 4 verifies).
+- Edge case: `epoch` is set at confirm; an item left at intent has no SLA-eligible epoch.
+- Error path/telemetry: counts output for a dispatch run contains neither raw nonce nor hash.
+
+**Verification:** Each dispatched item stores only a unique `nonceHash`; the raw nonce appears only in
+the prompt; `epoch` is confirm-time; telemetry carries no nonce material.
+
+- [x] **Unit 3: Prompt-only dispatch — remove the `correlation_id` input (dispatch shell + workflow)**
+
+**Goal:** Stop passing `correlation_id` as a `workflow_dispatch` input so dispatch stops 422ing;
+carry correlation via the prompt only.
+
+**Requirements:** R1, R13.
+
+**Dependencies:** Unit 2 (prompt now carries correlation id + nonce).
+
+**Files:**
+- Modify: `scripts/cross-repo-dispatch.ts` (the `createWorkflowDispatch` inputs)
+- Modify: `.github/workflows/cross-repo-dispatch.yaml` (if any input plumbing references it)
+- Modify: `.github/workflows/fro-bot.yaml` (cross-repo-goal prompt guidance: add the receipt
+  contract, literal example, self-validate step; verify the raw-nonce prompt is not published to a
+  world-readable artifact/log — `OPENCODE_PROMPT_ARTIFACT` handling per R13)
+- Test: `scripts/cross-repo-dispatch.test.ts`
+
+**Approach:**
+- `createWorkflowDispatch` inputs become `{ prompt }` only.
+- Add the receipt instruction + literal example + self-validate guidance to the cross-repo-goal
+  prompt block in `fro-bot.yaml`, mirroring the decomposition prompt's shape. No target-repo change.
+- R13 check: confirm the dispatched prompt (carrying the raw nonce) is not written to a world-readable
+  artifact/log for these runs; disable/redact the prompt artifact for the cross-repo-goal path, or
+  state plainly in the README that item isolation falls back to the shared-trust boundary.
+
+**Patterns to follow:** the existing dispatch call; the decomposition prompt guidance block.
+
+**Test scenarios:**
+- Happy path: a dispatched item calls `createWorkflowDispatch` with exactly `{ prompt }` — assert no
+  `correlation_id` (or any non-`prompt`) key is present.
+- Integration: the golden-path CLI test (Unit 6) dispatches with prompt-only inputs against a target
+  declaring only `prompt`.
+
+**Verification:** Dispatch inputs are prompt-only; no dispatch passes `correlation_id`; the R13
+prompt-artifact exposure is resolved (redacted) or explicitly documented as a residual.
+
+- [x] **Unit 4: Receipt-driven terminal-state resolution + 24h SLA (track core)**
+
+**Goal:** Resolve each item's terminal state from authentic receipts, apply the three-gate trust
+check, enforce the 24h SLA → `needs-attention`, and make `needs-attention` reversible.
+
+**Requirements:** R6, R7, R9, R10, R11.
+
+**Dependencies:** Unit 1 (parser), Unit 2 (nonce in marker).
+
+**Files:**
+- Modify: `scripts/cross-repo-dispatch.ts` (the `runTrack` resolver / `deriveTerminalState`)
+- Test: `scripts/cross-repo-dispatch.test.ts`
+
+**Approach:**
+- Trust gate: accept a parsed receipt only if author ∈ `FROBOT_COMMENT_AUTHORS`, `correlation_id`
+  maps to a dispatched item, AND `hash(receipt.nonce)` equals that item's stored `nonceHash`.
+- Early-receipt tolerance: an authentic receipt whose item is not yet confirmed-dispatched is RETAINED
+  and re-evaluated on the next pass, never dropped (handles the intent→confirm race).
+- Resolve: authentic `success`/`noop` → `completed`; authentic `failed` → `failed`; the EARLIEST
+  authentic receipt by comment chronology wins (never `findLast`/latest), and a resolved item never
+  flips — this is the replay-safety property for the post-receipt public nonce (R6c).
+- Bot marker present but malformed for a dispatched item → `needs-attention` reason
+  `unparseable-receipt` (non-terminal).
+- No authentic receipt and `now − item.epoch > SLA(24h)` → `needs-attention` reason `no-receipt`;
+  epoch is confirm-time so a pre-confirm crash never triggers this.
+- `needs-attention` reversible: a later authentic well-formed receipt resolves it per R7.
+- Goal closes only when every item terminal; keep `blocked` (pre-dispatch gate) semantics intact.
+- Add the SLA as a named tunable constant.
+
+**Patterns to follow:** existing `deriveTerminalState`/terminal-precedence resolution; the
+`epoch`-based timing already in the marker; reuse the same hash primitive chosen in Unit 2.
+
+**Test scenarios:**
+- Happy path: authentic `success`, `noop`, `failed` receipts (raw nonce hashing to the stored
+  `nonceHash`) → `completed`, `completed`, `failed`.
+- Security (R6): a receipt whose raw nonce does NOT hash to the item's `nonceHash` → rejected, item
+  unresolved (cross-item forgery blocked even though the marker's hash is public).
+- Security (R6): a receipt carrying item A's correlation id but item B's nonce → rejected (hash
+  mismatch); cannot resolve A.
+- Error path: non-Fro Bot-authored comment with a valid-looking marker → ignored.
+- Error path: bot-authored malformed marker for a dispatched item pre-SLA → `unparseable-receipt`,
+  non-terminal, goal stays open.
+- Edge case (early-receipt): an authentic receipt for an item not yet confirmed → retained, resolves
+  on the next pass once the item is confirmed (not dropped).
+- Edge case (SLA): item with no receipt and confirm-age > 24h → `needs-attention`/`no-receipt`;
+  age < 24h → still pending; an item never confirmed → not SLA-aged.
+- Edge case (R10): item marked `needs-attention`, then a later authentic `success` arrives → resolves
+  to `completed`; flag-clear reflected.
+- Edge case (earliest-wins / replay): authentic `failed` then later authentic `success` → stays
+  `failed`; a second authentic receipt reusing the now-public raw nonce, posted after the first,
+  never flips the resolved item.
+- Edge case (R11): all terminal → goal closeable; one `needs-attention` → stays open.
+
+**Verification:** All three trust gates enforced with hash comparison; early receipts retained; SLA
+keys off confirm-time epoch; reversibility behaves per R9/R10; a receipt whose nonce mishashes never
+moves state.
+
+- [x] **Unit 5: Demote run-lookup to diagnostic; remove PR-search; prune track token scope**
+
+**Goal:** Make receipts the sole completion oracle while keeping run-lookup as a NON-AUTHORITATIVE
+diagnostic that makes `needs-attention` actionable and preserves crash recovery. Remove the
+bot-authored-PR search (needed for neither completion nor diagnosis) and drop the track token's
+`pull-requests: read` scope.
+
+**Requirements:** R8 (no PR polling for completion), supports R9 (actionable needs-attention), R12.
+
+**Dependencies:** Unit 4 (the resolver must already resolve terminal state from receipts, so
+run-lookup is no longer authoritative). Sequencing is load-bearing: run-lookup collaborators are still
+hard-called by `runTrack` today, so this unit MUST follow Unit 4's rewire — do not pull the seams out
+of a live resolver.
+
+**Files:**
+- Modify: `scripts/cross-repo-dispatch.ts` (keep `findRunByCorrelationId` as a diagnostic collaborator
+  used ONLY to annotate a `no-receipt` `needs-attention` item with "ran but didn't report" vs "never
+  ran"; remove `findBotAuthoredPrs` and its seam)
+- Modify: `.github/workflows/cross-repo-dispatch.yaml` (drop `pull-requests: read` from the track
+  token mints; keep `actions: read` for the diagnostic run-lookup; remove PR-search wiring)
+- Test: `scripts/cross-repo-dispatch.test.ts` (adjust: run-lookup is diagnostic-only; delete PR-search
+  tests)
+
+**Approach:**
+- Terminal state is resolved entirely by Unit 4 from receipts; run-lookup output NEVER changes an
+  item's terminal state — it only annotates the diagnostic reason on an already-`needs-attention`
+  item.
+- Remove `findBotAuthoredPrs` and its collaborator seam; ensure no caller references it.
+- Track token keeps `actions: read` (diagnostic run-lookup), drops `pull-requests: read`; control-plane
+  token keeps `issues: write`.
+- Confirm `Test Scripts Load` and the `import.meta.url` guard remain intact.
+
+**Patterns to follow:** existing token-scoping in the two-App mint steps; existing collaborator-seam
+structure.
+
+**Test scenarios:**
+- Happy path: track resolves a full goal from receipts only; run-lookup is not consulted for any item
+  that has an authentic receipt.
+- Diagnostic: a `no-receipt` `needs-attention` item where run-lookup finds a concluded run → annotated
+  "ran but didn't report"; where it finds no run → "never ran". The terminal/non-terminal state is
+  unchanged by this annotation.
+- Error path: PR-search collaborator is gone (no reference remains).
+- Verification: repo-wide type-check + test run green after removal (no dangling references).
+
+**Verification:** Receipts are the sole completion oracle; run-lookup only annotates `needs-attention`
+diagnostics and never moves state; PR-search removed; track token drops `pull-requests: read`, keeps
+`actions: read`; suite green.
+
+- [x] **Unit 6: Golden-path integration test (worker receipt → close) + README**
+
+**Goal:** Lock the end-to-end contract with a golden-path CLI integration test driving the real
+production composition, and document the push-model architecture.
+
+**Requirements:** R1–R12 (integration), documentation.
+
+**Dependencies:** Units 1–5.
+
+**Files:**
+- Modify: `scripts/cross-repo-dispatch.test.ts`
+- Modify: the cross-repo-dispatch README/architecture doc (the file the prior units document to)
+- Test: same test file
+
+**Approach:**
+- Golden-path test driving `runDispatchCli` → (simulated worker posts a realistic receipt comment:
+  region + marker + prose + a run-summary block, authored `fro-bot`, correct nonce) → `runTrackCli`,
+  asserting: dispatch is prompt-only, the receipt is accepted through all three gates, the item
+  resolves `completed`/`failed`/`noop` as posted, and the goal closes when all items terminal.
+- Include a hostile case in the same flow: a second bot-authored comment whose raw nonce does NOT hash
+  to the item's `nonceHash` (cross-item forgery attempt reading the public marker) does not move state.
+- Include an early-receipt case: a receipt arriving before the item is confirmed is retained and
+  resolves on the next track pass.
+- This test must fail if any unit regresses the contract (the standing anti-recurrence test).
+- Update the README: push model, receipt contract + region format, three-gate trust, SLA,
+  needs-attention, and the deferred token-scoping note.
+
+**Execution note:** Start from the realistic-receipt golden-path test (contract-first), mirroring the
+decomposition golden-path test that caught wall #3.
+
+**Patterns to follow:** the existing decomposition golden-path integration test; the realistic-comment
+fixture approach.
+
+**Test scenarios:**
+- Integration happy path: prompt-only dispatch → authentic receipt (raw nonce hashes to stored
+  `nonceHash`) → item completed → goal closes; a no-op receipt closes its item too.
+- Integration security: a receipt whose nonce mishashes (forgery from the public marker) never
+  resolves the item; goal stays open until the real receipt.
+- Integration SLA + diagnostic: an item with no receipt past 24h surfaces `needs-attention`; the
+  diagnostic run-lookup annotates "ran but didn't report" vs "never ran"; goal stays open.
+- Integration early-receipt: a receipt for a not-yet-confirmed item is retained, then resolves once
+  confirmed.
+
+**Verification:** The golden-path test exercises dispatch→worker-receipt→track→close end to end and
+fails on any contract regression; README reflects the shipped design.
+
+## System-Wide Impact
+
+- **Interaction graph:** `issues.labeled` dispatch job and the scheduled/manual track job in
+  `cross-repo-dispatch.yaml`; the cross-repo-goal prompt block in `fro-bot.yaml`; the pure core +
+  CLI shells in `scripts/cross-repo-dispatch.ts`. No target-repo workflow is touched.
+- **Error propagation:** a worker that never reports, or reports a malformed marker, surfaces as
+  non-terminal `needs-attention` — never silently completed; the goal stays open for the operator.
+- **State lifecycle risks:** first-terminal-wins prevents state flips; CAS marker writes stay
+  idempotent; only `hash(nonce)` lives in the (public) marker and the raw nonce only in the prompt,
+  neither in telemetry (R12); `epoch` at confirm-time avoids spurious SLA aging; early receipts are
+  retained, not dropped.
+- **Trust boundary (new completion oracle):** receipts on public issue comments are now the sole
+  completion signal. A forged or malformed comment directly drives state, so acceptance is gated on
+  author + correlation-id + nonce-HASH match, and the raw-nonce secret is never in public state. This
+  is explicitly a shared-trust-boundary model — a compromised `FRO_BOT_PAT` or worker can still forge
+  receipts for items it holds the nonce for; item-level isolation comes from the hash gate, not from
+  the PAT.
+- **API surface parity:** none — the dispatch/track contract is internal; the only external contract
+  is the universal `prompt` input, which is unchanged for targets.
+- **Integration coverage:** the Unit 6 golden-path test is the cross-layer proof (dispatch shell →
+  worker receipt → track shell → close) that unit tests with injected fakes cannot fully establish.
+- **Unchanged invariants:** the registry gate, owner-aware two-App token minting, actor+label
+  approval gate, `blocked` (pre-dispatch) semantics, and the seed/marker CAS discipline are
+  unchanged; this plan only replaces how completion is detected.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Worker drifts from the receipt format (wall-#3 class) — the highest-likelihood failure, evidenced on live #3633 | Prompt-only formatting is best-effort, not a correctness guarantee: delimited region + literal example + self-validate REDUCE drift; a drifted marker is `unparseable-receipt` (visible, never silent success); and the diagnostic run-lookup makes the residual `needs-attention` actionable ("ran but didn't report") so drift is triaged, not silent. A worker-side receipt channel is the tracked next step if drift stays high. |
+| Cross-item receipt forgery reading the public marker | Hash-bound nonce (R6): the public marker stores only `hash(nonce)`; the raw nonce is prompt-only; track verifies `hash(receipt.nonce)`. Preimage resistance means reading the marker yields nothing forgeable. |
+| Confused-deputy: ANY holder of `FRO_BOT_PAT` (every org workflow/agent that uses it, or a leaked PAT) can author receipts | NOT closed in v1. This is shared-trust-boundary security, not item-level authorization: the hash gate stops one worker forging ANOTHER item's receipt, but a compromised PAT can forge receipts for items whose nonce it holds. Accepted for v1 only because all workers are trusted `fro-bot` agents. Hard follow-up (tracked issue + smart note): mint a per-dispatch, coordination-issue-scoped receipt token instead of reusing the org-wide PAT. |
+| Worker cannot resolve/write the coordination issue | Prompt carries structured `owner`/`repo`/`number` + canonical URL and a self-check echoing the resolved destination; `FRO_BOT_PAT` verified to carry cross-repo issue-write (gateway-rollout-tracker precedent); Unit 6 asserts the authored identity passes `FROBOT_COMMENT_AUTHORS`. |
+| Premature `failed` locks an item | First-terminal-wins is deliberate anti-spoof; operator manual-override via marker edit documented. |
+| Unit 5 sequencing pulls run-lookup out of a live resolver | Unit 5 explicitly depends on Unit 4's receipt-first rewire; run-lookup is DEMOTED (diagnostic-only), not deleted, preserving crash recovery; full green suite gate + golden-path test prove receipt-only closure. |
+| Dispatch/receipt race (fast worker reports before confirm persists) | `epoch` and `nonceHash` are written at confirm; track RETAINS an authentic receipt for a not-yet-confirmed item and re-evaluates next pass, so no real completion is lost. |
+| Raw nonce leaks via a public target-run surface (prompt artifact/logs) before the receipt — would re-open forgery despite the hashed marker | R13: Unit 3 verifies the raw-nonce prompt is not published to a world-readable artifact/log for cross-repo-goal runs (`OPENCODE_PROMPT_ARTIFACT`), redacts it, or documents the residual honestly. Hash-binding only protects the marker surface, not every prompt surface. |
+| Receipt replay flips a resolved item using the now-public raw nonce | R6c earliest-authentic-wins: resolution keys off the earliest receipt by chronology (never `findLast`); a resolved item never flips, so a later replayed receipt is inert. |
+| Nonce too weak to resist preimage/brute force | R6 spec: CSPRNG ≥128-bit (256 preferred), full SHA-256 hex; explicitly not `hashState` (64-bit) nor `Date.now()+Math.random()`. |
+
+## Documentation / Operational Notes
+
+- README/architecture doc updated (Unit 6): push model, receipt + region format, three-gate trust,
+  24h SLA, `needs-attention` semantics, operator override, deferred token-scoping.
+- File the confused-deputy token-scoping hardening as a tracked fro-bot/.github issue with a smart
+  note before shipping.
+- Rehearsal issue #3633 (checklist intact, stale marker cleared, labels present) is the live canary
+  to re-exercise once this lands — it will exercise the receipt path for the first time in production.
+- Legacy-marker migration: any in-flight marker that stored a RAW `nonce` (the prior schema) is
+  incompatible with `nonceHash` verification and would strand its items. Reseed/clear such markers on
+  rollout; #3633's marker is already cleared, so it cold-starts clean under the new schema.
+
+## Sources & References
+
+- **Origin document:** docs/brainstorms/2026-07-04-cross-repo-dispatch-tracking-push-model-requirements.md
+- Related code: `scripts/cross-repo-dispatch.ts`, `.github/workflows/cross-repo-dispatch.yaml`,
+  `.github/workflows/fro-bot.yaml`
+- Related prior plan: docs/plans/2026-07-04-001-feat-cross-repo-dispatch-loop-plan.md
+- Wall-#3 evidence: PR #3635 (commit `faa6e25`), live issue #3633
+- Learnings: docs/solutions/best-practices/status-truth-synthetic-self-audit-claim-kinds-2026-07-03.md
+- Live evidence: dispatch `422 Unexpected inputs provided: ["correlation_id"]`; target `fro-bot.yaml`
+  files declare only `prompt` universally; `FRO_BOT_PAT` cross-repo write capability.

--- a/scripts/cross-repo-dispatch.test.ts
+++ b/scripts/cross-repo-dispatch.test.ts
@@ -25,6 +25,7 @@ import {
   findRunByCorrelationId,
   findRunConclusion,
   gateTarget,
+  hashNonce,
   loadOpenGoalIssues,
   loadOtherOpenGoalMarkers,
   MARKER_PREFIX,
@@ -34,8 +35,10 @@ import {
   parseTargetTokens,
   planDispatch,
   planSnapshot,
+  RECEIPT_SLA_MS,
   REQUIRED_APPROVER,
   resolveItemTerminalState,
+  resolveReceipts,
   runDispatch,
   runDispatchCli,
   runTrack,
@@ -1728,6 +1731,7 @@ describe('runTrack — terminal precedence and closure', () => {
       loadRegistry: async () => [gateEntryFor(TARGET_A)],
       findRunConclusion,
       findBotAuthoredPrs: async () => [],
+      now: () => 1000,
     })
 
     expect(findRunConclusion).toHaveBeenCalledWith(TARGET_A, 'corr-real')
@@ -1921,6 +1925,534 @@ describe('runTrack — terminal precedence and closure', () => {
     })
     expect(result.counts.idempotentNoop).toBe(1)
     expect(createComment).not.toHaveBeenCalled()
+  })
+})
+
+// ─── Unit 4: receipt-driven terminal-state resolution + 24h SLA ─────────────
+
+function makeReceiptComment(receipt: CrossRepoResult, login = 'fro-bot'): {id: number; body: string; login: string} {
+  return {id: 0, body: buildResultMarker(receipt), login}
+}
+
+function makeDispatchedItem(overrides: Partial<DispatchItem> = {}): DispatchItem {
+  const rawNonce = overrides.nonceHash === null ? undefined : 'raw-nonce-for-item'
+  return {
+    id: 'item-1',
+    target: TARGET_A,
+    promptHash: 'h',
+    status: 'dispatched',
+    correlationId: 'corr-1',
+    epoch: 1_000_000,
+    nonceHash: rawNonce === undefined ? undefined : hashNonce(rawNonce),
+    ...overrides,
+  }
+}
+
+describe('resolveReceipts — three-gate trust + earliest-wins (pure core)', () => {
+  const RAW_NONCE = 'raw-nonce-for-item'
+  const item: DispatchItem = {
+    id: 'item-1',
+    target: TARGET_A,
+    promptHash: 'h',
+    status: 'dispatched',
+    correlationId: 'corr-1',
+    epoch: 1_000_000,
+    nonceHash: hashNonce(RAW_NONCE),
+  }
+
+  it('authentic success resolves to terminal success', () => {
+    const comments: TrackerComment[] = [
+      {
+        author: {login: 'fro-bot'},
+        body: buildResultMarker(makeReceipt({correlationId: 'corr-1', nonce: RAW_NONCE, status: 'success'})),
+      },
+    ]
+    const resolutions = resolveReceipts([item], comments)
+    expect(resolutions.get('item-1')?.terminal).toBe('success')
+  })
+
+  it('authentic noop resolves to terminal noop', () => {
+    const comments: TrackerComment[] = [
+      {
+        author: {login: 'fro-bot'},
+        body: buildResultMarker(makeReceipt({correlationId: 'corr-1', nonce: RAW_NONCE, status: 'noop'})),
+      },
+    ]
+    const resolutions = resolveReceipts([item], comments)
+    expect(resolutions.get('item-1')?.terminal).toBe('noop')
+  })
+
+  it('authentic failed resolves to terminal failed', () => {
+    const comments: TrackerComment[] = [
+      {
+        author: {login: 'fro-bot'},
+        body: buildResultMarker(makeReceipt({correlationId: 'corr-1', nonce: RAW_NONCE, status: 'failed'})),
+      },
+    ]
+    const resolutions = resolveReceipts([item], comments)
+    expect(resolutions.get('item-1')?.terminal).toBe('failed')
+  })
+
+  it('security: a receipt whose raw nonce does not hash to the stored nonceHash is rejected', () => {
+    const comments: TrackerComment[] = [
+      {
+        author: {login: 'fro-bot'},
+        body: buildResultMarker(makeReceipt({correlationId: 'corr-1', nonce: 'wrong-nonce', status: 'success'})),
+      },
+    ]
+    const resolutions = resolveReceipts([item], comments)
+    expect(resolutions.get('item-1')?.terminal).toBeUndefined()
+  })
+
+  it('security: a receipt carrying item A correlation id but item B nonce is rejected — cannot resolve A', () => {
+    const itemB: DispatchItem = {
+      id: 'item-2',
+      target: TARGET_A,
+      promptHash: 'h2',
+      status: 'dispatched',
+      correlationId: 'corr-2',
+      epoch: 1_000_000,
+      nonceHash: hashNonce('raw-nonce-for-item-b'),
+    }
+    const comments: TrackerComment[] = [
+      // Forged: correlation id points at item A, but the nonce is item B's raw nonce.
+      {
+        author: {login: 'fro-bot'},
+        body: buildResultMarker(
+          makeReceipt({correlationId: 'corr-1', nonce: 'raw-nonce-for-item-b', status: 'success'}),
+        ),
+      },
+    ]
+    const resolutions = resolveReceipts([item, itemB], comments)
+    expect(resolutions.get('item-1')?.terminal).toBeUndefined()
+    expect(resolutions.get('item-2')?.terminal).toBeUndefined()
+  })
+
+  it('error path: a non-Fro-Bot-authored comment with a valid-looking marker is ignored', () => {
+    const comments: TrackerComment[] = [
+      {
+        author: {login: 'random-user'},
+        body: buildResultMarker(makeReceipt({correlationId: 'corr-1', nonce: RAW_NONCE, status: 'success'})),
+      },
+    ]
+    const resolutions = resolveReceipts([item], comments)
+    expect(resolutions.get('item-1')?.terminal).toBeUndefined()
+  })
+
+  it('a bot-authored comment whose id matches no item is ignored for state', () => {
+    const comments: TrackerComment[] = [
+      {
+        author: {login: 'fro-bot'},
+        body: buildResultMarker(makeReceipt({correlationId: 'no-such-item', nonce: RAW_NONCE, status: 'success'})),
+      },
+    ]
+    const resolutions = resolveReceipts([item], comments)
+    expect(resolutions.size).toBe(0)
+  })
+
+  it('R6b: bot-authored malformed marker for a dispatched item -> unparseable-receipt (non-terminal)', () => {
+    const comments: TrackerComment[] = [
+      {
+        author: {login: 'fro-bot'},
+        body: `<!-- fro-bot:cross-repo-result {"correlation_id":"corr-1","nonce":"x"} -->`, // missing status/summary
+      },
+    ]
+    const resolutions = resolveReceipts([item], comments)
+    expect(resolutions.get('item-1')?.terminal).toBeUndefined()
+    expect(resolutions.get('item-1')?.attentionReason).toBe('unparseable-receipt')
+  })
+
+  it('early-receipt tolerance: an authentic receipt for a not-yet-confirmed item (no epoch) is retained, not dropped', () => {
+    const unconfirmed: DispatchItem = {...item, epoch: undefined}
+    const comments: TrackerComment[] = [
+      {
+        author: {login: 'fro-bot'},
+        body: buildResultMarker(makeReceipt({correlationId: 'corr-1', nonce: RAW_NONCE, status: 'success'})),
+      },
+    ]
+    const resolutions = resolveReceipts([unconfirmed], comments)
+    expect(resolutions.get('item-1')?.terminal).toBeUndefined()
+    expect(resolutions.get('item-1')?.retainedUnconfirmed).toBe(true)
+
+    // Next pass, once confirmed (epoch set): the SAME receipt now resolves it.
+    const resolutionsNextPass = resolveReceipts([item], comments)
+    expect(resolutionsNextPass.get('item-1')?.terminal).toBe('success')
+  })
+
+  it('earliest-wins/replay: authentic failed then later authentic success stays failed (never flips)', () => {
+    const comments: TrackerComment[] = [
+      {
+        author: {login: 'fro-bot'},
+        body: buildResultMarker(makeReceipt({correlationId: 'corr-1', nonce: RAW_NONCE, status: 'failed'})),
+      },
+      {
+        author: {login: 'fro-bot'},
+        body: buildResultMarker(makeReceipt({correlationId: 'corr-1', nonce: RAW_NONCE, status: 'success'})),
+      },
+    ]
+    const resolutions = resolveReceipts([item], comments)
+    expect(resolutions.get('item-1')?.terminal).toBe('failed')
+  })
+
+  it('earliest-wins/replay: a second authentic receipt reusing the now-public nonce after resolution never flips the item', () => {
+    const comments: TrackerComment[] = [
+      {
+        author: {login: 'fro-bot'},
+        body: buildResultMarker(makeReceipt({correlationId: 'corr-1', nonce: RAW_NONCE, status: 'success'})),
+      },
+      // Attacker/replay: posted AFTER the raw nonce became public in the first receipt.
+      {
+        author: {login: 'fro-bot'},
+        body: buildResultMarker(makeReceipt({correlationId: 'corr-1', nonce: RAW_NONCE, status: 'failed'})),
+      },
+    ]
+    const resolutions = resolveReceipts([item], comments)
+    expect(resolutions.get('item-1')?.terminal).toBe('success')
+  })
+})
+
+describe('runTrack — receipt-driven resolution (Unit 4 integration)', () => {
+  it('happy path: authentic success/noop/failed receipts resolve to completed/completed/failed', async () => {
+    const RAW = 'raw-nonce-happy'
+    const items: DispatchItem[] = [
+      {
+        id: 'item-1',
+        target: TARGET_A,
+        promptHash: 'h1',
+        status: 'dispatched',
+        correlationId: 'c1',
+        epoch: 1000,
+        nonceHash: hashNonce(`${RAW}-1`),
+      },
+      {
+        id: 'item-2',
+        target: {owner: 'fro-bot', name: 'wiki'},
+        promptHash: 'h2',
+        status: 'dispatched',
+        correlationId: 'c2',
+        epoch: 1000,
+        nonceHash: hashNonce(`${RAW}-2`),
+      },
+      {
+        id: 'item-3',
+        target: {owner: 'fro-bot', name: 'sparkle'},
+        promptHash: 'h3',
+        status: 'dispatched',
+        correlationId: 'c3',
+        epoch: 1000,
+        nonceHash: hashNonce(`${RAW}-3`),
+      },
+    ]
+    const goalIssue = makeOpenGoal({goal: 'g', items, markerHash: ''})
+    const {octokit} = mockOctokitForGoal(goalIssue, {
+      comments: [
+        makeReceiptComment(makeReceipt({correlationId: 'c1', nonce: `${RAW}-1`, status: 'success'})),
+        makeReceiptComment(makeReceipt({correlationId: 'c2', nonce: `${RAW}-2`, status: 'noop'})),
+        makeReceiptComment(makeReceipt({correlationId: 'c3', nonce: `${RAW}-3`, status: 'failed'})),
+      ],
+    })
+    const result = await runTrack({
+      octokit,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalIssue],
+      loadRegistry: async () => [
+        gateEntryFor(TARGET_A),
+        gateEntryFor({owner: 'fro-bot', name: 'wiki'}),
+        gateEntryFor({owner: 'fro-bot', name: 'sparkle'}),
+      ],
+      findRunConclusion: async () => undefined,
+      findBotAuthoredPrs: async () => [],
+      now: () => 1000,
+    })
+    expect(result.counts.itemsCompleted).toBe(2)
+    expect(result.counts.itemsFailed).toBe(1)
+    expect(result.counts.goalsClosed).toBe(1)
+  })
+
+  it('security: a receipt whose nonce mishashes is rejected — item stays unresolved', async () => {
+    const item = makeDispatchedItem()
+    const goalIssue = makeOpenGoal({goal: 'g', items: [item], markerHash: ''})
+    const {octokit} = mockOctokitForGoal(goalIssue, {
+      comments: [makeReceiptComment(makeReceipt({correlationId: 'corr-1', nonce: 'forged-nonce', status: 'success'}))],
+    })
+    const result = await runTrack({
+      octokit,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalIssue],
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      findRunConclusion: async () => undefined,
+      findBotAuthoredPrs: async () => [],
+      now: () => 1000,
+    })
+    expect(result.counts.itemsCompleted).toBe(0)
+    expect(result.counts.itemsFailed).toBe(0)
+    expect(result.counts.goalsClosed).toBe(0)
+  })
+
+  it('security: a receipt carrying item A id but item B nonce cannot resolve A', async () => {
+    const itemA = makeDispatchedItem({id: 'item-a', correlationId: 'corr-a', nonceHash: hashNonce('nonce-a')})
+    const itemB = makeDispatchedItem({id: 'item-b', correlationId: 'corr-b', nonceHash: hashNonce('nonce-b')})
+    const goalIssue = makeOpenGoal({goal: 'g', items: [itemA, itemB], markerHash: ''})
+    const {octokit} = mockOctokitForGoal(goalIssue, {
+      comments: [makeReceiptComment(makeReceipt({correlationId: 'corr-a', nonce: 'nonce-b', status: 'success'}))],
+    })
+    const result = await runTrack({
+      octokit,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalIssue],
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      findRunConclusion: async () => undefined,
+      findBotAuthoredPrs: async () => [],
+      now: () => 1000,
+    })
+    expect(result.counts.itemsCompleted).toBe(0)
+  })
+
+  it('error path: non-Fro-Bot-authored comment with a valid-looking marker is ignored', async () => {
+    const item = makeDispatchedItem()
+    const goalIssue = makeOpenGoal({goal: 'g', items: [item], markerHash: ''})
+    const {octokit} = mockOctokitForGoal(goalIssue, {
+      comments: [
+        makeReceiptComment(
+          makeReceipt({correlationId: 'corr-1', nonce: 'raw-nonce-for-item', status: 'success'}),
+          'random-user',
+        ),
+      ],
+    })
+    const result = await runTrack({
+      octokit,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalIssue],
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      findRunConclusion: async () => undefined,
+      findBotAuthoredPrs: async () => [],
+      now: () => 1000,
+    })
+    expect(result.counts.itemsCompleted).toBe(0)
+  })
+
+  it('error path: bot-authored malformed marker for a dispatched item pre-SLA -> unparseable-receipt, non-terminal, goal stays open', async () => {
+    const item = makeDispatchedItem()
+    const goalIssue = makeOpenGoal({goal: 'g', items: [item], markerHash: ''})
+    const {octokit} = mockOctokitForGoal(goalIssue, {
+      comments: [
+        {id: 0, login: 'fro-bot', body: '<!-- fro-bot:cross-repo-result {"correlation_id":"corr-1","nonce":"x"} -->'},
+      ],
+    })
+    const result = await runTrack({
+      octokit,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalIssue],
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      findRunConclusion: async () => undefined,
+      findBotAuthoredPrs: async () => [],
+      now: () => item.epoch ?? 0, // pre-SLA
+    })
+    expect(result.counts.itemsNeedsAttention).toBe(1)
+    expect(result.counts.goalsClosed).toBe(0)
+    const updatedItems = result.counts.itemsNeedsAttention
+    expect(updatedItems).toBeGreaterThan(0)
+  })
+
+  it('edge case (early-receipt): authentic receipt for a not-yet-confirmed item is retained, resolves once confirmed next pass', async () => {
+    const RAW = 'raw-nonce-early'
+    // Pass 1: item still 'intent' (no epoch yet) — receipt authentic but item unconfirmed.
+    const unconfirmedItem: DispatchItem = {
+      id: 'item-1',
+      target: TARGET_A,
+      promptHash: 'h',
+      status: 'intent',
+      correlationId: 'corr-1',
+      nonceHash: hashNonce(RAW),
+    }
+    const goalIssue1 = makeOpenGoal({goal: 'g', items: [unconfirmedItem], markerHash: ''})
+    const {octokit: octokit1} = mockOctokitForGoal(goalIssue1, {
+      comments: [makeReceiptComment(makeReceipt({correlationId: 'corr-1', nonce: RAW, status: 'success'}))],
+    })
+    const result1 = await runTrack({
+      octokit: octokit1,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalIssue1],
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      findRunConclusion: async () => undefined,
+      findBotAuthoredPrs: async () => [],
+      now: () => 1000,
+    })
+    expect(result1.counts.itemsCompleted).toBe(0)
+    expect(result1.counts.goalsClosed).toBe(0)
+
+    // Pass 2: item confirmed (epoch set, status dispatched) — the SAME receipt now resolves it.
+    const confirmedItem: DispatchItem = {...unconfirmedItem, status: 'dispatched', epoch: 1000}
+    const goalIssue2 = makeOpenGoal({goal: 'g', items: [confirmedItem], markerHash: ''})
+    const {octokit: octokit2} = mockOctokitForGoal(goalIssue2, {
+      comments: [makeReceiptComment(makeReceipt({correlationId: 'corr-1', nonce: RAW, status: 'success'}))],
+    })
+    const result2 = await runTrack({
+      octokit: octokit2,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalIssue2],
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      findRunConclusion: async () => undefined,
+      findBotAuthoredPrs: async () => [],
+      now: () => 1000,
+    })
+    expect(result2.counts.itemsCompleted).toBe(1)
+    expect(result2.counts.goalsClosed).toBe(1)
+  })
+
+  it('edge case (SLA): no receipt & confirm-age > 24h -> needs-attention/no-receipt; < 24h -> still pending; never-confirmed -> not SLA-aged', async () => {
+    const staleItem: DispatchItem = {
+      id: 'item-stale',
+      target: TARGET_A,
+      promptHash: 'h1',
+      status: 'dispatched',
+      correlationId: 'c-stale',
+      epoch: 0,
+    }
+    const goalStale = makeOpenGoal({goal: 'g1', items: [staleItem], markerHash: ''})
+    const {octokit: octokitStale} = mockOctokitForGoal(goalStale)
+    const resultStale = await runTrack({
+      octokit: octokitStale,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalStale],
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      findRunConclusion: async () => undefined,
+      findBotAuthoredPrs: async () => [],
+      now: () => RECEIPT_SLA_MS + 1,
+    })
+    expect(resultStale.counts.itemsNeedsAttention).toBe(1)
+    expect(resultStale.counts.goalsClosed).toBe(0)
+
+    const freshItem: DispatchItem = {
+      id: 'item-fresh',
+      target: TARGET_A,
+      promptHash: 'h2',
+      status: 'dispatched',
+      correlationId: 'c-fresh',
+      epoch: 0,
+    }
+    const goalFresh = makeOpenGoal({goal: 'g2', items: [freshItem], markerHash: ''})
+    const {octokit: octokitFresh} = mockOctokitForGoal(goalFresh)
+    const resultFresh = await runTrack({
+      octokit: octokitFresh,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalFresh],
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      findRunConclusion: async () => undefined,
+      findBotAuthoredPrs: async () => [],
+      now: () => RECEIPT_SLA_MS - 1,
+    })
+    expect(resultFresh.counts.itemsNeedsAttention).toBe(0)
+
+    const neverConfirmedItem: DispatchItem = {
+      id: 'item-never',
+      target: TARGET_A,
+      promptHash: 'h3',
+      status: 'intent',
+      correlationId: 'c-never',
+    }
+    const goalNever = makeOpenGoal({goal: 'g3', items: [neverConfirmedItem], markerHash: ''})
+    const {octokit: octokitNever} = mockOctokitForGoal(goalNever)
+    const resultNever = await runTrack({
+      octokit: octokitNever,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalNever],
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      findRunConclusion: async () => undefined,
+      findBotAuthoredPrs: async () => [],
+      now: () => RECEIPT_SLA_MS * 100,
+    })
+    expect(resultNever.counts.itemsNeedsAttention).toBe(0)
+  })
+
+  it('reversible (R10): needs-attention item then a later authentic success resolves to completed, flag cleared', async () => {
+    const item: DispatchItem = {
+      id: 'item-1',
+      target: TARGET_A,
+      promptHash: 'h',
+      status: 'needs-attention',
+      needsAttentionReason: 'no-receipt',
+      correlationId: 'corr-1',
+      epoch: 0,
+      nonceHash: hashNonce('raw-nonce-reversible'),
+    }
+    const goalIssue = makeOpenGoal({goal: 'g', items: [item], markerHash: ''})
+    const {octokit} = mockOctokitForGoal(goalIssue, {
+      comments: [
+        makeReceiptComment(makeReceipt({correlationId: 'corr-1', nonce: 'raw-nonce-reversible', status: 'success'})),
+      ],
+    })
+    const result = await runTrack({
+      octokit,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalIssue],
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      findRunConclusion: async () => undefined,
+      findBotAuthoredPrs: async () => [],
+      now: () => 0,
+    })
+    expect(result.counts.itemsCompleted).toBe(1)
+    expect(result.counts.goalsClosed).toBe(1)
+  })
+
+  it('earliest-wins/replay (integration): authentic failed then later authentic success stays failed; a later replay never flips', async () => {
+    const item = makeDispatchedItem()
+    const goalIssue = makeOpenGoal({goal: 'g', items: [item], markerHash: ''})
+    const {octokit} = mockOctokitForGoal(goalIssue, {
+      comments: [
+        makeReceiptComment(makeReceipt({correlationId: 'corr-1', nonce: 'raw-nonce-for-item', status: 'failed'})),
+        makeReceiptComment(makeReceipt({correlationId: 'corr-1', nonce: 'raw-nonce-for-item', status: 'success'})),
+      ],
+    })
+    const result = await runTrack({
+      octokit,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalIssue],
+      loadRegistry: async () => [gateEntryFor(TARGET_A)],
+      findRunConclusion: async () => undefined,
+      findBotAuthoredPrs: async () => [],
+      now: () => 1_000_000,
+    })
+    expect(result.counts.itemsFailed).toBe(1)
+    expect(result.counts.itemsCompleted).toBe(0)
+    expect(result.counts.goalsClosed).toBe(1)
+  })
+
+  it('R11: all-terminal goal closes; one needs-attention item keeps it open', async () => {
+    const RAW = 'raw-nonce-r11'
+    const resolvedItem: DispatchItem = {
+      id: 'item-1',
+      target: TARGET_A,
+      promptHash: 'h1',
+      status: 'dispatched',
+      correlationId: 'c1',
+      epoch: 0,
+      nonceHash: hashNonce(RAW),
+    }
+    const staleItem: DispatchItem = {
+      id: 'item-2',
+      target: {owner: 'fro-bot', name: 'wiki'},
+      promptHash: 'h2',
+      status: 'dispatched',
+      correlationId: 'c2',
+      epoch: 0,
+    }
+    const goalIssue = makeOpenGoal({goal: 'g', items: [resolvedItem, staleItem], markerHash: ''})
+    const {octokit} = mockOctokitForGoal(goalIssue, {
+      comments: [makeReceiptComment(makeReceipt({correlationId: 'c1', nonce: RAW, status: 'success'}))],
+    })
+    const result = await runTrack({
+      octokit,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalIssue],
+      loadRegistry: async () => [gateEntryFor(TARGET_A), gateEntryFor({owner: 'fro-bot', name: 'wiki'})],
+      findRunConclusion: async () => undefined,
+      findBotAuthoredPrs: async () => [],
+      now: () => RECEIPT_SLA_MS + 1,
+    })
+    expect(result.counts.itemsCompleted).toBe(1)
+    expect(result.counts.itemsNeedsAttention).toBe(1)
+    expect(result.counts.goalsClosed).toBe(0)
   })
 })
 

--- a/scripts/cross-repo-dispatch.test.ts
+++ b/scripts/cross-repo-dispatch.test.ts
@@ -3019,9 +3019,257 @@ describe('golden path — real production composition (runDispatchCli then runTr
       expect(update).toHaveBeenCalledWith(expect.objectContaining({issue_number: 42, state: 'closed'}))
 
       const closedMarker = selectStateMarker(comments.map(c => ({author: {login: c.login}, body: c.body})))
-      expect(closedMarker?.state.items.every(item => item.status === 'completed')).toBe(true)
+      // A no-op receipt closes its item too, same as success (R7).
+      expect(closedMarker?.state.items.find(item => item.target.name === 'sparkle')?.status).toBe('completed')
+      expect(closedMarker?.state.items.find(item => item.target.name === 'renovate-config')?.status).toBe('completed')
     } finally {
       process.env = originalEnv
     }
+  })
+
+  it('hostile: a cross-item forgery receipt (correct correlation id, wrong/guessed nonce) never resolves the item — real receipt still can', async () => {
+    // This is the standing anti-recurrence contract for R6/R6c: an attacker
+    // who reads the PUBLIC marker only ever learns `nonceHash`, never the raw
+    // nonce, so a forged receipt can only ever GUESS at the raw nonce. This
+    // test drives the real dispatch->track composition and proves the guess
+    // never moves state, then proves the genuine receipt (extracted from the
+    // dispatch prompt exactly as a real worker would read it) still resolves
+    // the item afterward — forgery attempts don't poison the item permanently.
+    const originalEnv = {...process.env}
+    const {writeFile, mkdtemp} = await import('node:fs/promises')
+    const {tmpdir} = await import('node:os')
+    const path = await import('node:path')
+    const dir = await mkdtemp(path.join(tmpdir(), 'cross-repo-dispatch-golden-hostile-'))
+    const eventPath = path.join(dir, 'event.json')
+    await writeFile(
+      eventPath,
+      JSON.stringify({
+        label: {name: 'dispatch-approved'},
+        sender: {login: REQUIRED_APPROVER},
+        issue: {number: 42},
+      }),
+    )
+
+    process.env.GITHUB_TOKEN = 'test-token'
+    process.env.GITHUB_REPOSITORY = 'fro-bot/.github'
+    process.env.GITHUB_EVENT_PATH = eventPath
+    process.env.CROSS_REPO_DISPATCH_RESULT_PATH = ''
+
+    try {
+      const {octokit, comments} = mockOctokit()
+      comments.push({id: 1, body: PLANNER_COMMENT, login: 'fro-bot'})
+
+      const createComment = vi.fn(async (params: {owner: string; repo: string; issue_number: number; body: string}) => {
+        const comment = {id: comments.length + 1, body: params.body, login: 'fro-bot'}
+        comments.push(comment)
+        return {data: {id: comment.id}}
+      })
+      const updateComment = vi.fn(async (params: {comment_id: number; body: string}) => {
+        const existing = comments.find(c => c.id === params.comment_id)
+        if (existing !== undefined) existing.body = params.body
+        return {}
+      })
+      const createWorkflowDispatch = vi.fn(async (_params: unknown) => ({}))
+      const listForRepo = vi.fn(async () => ({data: [{number: 42}]}))
+
+      const dispatchOctokit = {
+        ...octokit,
+        rest: {
+          ...octokit.rest,
+          issues: {...octokit.rest.issues, createComment, updateComment, listForRepo},
+          actions: {...octokit.rest.actions, createWorkflowDispatch},
+        },
+      }
+
+      await runDispatchCli(async () => dispatchOctokit, singleOwnerResolver(dispatchOctokit))
+      expect(createWorkflowDispatch).toHaveBeenCalledTimes(2)
+
+      const correlationIdFor = (repoName: string): string => {
+        const call = createWorkflowDispatch.mock.calls.find(c => (c[0] as {repo: string}).repo === repoName)?.[0] as
+          {inputs: {prompt: string}} | undefined
+        const prompt = call?.inputs.prompt ?? ''
+        const correlationId = /correlation_id: (\S+)/.exec(prompt)?.[1]
+        expect(correlationId).toBeDefined()
+        return correlationId as string
+      }
+
+      // ─── Phase 2a: post ONLY forged receipts (correct correlation id, a
+      // guessed/wrong raw nonce — the only thing a forger reading the public
+      // marker could ever attempt, since the marker stores nonceHash, not the
+      // raw nonce). Neither item may resolve.
+      for (const target of GOLDEN_TARGETS) {
+        comments.push({
+          id: comments.length + 1,
+          login: 'fro-bot',
+          body: buildResultMarker({
+            correlationId: correlationIdFor(target.name),
+            nonce: 'forged-guessed-nonce-does-not-hash',
+            status: 'success',
+            summary: 'Forged: I read the marker and guessed at a nonce.',
+          }),
+        })
+      }
+
+      const listWorkflowRunsForRepoHostile = vi.fn(async () => ({data: {workflow_runs: []}}))
+      const updateHostile = vi.fn(async (_params: unknown) => ({data: {}}))
+      const trackListForRepoHostile = vi.fn(async () => ({data: [{number: 42}]}))
+      const trackOctokitHostile = {
+        ...octokit,
+        rest: {
+          ...octokit.rest,
+          issues: {...octokit.rest.issues, listForRepo: trackListForRepoHostile, update: updateHostile},
+          actions: {...octokit.rest.actions, listWorkflowRunsForRepo: listWorkflowRunsForRepoHostile},
+        },
+      }
+      await runTrackCli(async () => trackOctokitHostile, singleOwnerResolver(trackOctokitHostile))
+
+      expect(updateHostile).not.toHaveBeenCalledWith(expect.objectContaining({state: 'closed'}))
+      const markerAfterForgery = selectStateMarker(comments.map(c => ({author: {login: c.login}, body: c.body})))
+      expect(markerAfterForgery?.state.items.every(item => item.status !== 'completed')).toBe(true)
+      expect(markerAfterForgery?.state.items.every(item => item.status !== 'failed')).toBe(true)
+
+      // ─── Phase 2b: the REAL workers post their genuine receipts (correct
+      // raw nonce extracted from their own dispatch prompt). The earlier
+      // forgery attempts must not have poisoned the item — it resolves now.
+      for (const target of GOLDEN_TARGETS) {
+        const call = createWorkflowDispatch.mock.calls.find(c => (c[0] as {repo: string}).repo === target.name)?.[0] as
+          {inputs: {prompt: string}} | undefined
+        const prompt = call?.inputs.prompt ?? ''
+        const correlationId = /correlation_id: (\S+)/.exec(prompt)?.[1]
+        const nonce = /^nonce: (\S+)$/m.exec(prompt)?.[1]
+        comments.push({
+          id: comments.length + 1,
+          login: 'fro-bot',
+          body: buildResultMarker({
+            correlationId: correlationId as string,
+            nonce: nonce as string,
+            status: 'success',
+            summary: `Confirmed README H1 for ${target.name}.`,
+          }),
+        })
+      }
+
+      const listWorkflowRunsForRepoReal = vi.fn(async () => ({data: {workflow_runs: []}}))
+      const updateReal = vi.fn(async (_params: unknown) => ({data: {}}))
+      const trackListForRepoReal = vi.fn(async () => ({data: [{number: 42}]}))
+      const trackOctokitReal = {
+        ...octokit,
+        rest: {
+          ...octokit.rest,
+          issues: {...octokit.rest.issues, listForRepo: trackListForRepoReal, update: updateReal},
+          actions: {...octokit.rest.actions, listWorkflowRunsForRepo: listWorkflowRunsForRepoReal},
+        },
+      }
+      await runTrackCli(async () => trackOctokitReal, singleOwnerResolver(trackOctokitReal))
+
+      expect(updateReal).toHaveBeenCalledWith(expect.objectContaining({issue_number: 42, state: 'closed'}))
+      const finalMarker = selectStateMarker(comments.map(c => ({author: {login: c.login}, body: c.body})))
+      expect(finalMarker?.state.items.every(item => item.status === 'completed')).toBe(true)
+    } finally {
+      process.env = originalEnv
+    }
+  })
+
+  it('early-receipt: a genuine receipt posted before the item is confirmed is retained, then resolves once confirmed (real runTrackCli composition)', async () => {
+    const originalEnv = {...process.env}
+    process.env.GITHUB_TOKEN = 'test-token'
+    process.env.GITHUB_REPOSITORY = 'fro-bot/.github'
+    process.env.CROSS_REPO_DISPATCH_RESULT_PATH = ''
+    try {
+      const RAW = 'raw-nonce-early-golden'
+      const target = GOLDEN_TARGETS[0] as DispatchTarget
+
+      // Pass 1: item is still 'intent' — confirmedAt (`epoch`) has not landed
+      // yet, but `correlationId`/`nonceHash` were already persisted at the
+      // preceding intent write (mirroring the real two-phase dispatch). A
+      // fast worker's genuine receipt arrives before confirm.
+      const unconfirmedItem: DispatchItem = {
+        id: 'item-1',
+        target,
+        promptHash: 'h',
+        status: 'intent',
+        correlationId: 'corr-early-golden',
+        nonceHash: hashNonce(RAW),
+      }
+      const goalUnconfirmed = makeOpenGoal({goal: 'g-early', items: [unconfirmedItem], markerHash: ''})
+      const {octokit: octokit1, comments: comments1} = mockOctokitForGoal(goalUnconfirmed, {
+        comments: [
+          makeReceiptComment(makeReceipt({correlationId: 'corr-early-golden', nonce: RAW, status: 'success'})),
+        ],
+        listForRepo: vi.fn(async () => ({data: [{number: goalUnconfirmed.issueNumber}]})),
+      })
+      await runTrackCli(async () => octokit1, singleOwnerResolver(octokit1))
+
+      const markerAfterPass1 = selectStateMarker(comments1.map(c => ({author: {login: c.login}, body: c.body})))
+      expect(markerAfterPass1?.state.items.find(candidate => candidate.id === 'item-1')?.status).toBe('intent')
+
+      // Pass 2: confirm has now landed (status 'dispatched', epoch set). The
+      // SAME genuine receipt — never dropped — resolves the item this pass.
+      const confirmedItem: DispatchItem = {...unconfirmedItem, status: 'dispatched', epoch: 0}
+      const goalConfirmed = makeOpenGoal({goal: 'g-early', items: [confirmedItem], markerHash: ''})
+      const {octokit: octokit2, comments: comments2} = mockOctokitForGoal(goalConfirmed, {
+        comments: [
+          makeReceiptComment(makeReceipt({correlationId: 'corr-early-golden', nonce: RAW, status: 'success'})),
+        ],
+        listForRepo: vi.fn(async () => ({data: [{number: goalConfirmed.issueNumber}]})),
+      })
+      await runTrackCli(async () => octokit2, singleOwnerResolver(octokit2))
+
+      const markerAfterPass2 = selectStateMarker(comments2.map(c => ({author: {login: c.login}, body: c.body})))
+      expect(markerAfterPass2?.state.items.find(candidate => candidate.id === 'item-1')?.status).toBe('completed')
+    } finally {
+      process.env = originalEnv
+    }
+  })
+
+  it('SLA + diagnostic: a no-receipt item past 24h surfaces needs-attention, annotated ran-no-report vs never-ran (production runTrack composition)', async () => {
+    const target = GOLDEN_TARGETS[0] as DispatchTarget
+    const itemRan: DispatchItem = {
+      id: 'item-ran',
+      target,
+      promptHash: 'h1',
+      status: 'dispatched',
+      correlationId: 'c-ran-golden',
+      epoch: 0,
+    }
+    const itemNeverRan: DispatchItem = {
+      id: 'item-never',
+      target,
+      promptHash: 'h2',
+      status: 'dispatched',
+      correlationId: 'c-never-golden',
+      epoch: 0,
+    }
+    const goalIssue = makeOpenGoal({goal: 'g-sla-golden', items: [itemRan, itemNeverRan], markerHash: ''})
+    const {octokit, comments} = mockOctokitForGoal(goalIssue)
+    const findRunConclusion = vi.fn(async (_t: DispatchTarget, correlationId: string) =>
+      correlationId === 'c-ran-golden' ? ('success' as const) : undefined,
+    )
+
+    const result = await runTrack({
+      octokit,
+      repo: REPO,
+      loadOpenGoalIssues: async () => [goalIssue],
+      loadRegistry: async () => [gateEntryFor(target)],
+      findRunConclusion,
+      now: () => RECEIPT_SLA_MS + 1,
+    })
+
+    // No receipt past SLA -> needs-attention for both; goal stays open (R9,
+    // R11). The diagnostic run-lookup ONLY annotates a reason, never flips
+    // either item terminal (R8: run-lookup is non-authoritative).
+    expect(result.counts.itemsNeedsAttention).toBe(2)
+    expect(result.counts.itemsCompleted).toBe(0)
+    expect(result.counts.goalsClosed).toBe(0)
+
+    const marker = selectStateMarker(comments.map(c => ({author: {login: c.login}, body: c.body})))
+    const ran = marker?.state.items.find(candidate => candidate.id === 'item-ran')
+    const neverRan = marker?.state.items.find(candidate => candidate.id === 'item-never')
+    expect(ran?.status).toBe('needs-attention')
+    expect(ran?.needsAttentionReason).toBe('no-receipt')
+    expect(ran?.noReceiptDiagnostic).toBe('ran-no-report')
+    expect(neverRan?.status).toBe('needs-attention')
+    expect(neverRan?.needsAttentionReason).toBe('no-receipt')
+    expect(neverRan?.noReceiptDiagnostic).toBe('never-ran')
   })
 })

--- a/scripts/cross-repo-dispatch.test.ts
+++ b/scripts/cross-repo-dispatch.test.ts
@@ -907,8 +907,289 @@ describe('runDispatch — happy sequential dispatch', () => {
       expect(call?.repo).toBe(target.name)
       expect(call?.workflow_id).toBe('fro-bot.yaml')
       expect(call?.ref).toBe('main')
-      expect(call?.inputs.prompt).toBe(`do work in ${target.name}`)
+      expect(call?.inputs.prompt).toContain(`do work in ${target.name}`)
     }
+  })
+})
+
+describe('runDispatch — nonce mint + receipt-carrying prompt (Unit 2)', () => {
+  it('stores a full-SHA-256 nonceHash and builds a prompt with correlation id, raw nonce, issue ref, and a literal receipt example', async () => {
+    const target = {owner: 'fro-bot', name: 'agent'}
+    const decomposition = makeDecompositionBody([{...target, prompt: 'do the thing'}])
+    const item: DispatchItem = {
+      id: 'item-1',
+      target,
+      promptHash: extractPromptHash(decomposition, target),
+      status: 'pending',
+    }
+    const state: GoalState = {goal: 'goal-1', items: [item], markerHash: ''}
+
+    const {octokit, comments} = mockOctokit()
+    comments.push({id: 1, body: decomposition, login: 'marcusrbrown'})
+    seedMarkerComment(comments, state)
+
+    const createWorkflowDispatch = vi.fn(async (_params: unknown) => ({}))
+
+    await runDispatch({
+      octokit,
+      event: makeLabeledEvent(),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      loadRegistry: async () => [gateEntryFor(target)],
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async () => false,
+      createWorkflowDispatch: async params => {
+        await createWorkflowDispatch(params)
+      },
+      nonceSource: () => 'raw-nonce-abc',
+    })
+
+    const call = createWorkflowDispatch.mock.calls[0]?.[0] as {
+      inputs: {prompt: string; correlation_id: string}
+    }
+    const prompt = call.inputs.prompt
+    const correlationId = call.inputs.correlation_id
+
+    expect(prompt).toContain(correlationId)
+    expect(prompt).toContain('raw-nonce-abc')
+    expect(prompt).toContain(`owner: ${REPO.owner}`)
+    expect(prompt).toContain(`repo: ${REPO.repo}`)
+    expect(prompt).toContain('number: 42')
+    expect(prompt).toContain(`https://github.com/${REPO.owner}/${REPO.repo}/issues/42`)
+    expect(prompt).toContain('fro-bot:cross-repo-result')
+    expect(prompt).toContain('"status":"success"')
+    expect(prompt).toContain('"status":"noop"')
+
+    const finalMarker = selectStateMarker(comments.map(c => ({author: {login: c.login}, body: c.body})))
+    const storedItem = finalMarker?.state.items.find(i => i.id === 'item-1')
+    expect(storedItem?.nonceHash).toBeDefined()
+    expect(storedItem?.nonceHash).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it('never stores the raw nonce in the marker, and the stored hash is not the 64-bit hashState truncation', async () => {
+    const target = {owner: 'fro-bot', name: 'agent'}
+    const decomposition = makeDecompositionBody([{...target, prompt: 'do the thing'}])
+    const item: DispatchItem = {
+      id: 'item-1',
+      target,
+      promptHash: extractPromptHash(decomposition, target),
+      status: 'pending',
+    }
+    const state: GoalState = {goal: 'goal-1', items: [item], markerHash: ''}
+
+    const {octokit, comments} = mockOctokit()
+    comments.push({id: 1, body: decomposition, login: 'marcusrbrown'})
+    seedMarkerComment(comments, state)
+
+    await runDispatch({
+      octokit,
+      event: makeLabeledEvent(),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      loadRegistry: async () => [gateEntryFor(target)],
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async () => false,
+      createWorkflowDispatch: async () => undefined,
+      nonceSource: () => 'super-secret-raw-nonce',
+    })
+
+    const markerBodies = comments.map(c => c.body).join('\n')
+    expect(markerBodies).not.toContain('super-secret-raw-nonce')
+
+    const finalMarker = selectStateMarker(comments.map(c => ({author: {login: c.login}, body: c.body})))
+    const storedItem = finalMarker?.state.items.find(i => i.id === 'item-1')
+    expect(storedItem?.nonceHash).toBeDefined()
+    // Full SHA-256 hex is 64 chars; hashState truncates to 16.
+    expect(storedItem?.nonceHash).toHaveLength(64)
+  })
+
+  it('gives two items in one goal distinct nonces and distinct hashes', async () => {
+    const targets = [
+      {owner: 'fro-bot', name: 'agent'},
+      {owner: 'fro-bot', name: 'wiki'},
+    ]
+    const decomposition = makeDecompositionBody(targets.map(t => ({...t, prompt: `do work in ${t.name}`})))
+    const items: DispatchItem[] = targets.map((target, index) => ({
+      id: `item-${index + 1}`,
+      target,
+      promptHash: extractPromptHash(decomposition, target),
+      status: 'pending',
+    }))
+    const state: GoalState = {goal: 'goal-1', items, markerHash: ''}
+
+    const {octokit, comments} = mockOctokit()
+    comments.push({id: 1, body: decomposition, login: 'marcusrbrown'})
+    seedMarkerComment(comments, state)
+
+    const createWorkflowDispatch = vi.fn(async (_params: unknown) => ({}))
+    const seenNonces: string[] = []
+
+    await runDispatch({
+      octokit,
+      event: makeLabeledEvent(),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      loadRegistry: async () => targets.map(t => gateEntryFor(t)),
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async () => false,
+      createWorkflowDispatch: async params => {
+        await createWorkflowDispatch(params)
+      },
+      nonceSource: (() => {
+        let n = 0
+        return () => {
+          const nonce = `distinct-nonce-${++n}`
+          seenNonces.push(nonce)
+          return nonce
+        }
+      })(),
+    })
+
+    expect(new Set(seenNonces).size).toBe(2)
+
+    const finalMarker = selectStateMarker(comments.map(c => ({author: {login: c.login}, body: c.body})))
+    const hashes = finalMarker?.state.items.map(i => i.nonceHash) ?? []
+    expect(hashes).toHaveLength(2)
+    expect(new Set(hashes).size).toBe(2)
+  })
+
+  it('mint↔prompt consistency: sha256hex(raw nonce embedded in the prompt) equals the stored nonceHash', async () => {
+    const target = {owner: 'fro-bot', name: 'agent'}
+    const decomposition = makeDecompositionBody([{...target, prompt: 'do the thing'}])
+    const item: DispatchItem = {
+      id: 'item-1',
+      target,
+      promptHash: extractPromptHash(decomposition, target),
+      status: 'pending',
+    }
+    const state: GoalState = {goal: 'goal-1', items: [item], markerHash: ''}
+
+    const {octokit, comments} = mockOctokit()
+    comments.push({id: 1, body: decomposition, login: 'marcusrbrown'})
+    seedMarkerComment(comments, state)
+
+    const createWorkflowDispatch = vi.fn(async (_params: unknown) => ({}))
+
+    await runDispatch({
+      octokit,
+      event: makeLabeledEvent(),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      loadRegistry: async () => [gateEntryFor(target)],
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async () => false,
+      createWorkflowDispatch: async params => {
+        await createWorkflowDispatch(params)
+      },
+      nonceSource: () => 'consistency-check-nonce',
+    })
+
+    const call = createWorkflowDispatch.mock.calls[0]?.[0] as {inputs: {prompt: string}}
+    const nonceLine = call.inputs.prompt.split('\n').find(line => line.startsWith('nonce: '))
+    const rawNonceFromPrompt = nonceLine?.slice('nonce: '.length)
+    expect(rawNonceFromPrompt).toBe('consistency-check-nonce')
+
+    const finalMarker = selectStateMarker(comments.map(c => ({author: {login: c.login}, body: c.body})))
+    const storedItem = finalMarker?.state.items.find(i => i.id === 'item-1')
+
+    expect(rawNonceFromPrompt).toBeDefined()
+    const {createHash} = await import('node:crypto')
+    const computedHash = createHash('sha256')
+      .update(rawNonceFromPrompt as string)
+      .digest('hex')
+    expect(storedItem?.nonceHash).toBe(computedHash)
+  })
+
+  it('sets epoch only at confirmed dispatch; an item left at intent has no SLA-eligible epoch', async () => {
+    const target = {owner: 'fro-bot', name: 'agent'}
+    const decomposition = makeDecompositionBody([{...target, prompt: 'do the thing'}])
+    const item: DispatchItem = {
+      id: 'item-1',
+      target,
+      promptHash: extractPromptHash(decomposition, target),
+      status: 'pending',
+    }
+    const state: GoalState = {goal: 'goal-1', items: [item], markerHash: ''}
+
+    const {octokit, comments} = mockOctokit()
+    comments.push({id: 1, body: decomposition, login: 'marcusrbrown'})
+    seedMarkerComment(comments, state)
+
+    // The approval-fingerprint write (1st updateComment call) and the intent
+    // write (2nd call) are allowed to land normally; the confirm write (3rd
+    // call, which would set 'dispatched' + epoch) is accepted by the mock (no
+    // throw) but silently discarded — simulating a crash-after-confirm
+    // scenario where the item is stranded at 'intent'.
+    let writeCount = 0
+    const originalUpdateComment = octokit.rest.issues.updateComment
+    const droppingUpdateComment = async (params: {owner: string; repo: string; comment_id: number; body: string}) => {
+      writeCount += 1
+      if (writeCount >= 3) {
+        return {}
+      }
+      return originalUpdateComment(params)
+    }
+
+    const patchedOctokit = {
+      ...octokit,
+      rest: {
+        ...octokit.rest,
+        issues: {
+          ...octokit.rest.issues,
+          updateComment: droppingUpdateComment,
+        },
+      },
+    }
+
+    await runDispatch({
+      octokit: patchedOctokit,
+      event: makeLabeledEvent(),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      loadRegistry: async () => [gateEntryFor(target)],
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async () => false,
+      createWorkflowDispatch: async () => undefined,
+      nonceSource: () => 'intent-only-nonce',
+    })
+
+    const finalMarker = selectStateMarker(comments.map(c => ({author: {login: c.login}, body: c.body})))
+    const storedItem = finalMarker?.state.items.find(i => i.id === 'item-1')
+    expect(storedItem?.status).toBe('intent')
+    expect(storedItem?.epoch).toBeUndefined()
+  })
+
+  it('telemetry: counts output for a dispatch run contains neither the raw nonce nor the hash', async () => {
+    const target = {owner: 'fro-bot', name: 'agent'}
+    const decomposition = makeDecompositionBody([{...target, prompt: 'do the thing'}])
+    const item: DispatchItem = {
+      id: 'item-1',
+      target,
+      promptHash: extractPromptHash(decomposition, target),
+      status: 'pending',
+    }
+    const state: GoalState = {goal: 'goal-1', items: [item], markerHash: ''}
+
+    const {octokit, comments} = mockOctokit()
+    comments.push({id: 1, body: decomposition, login: 'marcusrbrown'})
+    seedMarkerComment(comments, state)
+
+    const result = await runDispatch({
+      octokit,
+      event: makeLabeledEvent(),
+      repo: REPO,
+      approveLabel: 'dispatch-approved',
+      loadRegistry: async () => [gateEntryFor(target)],
+      loadOtherOpenGoalMarkers: async () => [],
+      findRunByCorrelationId: async () => false,
+      createWorkflowDispatch: async () => undefined,
+      nonceSource: () => 'telemetry-check-nonce',
+    })
+
+    const countsJson = JSON.stringify(result.counts)
+    expect(countsJson).not.toContain('telemetry-check-nonce')
+    // No field on RunDispatchCounts carries nonce material at all — it's counts-only.
+    expect(Object.keys(result.counts).every(key => !key.toLowerCase().includes('nonce'))).toBe(true)
   })
 })
 
@@ -964,7 +1245,7 @@ describe('runDispatch — seeds marker from decomposition checklist', () => {
       const call = createWorkflowDispatch.mock.calls[index]?.[0]
       expect(call?.owner).toBe(target.owner)
       expect(call?.repo).toBe(target.name)
-      expect(call?.inputs.prompt).toBe(`do work in ${target.name}`)
+      expect(call?.inputs.prompt).toContain(`do work in ${target.name}`)
     }
   })
 
@@ -1305,7 +1586,7 @@ describe('runDispatch — resume reconciliation by correlation-id', () => {
       promptHash: 'abcd1234abcd1234',
       status: 'intent',
       correlationId: 'corr-existing-1',
-      nonce: 'nonce-1',
+      nonceHash: 'nonce-hash-1',
     }
     const state: GoalState = {
       goal: 'goal-1',
@@ -1366,7 +1647,7 @@ describe('runDispatch — CAS mismatch defers', () => {
       spin += 1
       const spinning: GoalState = {
         goal: 'goal-1',
-        items: [{...item, nonce: `spin-${spin}`}],
+        items: [{...item, nonceHash: `spin-${spin}`}],
         approvalFingerprint: fingerprint,
         markerHash: '',
       }
@@ -2171,7 +2452,7 @@ describe('CLI wiring — real collaborators, not stubs', () => {
         promptHash: 'abcd1234abcd1234',
         status: 'intent',
         correlationId: 'corr-resume-1',
-        nonce: 'nonce-1',
+        nonceHash: 'nonce-hash-1',
       }
       const state: GoalState = {
         goal: 'goal-1',

--- a/scripts/cross-repo-dispatch.test.ts
+++ b/scripts/cross-repo-dispatch.test.ts
@@ -1,5 +1,6 @@
 import type {
   CrossRepoDispatchOctokitClient,
+  CrossRepoResult,
   DispatchItem,
   DispatchTarget,
   GateEntry,
@@ -14,6 +15,7 @@ import {describe, expect, it, vi} from 'vitest'
 
 import {
   buildMarkerComment,
+  buildResultMarker,
   computeApprovalFingerprint,
   createTargetClientResolver,
   CROSS_REPO_GOAL_LABEL,
@@ -28,6 +30,7 @@ import {
   MARKER_PREFIX,
   MAX_ITEMS_PER_GOAL,
   parseDecomposition,
+  parseResult,
   parseTargetTokens,
   planDispatch,
   planSnapshot,
@@ -241,6 +244,202 @@ describe('parseDecomposition', () => {
     expect(result.items).toHaveLength(2)
     expect(result.items[0]?.target).toEqual({owner: 'marcusrbrown', name: 'sparkle'})
     expect(result.items[1]?.target).toEqual({owner: 'marcusrbrown', name: 'renovate-config'})
+  })
+})
+
+function makeReceipt(overrides: Partial<CrossRepoResult> = {}): CrossRepoResult {
+  return {
+    correlationId: 'abc123correlation',
+    nonce: 'raw-nonce-value-1234567890',
+    status: 'success',
+    summary: 'did the thing',
+    ...overrides,
+  }
+}
+
+describe('buildResultMarker / parseResult round-trip', () => {
+  it.each(['success', 'noop', 'failed'] as const)(
+    'round-trips a %s receipt through region + marker + prose',
+    status => {
+      const receipt = makeReceipt({status})
+      const body = ['Some prose before the receipt.', buildResultMarker(receipt), 'Some prose after the receipt.'].join(
+        '\n',
+      )
+      const outcome = parseResult(body)
+      expect(outcome.ok).toBe(true)
+      expect(outcome.result).toEqual(receipt)
+    },
+  )
+
+  it('emits the documented delimited-region shape', () => {
+    const body = buildResultMarker(makeReceipt())
+    const lines = body.split('\n')
+    expect(lines[0]).toBe('<!-- fro-bot:cross-repo-result:start -->')
+    expect(lines[1]).toMatch(/^<!-- fro-bot:cross-repo-result \{.*\} -->$/)
+    expect(lines[2]).toBe('<!-- fro-bot:cross-repo-result:end -->')
+  })
+
+  it('round-trips the optional pr field when present', () => {
+    const receipt = makeReceipt({pr: 'https://github.com/fro-bot/agent/pull/1'})
+    const outcome = parseResult(buildResultMarker(receipt))
+    expect(outcome.ok).toBe(true)
+    expect(outcome.result).toEqual(receipt)
+  })
+
+  it('omits pr from the parsed result when the receipt has none', () => {
+    const outcome = parseResult(buildResultMarker(makeReceipt()))
+    expect(outcome.ok).toBe(true)
+    expect(outcome.result?.pr).toBeUndefined()
+  })
+
+  it('prefers the delimited region, ignoring an unrelated marker-shaped string outside it', () => {
+    const receipt = makeReceipt({correlationId: 'inside-region'})
+    const body = [
+      '<!-- fro-bot:cross-repo-result {"correlation_id":"outside-region","nonce":"n","status":"failed","summary":"x"} -->',
+      buildResultMarker(receipt),
+    ].join('\n')
+    // Region-preference only applies once a region exists; here the bare
+    // marker precedes the region. extractResultMarkerJson takes the LAST
+    // match within the selected scope (region body when present), so the
+    // in-region receipt wins once the region is extracted.
+    const outcome = parseResult(body)
+    expect(outcome.ok).toBe(true)
+    expect(outcome.result?.correlationId).toBe('inside-region')
+  })
+
+  it('parses a marker inside a fenced code block with adjacent prose, region present', () => {
+    const receipt = makeReceipt({status: 'noop', summary: 'nothing to do'})
+    const body = [
+      'Worker report:',
+      '<!-- fro-bot:cross-repo-result:start -->',
+      '```',
+      JSON.stringify({
+        correlation_id: receipt.correlationId,
+        nonce: receipt.nonce,
+        status: 'noop',
+        summary: 'nothing to do',
+      }),
+      '```',
+      '<!-- fro-bot:cross-repo-result:end -->',
+      'End of report.',
+    ].join('\n')
+    // The fenced block above deliberately omits the marker HTML comment
+    // itself (workers sometimes wrap only the JSON) — exercised instead via
+    // the canonical marker-inside-region path below for the parseable case.
+    const canonicalBody = ['Worker report:', buildResultMarker(receipt), 'End of report.'].join('\n')
+    const outcome = parseResult(canonicalBody)
+    expect(outcome.ok).toBe(true)
+    expect(outcome.result).toEqual(receipt)
+    // The malformed fenced-only variant (no marker comment) is `absent`.
+    expect(parseResult(body).reason).toBe('absent')
+  })
+
+  it('parses a bare marker without the region via body-scan fallback', () => {
+    const receipt = makeReceipt()
+    const marker = `<!-- fro-bot:cross-repo-result ${JSON.stringify({
+      correlation_id: receipt.correlationId,
+      nonce: receipt.nonce,
+      status: receipt.status,
+      summary: receipt.summary,
+    })} -->`
+    const body = `Some prose.\n${marker}\nMore prose.`
+    const outcome = parseResult(body)
+    expect(outcome.ok).toBe(true)
+    expect(outcome.result).toEqual(receipt)
+  })
+
+  it('round-trips a nonce/summary containing characters that could break JSON quoting', () => {
+    const receipt = makeReceipt({
+      nonce: 'n"o\\nce\nwith\tquotes"and\\backslashes',
+      summary: 'summary with "quotes", \\backslashes\\, and\nnewlines',
+    })
+    const outcome = parseResult(buildResultMarker(receipt))
+    expect(outcome.ok).toBe(true)
+    expect(outcome.result).toEqual(receipt)
+  })
+})
+
+describe('parseResult — malformed vs absent', () => {
+  it('returns absent when no receipt marker is present at all', () => {
+    const outcome = parseResult('just a regular comment with no receipt')
+    expect(outcome.ok).toBe(false)
+    expect(outcome.reason).toBe('absent')
+    expect(outcome.result).toBeUndefined()
+  })
+
+  it('returns absent for an empty body', () => {
+    const outcome = parseResult('')
+    expect(outcome.ok).toBe(false)
+    expect(outcome.reason).toBe('absent')
+  })
+
+  it('returns malformed for invalid JSON in the marker', () => {
+    const outcome = parseResult('<!-- fro-bot:cross-repo-result {not json} -->')
+    expect(outcome.ok).toBe(false)
+    expect(outcome.reason).toBe('malformed')
+  })
+
+  it('returns malformed when nonce is missing', () => {
+    const body = `<!-- fro-bot:cross-repo-result ${JSON.stringify({
+      correlation_id: 'abc',
+      status: 'success',
+      summary: 'done',
+    })} -->`
+    const outcome = parseResult(body)
+    expect(outcome.ok).toBe(false)
+    expect(outcome.reason).toBe('malformed')
+  })
+
+  it('returns malformed when correlation_id is missing', () => {
+    const body = `<!-- fro-bot:cross-repo-result ${JSON.stringify({
+      nonce: 'n',
+      status: 'success',
+      summary: 'done',
+    })} -->`
+    const outcome = parseResult(body)
+    expect(outcome.ok).toBe(false)
+    expect(outcome.reason).toBe('malformed')
+  })
+
+  it('returns malformed when status is outside the closed vocabulary', () => {
+    const body = `<!-- fro-bot:cross-repo-result ${JSON.stringify({
+      correlation_id: 'abc',
+      nonce: 'n',
+      status: 'blocked',
+      summary: 'done',
+    })} -->`
+    const outcome = parseResult(body)
+    expect(outcome.ok).toBe(false)
+    expect(outcome.reason).toBe('malformed')
+  })
+
+  it('returns malformed when summary is missing', () => {
+    const body = `<!-- fro-bot:cross-repo-result ${JSON.stringify({
+      correlation_id: 'abc',
+      nonce: 'n',
+      status: 'success',
+    })} -->`
+    const outcome = parseResult(body)
+    expect(outcome.ok).toBe(false)
+    expect(outcome.reason).toBe('malformed')
+  })
+
+  it('never returns a partial result on a malformed marker', () => {
+    const outcome = parseResult('<!-- fro-bot:cross-repo-result {"correlation_id":"abc"} -->')
+    expect(outcome.ok).toBe(false)
+    expect(outcome.result).toBeUndefined()
+  })
+})
+
+describe('parseResult — nonce never logged/printed (R12 discipline check)', () => {
+  it('parseResult itself performs no console output', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    parseResult(buildResultMarker(makeReceipt({nonce: 'super-secret-nonce-value'})))
+    expect(spy).not.toHaveBeenCalled()
+    expect(errSpy).not.toHaveBeenCalled()
+    spy.mockRestore()
+    errSpy.mockRestore()
   })
 })
 

--- a/scripts/cross-repo-dispatch.test.ts
+++ b/scripts/cross-repo-dispatch.test.ts
@@ -878,7 +878,7 @@ describe('runDispatch — happy sequential dispatch', () => {
         repo: string
         workflow_id: string
         ref: string
-        inputs: {prompt: string; correlation_id: string}
+        inputs: {prompt: string}
       }) => ({}),
     )
 
@@ -908,6 +908,8 @@ describe('runDispatch — happy sequential dispatch', () => {
       expect(call?.workflow_id).toBe('fro-bot.yaml')
       expect(call?.ref).toBe('main')
       expect(call?.inputs.prompt).toContain(`do work in ${target.name}`)
+      expect(call?.inputs).not.toHaveProperty('correlation_id')
+      expect(Object.keys(call?.inputs ?? {})).toEqual(['prompt'])
     }
   })
 })
@@ -945,12 +947,16 @@ describe('runDispatch — nonce mint + receipt-carrying prompt (Unit 2)', () => 
     })
 
     const call = createWorkflowDispatch.mock.calls[0]?.[0] as {
-      inputs: {prompt: string; correlation_id: string}
+      inputs: {prompt: string}
     }
+    expect(call.inputs).not.toHaveProperty('correlation_id')
+    expect(Object.keys(call.inputs)).toEqual(['prompt'])
     const prompt = call.inputs.prompt
-    const correlationId = call.inputs.correlation_id
+    const correlationIdMatch = /correlation_id: (\S+)/.exec(prompt)
+    const correlationId = correlationIdMatch?.[1]
+    expect(correlationId).toBeDefined()
 
-    expect(prompt).toContain(correlationId)
+    expect(prompt).toContain(correlationId as string)
     expect(prompt).toContain('raw-nonce-abc')
     expect(prompt).toContain(`owner: ${REPO.owner}`)
     expect(prompt).toContain(`repo: ${REPO.repo}`)
@@ -1217,7 +1223,7 @@ describe('runDispatch — seeds marker from decomposition checklist', () => {
         repo: string
         workflow_id: string
         ref: string
-        inputs: {prompt: string; correlation_id: string}
+        inputs: {prompt: string}
       }) => ({}),
     )
 

--- a/scripts/cross-repo-dispatch.test.ts
+++ b/scripts/cross-repo-dispatch.test.ts
@@ -7,7 +7,6 @@ import type {
   GoalState,
   LabeledEventPayload,
   OpenGoalIssue,
-  PrLookupResult,
   TrackerComment,
 } from './cross-repo-dispatch.ts'
 import process from 'node:process'
@@ -21,7 +20,6 @@ import {
   CROSS_REPO_GOAL_LABEL,
   extractItemPrompts,
   extractMarker,
-  findBotAuthoredPrs,
   findRunByCorrelationId,
   findRunConclusion,
   gateTarget,
@@ -37,7 +35,6 @@ import {
   planSnapshot,
   RECEIPT_SLA_MS,
   REQUIRED_APPROVER,
-  resolveItemTerminalState,
   resolveReceipts,
   runDispatch,
   runDispatchCli,
@@ -544,84 +541,6 @@ describe('gateTarget', () => {
   })
 })
 
-describe('resolveItemTerminalState — precedence table', () => {
-  it('gate-block takes precedence over everything', () => {
-    expect(resolveItemTerminalState({gateBlocked: true, runConclusion: 'success'})).toBe('blocked')
-  })
-
-  it('run failure resolves to failed', () => {
-    expect(resolveItemTerminalState({runConclusion: 'failure'})).toBe('failed')
-  })
-
-  it('no run conclusion yet resolves to dispatched (non-terminal)', () => {
-    expect(resolveItemTerminalState({})).toBe('dispatched')
-  })
-
-  it('success with no PR (no-op success) resolves to completed', () => {
-    expect(resolveItemTerminalState({runConclusion: 'success', prs: []})).toBe('completed')
-  })
-
-  it('success with one merged bot PR resolves to completed', () => {
-    expect(
-      resolveItemTerminalState({
-        runConclusion: 'success',
-        prs: [{merged: true, closed: true, authorIsBot: true}],
-      }),
-    ).toBe('completed')
-  })
-
-  it('success with only closed-unmerged bot PRs resolves to failed', () => {
-    expect(
-      resolveItemTerminalState({
-        runConclusion: 'success',
-        prs: [{merged: false, closed: true, authorIsBot: true}],
-      }),
-    ).toBe('failed')
-  })
-
-  it('success with a still-open bot PR resolves to dispatched (non-terminal)', () => {
-    expect(
-      resolveItemTerminalState({
-        runConclusion: 'success',
-        prs: [{merged: false, closed: false, authorIsBot: true}],
-      }),
-    ).toBe('dispatched')
-  })
-
-  it('multi-PR: terminal only when all are terminal, completed if any merged', () => {
-    expect(
-      resolveItemTerminalState({
-        runConclusion: 'success',
-        prs: [
-          {merged: false, closed: true, authorIsBot: true},
-          {merged: true, closed: true, authorIsBot: true},
-        ],
-      }),
-    ).toBe('completed')
-  })
-
-  it('multi-PR: all closed-unmerged resolves to failed', () => {
-    expect(
-      resolveItemTerminalState({
-        runConclusion: 'success',
-        prs: [
-          {merged: false, closed: true, authorIsBot: true},
-          {merged: false, closed: true, authorIsBot: true},
-        ],
-      }),
-    ).toBe('failed')
-  })
-
-  it('a forged non-bot PR is ignored — no-op success completes', () => {
-    expect(
-      resolveItemTerminalState({
-        runConclusion: 'success',
-        prs: [{merged: true, closed: true, authorIsBot: false}],
-      }),
-    ).toBe('completed')
-  })
-})
-
 describe('planDispatch', () => {
   it('skips already-dispatched and terminal items', () => {
     const state = makeState({
@@ -670,10 +589,10 @@ describe('planDispatch', () => {
 })
 
 describe('planSnapshot', () => {
-  it('applies terminal resolution per dispatched item and flags allTerminal', () => {
+  it('applies a gate-block signal per dispatched item and flags allTerminal', () => {
     const state = makeState({items: [makeItem({id: 'a', status: 'dispatched'})], markerHash: 'old'})
-    const result = planSnapshot({state, signals: {a: {runConclusion: 'success', prs: []}}})
-    expect(result.state.items[0]?.status).toBe('completed')
+    const result = planSnapshot({state, signals: {a: {gateBlocked: true}}})
+    expect(result.state.items[0]?.status).toBe('blocked')
     expect(result.allTerminal).toBe(true)
     expect(result.shouldWrite).toBe(true)
   })
@@ -683,7 +602,7 @@ describe('planSnapshot', () => {
       items: [makeItem({id: 'a', status: 'dispatched'}), makeItem({id: 'b', status: 'dispatched'})],
       markerHash: 'old',
     })
-    const result = planSnapshot({state, signals: {a: {runConclusion: 'success', prs: []}}})
+    const result = planSnapshot({state, signals: {a: {gateBlocked: true}}})
     expect(result.allTerminal).toBe(false)
   })
 
@@ -715,7 +634,6 @@ function mockOctokit(
     update?: ReturnType<typeof vi.fn>
     listForRepo?: ReturnType<typeof vi.fn>
     listWorkflowRunsForRepo?: ReturnType<typeof vi.fn>
-    issuesAndPullRequests?: ReturnType<typeof vi.fn>
   } = {},
 ): {octokit: CrossRepoDispatchOctokitClient; comments: MockComment[]} {
   const comments = overrides.comments ?? []
@@ -760,12 +678,6 @@ function mockOctokit(
           vi.fn(async () => ({
             data: {workflow_runs: []},
           }))) as CrossRepoDispatchOctokitClient['rest']['actions']['listWorkflowRunsForRepo'],
-      },
-      search: {
-        issuesAndPullRequests: (overrides.issuesAndPullRequests ??
-          vi.fn(async () => ({
-            data: {items: []},
-          }))) as CrossRepoDispatchOctokitClient['rest']['search']['issuesAndPullRequests'],
       },
     },
   }
@@ -1706,46 +1618,44 @@ function mockOctokitForGoal(goalIssue: OpenGoalIssue, overrides: Parameters<type
   })
 }
 
-describe('runTrack — terminal precedence and closure', () => {
-  it('picks the correct run by correlation-id when a coincidental run shares the epoch window', async () => {
+describe('runTrack — run-lookup is diagnostic-only, never authoritative (Unit 5)', () => {
+  it('a dispatched item with no receipt and pre-SLA is untouched — run-lookup is not consulted at all', async () => {
     const item: DispatchItem = {
       id: 'item-1',
       target: TARGET_A,
-      promptHash: 'abcd1234abcd1234',
+      promptHash: 'h',
       status: 'dispatched',
-      correlationId: 'corr-real',
-      epoch: 1000,
+      correlationId: 'c1',
+      epoch: 0,
     }
-    const state: GoalState = {goal: 'goal-1', items: [item], markerHash: ''}
-    const goalIssue = makeOpenGoal(state)
-
-    const findRunConclusion = vi.fn(async (_target: DispatchTarget, correlationId: string) =>
-      correlationId === 'corr-real' ? ('success' as const) : ('failure' as const),
-    )
-
+    const goalIssue = makeOpenGoal({goal: 'g', items: [item], markerHash: ''})
     const {octokit} = mockOctokitForGoal(goalIssue)
+    const findRunConclusion = vi.fn(async () => 'success' as const)
     const result = await runTrack({
       octokit,
       repo: REPO,
       loadOpenGoalIssues: async () => [goalIssue],
       loadRegistry: async () => [gateEntryFor(TARGET_A)],
       findRunConclusion,
-      findBotAuthoredPrs: async () => [],
-      now: () => 1000,
+      now: () => RECEIPT_SLA_MS - 1,
     })
-
-    expect(findRunConclusion).toHaveBeenCalledWith(TARGET_A, 'corr-real')
-    expect(result.counts.itemsCompleted).toBe(1)
-    expect(result.counts.goalsClosed).toBe(1)
+    // Pre-SLA, no receipt: item stays dispatched (non-terminal), and
+    // run-lookup is never called — it only fires once an item is already
+    // needs-attention/no-receipt.
+    expect(findRunConclusion).not.toHaveBeenCalled()
+    expect(result.counts.itemsCompleted).toBe(0)
+    expect(result.counts.itemsFailed).toBe(0)
+    expect(result.counts.goalsClosed).toBe(0)
   })
 
-  it('run-success with no PR resolves to completed', async () => {
+  it('a concluded run for a no-receipt needs-attention item never flips it terminal, even on run success', async () => {
     const item: DispatchItem = {
       id: 'item-1',
       target: TARGET_A,
       promptHash: 'h',
       status: 'dispatched',
       correlationId: 'c1',
+      epoch: 0,
     }
     const goalIssue = makeOpenGoal({goal: 'g', items: [item], markerHash: ''})
     const {octokit} = mockOctokitForGoal(goalIssue)
@@ -1755,83 +1665,81 @@ describe('runTrack — terminal precedence and closure', () => {
       loadOpenGoalIssues: async () => [goalIssue],
       loadRegistry: async () => [gateEntryFor(TARGET_A)],
       findRunConclusion: async () => 'success',
-      findBotAuthoredPrs: async () => [],
+      now: () => RECEIPT_SLA_MS + 1,
     })
-    expect(result.counts.itemsCompleted).toBe(1)
+    // Past SLA, no receipt -> needs-attention, NOT completed, regardless of
+    // the run-lookup's (diagnostic-only) success conclusion.
+    expect(result.counts.itemsCompleted).toBe(0)
+    expect(result.counts.itemsNeedsAttention).toBe(1)
+    expect(result.counts.goalsClosed).toBe(0)
   })
 
-  it('run-success with a bot-merged PR resolves to completed', async () => {
+  it('diagnostic: a no-receipt needs-attention item with a concluded run is annotated "ran-no-report"', async () => {
     const item: DispatchItem = {
       id: 'item-1',
       target: TARGET_A,
       promptHash: 'h',
       status: 'dispatched',
       correlationId: 'c1',
+      epoch: 0,
     }
     const goalIssue = makeOpenGoal({goal: 'g', items: [item], markerHash: ''})
-    const {octokit} = mockOctokitForGoal(goalIssue)
-    const result = await runTrack({
+    const {octokit, comments} = mockOctokitForGoal(goalIssue)
+    const findRunConclusion = vi.fn(async () => 'success' as const)
+    await runTrack({
       octokit,
       repo: REPO,
       loadOpenGoalIssues: async () => [goalIssue],
       loadRegistry: async () => [gateEntryFor(TARGET_A)],
-      findRunConclusion: async () => 'success',
-      findBotAuthoredPrs: async (): Promise<PrLookupResult[]> => [{merged: true, closed: true, authorIsBot: true}],
+      findRunConclusion,
+      now: () => RECEIPT_SLA_MS + 1,
     })
-    expect(result.counts.itemsCompleted).toBe(1)
+    expect(findRunConclusion).toHaveBeenCalledWith(TARGET_A, 'c1')
+    const markerComment = comments.find(c => c.body.includes('cross-repo-dispatch'))
+    const marker = markerComment === undefined ? null : extractMarker(markerComment.body)
+    const updatedItem = marker?.state.items.find(candidate => candidate.id === 'item-1')
+    expect(updatedItem?.status).toBe('needs-attention')
+    expect(updatedItem?.needsAttentionReason).toBe('no-receipt')
+    expect(updatedItem?.noReceiptDiagnostic).toBe('ran-no-report')
   })
 
-  it('a forged non-bot PR is ignored — no false completion signal from it alone', async () => {
+  it('diagnostic: a no-receipt needs-attention item with no run at all is annotated "never-ran"', async () => {
     const item: DispatchItem = {
       id: 'item-1',
       target: TARGET_A,
       promptHash: 'h',
       status: 'dispatched',
       correlationId: 'c1',
+      epoch: 0,
     }
     const goalIssue = makeOpenGoal({goal: 'g', items: [item], markerHash: ''})
-    const {octokit} = mockOctokitForGoal(goalIssue)
-    const result = await runTrack({
+    const {octokit, comments} = mockOctokitForGoal(goalIssue)
+    const findRunConclusion = vi.fn(async () => undefined)
+    await runTrack({
       octokit,
       repo: REPO,
       loadOpenGoalIssues: async () => [goalIssue],
       loadRegistry: async () => [gateEntryFor(TARGET_A)],
-      findRunConclusion: async () => 'success',
-      findBotAuthoredPrs: async (): Promise<PrLookupResult[]> => [{merged: true, closed: true, authorIsBot: false}],
+      findRunConclusion,
+      now: () => RECEIPT_SLA_MS + 1,
     })
-    // Forged PR is filtered out entirely -> no bot PRs -> no-op success -> completed,
-    // but crucially NOT because the forged PR's merged=true was trusted.
-    expect(result.counts.itemsCompleted).toBe(1)
+    expect(findRunConclusion).toHaveBeenCalledWith(TARGET_A, 'c1')
+    const markerComment = comments.find(c => c.body.includes('cross-repo-dispatch'))
+    const marker = markerComment === undefined ? null : extractMarker(markerComment.body)
+    const updatedItem = marker?.state.items.find(candidate => candidate.id === 'item-1')
+    expect(updatedItem?.status).toBe('needs-attention')
+    expect(updatedItem?.needsAttentionReason).toBe('no-receipt')
+    expect(updatedItem?.noReceiptDiagnostic).toBe('never-ran')
   })
 
-  it('run-success with closed-unmerged PR resolves to failed', async () => {
+  it('run-failure for a no-receipt needs-attention item does not resolve it to failed', async () => {
     const item: DispatchItem = {
       id: 'item-1',
       target: TARGET_A,
       promptHash: 'h',
       status: 'dispatched',
       correlationId: 'c1',
-    }
-    const goalIssue = makeOpenGoal({goal: 'g', items: [item], markerHash: ''})
-    const {octokit} = mockOctokitForGoal(goalIssue)
-    const result = await runTrack({
-      octokit,
-      repo: REPO,
-      loadOpenGoalIssues: async () => [goalIssue],
-      loadRegistry: async () => [gateEntryFor(TARGET_A)],
-      findRunConclusion: async () => 'success',
-      findBotAuthoredPrs: async (): Promise<PrLookupResult[]> => [{merged: false, closed: true, authorIsBot: true}],
-    })
-    expect(result.counts.itemsFailed).toBe(1)
-  })
-
-  it('run-failure resolves to failed', async () => {
-    const item: DispatchItem = {
-      id: 'item-1',
-      target: TARGET_A,
-      promptHash: 'h',
-      status: 'dispatched',
-      correlationId: 'c1',
+      epoch: 0,
     }
     const goalIssue = makeOpenGoal({goal: 'g', items: [item], markerHash: ''})
     const {octokit} = mockOctokitForGoal(goalIssue)
@@ -1841,70 +1749,35 @@ describe('runTrack — terminal precedence and closure', () => {
       loadOpenGoalIssues: async () => [goalIssue],
       loadRegistry: async () => [gateEntryFor(TARGET_A)],
       findRunConclusion: async () => 'failure',
-      findBotAuthoredPrs: async () => [],
+      now: () => RECEIPT_SLA_MS + 1,
     })
-    expect(result.counts.itemsFailed).toBe(1)
+    expect(result.counts.itemsFailed).toBe(0)
+    expect(result.counts.itemsNeedsAttention).toBe(1)
   })
 
-  it('partial completion keeps the issue open (not all terminal)', async () => {
-    const items: DispatchItem[] = [
-      {id: 'item-1', target: TARGET_A, promptHash: 'h1', status: 'dispatched', correlationId: 'c1'},
-      {
-        id: 'item-2',
-        target: {owner: 'fro-bot', name: 'wiki'},
-        promptHash: 'h2',
-        status: 'dispatched',
-        correlationId: 'c2',
-      },
-    ]
-    const goalIssue = makeOpenGoal({goal: 'g', items, markerHash: ''})
+  it('gate-blocked item resolves to blocked without ever consulting run-lookup', async () => {
+    const item: DispatchItem = {
+      id: 'item-1',
+      target: TARGET_A,
+      promptHash: 'h',
+      status: 'dispatched',
+      correlationId: 'c1',
+      epoch: 0,
+    }
+    const goalIssue = makeOpenGoal({goal: 'g', items: [item], markerHash: ''})
     const {octokit} = mockOctokitForGoal(goalIssue)
+    const findRunConclusion = vi.fn(async () => 'success' as const)
     const result = await runTrack({
       octokit,
       repo: REPO,
       loadOpenGoalIssues: async () => [goalIssue],
-      loadRegistry: async () => [gateEntryFor(TARGET_A), gateEntryFor({owner: 'fro-bot', name: 'wiki'})],
-      findRunConclusion: async (_target, correlationId) => (correlationId === 'c1' ? 'success' : undefined),
-      findBotAuthoredPrs: async () => [],
+      loadRegistry: async () => [], // TARGET_A not registered -> ineligible
+      findRunConclusion,
+      now: () => 0,
     })
-    expect(result.counts.itemsCompleted).toBe(1)
-    expect(result.counts.goalsClosed).toBe(0)
-    expect(result.counts.itemsStillOpen).toBe(1)
-  })
-
-  it('all-terminal closes the issue and posts a counts-only summary', async () => {
-    const items: DispatchItem[] = [
-      {id: 'item-1', target: TARGET_A, promptHash: 'h1', status: 'dispatched', correlationId: 'c1'},
-      {
-        id: 'item-2',
-        target: {owner: 'fro-bot', name: 'wiki'},
-        promptHash: 'h2',
-        status: 'dispatched',
-        correlationId: 'c2',
-      },
-    ]
-    const goalIssue = makeOpenGoal({goal: 'g', items, markerHash: ''})
-    const createComment = vi.fn(async (_params: {body: string}) => ({data: {id: 1}}))
-    const updateComment = vi.fn(async (_params: {comment_id: number; body: string}) => ({}))
-    const update = vi.fn(async (_params: unknown) => ({data: {}}))
-    const {octokit} = mockOctokitForGoal(goalIssue, {createComment, updateComment, update})
-    const result = await runTrack({
-      octokit,
-      repo: REPO,
-      loadOpenGoalIssues: async () => [goalIssue],
-      loadRegistry: async () => [gateEntryFor(TARGET_A), gateEntryFor({owner: 'fro-bot', name: 'wiki'})],
-      findRunConclusion: async () => 'success',
-      findBotAuthoredPrs: async () => [],
-    })
+    expect(findRunConclusion).not.toHaveBeenCalled()
+    expect(result.counts.itemsBlocked).toBe(1)
     expect(result.counts.goalsClosed).toBe(1)
-    // The marker comment already exists (seeded) so its update is in-place;
-    // only the closing summary uses createComment (a distinct human-facing artifact).
-    expect(updateComment).toHaveBeenCalledOnce()
-    expect(createComment).toHaveBeenCalledOnce()
-    expect(update).toHaveBeenCalledWith(expect.objectContaining({state: 'closed'}))
-    const summaryBody = createComment.mock.calls[0]?.[0]?.body as string
-    expect(summaryBody).not.toContain('fro-bot/agent')
-    expect(summaryBody).not.toContain('fro-bot/wiki')
   })
 
   it('is idempotent — no signal change yields no write and no comment', async () => {
@@ -1921,7 +1794,6 @@ describe('runTrack — terminal precedence and closure', () => {
       loadOpenGoalIssues: async () => [goalIssue],
       loadRegistry: async () => [gateEntryFor(TARGET_A)],
       findRunConclusion: async () => 'success',
-      findBotAuthoredPrs: async () => [],
     })
     expect(result.counts.idempotentNoop).toBe(1)
     expect(createComment).not.toHaveBeenCalled()
@@ -2161,7 +2033,6 @@ describe('runTrack — receipt-driven resolution (Unit 4 integration)', () => {
         gateEntryFor({owner: 'fro-bot', name: 'sparkle'}),
       ],
       findRunConclusion: async () => undefined,
-      findBotAuthoredPrs: async () => [],
       now: () => 1000,
     })
     expect(result.counts.itemsCompleted).toBe(2)
@@ -2181,7 +2052,6 @@ describe('runTrack — receipt-driven resolution (Unit 4 integration)', () => {
       loadOpenGoalIssues: async () => [goalIssue],
       loadRegistry: async () => [gateEntryFor(TARGET_A)],
       findRunConclusion: async () => undefined,
-      findBotAuthoredPrs: async () => [],
       now: () => 1000,
     })
     expect(result.counts.itemsCompleted).toBe(0)
@@ -2202,7 +2072,6 @@ describe('runTrack — receipt-driven resolution (Unit 4 integration)', () => {
       loadOpenGoalIssues: async () => [goalIssue],
       loadRegistry: async () => [gateEntryFor(TARGET_A)],
       findRunConclusion: async () => undefined,
-      findBotAuthoredPrs: async () => [],
       now: () => 1000,
     })
     expect(result.counts.itemsCompleted).toBe(0)
@@ -2225,7 +2094,6 @@ describe('runTrack — receipt-driven resolution (Unit 4 integration)', () => {
       loadOpenGoalIssues: async () => [goalIssue],
       loadRegistry: async () => [gateEntryFor(TARGET_A)],
       findRunConclusion: async () => undefined,
-      findBotAuthoredPrs: async () => [],
       now: () => 1000,
     })
     expect(result.counts.itemsCompleted).toBe(0)
@@ -2245,7 +2113,6 @@ describe('runTrack — receipt-driven resolution (Unit 4 integration)', () => {
       loadOpenGoalIssues: async () => [goalIssue],
       loadRegistry: async () => [gateEntryFor(TARGET_A)],
       findRunConclusion: async () => undefined,
-      findBotAuthoredPrs: async () => [],
       now: () => item.epoch ?? 0, // pre-SLA
     })
     expect(result.counts.itemsNeedsAttention).toBe(1)
@@ -2275,7 +2142,6 @@ describe('runTrack — receipt-driven resolution (Unit 4 integration)', () => {
       loadOpenGoalIssues: async () => [goalIssue1],
       loadRegistry: async () => [gateEntryFor(TARGET_A)],
       findRunConclusion: async () => undefined,
-      findBotAuthoredPrs: async () => [],
       now: () => 1000,
     })
     expect(result1.counts.itemsCompleted).toBe(0)
@@ -2293,7 +2159,6 @@ describe('runTrack — receipt-driven resolution (Unit 4 integration)', () => {
       loadOpenGoalIssues: async () => [goalIssue2],
       loadRegistry: async () => [gateEntryFor(TARGET_A)],
       findRunConclusion: async () => undefined,
-      findBotAuthoredPrs: async () => [],
       now: () => 1000,
     })
     expect(result2.counts.itemsCompleted).toBe(1)
@@ -2317,7 +2182,6 @@ describe('runTrack — receipt-driven resolution (Unit 4 integration)', () => {
       loadOpenGoalIssues: async () => [goalStale],
       loadRegistry: async () => [gateEntryFor(TARGET_A)],
       findRunConclusion: async () => undefined,
-      findBotAuthoredPrs: async () => [],
       now: () => RECEIPT_SLA_MS + 1,
     })
     expect(resultStale.counts.itemsNeedsAttention).toBe(1)
@@ -2339,7 +2203,6 @@ describe('runTrack — receipt-driven resolution (Unit 4 integration)', () => {
       loadOpenGoalIssues: async () => [goalFresh],
       loadRegistry: async () => [gateEntryFor(TARGET_A)],
       findRunConclusion: async () => undefined,
-      findBotAuthoredPrs: async () => [],
       now: () => RECEIPT_SLA_MS - 1,
     })
     expect(resultFresh.counts.itemsNeedsAttention).toBe(0)
@@ -2359,7 +2222,6 @@ describe('runTrack — receipt-driven resolution (Unit 4 integration)', () => {
       loadOpenGoalIssues: async () => [goalNever],
       loadRegistry: async () => [gateEntryFor(TARGET_A)],
       findRunConclusion: async () => undefined,
-      findBotAuthoredPrs: async () => [],
       now: () => RECEIPT_SLA_MS * 100,
     })
     expect(resultNever.counts.itemsNeedsAttention).toBe(0)
@@ -2388,7 +2250,6 @@ describe('runTrack — receipt-driven resolution (Unit 4 integration)', () => {
       loadOpenGoalIssues: async () => [goalIssue],
       loadRegistry: async () => [gateEntryFor(TARGET_A)],
       findRunConclusion: async () => undefined,
-      findBotAuthoredPrs: async () => [],
       now: () => 0,
     })
     expect(result.counts.itemsCompleted).toBe(1)
@@ -2410,7 +2271,6 @@ describe('runTrack — receipt-driven resolution (Unit 4 integration)', () => {
       loadOpenGoalIssues: async () => [goalIssue],
       loadRegistry: async () => [gateEntryFor(TARGET_A)],
       findRunConclusion: async () => undefined,
-      findBotAuthoredPrs: async () => [],
       now: () => 1_000_000,
     })
     expect(result.counts.itemsFailed).toBe(1)
@@ -2447,7 +2307,6 @@ describe('runTrack — receipt-driven resolution (Unit 4 integration)', () => {
       loadOpenGoalIssues: async () => [goalIssue],
       loadRegistry: async () => [gateEntryFor(TARGET_A), gateEntryFor({owner: 'fro-bot', name: 'wiki'})],
       findRunConclusion: async () => undefined,
-      findBotAuthoredPrs: async () => [],
       now: () => RECEIPT_SLA_MS + 1,
     })
     expect(result.counts.itemsCompleted).toBe(1)
@@ -2576,36 +2435,6 @@ describe('loadOtherOpenGoalMarkers', () => {
     const result = await loadOtherOpenGoalMarkers(patched.octokit, REPO, 42)
     expect(result).toHaveLength(1)
     expect(result[0]?.goal).toBe('goal-other')
-  })
-})
-
-describe('findBotAuthoredPrs — anti-spoof', () => {
-  it('includes a bot-authored PR carrying the correlation id', async () => {
-    const issuesAndPullRequests = vi.fn(async () => ({
-      data: {
-        items: [{number: 1, state: 'closed', user: {login: 'fro-bot'}, pull_request: {merged_at: '2026-01-01'}}],
-      },
-    }))
-    const {octokit} = mockOctokit({issuesAndPullRequests})
-    const result = await findBotAuthoredPrs(octokit)(TARGET_A, 'corr-1')
-    expect(issuesAndPullRequests).toHaveBeenCalledWith(
-      expect.objectContaining({q: expect.stringContaining('corr-1') as string}),
-    )
-    expect(result).toEqual([{merged: true, closed: true, authorIsBot: true}])
-  })
-
-  it('excludes a forged PR authored by a non-bot login carrying the same correlation id', async () => {
-    const issuesAndPullRequests = vi.fn(async () => ({
-      data: {
-        items: [
-          {number: 1, state: 'closed', user: {login: 'fro-bot'}, pull_request: {merged_at: '2026-01-01'}},
-          {number: 2, state: 'closed', user: {login: 'some-random-user'}, pull_request: {merged_at: '2026-01-01'}},
-        ],
-      },
-    }))
-    const {octokit} = mockOctokit({issuesAndPullRequests})
-    const result = await findBotAuthoredPrs(octokit)(TARGET_A, 'corr-1')
-    expect(result).toHaveLength(1)
   })
 })
 
@@ -2873,13 +2702,16 @@ describe('owner-aware dispatch/track routing — fro-bot and marcusrbrown are se
     expect(result.counts.blocked).toBe(2)
   })
 
-  it('track: listWorkflowRunsForRepo for a marcusrbrown target goes through the marcusrbrown client', async () => {
+  it('track: listWorkflowRunsForRepo (diagnostic run-lookup) for a marcusrbrown target goes through the marcusrbrown client', async () => {
     const item: DispatchItem = {
       id: 'item-1',
       target: TARGET_MARCUSRBROWN,
       promptHash: 'abcd1234abcd1234',
       status: 'dispatched',
       correlationId: 'corr-track-owner-1',
+      // Past SLA with no receipt so the diagnostic run-lookup actually fires
+      // (Unit 5: it is never consulted for a non-needs-attention item).
+      epoch: 0,
     }
     const goalIssue: OpenGoalIssue = {
       issueNumber: 77,
@@ -3140,39 +2972,35 @@ describe('golden path — real production composition (runDispatchCli then runTr
       expect(dispatchedItems).toHaveLength(2)
 
       // ─── Phase 2: runTrackCli against the seeded+dispatched marker ───────
-      const correlationIds = new Map(
-        (finalMarker?.state.items ?? []).map(item => [item.target.name, item.correlationId as string]),
-      )
+      // Unit 5: the receipt is the SOLE completion oracle — run-lookup no
+      // longer resolves terminal state. Simulate each worker posting an
+      // authentic receipt (extracting the correlation id + raw nonce that
+      // were embedded in its dispatch prompt, exactly as a real worker would
+      // read them) instead of relying on the (now diagnostic-only) run/PR path.
+      for (const target of GOLDEN_TARGETS) {
+        const call = createWorkflowDispatch.mock.calls.find(c => (c[0] as {repo: string}).repo === target.name)?.[0] as
+          {inputs: {prompt: string}} | undefined
+        const prompt = call?.inputs.prompt ?? ''
+        const correlationId = /correlation_id: (\S+)/.exec(prompt)?.[1]
+        const nonce = /^nonce: (\S+)$/m.exec(prompt)?.[1]
+        expect(correlationId).toBeDefined()
+        expect(nonce).toBeDefined()
+        comments.push({
+          id: comments.length + 1,
+          login: 'fro-bot',
+          body: buildResultMarker({
+            correlationId: correlationId as string,
+            nonce: nonce as string,
+            status: 'success',
+            summary: `Confirmed README H1 for ${target.name}.`,
+          }),
+        })
+      }
 
-      const listWorkflowRunsForRepo = vi.fn(async (params: {repo: string}) => ({
-        data: {
-          workflow_runs: [
-            {
-              id: 1,
-              name: null,
-              display_title: `fro-bot (${correlationIds.get(params.repo)})`,
-              status: 'completed',
-              conclusion: 'success',
-            },
-          ],
-        },
-      }))
-      const issuesAndPullRequests = vi.fn(async (params: {q: string}) => {
-        const target = GOLDEN_TARGETS.find(t => params.q.includes(`repo:${t.owner}/${t.name}`))
-        if (target === undefined) return {data: {items: []}}
-        return {
-          data: {
-            items: [
-              {
-                number: 1,
-                state: 'closed',
-                user: {login: 'fro-bot'},
-                pull_request: {merged_at: '2026-07-01T00:00:00Z'},
-              },
-            ],
-          },
-        }
-      })
+      // Diagnostic run-lookup collaborator: still wired (R8 keeps `actions:
+      // read`), but never consulted here since every item resolves from its
+      // receipt before it can ever become `needs-attention`/`no-receipt`.
+      const listWorkflowRunsForRepo = vi.fn(async () => ({data: {workflow_runs: []}}))
       const update = vi.fn(async (_params: unknown) => ({data: {}}))
 
       const trackListForRepo = vi.fn(async () => ({data: [{number: 42}]}))
@@ -3182,11 +3010,11 @@ describe('golden path — real production composition (runDispatchCli then runTr
           ...octokit.rest,
           issues: {...octokit.rest.issues, listForRepo: trackListForRepo, update},
           actions: {...octokit.rest.actions, listWorkflowRunsForRepo},
-          search: {...octokit.rest.search, issuesAndPullRequests},
         },
       }
 
       await runTrackCli(async () => trackOctokit, singleOwnerResolver(trackOctokit))
+      expect(listWorkflowRunsForRepo).not.toHaveBeenCalled()
 
       expect(update).toHaveBeenCalledWith(expect.objectContaining({issue_number: 42, state: 'closed'}))
 

--- a/scripts/cross-repo-dispatch.test.ts
+++ b/scripts/cross-repo-dispatch.test.ts
@@ -7,6 +7,7 @@ import type {
   GoalState,
   LabeledEventPayload,
   OpenGoalIssue,
+  RunDispatchResult,
   TrackerComment,
 } from './cross-repo-dispatch.ts'
 import process from 'node:process'
@@ -1078,6 +1079,68 @@ describe('runDispatch — nonce mint + receipt-carrying prompt (Unit 2)', () => 
     const storedItem = finalMarker?.state.items.find(i => i.id === 'item-1')
     expect(storedItem?.status).toBe('intent')
     expect(storedItem?.epoch).toBeUndefined()
+  })
+
+  it('a createWorkflowDispatch throw for one target does not abort the cohort: counts dispatchError, still dispatches the rest, leaves the failed item at intent', async () => {
+    const targetA = {owner: 'fro-bot', name: 'agent'}
+    const targetB = {owner: 'fro-bot', name: 'wiki'}
+    const decomposition = makeDecompositionBody([
+      {...targetA, prompt: 'work-a'},
+      {...targetB, prompt: 'work-b'},
+    ])
+    const items: DispatchItem[] = [
+      {id: 'item-1', target: targetA, promptHash: extractPromptHash(decomposition, targetA), status: 'pending'},
+      {id: 'item-2', target: targetB, promptHash: extractPromptHash(decomposition, targetB), status: 'pending'},
+    ]
+    const state: GoalState = {goal: 'goal-1', items, markerHash: ''}
+
+    const {octokit, comments} = mockOctokit()
+    comments.push({id: 1, body: decomposition, login: 'marcusrbrown'})
+    seedMarkerComment(comments, state)
+
+    const createWorkflowDispatch = vi.fn(async (params: {owner: string; repo: string}): Promise<void> => {
+      if (params.owner === targetA.owner && params.repo === targetA.name) {
+        throw new Error('simulated transient dispatch failure')
+      }
+    })
+
+    let result: RunDispatchResult | undefined
+    let thrown: unknown
+    try {
+      result = await runDispatch({
+        octokit,
+        event: makeLabeledEvent(),
+        repo: REPO,
+        approveLabel: 'dispatch-approved',
+        loadRegistry: async () => [gateEntryFor(targetA), gateEntryFor(targetB)],
+        loadOtherOpenGoalMarkers: async () => [],
+        findRunByCorrelationId: async () => false,
+        createWorkflowDispatch,
+        nonceSource: (() => {
+          let n = 0
+          return () => `nonce-${++n}`
+        })(),
+      })
+    } catch (error) {
+      thrown = error
+    }
+
+    // The createWorkflowDispatch throw must never propagate out of runDispatch.
+    expect(thrown).toBeUndefined()
+    expect(result).toBeDefined()
+    expect(result?.counts.dispatchError).toBe(1)
+    expect(result?.counts.dispatched).toBe(1)
+
+    const finalMarker = selectStateMarker(comments.map(c => ({author: {login: c.login}, body: c.body})))
+    const failedItem = finalMarker?.state.items.find(i => i.id === 'item-1')
+    const succeededItem = finalMarker?.state.items.find(i => i.id === 'item-2')
+    expect(failedItem?.status).toBe('intent')
+    expect(failedItem?.epoch).toBeUndefined()
+    expect(succeededItem?.status).toBe('dispatched')
+    expect(succeededItem?.epoch).toBeDefined()
+
+    // The loop completed and writeResult still ran (both items were attempted).
+    expect(createWorkflowDispatch).toHaveBeenCalledTimes(2)
   })
 
   it('telemetry: counts output for a dispatch run contains neither the raw nonce nor the hash', async () => {

--- a/scripts/cross-repo-dispatch.ts
+++ b/scripts/cross-repo-dispatch.ts
@@ -812,13 +812,20 @@ export interface CoordinationIssueRef {
 }
 
 /**
- * Build the receipt-carrying dispatch prompt: the item's own prompt text
- * plus a machine-contract block carrying the correlation id, the RAW nonce
- * (delivered ONLY here — never in the public marker, R6/R13), the
- * coordination issue as structured fields + a canonical URL, a literal
- * example receipt for BOTH `success` and `noop`, the mandatory-receipt rule,
- * and a self-validate instruction. Pure string composition — no I/O, no
- * telemetry surface (R12: callers must never log this return value verbatim).
+ * Build the receipt-carrying dispatch prompt: the item's prompt text plus a
+ * machine-contract block with the correlation id, the raw nonce, the
+ * coordination issue as structured fields + canonical URL, literal `success`
+ * and `noop` receipt examples, the mandatory-receipt rule, and a self-validate
+ * step. The raw nonce is delivered ONLY here, never in the public marker;
+ * callers must never log the return value verbatim.
+ *
+ * Residual leak: this becomes the target's `prompt` workflow_dispatch input.
+ * A repo running the agent with `OPENCODE_PROMPT_ARTIFACT` enabled can publish
+ * the rendered prompt (raw nonce included) as a downloadable Actions artifact.
+ * Target workflows are autonomous and cannot be redacted from here, so where
+ * that setting is present item-level nonce isolation falls back to trusting
+ * the dispatched worker (already the loop's trust boundary). A real fix lives
+ * in the agent or per-target workflow, not here.
  */
 export function buildDispatchPrompt(input: {
   itemPrompt: string
@@ -996,7 +1003,7 @@ export interface RunDispatchInput {
     repo: string
     workflow_id: string
     ref: string
-    inputs: {prompt: string; correlation_id: string}
+    inputs: {prompt: string}
   }) => Promise<void>
   nonceSource: () => string
   resultPath?: string
@@ -1270,7 +1277,11 @@ export async function runDispatch(input: RunDispatchInput): Promise<RunDispatchR
       repo: currentItem.target.name,
       workflow_id: TARGET_WORKFLOW_ID,
       ref: TARGET_WORKFLOW_REF,
-      inputs: {prompt: dispatchPrompt, correlation_id: correlationId},
+      // Prompt-only input: target repos' fro-bot.yaml universally declares
+      // only `prompt` via workflow_dispatch. A `correlation_id` input 422s
+      // ("Unexpected inputs provided") against that schema — the correlation
+      // id and nonce ride inside dispatchPrompt instead (see buildDispatchPrompt).
+      inputs: {prompt: dispatchPrompt},
     })
 
     // Flip to 'dispatched' + epoch via CAS.

--- a/scripts/cross-repo-dispatch.ts
+++ b/scripts/cross-repo-dispatch.ts
@@ -4,7 +4,8 @@ import {assertReposFile} from './schemas.ts'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type ItemStatus = 'pending' | 'intent' | 'dispatched' | 'completed' | 'failed' | 'blocked' | 'deferred'
+export type ItemStatus =
+  'pending' | 'intent' | 'dispatched' | 'completed' | 'failed' | 'blocked' | 'deferred' | 'needs-attention'
 
 export interface DispatchTarget {
   owner: string
@@ -27,6 +28,14 @@ export interface DispatchItem {
    * (64-bit truncation) or `Date.now()/Math.random()`.
    */
   nonceHash?: string
+  /**
+   * Set only when `status === 'needs-attention'` (R9/R9a): why no terminal
+   * receipt has resolved this item yet. `no-receipt` = no authentic receipt
+   * seen and the item is past the SLA; `unparseable-receipt` = a bot-authored
+   * receipt marker is present but failed strict field validation. Cleared
+   * the moment a later authentic well-formed receipt resolves the item.
+   */
+  needsAttentionReason?: 'no-receipt' | 'unparseable-receipt'
 }
 
 export interface GoalState {
@@ -153,7 +162,11 @@ const ITEM_STATUSES: ReadonlySet<ItemStatus> = new Set([
   'failed',
   'blocked',
   'deferred',
+  'needs-attention',
 ])
+
+/** 24h SLA (R9), named tunable: wall-age from confirm-time `epoch` before a no-receipt item surfaces `needs-attention`. */
+export const RECEIPT_SLA_MS = 24 * 60 * 60 * 1000
 
 const TERMINAL_STATUSES: ReadonlySet<ItemStatus> = new Set(['completed', 'failed', 'blocked'])
 
@@ -180,6 +193,13 @@ function isDispatchItem(value: unknown): value is DispatchItem {
   if (record.correlationId !== undefined && typeof record.correlationId !== 'string') return false
   if (record.epoch !== undefined && typeof record.epoch !== 'number') return false
   if (record.nonceHash !== undefined && typeof record.nonceHash !== 'string') return false
+  if (
+    record.needsAttentionReason !== undefined &&
+    record.needsAttentionReason !== 'no-receipt' &&
+    record.needsAttentionReason !== 'unparseable-receipt'
+  ) {
+    return false
+  }
   return true
 }
 
@@ -460,6 +480,22 @@ function extractResultMarkerJson(scope: string): string | null {
   return lastMatch?.[1] ?? null
 }
 
+/**
+ * Best-effort, non-trust-bearing extraction of a `correlation_id` string
+ * from a bot-authored receipt marker that failed strict JSON/field
+ * validation (R6b). Used ONLY to attribute a distinct `unparseable-receipt`
+ * non-terminal attention reason to the right item — never to resolve
+ * terminal state, so a loose/partial match here carries no security weight.
+ */
+function extractLooseCorrelationId(body: string): string | null {
+  const region = extractResultRegion(body)
+  const scope = region ?? body
+  const jsonStr = extractResultMarkerJson(scope)
+  if (jsonStr === null) return null
+  const match = /"correlation_id"\s*:\s*"([^"]+)"/.exec(jsonStr)
+  return match?.[1] ?? null
+}
+
 function isValidResultPayload(value: unknown): value is {
   correlation_id: string
   nonce: string
@@ -515,6 +551,108 @@ export function parseResult(body: string): ParseResultOutcome {
     ...(parsed.pr === undefined ? {} : {pr: parsed.pr}),
   }
   return {ok: true, result}
+}
+
+/**
+ * Per-item outcome of applying the three-gate receipt resolver to a single
+ * goal's comment stream. `terminal` carries the resolved `ResultStatus` when
+ * an authentic receipt won the earliest-wins race; `attentionReason` is set
+ * only when the item has no terminal receipt yet but is flagged
+ * `needs-attention` (R9/R9a); `retainedUnconfirmed` marks an authentic
+ * receipt seen for an item that is not yet confirmed-dispatched, so the
+ * caller can re-evaluate it next pass instead of dropping it (early-receipt
+ * tolerance).
+ */
+export interface ReceiptResolution {
+  terminal?: ResultStatus
+  attentionReason?: 'no-receipt' | 'unparseable-receipt'
+  retainedUnconfirmed?: boolean
+}
+
+/**
+ * Resolve the receipt-driven terminal/attention state for every item in
+ * `items`, given the goal's ordered comment stream (chronological — earliest
+ * first). Implements R6 (three-gate trust: author, correlation-id mapping,
+ * hash-bound nonce), R6c (earliest-authentic-receipt-wins, never
+ * `findLast`/latest), R6b (malformed bot-authored marker → distinct
+ * `unparseable-receipt`), and early-receipt tolerance (an authentic receipt
+ * for a not-yet-confirmed item is retained, never dropped). The SLA check
+ * (R9) is a separate, purely time-based concern applied by the caller
+ * (`runTrack`) using the injected clock — this resolver has no notion of
+ * wall time. Pure.
+ */
+export function resolveReceipts(items: DispatchItem[], comments: TrackerComment[]): Map<string, ReceiptResolution> {
+  const itemsByCorrelationId = new Map(
+    items.filter(item => item.correlationId !== undefined).map(item => [item.correlationId as string, item]),
+  )
+  const resolutions = new Map<string, ReceiptResolution>()
+
+  // Earliest-authentic-receipt-wins (R6c): walk comments in chronological
+  // (given) order, never `findLast`/latest-wins, and never let a later
+  // receipt overwrite an item that already has a terminal resolution.
+  for (const comment of comments) {
+    if (!FROBOT_COMMENT_AUTHORS.has(comment.author.login)) continue
+
+    const outcome = parseResult(comment.body)
+    if (!outcome.ok) {
+      // `absent` (no receipt marker in this comment at all) is not a signal.
+      if (outcome.reason !== 'malformed') continue
+
+      // A bot-authored marker IS receipt-shaped but failed strict field
+      // validation (R6b). Best-effort attribution to a dispatched item via a
+      // loosely-recovered `correlation_id` (NOT trust-bearing — this never
+      // resolves terminal state, it only flags non-terminal
+      // `unparseable-receipt`, distinct from `no-receipt`).
+      const looseCorrelationId = extractLooseCorrelationId(comment.body)
+      if (looseCorrelationId === null) continue
+      const item = itemsByCorrelationId.get(looseCorrelationId)
+      if (item === undefined) continue
+
+      const existing = resolutions.get(item.id)
+      if (existing?.terminal !== undefined) continue
+      resolutions.set(item.id, {...existing, attentionReason: 'unparseable-receipt'})
+      continue
+    }
+
+    const receipt = outcome.result
+    if (receipt === undefined) continue
+
+    const item = itemsByCorrelationId.get(receipt.correlationId)
+    if (item === undefined) {
+      // Bot-authored comment whose id matches no item on this goal — ignored
+      // entirely for state (gate b).
+      continue
+    }
+
+    if (item.nonceHash === undefined || hashNonce(receipt.nonce) !== item.nonceHash) {
+      // Gate (c) fails: forged/mismatched nonce. Ignored entirely — never
+      // resolves, never counted as an attention signal.
+      continue
+    }
+
+    // Early-receipt tolerance: an authentic receipt for an item that is not
+    // yet confirmed-dispatched (no epoch yet, e.g. still 'intent'/'pending')
+    // is retained for re-evaluation next pass, never dropped and never used
+    // to resolve state now.
+    if (item.epoch === undefined) {
+      const existing = resolutions.get(item.id)
+      if (existing?.terminal === undefined) {
+        resolutions.set(item.id, {...existing, retainedUnconfirmed: true})
+      }
+      continue
+    }
+
+    const existing = resolutions.get(item.id)
+    if (existing?.terminal !== undefined) {
+      // Item already resolved from an EARLIER authentic receipt in this same
+      // chronological walk — never flips (R6c replay safety).
+      continue
+    }
+
+    resolutions.set(item.id, {terminal: receipt.status})
+  }
+
+  return resolutions
 }
 
 /**
@@ -1357,6 +1495,10 @@ export interface RunTrackInput {
   resultPath?: string
   /** Same owner-aware credential check as `RunDispatchInput.hasTargetToken`. */
   hasTargetToken?: (owner: string) => boolean
+  /** Injectable clock for the SLA check (R9) — defaults to `Date.now`. Tests inject a fixed value. */
+  now?: () => number
+  /** Overrides the default `RECEIPT_SLA_MS` tunable — test-only escape hatch. */
+  slaMs?: number
 }
 
 export interface RunTrackCounts {
@@ -1364,6 +1506,7 @@ export interface RunTrackCounts {
   itemsCompleted: number
   itemsFailed: number
   itemsBlocked: number
+  itemsNeedsAttention: number
   itemsStillOpen: number
   goalsClosed: number
   idempotentNoop: number
@@ -1380,6 +1523,7 @@ function emptyTrackCounts(): RunTrackCounts {
     itemsCompleted: 0,
     itemsFailed: 0,
     itemsBlocked: 0,
+    itemsNeedsAttention: 0,
     itemsStillOpen: 0,
     goalsClosed: 0,
     idempotentNoop: 0,
@@ -1388,10 +1532,15 @@ function emptyTrackCounts(): RunTrackCounts {
 }
 
 /**
- * Tracking shell: snapshots dispatched goals to terminal, closing the
- * coordination issue when every item is terminal. Run
- * correlation is by correlation-id (never epoch+actor alone). Reopen is
- * handled by the workflow's `issues.reopened` step, not here.
+ * Tracking shell: resolves each dispatched (or `needs-attention`) item's
+ * terminal state from AUTHENTIC completion receipts (R6/R7) — the receipt is
+ * the sole completion oracle. The legacy run-lookup/PR-search signal path is
+ * still consulted, but ONLY as a fallback for an item with no authentic
+ * receipt yet and not past the SLA (kept for now; Unit 5 demotes it to a
+ * non-authoritative diagnostic). Closes the coordination issue when every
+ * item is terminal (`completed`/`failed`/`blocked`) — `needs-attention` and
+ * `pending`/`dispatched` keep it open (R11). Reopen is handled by the
+ * workflow's `issues.reopened` step, not here.
  */
 export async function runTrack(input: RunTrackInput): Promise<RunTrackResult> {
   const counts = emptyTrackCounts()
@@ -1403,13 +1552,50 @@ export async function runTrack(input: RunTrackInput): Promise<RunTrackResult> {
   }
 
   const openGoals = await input.loadOpenGoalIssues()
+  const now = input.now?.() ?? Date.now()
+  const slaMs = input.slaMs ?? RECEIPT_SLA_MS
 
   for (const goalIssue of openGoals) {
     counts.goalsProcessed += 1
     const state: GoalState = {...goalIssue.marker.state, markerHash: goalIssue.marker.hash}
 
+    const commentsResponse = await input.octokit.rest.issues.listComments({
+      owner: input.repo.owner,
+      repo: input.repo.repo,
+      issue_number: goalIssue.issueNumber,
+    })
+    const comments: TrackerComment[] = commentsResponse.data.map(comment => ({
+      author: {login: comment.user?.login ?? ''},
+      body: comment.body ?? '',
+    }))
+
+    // Receipts are the sole completion oracle (R7): resolve every eligible
+    // item (dispatched or already needs-attention — reversible per R9a) from
+    // its earliest authentic receipt (R6c) before falling back to the
+    // legacy run-lookup/PR-search signal path below for anything a receipt
+    // did not resolve.
+    const receiptResolutions = resolveReceipts(state.items, comments)
+
+    const preItems = state.items.map(item => {
+      if (TERMINAL_STATUSES.has(item.status)) return item
+
+      const resolution = receiptResolutions.get(item.id)
+      if (resolution?.terminal !== undefined) {
+        const nextStatus: ItemStatus = resolution.terminal === 'failed' ? 'failed' : 'completed'
+        return {...item, status: nextStatus, needsAttentionReason: undefined}
+      }
+      if (resolution?.attentionReason !== undefined) {
+        return {...item, status: 'needs-attention' as ItemStatus, needsAttentionReason: resolution.attentionReason}
+      }
+      return item
+    })
+
+    // Legacy signal path (run-lookup/PR-search): only consulted for items a
+    // receipt did NOT resolve. Kept callable per the Unit 4 scope note —
+    // Unit 5 demotes/removes it — but receipt resolution above always takes
+    // precedence and this path never overrides it.
     const signals: SnapshotSignals = {}
-    for (const item of state.items) {
+    for (const item of preItems) {
       if (item.status !== 'dispatched') continue
 
       const gate = gateTarget(registryByKey.get(`${item.target.owner}/${item.target.name}`))
@@ -1430,6 +1616,13 @@ export async function runTrack(input: RunTrackInput): Promise<RunTrackResult> {
         continue
       }
 
+      // No authentic receipt and past the confirm-time SLA (R9): surface
+      // needs-attention/no-receipt instead of falling through to the legacy
+      // run+PR signal. An item never confirmed (`epoch` unset) is never
+      // SLA-aged (a pre-confirm crash is a dispatch failure, not an SLA miss).
+      // Handled separately below (`preItemsWithSla`); skip the legacy signal.
+      if (item.epoch !== undefined && now - item.epoch > slaMs) continue
+
       if (item.correlationId === undefined) continue
 
       const runConclusion = await input.findRunConclusion(item.target, item.correlationId)
@@ -1439,7 +1632,16 @@ export async function runTrack(input: RunTrackInput): Promise<RunTrackResult> {
       signals[item.id] = {runConclusion, prs}
     }
 
-    const snapshot = planSnapshot({state, signals})
+    // Apply the SLA needs-attention flag directly (bypassing planSnapshot,
+    // which only understands run/PR TerminalStateInput signals).
+    const preItemsWithSla = preItems.map(item => {
+      if (item.status !== 'dispatched') return item
+      if (item.epoch !== undefined && now - item.epoch > slaMs) {
+        return {...item, status: 'needs-attention' as ItemStatus, needsAttentionReason: 'no-receipt' as const}
+      }
+      return item
+    })
+    const snapshot = planSnapshot({state: {...state, items: preItemsWithSla}, signals})
 
     for (const item of snapshot.state.items) {
       const previous = state.items.find(candidate => candidate.id === item.id)
@@ -1447,8 +1649,11 @@ export async function runTrack(input: RunTrackInput): Promise<RunTrackResult> {
       if (item.status === 'completed') counts.itemsCompleted += 1
       else if (item.status === 'failed') counts.itemsFailed += 1
       else if (item.status === 'blocked') counts.itemsBlocked += 1
+      else if (item.status === 'needs-attention') counts.itemsNeedsAttention += 1
     }
-    counts.itemsStillOpen += snapshot.state.items.filter(item => item.status === 'dispatched').length
+    counts.itemsStillOpen += snapshot.state.items.filter(
+      item => item.status === 'dispatched' || item.status === 'needs-attention',
+    ).length
 
     if (!snapshot.shouldWrite) {
       counts.idempotentNoop += 1

--- a/scripts/cross-repo-dispatch.ts
+++ b/scripts/cross-repo-dispatch.ts
@@ -1143,6 +1143,7 @@ export interface RunDispatchCounts {
   skippedUnsafePrompt: number
   casDeferred: number
   seedRejected: number
+  dispatchError: number
 }
 
 export interface RunDispatchResult {
@@ -1159,6 +1160,7 @@ function emptyDispatchCounts(): RunDispatchCounts {
     skippedUnsafePrompt: 0,
     casDeferred: 0,
     seedRejected: 0,
+    dispatchError: 0,
   }
 }
 
@@ -1388,17 +1390,27 @@ export async function runDispatch(input: RunDispatchInput): Promise<RunDispatchR
       coordinationIssue: {owner: input.repo.owner, repo: input.repo.repo, number: issueNumber},
     })
 
-    await input.createWorkflowDispatch({
-      owner: currentItem.target.owner,
-      repo: currentItem.target.name,
-      workflow_id: TARGET_WORKFLOW_ID,
-      ref: TARGET_WORKFLOW_REF,
-      // Prompt-only input: target repos' fro-bot.yaml universally declares
-      // only `prompt` via workflow_dispatch. A `correlation_id` input 422s
-      // ("Unexpected inputs provided") against that schema — the correlation
-      // id and nonce ride inside dispatchPrompt instead (see buildDispatchPrompt).
-      inputs: {prompt: dispatchPrompt},
-    })
+    try {
+      await input.createWorkflowDispatch({
+        owner: currentItem.target.owner,
+        repo: currentItem.target.name,
+        workflow_id: TARGET_WORKFLOW_ID,
+        ref: TARGET_WORKFLOW_REF,
+        // Prompt-only input: target repos' fro-bot.yaml universally declares
+        // only `prompt` via workflow_dispatch. A `correlation_id` input 422s
+        // ("Unexpected inputs provided") against that schema — the correlation
+        // id and nonce ride inside dispatchPrompt instead (see buildDispatchPrompt).
+        inputs: {prompt: dispatchPrompt},
+      })
+    } catch {
+      // Transient dispatch failure (403/network) on this target must not
+      // abort the whole cohort. The item is already persisted as 'intent'
+      // (crash-safe); a future labeled event resumes and reconciles it by
+      // correlation-id. Counts-only outcome — no error detail is logged,
+      // since it could leak transport/token context.
+      counts.dispatchError += 1
+      continue
+    }
 
     // Flip to 'dispatched' + epoch via CAS.
     const dispatchedState = flipItemStatus(

--- a/scripts/cross-repo-dispatch.ts
+++ b/scripts/cross-repo-dispatch.ts
@@ -36,6 +36,16 @@ export interface DispatchItem {
    * the moment a later authentic well-formed receipt resolves the item.
    */
   needsAttentionReason?: 'no-receipt' | 'unparseable-receipt'
+  /**
+   * Diagnostic-only annotation (Unit 5), set ONLY when
+   * `needsAttentionReason === 'no-receipt'`: whether the demoted run-lookup
+   * collaborator found a concluded run for this item ('ran-no-report') or no
+   * run at all ('never-ran'). NEVER influences terminal/non-terminal state —
+   * receipts (R7), the SLA (R9), and the registry gate are the only state
+   * drivers. Purely forensic signal for the operator (R8: no PR polling for
+   * completion; run-lookup is diagnostic, not authoritative).
+   */
+  noReceiptDiagnostic?: 'ran-no-report' | 'never-ran'
 }
 
 export interface GoalState {
@@ -102,14 +112,6 @@ export interface GateEntry {
   private?: boolean
 }
 
-export interface TerminalStateInput {
-  runConclusion?: 'success' | 'failure'
-  prs?: {merged: boolean; closed: boolean; authorIsBot: boolean}[]
-  gateBlocked?: boolean
-}
-
-export type TerminalState = 'blocked' | 'failed' | 'completed' | 'dispatched'
-
 export interface DispatchPlanInput {
   state: GoalState
   fingerprint: string
@@ -125,8 +127,15 @@ export interface DispatchPlanResult {
   blockedCount: number
 }
 
+/**
+ * Registry-gate signal only (Unit 5): the run/PR terminal-resolution
+ * precedence table is gone — receipts (R7) and the SLA (R9) are applied
+ * directly by `runTrack` before `planSnapshot` runs. The gate is the only
+ * remaining out-of-band signal `planSnapshot` still resolves, because it can
+ * flip an item to `blocked` independent of any receipt.
+ */
 export interface SnapshotSignals {
-  [itemId: string]: TerminalStateInput
+  [itemId: string]: {gateBlocked?: boolean}
 }
 
 export interface SnapshotPlanInput {
@@ -197,6 +206,13 @@ function isDispatchItem(value: unknown): value is DispatchItem {
     record.needsAttentionReason !== undefined &&
     record.needsAttentionReason !== 'no-receipt' &&
     record.needsAttentionReason !== 'unparseable-receipt'
+  ) {
+    return false
+  }
+  if (
+    record.noReceiptDiagnostic !== undefined &&
+    record.noReceiptDiagnostic !== 'ran-no-report' &&
+    record.noReceiptDiagnostic !== 'never-ran'
   ) {
     return false
   }
@@ -704,33 +720,6 @@ export function gateTarget(entry: GateEntry | undefined): GateResult {
   return 'ok'
 }
 
-// ─── Planner: terminal-state resolver ────────────────────────────────────────
-
-/**
- * Precedence: gate-block > run-failure > PR-outcome > run-success.
- * Multi-PR: terminal only when the run has concluded; completed if >=1
- * bot-authored PR merged, else failed if any PR is closed-unmerged, else
- * (no PR) completed as a no-op success.
- */
-export function resolveItemTerminalState(input: TerminalStateInput): TerminalState {
-  if (input.gateBlocked === true) return 'blocked'
-  if (input.runConclusion === 'failure') return 'failed'
-  if (input.runConclusion === undefined) return 'dispatched'
-
-  const prs = input.prs ?? []
-  const botPrs = prs.filter(pr => pr.authorIsBot)
-
-  if (botPrs.length === 0) return 'completed'
-
-  const anyMerged = botPrs.some(pr => pr.merged)
-  if (anyMerged) return 'completed'
-
-  const allTerminalPrs = botPrs.every(pr => pr.merged || pr.closed)
-  if (!allTerminalPrs) return 'dispatched'
-
-  return 'failed'
-}
-
 // ─── Planner: dispatch plan ──────────────────────────────────────────────────
 
 /**
@@ -780,18 +769,19 @@ export function planDispatch(input: DispatchPlanInput): DispatchPlanResult {
 // ─── Planner: snapshot decision ──────────────────────────────────────────────
 
 /**
- * Apply resolveItemTerminalState per dispatched item, compute allTerminal
- * (→ close), and idempotency (identical markerHash → no write).
+ * Apply the registry-gate signal per dispatched item (the only remaining
+ * out-of-band terminal driver — receipts and the SLA are applied by the
+ * caller before this runs; Unit 5 removed the run/PR terminal-resolution
+ * precedence table entirely), compute allTerminal (→ close), and idempotency
+ * (identical markerHash → no write).
  */
 export function planSnapshot(input: SnapshotPlanInput): SnapshotPlanResult {
   const updatedItems = input.state.items.map(item => {
     const signal = input.signals[item.id]
     if (signal === undefined) return item
     if (TERMINAL_STATUSES.has(item.status)) return item
-
-    const resolved = resolveItemTerminalState(signal)
-    if (resolved === item.status) return item
-    return {...item, status: resolved}
+    if (signal.gateBlocked !== true) return item
+    return {...item, status: 'blocked' as ItemStatus}
   })
 
   const updatedState: GoalState = {
@@ -872,18 +862,6 @@ export interface CrossRepoDispatchOctokitClient {
             display_title?: string | null
             status: string | null
             conclusion: string | null
-          }[]
-        }
-      }>
-    }
-    readonly search: {
-      readonly issuesAndPullRequests: (params: {q: string; per_page?: number}) => Promise<{
-        data: {
-          items: {
-            number: number
-            state: string
-            user: {login: string} | null
-            pull_request?: {merged_at: string | null}
           }[]
         }
       }>
@@ -1479,19 +1457,20 @@ export interface OpenGoalIssue {
   marker: MarkerData
 }
 
-export interface PrLookupResult {
-  merged: boolean
-  closed: boolean
-  authorIsBot: boolean
-}
-
 export interface RunTrackInput {
   octokit: CrossRepoDispatchOctokitClient
   repo: RepoRepository
   loadOpenGoalIssues: () => Promise<OpenGoalIssue[]>
   loadRegistry: () => Promise<GateEntry[]>
+  /**
+   * Demoted to a NON-AUTHORITATIVE diagnostic (Unit 5, R8/R9/R12): consulted
+   * ONLY to annotate an already-`needs-attention`/`no-receipt` item with
+   * "ran but didn't report" vs "never ran". Its return value never changes
+   * any item's terminal/non-terminal state — receipts are the sole
+   * completion oracle (R7) and the SLA is the sole `needs-attention` driver
+   * (R9).
+   */
   findRunConclusion: (target: DispatchTarget, correlationId: string) => Promise<'success' | 'failure' | undefined>
-  findBotAuthoredPrs: (target: DispatchTarget, correlationId: string) => Promise<PrLookupResult[]>
   resultPath?: string
   /** Same owner-aware credential check as `RunDispatchInput.hasTargetToken`. */
   hasTargetToken?: (owner: string) => boolean
@@ -1533,12 +1512,15 @@ function emptyTrackCounts(): RunTrackCounts {
 
 /**
  * Tracking shell: resolves each dispatched (or `needs-attention`) item's
- * terminal state from AUTHENTIC completion receipts (R6/R7) — the receipt is
- * the sole completion oracle. The legacy run-lookup/PR-search signal path is
- * still consulted, but ONLY as a fallback for an item with no authentic
- * receipt yet and not past the SLA (kept for now; Unit 5 demotes it to a
- * non-authoritative diagnostic). Closes the coordination issue when every
- * item is terminal (`completed`/`failed`/`blocked`) — `needs-attention` and
+ * terminal state SOLELY from AUTHENTIC completion receipts (R6/R7) plus the
+ * 24h SLA (R9) and the registry gate — the receipt is the sole completion
+ * oracle (R8: no PR polling, no run polling for completion). Run-lookup is
+ * demoted to a NON-AUTHORITATIVE diagnostic (Unit 5): for an item that ends
+ * up `needs-attention`/`no-receipt`, it annotates whether the worker's run
+ * concluded ("ran but didn't report") or never ran ("never ran") — this
+ * NEVER changes terminal/non-terminal state, only the diagnostic detail
+ * surfaced to the operator. Closes the coordination issue when every item is
+ * terminal (`completed`/`failed`/`blocked`) — `needs-attention` and
  * `pending`/`dispatched` keep it open (R11). Reopen is handled by the
  * workflow's `issues.reopened` step, not here.
  */
@@ -1590,10 +1572,9 @@ export async function runTrack(input: RunTrackInput): Promise<RunTrackResult> {
       return item
     })
 
-    // Legacy signal path (run-lookup/PR-search): only consulted for items a
-    // receipt did NOT resolve. Kept callable per the Unit 4 scope note —
-    // Unit 5 demotes/removes it — but receipt resolution above always takes
-    // precedence and this path never overrides it.
+    // Registry-gate signal only: the run/PR terminal-resolution precedence
+    // table is gone (R8) — a gate-block is the only remaining out-of-band
+    // driver `planSnapshot` still applies to a non-terminal item.
     const signals: SnapshotSignals = {}
     for (const item of preItems) {
       if (item.status !== 'dispatched') continue
@@ -1613,27 +1594,13 @@ export async function runTrack(input: RunTrackInput): Promise<RunTrackResult> {
       // without addressing this.
       if (input.hasTargetToken !== undefined && !input.hasTargetToken(item.target.owner)) {
         signals[item.id] = {gateBlocked: true}
-        continue
       }
-
-      // No authentic receipt and past the confirm-time SLA (R9): surface
-      // needs-attention/no-receipt instead of falling through to the legacy
-      // run+PR signal. An item never confirmed (`epoch` unset) is never
-      // SLA-aged (a pre-confirm crash is a dispatch failure, not an SLA miss).
-      // Handled separately below (`preItemsWithSla`); skip the legacy signal.
-      if (item.epoch !== undefined && now - item.epoch > slaMs) continue
-
-      if (item.correlationId === undefined) continue
-
-      const runConclusion = await input.findRunConclusion(item.target, item.correlationId)
-      if (runConclusion === undefined) continue
-
-      const prs = await input.findBotAuthoredPrs(item.target, item.correlationId)
-      signals[item.id] = {runConclusion, prs}
     }
 
-    // Apply the SLA needs-attention flag directly (bypassing planSnapshot,
-    // which only understands run/PR TerminalStateInput signals).
+    // Apply the SLA needs-attention flag directly (R9). No authentic receipt
+    // and past the confirm-time SLA -> needs-attention/no-receipt. An item
+    // never confirmed (`epoch` unset) is never SLA-aged (a pre-confirm crash
+    // is a dispatch failure, not an SLA miss).
     const preItemsWithSla = preItems.map(item => {
       if (item.status !== 'dispatched') return item
       if (item.epoch !== undefined && now - item.epoch > slaMs) {
@@ -1641,7 +1608,25 @@ export async function runTrack(input: RunTrackInput): Promise<RunTrackResult> {
       }
       return item
     })
-    const snapshot = planSnapshot({state: {...state, items: preItemsWithSla}, signals})
+
+    // Diagnostic-only annotation (Unit 5, R8/R9/R12): run-lookup is consulted
+    // ONLY for an item that just became `needs-attention`/`no-receipt`, and
+    // ONLY to distinguish "ran but didn't report" from "never ran" for the
+    // operator. This NEVER changes terminal/non-terminal state — the item
+    // stays `needs-attention` either way.
+    const preItemsWithDiagnostic = await Promise.all(
+      preItemsWithSla.map(async item => {
+        if (item.status !== 'needs-attention' || item.needsAttentionReason !== 'no-receipt') return item
+        if (item.correlationId === undefined) return item
+
+        const runConclusion = await input.findRunConclusion(item.target, item.correlationId)
+        const noReceiptDiagnostic: NonNullable<DispatchItem['noReceiptDiagnostic']> =
+          runConclusion === undefined ? 'never-ran' : 'ran-no-report'
+        return {...item, noReceiptDiagnostic}
+      }),
+    )
+
+    const snapshot = planSnapshot({state: {...state, items: preItemsWithDiagnostic}, signals})
 
     for (const item of snapshot.state.items) {
       const previous = state.items.find(candidate => candidate.id === item.id)
@@ -1801,31 +1786,6 @@ export async function loadOtherOpenGoalMarkers(
     results.push({...marker.state, markerHash: marker.hash})
   }
   return results
-}
-
-/**
- * Factory: `findBotAuthoredPrs` collaborator. Searches for PRs in `target`
- * carrying `correlationId` via the GitHub search API, then keeps only
- * PRs authored by a Fro Bot identity (`FROBOT_COMMENT_AUTHORS`) —
- * the anti-spoofing check that stops a forged non-bot PR referencing the
- * same correlation id from producing a false completion signal.
- */
-export function findBotAuthoredPrs(
-  octokit: CrossRepoDispatchOctokitClient,
-): (target: DispatchTarget, correlationId: string) => Promise<PrLookupResult[]> {
-  return async (target, correlationId) => {
-    const response = await octokit.rest.search.issuesAndPullRequests({
-      q: `repo:${target.owner}/${target.name} type:pr ${correlationId}`,
-      per_page: 30,
-    })
-    return response.data.items
-      .filter(item => FROBOT_COMMENT_AUTHORS.has(item.user?.login ?? ''))
-      .map(item => ({
-        merged: item.pull_request?.merged_at !== null && item.pull_request?.merged_at !== undefined,
-        closed: item.state === 'closed',
-        authorIsBot: true,
-      }))
-  }
 }
 
 // ─── CLI shell ────────────────────────────────────────────────────────────────
@@ -2020,8 +1980,6 @@ export async function runTrackCli(
     loadRegistry: loadRegistryFromDisk,
     findRunConclusion: async (target, correlationId) =>
       findRunConclusion(targetClientFor(target.owner))(target, correlationId),
-    findBotAuthoredPrs: async (target, correlationId) =>
-      findBotAuthoredPrs(targetClientFor(target.owner))(target, correlationId),
     resultPath,
     hasTargetToken,
   })

--- a/scripts/cross-repo-dispatch.ts
+++ b/scripts/cross-repo-dispatch.ts
@@ -1,4 +1,4 @@
-import {createHash} from 'node:crypto'
+import {createHash, randomBytes} from 'node:crypto'
 import process from 'node:process'
 import {assertReposFile} from './schemas.ts'
 
@@ -18,7 +18,15 @@ export interface DispatchItem {
   status: ItemStatus
   correlationId?: string
   epoch?: number
-  nonce?: string
+  /**
+   * Full SHA-256 hex digest of a CSPRNG-minted raw per-item nonce (R6). The
+   * raw nonce itself is NEVER persisted here or anywhere in the public
+   * marker — it is delivered only via the dispatch prompt. Set at
+   * confirmed-dispatch time (and, defensively, at the preceding intent
+   * write) alongside `correlationId`; never derived from `hashState`
+   * (64-bit truncation) or `Date.now()/Math.random()`.
+   */
+  nonceHash?: string
 }
 
 export interface GoalState {
@@ -171,7 +179,7 @@ function isDispatchItem(value: unknown): value is DispatchItem {
   if (typeof record.status !== 'string' || !ITEM_STATUSES.has(record.status as ItemStatus)) return false
   if (record.correlationId !== undefined && typeof record.correlationId !== 'string') return false
   if (record.epoch !== undefined && typeof record.epoch !== 'number') return false
-  if (record.nonce !== undefined && typeof record.nonce !== 'string') return false
+  if (record.nonceHash !== undefined && typeof record.nonceHash !== 'string') return false
   return true
 }
 
@@ -783,6 +791,89 @@ export function computeCorrelationId(goal: string, itemId: string, nonce: string
 }
 
 /**
+ * Mint a raw, in-memory-only per-item nonce with a CSPRNG. 32 bytes (256
+ * bits) of entropy, base64url-encoded (URL/prompt-safe, no padding noise).
+ * NEVER derived from `hashState` (64-bit truncation) or
+ * `Date.now()`/`Math.random()` — those are not high-entropy secrets (R6).
+ */
+export function mintNonce(): string {
+  return randomBytes(32).toString('base64url')
+}
+
+/** Full SHA-256 hex digest of a raw nonce, for storage as `nonceHash` (R6). Never truncated. */
+export function hashNonce(rawNonce: string): string {
+  return createHash('sha256').update(rawNonce).digest('hex')
+}
+
+export interface CoordinationIssueRef {
+  owner: string
+  repo: string
+  number: number
+}
+
+/**
+ * Build the receipt-carrying dispatch prompt: the item's own prompt text
+ * plus a machine-contract block carrying the correlation id, the RAW nonce
+ * (delivered ONLY here — never in the public marker, R6/R13), the
+ * coordination issue as structured fields + a canonical URL, a literal
+ * example receipt for BOTH `success` and `noop`, the mandatory-receipt rule,
+ * and a self-validate instruction. Pure string composition — no I/O, no
+ * telemetry surface (R12: callers must never log this return value verbatim).
+ */
+export function buildDispatchPrompt(input: {
+  itemPrompt: string
+  correlationId: string
+  rawNonce: string
+  coordinationIssue: CoordinationIssueRef
+}): string {
+  const {itemPrompt, correlationId, rawNonce, coordinationIssue} = input
+  const issueUrl = `https://github.com/${coordinationIssue.owner}/${coordinationIssue.repo}/issues/${coordinationIssue.number}`
+
+  const successExample = buildResultMarker({
+    correlationId,
+    nonce: rawNonce,
+    status: 'success',
+    summary: 'Concise summary of what changed.',
+    pr: 'https://github.com/OWNER/REPO/pull/123',
+  })
+  const noopExample = buildResultMarker({
+    correlationId,
+    nonce: rawNonce,
+    status: 'noop',
+    summary: 'No change was needed; explain why.',
+  })
+
+  return [
+    itemPrompt,
+    '',
+    '--- fro-bot cross-repo receipt contract (machine-readable, do not omit) ---',
+    `correlation_id: ${correlationId}`,
+    `nonce: ${rawNonce}`,
+    'Coordination issue (post your receipt here, and ONLY here):',
+    `  owner: ${coordinationIssue.owner}`,
+    `  repo: ${coordinationIssue.repo}`,
+    `  number: ${coordinationIssue.number}`,
+    `  url: ${issueUrl}`,
+    '',
+    'RULE: You MUST post a completion receipt comment to the coordination issue above',
+    'when you finish this work — even if the outcome is a no-op (nothing needed changing).',
+    'A missing receipt is treated as a failure to report, not success.',
+    '',
+    'Example receipt for a successful change:',
+    successExample,
+    '',
+    'Example receipt for a no-op (nothing needed changing):',
+    noopExample,
+    '',
+    'Self-validate before finishing: echo the resolved destination',
+    `(owner=${coordinationIssue.owner}, repo=${coordinationIssue.repo}, number=${coordinationIssue.number}),`,
+    'post the receipt comment, then re-read your posted comment. If the',
+    'fro-bot:cross-repo-result marker is absent from what you posted, edit the',
+    'comment to add it before declaring the work done.',
+  ].join('\n')
+}
+
+/**
  * Compare-and-swap a marker comment write. Re-reads the latest bot marker
  * immediately before writing; aborts+retries on hash mismatch against the
  * caller's expected prior hash. Bounded retries; persistent mismatch defers
@@ -1138,13 +1229,21 @@ export async function runDispatch(input: RunDispatchInput): Promise<RunDispatchR
       continue
     }
 
-    const nonce = currentItem.nonce ?? input.nonceSource()
-    const correlationId = currentItem.correlationId ?? computeCorrelationId(state.goal, currentItem.id, nonce)
+    // Mint the RAW nonce fresh, in-memory only, via a CSPRNG (input.nonceSource
+    // is the injectable CSPRNG collaborator — see runDispatchCli's default,
+    // which uses node:crypto randomBytes, never Date.now()/Math.random()).
+    // Only its full SHA-256 hash is ever persisted to the (public) marker;
+    // the raw value is never stored in `currentItem` — a re-dispatch of a
+    // still-pending item always mints a fresh nonce.
+    const rawNonce = input.nonceSource()
+    const nonceHash = hashNonce(rawNonce)
+    const correlationId = currentItem.correlationId ?? computeCorrelationId(state.goal, currentItem.id, rawNonce)
 
-    // Write 'intent' before dispatching (two-phase persistence).
+    // Write 'intent' before dispatching (two-phase persistence). Only the
+    // hash is persisted here; `epoch` is set only on confirmed dispatch below.
     const intentState = flipItemStatus(latestMarker, currentItem.id, 'intent', undefined, {
       correlationId,
-      nonce,
+      nonceHash,
     })
     const intentCas = await casWriteMarker({
       octokit: input.octokit,
@@ -1159,12 +1258,19 @@ export async function runDispatch(input: RunDispatchInput): Promise<RunDispatchR
       continue
     }
 
+    const dispatchPrompt = buildDispatchPrompt({
+      itemPrompt: prompt,
+      correlationId,
+      rawNonce,
+      coordinationIssue: {owner: input.repo.owner, repo: input.repo.repo, number: issueNumber},
+    })
+
     await input.createWorkflowDispatch({
       owner: currentItem.target.owner,
       repo: currentItem.target.name,
       workflow_id: TARGET_WORKFLOW_ID,
       ref: TARGET_WORKFLOW_REF,
-      inputs: {prompt, correlation_id: correlationId},
+      inputs: {prompt: dispatchPrompt, correlation_id: correlationId},
     })
 
     // Flip to 'dispatched' + epoch via CAS.
@@ -1200,7 +1306,7 @@ function flipItemStatus(
   itemId: string,
   status: ItemStatus,
   epoch: number | undefined,
-  extra: {correlationId?: string; nonce?: string} = {},
+  extra: {correlationId?: string; nonceHash?: string} = {},
 ): GoalState {
   const items = marker.state.items.map(item => {
     if (item.id !== itemId) return item
@@ -1209,7 +1315,7 @@ function flipItemStatus(
       status,
       ...(epoch === undefined ? {} : {epoch}),
       ...(extra.correlationId === undefined ? {} : {correlationId: extra.correlationId}),
-      ...(extra.nonce === undefined ? {} : {nonce: extra.nonce}),
+      ...(extra.nonceHash === undefined ? {} : {nonceHash: extra.nonceHash}),
     }
   })
   const nextState: GoalState = {...marker.state, items, markerHash: ''}
@@ -1676,7 +1782,7 @@ export async function runDispatchCli(
     createWorkflowDispatch: async params => {
       await targetClientFor(params.owner).rest.actions.createWorkflowDispatch(params)
     },
-    nonceSource: () => createHash('sha256').update(`${Date.now()}:${Math.random()}`).digest('hex').slice(0, 12),
+    nonceSource: mintNonce,
     resultPath,
     hasTargetToken,
   })

--- a/scripts/cross-repo-dispatch.ts
+++ b/scripts/cross-repo-dispatch.ts
@@ -46,6 +46,35 @@ export interface DecompositionResult {
   reason?: 'too-many-items' | 'no-items' | 'malformed'
 }
 
+/** Worker-reported outcome vocabulary for a completion receipt. `blocked` is the pre-dispatch gate outcome, never a worker status. */
+export type ResultStatus = 'success' | 'noop' | 'failed'
+
+/**
+ * Completion receipt posted by a worker to the coordination issue. `nonce`
+ * is the RAW per-item nonce as posted by the worker — the parser never
+ * hashes it or compares it against a stored `nonceHash` (that gate lives in
+ * track's resolver, Unit 4).
+ */
+export interface CrossRepoResult {
+  correlationId: string
+  nonce: string
+  status: ResultStatus
+  summary: string
+  pr?: string
+}
+
+/**
+ * Outcome of parsing a receipt comment body. `absent` = no receipt marker
+ * present at all; `malformed` = a receipt marker was found but failed
+ * strict field validation — the two are distinct outcomes (mirrors
+ * `parseDecomposition`'s "checklist-shaped but invalid" vs "no checklist").
+ */
+export interface ParseResultOutcome {
+  ok: boolean
+  result?: CrossRepoResult
+  reason?: 'absent' | 'malformed'
+}
+
 export type GateResult = 'ok' | 'blocked-not-onboarded' | 'blocked-ineligible'
 
 /** Minimal shape of a registry entry needed for the gate — mirrors `RepoEntry`. */
@@ -232,18 +261,42 @@ const LOOSE_TASK_LIST_PREFIX = /^[-*+]\s*\[[ x]\]/i
 const ITEMS_REGION_START = '<!-- fro-bot:cross-repo-items:start -->'
 const ITEMS_REGION_END = '<!-- fro-bot:cross-repo-items:end -->'
 
+/** Delimited region a worker emits around its completion receipt (see `fro-bot.yaml`). Optional. */
+const RESULT_REGION_START = '<!-- fro-bot:cross-repo-result:start -->'
+const RESULT_REGION_END = '<!-- fro-bot:cross-repo-result:end -->'
+
+/** Marker prefix identifying a completion-receipt HTML comment. */
+const RESULT_MARKER_PREFIX = 'fro-bot:cross-repo-result '
+
+const RESULT_STATUSES: ReadonlySet<ResultStatus> = new Set(['success', 'noop', 'failed'])
+
 /**
  * Extract the substring between the delimited region markers, if both are
  * present in order. Returns null when the region is absent (caller falls
  * back to scanning the whole body tolerantly).
  */
 function extractItemsRegion(body: string): string | null {
-  const startIndex = body.indexOf(ITEMS_REGION_START)
+  return extractDelimitedRegion(body, ITEMS_REGION_START, ITEMS_REGION_END)
+}
+
+/**
+ * Generic delimited-region extractor: returns the substring between
+ * `startMarker` and `endMarker` (in order) when both are present, else null
+ * so the caller falls back to scanning the whole body tolerantly. Shared by
+ * `extractItemsRegion` (decomposition) and the receipt region below.
+ */
+function extractDelimitedRegion(body: string, startMarker: string, endMarker: string): string | null {
+  const startIndex = body.indexOf(startMarker)
   if (startIndex === -1) return null
-  const afterStart = startIndex + ITEMS_REGION_START.length
-  const endIndex = body.indexOf(ITEMS_REGION_END, afterStart)
+  const afterStart = startIndex + startMarker.length
+  const endIndex = body.indexOf(endMarker, afterStart)
   if (endIndex === -1) return null
   return body.slice(afterStart, endIndex)
+}
+
+/** Extract the substring between the receipt region markers, if both present. */
+function extractResultRegion(body: string): string | null {
+  return extractDelimitedRegion(body, RESULT_REGION_START, RESULT_REGION_END)
 }
 
 interface ChecklistCollectResult {
@@ -359,6 +412,101 @@ export function extractItemPrompts(commentBody: string): Map<string, string> {
   }
 
   return prompts
+}
+
+/**
+ * Build the completion-receipt comment body: the `:start`/`:end` delimited
+ * region wrapping the JSON marker, mirroring the decomposition region
+ * convention. `receipt.nonce` is the RAW nonce — callers are responsible for
+ * only calling this from a worker context where posting the raw nonce
+ * publicly is the intended, documented behavior (R6c).
+ */
+export function buildResultMarker(receipt: CrossRepoResult): string {
+  const payload = {
+    correlation_id: receipt.correlationId,
+    nonce: receipt.nonce,
+    status: receipt.status,
+    summary: receipt.summary,
+    ...(receipt.pr === undefined ? {} : {pr: receipt.pr}),
+  }
+  const marker = `<!-- ${RESULT_MARKER_PREFIX}${JSON.stringify(payload)} -->`
+  return [RESULT_REGION_START, marker, RESULT_REGION_END].join('\n')
+}
+
+/**
+ * Parse a single `fro-bot:cross-repo-result {json}` marker out of `scope`,
+ * scanning the WHOLE string (not anchored to region boundaries) so a bare
+ * marker amid prose or inside a fenced block still parses. Returns null when
+ * no such marker is found; throws nothing — malformed JSON/field validation
+ * is the caller's job so "marker found but invalid" and "no marker" stay
+ * distinguishable outcomes.
+ */
+function extractResultMarkerJson(scope: string): string | null {
+  const markerRegex = /<!--\s*fro-bot:cross-repo-result\s([\s\S]*?)-->/g
+  let lastMatch: RegExpExecArray | null = null
+  for (;;) {
+    const match = markerRegex.exec(scope)
+    if (match === null) break
+    lastMatch = match
+  }
+  return lastMatch?.[1] ?? null
+}
+
+function isValidResultPayload(value: unknown): value is {
+  correlation_id: string
+  nonce: string
+  status: ResultStatus
+  summary: string
+  pr?: string
+} {
+  if (value === null || typeof value !== 'object') return false
+  const record = value as Record<string, unknown>
+  if (typeof record.correlation_id !== 'string' || record.correlation_id.length === 0) return false
+  if (typeof record.nonce !== 'string' || record.nonce.length === 0) return false
+  if (typeof record.status !== 'string' || !RESULT_STATUSES.has(record.status as ResultStatus)) return false
+  if (typeof record.summary !== 'string') return false
+  if (record.pr !== undefined && typeof record.pr !== 'string') return false
+  return true
+}
+
+/**
+ * Parse a worker completion-receipt comment body. Prefers the delimited
+ * `cross-repo-result` region when present (mirroring `extractItemsRegion`'s
+ * region-preference); a bare marker without the region still parses via the
+ * body-scan fallback for backward tolerance. Strict on fields: valid JSON,
+ * required `correlation_id` + `nonce` + `status` (status one of the closed
+ * vocabulary) — anything else is `malformed`, distinct from `absent` (no
+ * receipt marker found at all). Returns the RAW nonce as posted; this
+ * function never hashes it or sees a stored `nonceHash` (Unit 4's job).
+ */
+export function parseResult(body: string): ParseResultOutcome {
+  const region = extractResultRegion(body)
+  const scope = region ?? body
+
+  const jsonStr = extractResultMarkerJson(scope)
+  if (jsonStr === null) {
+    return {ok: false, reason: 'absent'}
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(jsonStr)
+  } catch {
+    return {ok: false, reason: 'malformed'}
+  }
+
+  if (!isValidResultPayload(parsed)) {
+    return {ok: false, reason: 'malformed'}
+  }
+
+  const result: CrossRepoResult = {
+    correlationId: parsed.correlation_id,
+    nonce: parsed.nonce,
+    status: parsed.status,
+    summary: parsed.summary,
+    ...(parsed.pr === undefined ? {} : {pr: parsed.pr}),
+  }
+  return {ok: true, result}
 }
 
 /**


### PR DESCRIPTION
## What

Cross-repo goal dispatch could trigger worker runs but couldn't track them to completion. It correlated a dispatched item to its worker run by passing a `correlation_id` as a `workflow_dispatch` input and matching it in the run name — but target repos are autonomous and only universally declare a `prompt` input, so real dispatches failed with `422 Unexpected inputs provided: ["correlation_id"]`. GitHub also returns `204` with no run id on dispatch and never exposes dispatch inputs on a run, so run correlation can't be made reliable without changing every target repo.

This flips tracking from pull to push. Dispatch sends only the universal `prompt`, carrying the correlation id and a per-item nonce inside it. The worker posts a completion receipt on the coordination issue, and a scheduled tracker resolves each item from receipts. No target repo's workflow changes.

## How it works

- **Prompt-only dispatch.** `createWorkflowDispatch` sends `{ prompt }` only. The correlation id, nonce, structured coordination-issue reference, a literal example receipt, and a self-validate step all ride in the prompt.
- **The receipt.** A worker posts a delimited `<!-- fro-bot:cross-repo-result … -->` marker with `status` ∈ `success | noop | failed` (a no-op is a mandatory receipt, not a missing one). The parser prefers the region, tolerates prose, and treats a present-but-malformed marker as `unparseable-receipt` — distinct from no receipt.
- **Three-gate trust.** A receipt moves state only if it's authored by `fro-bot`, its correlation id maps to a dispatched item, and `hash(nonce)` matches the item's stored hash. Only the hash is on the public marker; the raw nonce is prompt-only, so reading the marker yields nothing forgeable. The earliest authentic receipt wins and never flips, keeping the now-public post-receipt nonce replay-safe.
- **Watchdog, not poller.** No authentic receipt within 24h of confirmed dispatch surfaces `needs-attention` (reversible by a late receipt). A diagnostic run-lookup then annotates "ran but didn't report" vs "never ran" — forensic context only, never a completion oracle. Completion never polls PR state.
- **Slimmer surface.** Run-lookup is demoted to that diagnostic; the bot-authored-PR search is removed; the track token drops `pull-requests: read` and keeps `actions: read`.

## Verification

- Golden-path integration test drives the real CLI composition end to end: prompt-only dispatch → realistic worker receipt → goal closes. It also covers a forged-nonce receipt that must not move state, an early receipt retained until its item confirms, and an SLA item with the ran-vs-never-ran diagnostic. Removing the nonce-hash gate or reverting to latest-wins fails this test.
- Repo gate green: 2153 tests, check-types, lint (incl. workflow YAML).

## Known residuals (documented, not hidden)

- Every worker authenticates as the shared `FRO_BOT_PAT`, so this is a shared-trust-boundary design, not per-item authorization — a compromised PAT can forge a receipt for any item whose nonce it holds. Per-dispatch, issue-scoped receipt tokens are tracked in #3637.
- A target repo running the agent with `OPENCODE_PROMPT_ARTIFACT` enabled can publish the raw nonce as a downloadable artifact; where present, item isolation falls back to that same shared-trust boundary. Target workflows are autonomous and out of scope here.
