### PR TITLE
fix: tolerate markdown-escaped receipts without weakening the trust gate

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -163,6 +163,10 @@ env:
       (owner/repo/number) and re-reads its own posted comment to confirm the
       marker round-trips; if the marker is missing, it edits the comment to
       add it before declaring the item done.
+    - `summary` must be plain text: no markdown formatting, backticks, or
+      backslash escapes, and the marker as a whole must be valid JSON — an
+      escaped character like `\#` breaks the parser and turns a successful
+      run into an unparseable receipt.
 
   SCHEDULE_PROMPT: |
     Run the daily Fro Bot pass for fro-bot/.github — the autonomous control

--- a/scripts/cross-repo-dispatch.test.ts
+++ b/scripts/cross-repo-dispatch.test.ts
@@ -359,6 +359,49 @@ describe('buildResultMarker / parseResult round-trip', () => {
     expect(outcome.ok).toBe(true)
     expect(outcome.result).toEqual(receipt)
   })
+
+  it('parses a receipt whose summary contains a literal --> without truncating the payload', () => {
+    const receipt = makeReceipt({summary: 'see the arrow --> here; no change'})
+    const outcome = parseResult(buildResultMarker(receipt))
+    expect(outcome.ok).toBe(true)
+    expect(outcome.result).toEqual(receipt)
+  })
+
+  it('tracks string scope correctly when an escaped quote precedes an in-string -->', () => {
+    const receipt = makeReceipt({summary: String.raw`note \"quoted\" then --> an arrow`})
+    const outcome = parseResult(buildResultMarker(receipt))
+    expect(outcome.ok).toBe(true)
+    expect(outcome.result).toEqual(receipt)
+  })
+
+  it('still applies last-marker-wins when the winning payload contains a literal -->', () => {
+    const bareMarker = (receipt: CrossRepoResult) =>
+      `<!-- fro-bot:cross-repo-result ${JSON.stringify({
+        correlation_id: receipt.correlationId,
+        nonce: receipt.nonce,
+        status: receipt.status,
+        summary: receipt.summary,
+      })} -->`
+    const first = makeReceipt({correlationId: 'first-marker', summary: 'first'})
+    const second = makeReceipt({correlationId: 'second-marker', summary: 'second --> arrow'})
+    const body = `Some prose.\n${bareMarker(first)}\n${bareMarker(second)}\nMore prose.`
+    const outcome = parseResult(body)
+    expect(outcome.ok).toBe(true)
+    expect(outcome.result?.correlationId).toBe('second-marker')
+    expect(outcome.result?.summary).toBe('second --> arrow')
+  })
+
+  it('treats a marker with no closing --> at all as absent', () => {
+    const body = `<!-- fro-bot:cross-repo-result ${JSON.stringify({
+      correlation_id: 'abc',
+      nonce: 'n',
+      status: 'success',
+      summary: 'unterminated',
+    })}`
+    const outcome = parseResult(body)
+    expect(outcome.ok).toBe(false)
+    expect(outcome.reason).toBe('absent')
+  })
 })
 
 describe('parseResult — malformed vs absent', () => {

--- a/scripts/cross-repo-dispatch.test.ts
+++ b/scripts/cross-repo-dispatch.test.ts
@@ -35,6 +35,7 @@ import {
   planDispatch,
   planSnapshot,
   RECEIPT_SLA_MS,
+  repairJsonStringEscapes,
   REQUIRED_APPROVER,
   resolveReceipts,
   runDispatch,
@@ -429,6 +430,95 @@ describe('parseResult — malformed vs absent', () => {
     const outcome = parseResult('<!-- fro-bot:cross-repo-result {"correlation_id":"abc"} -->')
     expect(outcome.ok).toBe(false)
     expect(outcome.result).toBeUndefined()
+  })
+})
+
+describe('repairJsonStringEscapes', () => {
+  it('drops the backslash from markdown-style escapes inside a string', () => {
+    expect(repairJsonStringEscapes(String.raw`"\# Renovate Config Presets"`)).toBe('"# Renovate Config Presets"')
+    expect(repairJsonStringEscapes(String.raw`"a \*bold\* b"`)).toBe('"a *bold* b"')
+    expect(repairJsonStringEscapes(String.raw`"a \_em\_ b"`)).toBe('"a _em_ b"')
+    expect(repairJsonStringEscapes(String.raw`"a \[link\] b"`)).toBe('"a [link] b"')
+  })
+
+  it('preserves valid JSON escapes unchanged, including a well-formed unicode escape', () => {
+    const raw = String.raw`"line\nbreak\ttab\"quote\\backslash\u00e9"`
+    expect(repairJsonStringEscapes(raw)).toBe(raw)
+  })
+
+  it('leaves a malformed unicode escape untouched (does not over-tolerate)', () => {
+    expect(repairJsonStringEscapes(String.raw`"bad\uxeee"`)).toBe(String.raw`"bad\uxeee"`)
+    expect(repairJsonStringEscapes(String.raw`"bad\u12"`)).toBe(String.raw`"bad\u12"`)
+  })
+
+  it('leaves a trailing lone backslash before the closing quote untouched', () => {
+    expect(repairJsonStringEscapes(String.raw`"trailing\"`)).toBe(String.raw`"trailing\"`)
+  })
+
+  it('does not touch a backslash outside a string literal', () => {
+    expect(repairJsonStringEscapes(String.raw`{\#not-a-string}`)).toBe(String.raw`{\#not-a-string}`)
+  })
+
+  it('does not toggle string state on an escaped quote', () => {
+    // Without \" being recognized as non-toggling, the markdown escape after
+    // it would incorrectly be treated as outside a string.
+    expect(repairJsonStringEscapes(String.raw`"a\"b\#c"`)).toBe(String.raw`"a\"b#c"`)
+  })
+})
+
+describe('parseResult — tolerant escape repair (markdown-escape drift)', () => {
+  it('repairs the real-world failing case: backslash-hash inside summary', () => {
+    const body = String.raw`<!-- fro-bot:cross-repo-result {"correlation_id":"abc123correlation","nonce":"raw-nonce-value-1234567890","status":"success","summary":"\# Renovate Config Presets"} -->`
+    const outcome = parseResult(body)
+    expect(outcome.ok).toBe(true)
+    expect(outcome.result).toEqual({
+      correlationId: 'abc123correlation',
+      nonce: 'raw-nonce-value-1234567890',
+      status: 'success',
+      summary: '# Renovate Config Presets',
+    })
+  })
+
+  it('repairs asterisk, underscore, and bracket escapes in summary', () => {
+    const body = String.raw`<!-- fro-bot:cross-repo-result {"correlation_id":"c","nonce":"n","status":"success","summary":"\*bold\* \_em\_ \[link\]"} -->`
+    const outcome = parseResult(body)
+    expect(outcome.ok).toBe(true)
+    expect(outcome.result?.summary).toBe('*bold* _em_ [link]')
+  })
+
+  it('leaves a valid escape sequence unaffected by the repair path (still parses via strict JSON.parse)', () => {
+    const payload = {
+      correlation_id: 'c',
+      nonce: 'n',
+      status: 'success' as const,
+      summary: 'line\nbreak\ttab"quote\\backslash\u00E9',
+    }
+    const body = `<!-- fro-bot:cross-repo-result ${JSON.stringify(payload)} -->`
+    const outcome = parseResult(body)
+    expect(outcome.ok).toBe(true)
+    expect(outcome.result?.summary).toBe('line\nbreak\ttab"quote\\backslash\u00E9')
+  })
+
+  it('does not repair a malformed unicode escape — still malformed', () => {
+    const body = String.raw`<!-- fro-bot:cross-repo-result {"correlation_id":"c","nonce":"n","status":"success","summary":"bad\uxeee"} -->`
+    const outcome = parseResult(body)
+    expect(outcome.ok).toBe(false)
+    expect(outcome.reason).toBe('malformed')
+  })
+
+  it('a genuinely broken marker (unterminated string) remains malformed after repair attempt', () => {
+    const body =
+      '<!-- fro-bot:cross-repo-result {"correlation_id":"c","nonce":"n","status":"success","summary":"unterminated -->'
+    const outcome = parseResult(body)
+    expect(outcome.ok).toBe(false)
+    expect(outcome.reason).toBe('malformed')
+  })
+
+  it('a canonical buildResultMarker receipt with no bad escapes parses via the strict-first path unchanged', () => {
+    const receipt = makeReceipt({summary: 'clean summary, no markdown escapes here'})
+    const outcome = parseResult(buildResultMarker(receipt))
+    expect(outcome.ok).toBe(true)
+    expect(outcome.result).toEqual(receipt)
   })
 })
 
@@ -1935,6 +2025,19 @@ describe('resolveReceipts — three-gate trust + earliest-wins (pure core)', () 
         body: buildResultMarker(makeReceipt({correlationId: 'corr-1', nonce: 'wrong-nonce', status: 'success'})),
       },
     ]
