### PR TITLE
docs: correct workflow count in README structure tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ This repository provides shared configurations and automation for the Fro Bot ec
 ├── .github/                # GitHub-specific configurations
 │   ├── actions/setup/      # Composite bootstrap action
 │   ├── hooks/              # Copilot governance hooks
-│   ├── workflows/          # 24 GitHub Actions workflows (see Automation)
+│   ├── workflows/          # 25 GitHub Actions workflows (see Automation)
 │   ├── copilot-instructions.md  # Canonical AI-assistant guidance
 │   ├── renovate.json5      # Dependency management config
 │   └── settings.yml        # Repository settings via Probot


### PR DESCRIPTION
The repository structure tree in the README annotated `.github/workflows/` as holding 24 workflows. There are 25 workflow files there. This corrects the count to match the tree.