+    const resolutions = resolveReceipts([item], comments)
+    expect(resolutions.get('item-1')?.terminal).toBeUndefined()
+  })
+
+  it('security: tolerant escape repair does not bypass the nonce hash gate — a repaired nonce that still mismatches nonceHash is rejected', () => {
+    // The nonce field itself contains a markdown-style escape that repairJsonStringEscapes
+    // will strip (\# -> #), so JSON.parse succeeds on the repaired copy. The repaired,
+    // human-readable nonce does NOT hash to this item's stored nonceHash (which was
+    // computed over the real raw nonce), so the receipt must still be rejected outright.
+    const body = String.raw`<!-- fro-bot:cross-repo-result {"correlation_id":"corr-1","nonce":"\# not-the-real-nonce","status":"success","summary":"done"} -->`
+    const comments: TrackerComment[] = [{author: {login: 'fro-bot'}, body}]
+    // Sanity: the repair does make this parseable at all (parseResult succeeds).
+    expect(parseResult(body).ok).toBe(true)
     const resolutions = resolveReceipts([item], comments)
     expect(resolutions.get('item-1')?.terminal).toBeUndefined()
   })

--- a/scripts/cross-repo-dispatch.ts
+++ b/scripts/cross-repo-dispatch.ts
@@ -484,16 +484,69 @@ export function buildResultMarker(receipt: CrossRepoResult): string {
  * no such marker is found; throws nothing — malformed JSON/field validation
  * is the caller's job so "marker found but invalid" and "no marker" stay
  * distinguishable outcomes.
+ *
+ * The `-->` terminator is string-aware: a `-->` that appears inside a
+ * double-quoted JSON string value (e.g. a `summary` containing a literal
+ * arrow) does not close the marker — only an out-of-string `-->` does. This
+ * mirrors `repairJsonStringEscapes`'s string-scope discipline: a string is
+ * entered on `"`, exited on an unescaped `"`, and `\"`/`\\` inside a string
+ * do not toggle scope. If an occurrence's prefix is found but no
+ * out-of-string `-->` follows before the end of `scope`, that occurrence is
+ * treated as an incomplete marker (skipped), matching how the old
+ * non-greedy regex would simply fail to match it.
  */
-function extractResultMarkerJson(scope: string): string | null {
-  const markerRegex = /<!--\s*fro-bot:cross-repo-result\s([\s\S]*?)-->/g
-  let lastMatch: RegExpExecArray | null = null
-  for (;;) {
-    const match = markerRegex.exec(scope)
-    if (match === null) break
-    lastMatch = match
+const MARKER_PREFIX_REGEX = /<!--\s*fro-bot:cross-repo-result\s/g
+
+function findMarkerTerminator(scope: string, payloadStart: number): number | null {
+  let inString = false
+  // Fallback for genuinely malformed JSON (e.g. an unterminated string that
+  // never closes before EOF): if no out-of-string `-->` is ever found, fall
+  // back to the first literal `-->` regardless of string state, mirroring
+  // the old non-greedy-regex behavior so such payloads still reach
+  // JSON.parse and surface as `malformed` rather than vanishing into
+  // `absent`. A marker with no `-->` anywhere remains a true `absent`.
+  let naiveFallback: number | null = null
+
+  for (let i = payloadStart; i < scope.length; i++) {
+    const ch = scope[i]
+    const atArrow = ch === '-' && scope.startsWith('-->', i)
+
+    if (atArrow && naiveFallback === null) naiveFallback = i
+
+    if (inString) {
+      if (ch === '\\') {
+        // Skip the escaped character so `\"` and `\\` don't toggle/confuse scope.
+        i += 1
+        continue
+      }
+      if (ch === '"') inString = false
+      continue
+    }
+
+    if (ch === '"') {
+      inString = true
+      continue
+    }
+
+    if (atArrow) return i
   }
-  return lastMatch?.[1] ?? null
+  return naiveFallback
+}
+
+function extractResultMarkerJson(scope: string): string | null {
+  let lastPayload: string | null = null
+  MARKER_PREFIX_REGEX.lastIndex = 0
+  for (;;) {
+    const match = MARKER_PREFIX_REGEX.exec(scope)
+    if (match === null) break
+
+    const payloadStart = match.index + match[0].length
+    const terminatorIndex = findMarkerTerminator(scope, payloadStart)
+    if (terminatorIndex === null) continue
+
+    lastPayload = scope.slice(payloadStart, terminatorIndex)
+  }
+  return lastPayload
 }
 
 /**

--- a/scripts/cross-repo-dispatch.ts
+++ b/scripts/cross-repo-dispatch.ts
@@ -529,6 +529,90 @@ function isValidResultPayload(value: unknown): value is {
   return true
 }
 
+const VALID_JSON_ESCAPES = new Set(['"', '\\', '/', 'b', 'f', 'n', 'r', 't', 'u'])
+const HEX_DIGIT = /[0-9a-f]/i
+
+/**
+ * Repair markdown-style backslash-escapes (`\#`, `` \` ``, `\*`, `\_`, `\[`,
+ * `\]`, etc.) that LLM workers occasionally emit inside JSON string values —
+ * the drift class where an agent markdown-escapes a special character before
+ * realizing it's writing JSON, not prose. Walks `raw` tracking whether the
+ * cursor is inside a double-quoted string (an escaped quote `\"` does not
+ * toggle string state) and only rewrites escapes found INSIDE strings; text
+ * outside strings is passed through untouched.
+ *
+ * Inside a string, for each `\X`:
+ * - a valid JSON escape (`\" \\ \/ \b \f \n \r \t`, or `\u` followed by
+ *   exactly 4 hex digits) is preserved unchanged.
+ * - a malformed `\u` (not followed by 4 hex digits) is left as-is —
+ *   deliberately NOT repaired, so parsing still fails on genuinely broken
+ *   unicode escapes rather than silently guessing at intent.
+ * - a trailing/lone backslash (end of string, or immediately before the
+ *   closing quote) is left as-is for the same reason.
+ * - anything else (`\#`, `` \` ``, `\*`, `\_`, `\[`, `\]`, `\(`, ...) has the
+ *   backslash dropped, keeping the literal character.
+ *
+ * Security note: this only widens which receipts can ATTEMPT JSON.parse.
+ * The three trust gates in `resolveReceipts` (Fro Bot author, correlation_id
+ * maps to a dispatched item, hash(nonce) === nonceHash) run unchanged AFTER
+ * parse — repairing escapes cannot forge a nonce preimage or an author.
+ */
+export function repairJsonStringEscapes(raw: string): string {
+  let result = ''
+  let inString = false
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i]
+
+    if (!inString) {
+      result += ch
+      if (ch === '"') inString = true
+      continue
+    }
+
+    if (ch === '"') {
+      inString = false
+      result += ch
+      continue
+    }
+
+    if (ch !== '\\') {
+      result += ch
+      continue
+    }
+
+    const next = raw[i + 1]
+    if (next === undefined) {
+      // Trailing lone backslash: leave as-is, don't invent meaning.
+      result += ch
+      continue
+    }
+
+    if (next === 'u') {
+      const hex = raw.slice(i + 2, i + 6)
+      if (hex.length === 4 && [...hex].every(c => HEX_DIGIT.test(c))) {
+        result += raw.slice(i, i + 6)
+        i += 5
+      } else {
+        // Malformed unicode escape: leave untouched so parse still fails.
+        result += ch
+      }
+      continue
+    }
+
+    if (VALID_JSON_ESCAPES.has(next)) {
+      result += ch + next
+      i += 1
+      continue
+    }
+
+    // Not a valid JSON escape introducer (markdown-style escape): drop the
+    // backslash, keep the literal character.
+    result += next
+    i += 1
+  }
+  return result
+}
+
 /**
  * Parse a worker completion-receipt comment body. Prefers the delimited
  * `cross-repo-result` region when present (mirroring `extractItemsRegion`'s
@@ -552,7 +636,14 @@ export function parseResult(body: string): ParseResultOutcome {
   try {
     parsed = JSON.parse(jsonStr)
   } catch {
-    return {ok: false, reason: 'malformed'}
+    // Strict parse failed — retry once against a repaired copy tolerant of
+    // markdown-style backslash-escapes inside string values (e.g. `\#`). If
+    // this still throws, fall through to the existing `malformed` outcome.
+    try {
+      parsed = JSON.parse(repairJsonStringEscapes(jsonStr))
+    } catch {
+      return {ok: false, reason: 'malformed'}
+    }
   }
 
   if (!isValidResultPayload(parsed)) {


### PR DESCRIPTION
## What

A cross-repo worker completed its task correctly and posted a no-op receipt, but the item stalled as `needs-attention` because the receipt's JSON `summary` contained `\#` — a worker markdown-escaped the `#` before it went into JSON, and `\#` is not a legal JSON escape, so `JSON.parse` threw and the receipt was classed `unparseable-receipt`.

This is the LLM-emits-a-machine-contract drift class the tracking loop was built to survive: an agent escaping markdown characters (`#`, backtick, `*`, `_`, `[`) inside JSON string values. The safety net worked (the goal stayed open rather than silently completing), but a genuinely-done item shouldn't need human attention over a stray backslash.

## Fix

Consumer-side tolerant parse, so the durable fix lives where we control it rather than in every worker's prompt:

- `parseResult` tries **strict `JSON.parse` first**; only on failure does it run an escape repair and retry. If it still fails, the existing `malformed` → `unparseable-receipt` outcome is preserved (marker-present-but-unrecoverable still fails closed, never degrades to "absent").
- The repair (`repairJsonStringEscapes`) is **grammar-aware**: it walks the payload tracking JSON string scope and only rewrites escapes *inside* strings. It drops the backslash from markdown-style escapes (`\#` → `#`), **preserves** valid JSON escapes (`\" \\ \/ \b \f \n \r \t`, valid `\uXXXX`), and deliberately **leaves malformed `\u` and lone trailing backslashes to fail** rather than guessing intent.

## Trust is unchanged

The three receipt gates in `resolveReceipts` — Fro Bot author, correlation-id maps to a dispatched item, and `hash(nonce) == nonceHash` — run **after** parse and are untouched. Tolerance only widens which receipts *attempt* the gates; it cannot forge a nonce preimage. A regression test confirms a repaired receipt whose nonce doesn't hash-match is still rejected. Design reviewed against these exact conditions.

## Verification

- Reproduced against the actual production receipt: the `\#` body now parses (`status: noop`, correct ids, summary repaired to plain text); a malformed `\ux` body still returns `malformed`.
- Worker prompt now also asks for plain-text summaries (defense in depth).
- Repo gate green: 2167 tests, check-types, lint (incl. workflow YAML).
