### PR TITLE
docs(solutions): capture four cross-repo-dispatch learnings

### DIFF
--- a/docs/solutions/best-practices/per-owner-installation-tokens-2026-07-06.md
+++ b/docs/solutions/best-practices/per-owner-installation-tokens-2026-07-06.md
@@ -1,0 +1,83 @@
+---
+title: A token minted for one installation cannot speak for another — mint per-owner, fail loud
+date: 2026-07-06
+category: best-practices
+module: scripts/cross-repo-dispatch.ts
+problem_type: best_practice
+component: development_workflow
+severity: high
+applies_when:
+  - a coordinator acts on repos across more than one owner or App installation
+  - you are minting a GitHub App token and about to reuse it beyond its installation
+  - a tracking or reconcile pass treats a missing token as a terminal state
+tags:
+  - github-app
+  - installation-token
+  - cross-repo
+  - least-privilege
+  - credential-topology
+  - fail-loud
+---
+
+# A token minted for one installation cannot speak for another — mint per-owner, fail loud
+
+## Context
+
+Cross-repo dispatch minted a single token scoped to the coordinating repo's owner and used it to
+`createWorkflowDispatch` into repos owned by a *different* account. It returned `403 Resource not
+accessible by integration` even though the token carried `actions: write`. The 403 was not a missing
+permission you could grant — it was an **installation boundary** being pretended away. A GitHub App
+token minted for owner A's installation has no authority in owner B's installation, full stop.
+
+## Guidance
+
+Split the credential topology by role, and mint a distinct token per installation you act against:
+
+- **Control-plane credential** — narrow scope (e.g. `issues: write` restricted to the coordinating
+  repo) for marker/comment/close operations on the coordination surface.
+- **Per-owner target tokens** — one minted for each installation the coordinator dispatches into,
+  each scoped to what that target action needs (`actions: write` for dispatch). Route target
+  operations through an owner-keyed token map; fail closed if an eligible owner has no token.
+
+When the owners belong to different GitHub Apps (here: a `fro-bot` App for `fro-bot/*` targets and a
+separate `mrbro-bot` App for `marcusrbrown/*` targets), mint from the matching App's credentials per
+owner. The consumer code only ever sees an owner→token map and does not care which App minted each
+entry — keep the App private keys in the workflow mint layer, out of the script.
+
+## Why This Matters
+
+"One token, one call" thinking silently breaks in a multi-installation system, and the failure is a
+runtime 403 rather than a compile error. Getting the topology right up front avoids a class of
+"works for my repos, 403s for yours" bugs. There is also a **fail-loud** invariant that is
+load-bearing for correctness downstream: the mint steps are **not** `continue-on-error`, so a
+misconfigured or missing App secret fails the whole job and the token map is always fully populated.
+
+## When to Apply
+
+- A coordinator acts on repos across more than one owner/installation.
+- You are minting a GitHub App token and about to reuse it beyond the installation it was minted for.
+- A tracking/reconcile pass treats a missing token as a terminal state (e.g. `blocked`).
+
+## Examples
+
+A subtle operational invariant surfaced in review and is worth recording next to the fix: the
+token-gap handling in the tracking pass assumes dispatch-time mint parity. Because mints fail loud,
+the token map is always complete, so a token gap can only mean broken infra — not an expected runtime
+state. If a future change removes an owner from the mint set or reintroduces `continue-on-error`, an
+already-dispatched item could be silently re-marked `blocked`, overwriting a real `completed`/`failed`
+conclusion. Annotate the token-gap path so nobody softens the mints without seeing that consequence.
+
+Minor but reusable hygiene note: interpolating a token map as inline JSON in a workflow `env:` block
+is safe *only* because App tokens (`ghs_[A-Za-z0-9_]+`) are auto-masked and their charset cannot break
+JSON quoting or inject a key. Safety that depends on the value's charset deserves a comment so it is
+not accidentally extended to values without that guarantee.
+
+## Related
+
+- Source PR (merge commit): `a3dca8f8d603b1f2719b022addfb17751dd7095a`
+- `docs/solutions/best-practices/credential-mint-time-permission-scoping-2026-06-22.md` — the
+  complementary lesson that a *second* credential gives rotation isolation, not permission isolation;
+  scope at mint time. This doc is the installation-boundary counterpart: even correctly-scoped, a
+  token cannot cross into another installation.
+- `docs/solutions/best-practices/worker-authored-hash-bound-receipts-2026-07-06.md` — the dispatch
+  loop these tokens serve

--- a/docs/solutions/best-practices/repair-before-a-trust-gate-not-inside-it-2026-07-06.md
+++ b/docs/solutions/best-practices/repair-before-a-trust-gate-not-inside-it-2026-07-06.md
@@ -1,0 +1,86 @@
+---
+title: Widen input tolerance in a repair layer that sits before a trust gate, never inside it
+date: 2026-07-06
+category: best-practices
+module: scripts/cross-repo-dispatch.ts
+problem_type: best_practice
+component: development_workflow
+severity: high
+applies_when:
+  - accepting almost-valid human- or LLM-authored input for a strict machine format
+  - that input feeds an authentication or authorization decision downstream
+  - you are tempted to sanitize input inside the trust check itself
+tags:
+  - tolerant-parsing
+  - trust-gate
+  - strict-first-repair-second
+  - json-escape
+  - fail-closed
+  - security-invariant
+---
+
+# Widen input tolerance in a repair layer that sits before a trust gate, never inside it
+
+## Context
+
+A cross-repo worker did its task correctly and posted a no-op completion receipt, but the item
+stalled because the receipt's JSON `summary` contained `\#` — a worker markdown-escaped the `#`
+before it went into JSON, and `\#` is not a legal JSON escape, so `JSON.parse` threw and the receipt
+was classed unparseable. This is the recurring LLM-emits-a-machine-contract drift class: agents
+escaping markdown characters (`#`, backtick, `*`, `_`, `[`) inside JSON string values. The work was
+done; only the serialization drifted.
+
+## Guidance
+
+Accept slightly-malformed input with a **strict-first / repair-second** sequence, and place the
+repair layer strictly **before** the trust gate — never inside it:
+
+1. Try strict parse first. Valid input never touches the repair path.
+2. Only on failure, run a **grammar-aware** repair (scoped to string literals, not a global regex),
+   then retry.
+3. If it still fails, keep the existing `malformed` outcome — a marker present but unrecoverable
+   fails closed and stays visible, never degrading to "absent."
+
+The security invariant to preserve: **the repair widens which candidate inputs get to attempt the
+gates; it never touches the gates and cannot manufacture a valid credential.** Here the three
+authenticity checks (author, correlation-id mapping, `hashNonce(receipt.nonce) === item.nonceHash`)
+run unchanged after parsing. A repair layer can widen the door but must not be able to forge a key.
+
+## Why This Matters
+
+Widening tolerance is where security boundaries quietly erode if the repair is done in the wrong
+place. The reason this repair is safe is worth stating as a reusable invariant: it cannot forge a
+preimage. Nonces are minted from `randomBytes(32).toString('base64url')`, whose alphabet
+(`[A-Za-z0-9_-]`) contains nothing the escape-repair walker rewrites — so a legitimate nonce passes
+through untouched, while a nonce mangled by repair simply fails the hash gate. Tolerance only lets
+more receipts *attempt* the gates; it can never move a forged one past them.
+
+## When to Apply
+
+- You need to accept human- or LLM-authored input that is *almost* valid for a strict machine format.
+- That input feeds an authentication/authorization decision downstream.
+- You are tempted to "clean up" the input inside the trust check — don't; repair before, gate after.
+
+## Examples
+
+Two secondary lessons carried the same weight as the main fix:
+
+1. **Fail closed on genuinely-corrupt input.** The grammar-aware walker preserves valid escapes
+   (`\" \\ \/ \b \f \n \r \t`, well-formed `\uXXXX`) and deliberately leaves malformed `\u` escapes
+   and lone trailing backslashes broken rather than guessing intent. Do not invent bytes.
+2. **The regression test that matters most proves a repaired-but-mismatched nonce is still
+   rejected.** Without it, a future loosening of the repair could silently weaken the boundary and no
+   test would notice.
+
+A related edge from the same review: marker extraction that terminated at the first `-->` truncated a
+receipt whose summary contained a literal `-->`. The fix made extraction string-scope-aware (only an
+out-of-string `-->` terminates), the same discipline as the escape walker — parse structure with
+awareness of string literals, not with a greedy delimiter match.
+
+## Related
+
+- Source PR (merge commit): `c936909bff90fd22f45c9201cb336e7acbd0ea8d`
+- `docs/solutions/best-practices/worker-authored-hash-bound-receipts-2026-07-06.md` — the receipt
+  design whose trust gate this tolerance sits in front of
+- `docs/solutions/best-practices/loose-then-tight-schema-migration-pattern-2026-05-05.md` — a related
+  "be liberal in what you accept, on your terms" pattern in a different layer

--- a/docs/solutions/best-practices/test-the-integration-seam-not-the-endpoints-2026-07-06.md
+++ b/docs/solutions/best-practices/test-the-integration-seam-not-the-endpoints-2026-07-06.md
@@ -1,0 +1,90 @@
+---
+title: A code path exercised only by pre-built fixtures is an untested seam — test the seam, not the endpoints
+date: 2026-07-06
+category: best-practices
+module: scripts/cross-repo-dispatch.ts
+problem_type: best_practice
+component: testing_framework
+severity: high
+applies_when:
+  - a function has unit tests but its real callers feed it differently than the fixtures do
+  - bugs keep recurring at the same integration boundary despite green unit suites
+  - you are writing a parser for input that legitimately mixes free-text and structured content
+tags:
+  - integration-test
+  - golden-path
+  - test-seam
+  - two-phase-parser
+  - anti-recurrence
+  - fixtures
+---
+
+# A code path exercised only by pre-built fixtures is an untested seam — test the seam, not the endpoints
+
+## Context
+
+The planner → dispatch bridge in the cross-repo loop broke in production three times in a row, each
+caught only by a live rehearsal after passing unit tests and review. The pattern was identical every
+time: unit tests injected **pre-built markers** directly and never exercised the real
+planner-comment → seeded-marker → dispatch composition. `parseDecomposition` existed and was
+unit-tested, but the one seam that mattered was never walked — approving a fresh goal would have
+dispatched into the void. Separately, a strict parser that failed on the first prose line was the
+wrong shape for input that legitimately mixes prose and checklist items.
+
+## Guidance
+
+**Whenever a transformation's real callers are bypassed by fixtures, treat that seam as untested
+regardless of unit coverage.** A function that is only ever exercised with hand-built inputs is a
+bridge built and never walked. The fix is a **golden-path integration test** that drives the actual
+production composition (here: dispatch → track) against a *captured real* input — a planner comment
+with prose, checklist, and a run-summary block, no pre-seeded marker. It must fail against the old
+code and pass against the new, so it becomes a standing contract rather than a unit-tested island.
+
+For the parser shape specifically, prefer a **two-phase** design over strict-line-by-line:
+
+1. A scope-narrowing step that isolates the delimited region when present.
+2. A collection step that **skips** non-checklist-shaped lines but still fails `malformed` on a
+   task-list-*shaped* line that breaks the grammar.
+
+That distinction is the whole point: a typo'd item stays an error while surrounding prose stays
+invisible. Decouple ordinal ids from the source line index so that adding prose does not shift ids.
+
+## Why This Matters
+
+Comprehensive unit tests create false confidence exactly where systems break: at the boundaries the
+tests do not cross. Three PRs shipped green through the same un-integration-tested seam. The
+golden-path test is the correct answer whenever bugs keep recurring at one boundary — it converts a
+repeated failure mode into a regression that cannot ship silently.
+
+## When to Apply
+
+- A function has unit tests but its real callers feed it differently than the fixtures do.
+- Bugs keep recurring at the same integration boundary despite green unit suites.
+- You are writing a parser for input that legitimately mixes free-text and structured content.
+
+## Examples
+
+The seed path added no new trust surface, which is the clean way to introduce a new entry point:
+seeded items enter the existing state machine as `pending` and then flow through every existing
+control — the registry gate, the approval-fingerprint CAS, the prompt-safety policy, and the
+two-phase intent → dispatched write — exactly like a hand-authored marker. Reusing the existing gates
+rather than bypassing them is what keeps a new entry point from widening the boundary.
+
+Two secondary notes worth carrying forward:
+
+1. **Avoid parsing the winning input twice** (once inside a `findLast` predicate, once after) — hoist
+   the parsed result if the seam needs tightening.
+2. **A fail-closed rejection is the safe direction, but emit a distinct diagnostic.** An over-cap
+   checklist that makes the parse fail and the run bail should be distinguishable from "no checklist
+   found" — `checklist rejected by cap` vs `no checklist present`.
+3. **Sibling functions that share a documented grammar should share rejection semantics.** One path
+   returning `malformed` on a bad line while the other silently continues is a latent divergence —
+   reconcile it or document why the scopes differ.
+
+## Related
+
+- Source PRs (merge commits): `faa6e2569e110d7cf272bbc9e2d60679d4ba7230` (two-phase parser +
+  golden-path test) and `a2fda59d7a76b7a6b4c8a44eee4f6fdc23e17c55` (the seed-path seam that the same
+  live rehearsal first exposed)
+- `docs/solutions/best-practices/worker-authored-hash-bound-receipts-2026-07-06.md` — the same loop's
+  completion half, verified with the same golden-path discipline

--- a/docs/solutions/best-practices/worker-authored-hash-bound-receipts-2026-07-06.md
+++ b/docs/solutions/best-practices/worker-authored-hash-bound-receipts-2026-07-06.md
@@ -1,0 +1,99 @@
+---
+title: When a platform gives no reliable correlation handle, invert poll to a worker-authored hash-bound receipt
+date: 2026-07-06
+category: best-practices
+module: scripts/cross-repo-dispatch.ts
+problem_type: best_practice
+component: development_workflow
+severity: high
+applies_when:
+  - a coordinator dispatches work to an autonomous worker it cannot poll reliably for completion
+  - the platform returns no correlation handle (e.g. GitHub dispatch returns 204 with no run id)
+  - a completion signal must travel back over a public channel but must be authentic
+  - modifying every worker/target to accept a correlation input is infeasible
+tags:
+  - cross-repo-dispatch
+  - push-vs-poll
+  - completion-tracking
+  - hash-bound-nonce
+  - trust-gate
+  - replay-safety
+---
+
+# When a platform gives no reliable correlation handle, invert poll to a worker-authored hash-bound receipt
+
+## Context
+
+The cross-repo dispatch loop needed to track a dispatched worker run to completion. The first
+design correlated a dispatched item to its worker run by passing a `correlation_id` as a
+`workflow_dispatch` input and matching it in the run name. That failed in production two ways:
+target repos are autonomous and only universally declare a `prompt` input, so a `correlation_id`
+input returned `422 Unexpected inputs provided`; and GitHub's dispatch API returns `204 No Content`
+with no run id and never exposes dispatch inputs on a run, so run-correlation cannot be made robust
+without changing every target repo.
+
+## Guidance
+
+When the platform will not hand you a reliable correlation handle, **invert the flow**: stop polling
+the coordinator's guess and have the worker — which already knows how the run went and already holds
+a credential that can write back — author its own completion receipt to the coordination surface. The
+worker becomes the source of truth instead of the coordinator inferring it from plumbing that does
+not expose intent.
+
+The load-bearing part is the trust model, and it generalizes to any cross-boundary completion signal
+posted over a public channel. Gate acceptance on **three** checks:
+
+1. **Author** — the receipt was posted by a trusted identity (an allowlisted bot author).
+2. **Correlation mapping** — the receipt's id maps to a currently dispatched item.
+3. **Hash-bound nonce** — `hash(receipt.nonce)` equals the item's stored `nonceHash`.
+
+Only the **hash** of the nonce ever appears in the public marker; the raw nonce is delivered to the
+worker prompt-only (a dispatch input, never public). Reading the public marker therefore yields
+nothing forgeable — a worker for item B cannot forge item A's receipt. Resolution is
+**earliest-authentic-receipt-wins**: the raw nonce becomes public the instant the real worker posts
+its receipt, so a later replay of that now-public nonce must not be able to flip an already-resolved
+item.
+
+## Why This Matters
+
+A public channel (a GitHub issue) is being used to carry a private authenticity claim. The naive
+version — "trust any comment from the bot author" — fails because the bot identity is broadly shared
+and correlation ids sit in plain sight, so any worker could forge another item's receipt. The
+hash-binding is what makes the third gate real: storing the raw nonce publicly would be security
+theater (any other worker reads it before its own receipt), while storing only the hash keeps the
+secret out of public state. Preimage resistance does the rest.
+
+Two failure modes must fail safe, not silent:
+
+- A worker that never reports, or reports past an SLA, resolves to a **non-terminal**
+  `needs-attention` — never a silent "completed." The goal stays open for a human.
+- A receipt that is present but malformed is a distinct `unparseable-receipt`, not treated as
+  absent — a botched receipt is visible, not swallowed.
+
+## When to Apply
+
+- A coordinator dispatches to workers it cannot reliably poll for a run outcome.
+- The completion signal must cross a trust boundary over a public medium.
+- You are tempted to add a correlation input to every worker — and cannot, because the workers are
+  autonomous and heterogeneous.
+
+## Examples
+
+The anti-recurrence contract worth emulating is a **hostile-forgery test that drives the real
+dispatch → track composition**, not a stub: a guessed/mismatched nonce never moves state, the genuine
+receipt still resolves, and a forgery attempt cannot permanently poison the item. Removing the
+nonce-hash gate or reverting resolution to latest-wins must fail that test.
+
+Nonce spec that made the gate sound: minted from `randomBytes(32).toString('base64url')` (CSPRNG,
+256-bit), stored as a full (untruncated) SHA-256 hex digest. A truncated hash or a
+`Date.now()+Math.random()` token would undermine the whole gate.
+
+## Related
+
+- Source PR (merge commit): `e406ff157a5dbfecdd298942ab83a165ad42ea2f`
+- `docs/solutions/best-practices/repair-before-a-trust-gate-not-inside-it-2026-07-06.md` — the
+  companion parse-tolerance invariant for the same receipts
+- `docs/solutions/best-practices/per-owner-installation-tokens-2026-07-06.md` — the credential
+  topology the dispatch half depends on
+- Known residual: shared-PAT receipt authorship is a confused-deputy boundary (tracked in
+  fro-bot/.github#3637), closed only by a per-dispatch, issue-scoped receipt token


### PR DESCRIPTION
## What

Authors four reusable learnings into `docs/solutions/best-practices/`, distilled from the cross-repo dispatch push-model arc. Closes the Capture Learnings proposals for the merged work.

| Doc | Learning | Source merge |
|-----|----------|--------------|
| `worker-authored-hash-bound-receipts` | When a platform gives no reliable correlation handle, invert poll to a worker-authored, hash-bound receipt; gate on author + correlation-id + `hash(nonce)`, earliest-authentic-wins for replay safety | `e406ff1` (#3638) |
| `repair-before-a-trust-gate-not-inside-it` | Widen input tolerance with strict-first/repair-second, placed *before* the trust gate — the repair can't forge a preimage | `c936909` (#3641) |
| `per-owner-installation-tokens` | A token minted for one installation can't speak for another; split control-plane from per-owner target tokens and fail loud on a missing mint | `a3dca8f` (#3636) |
| `test-the-integration-seam-not-the-endpoints` | A path exercised only by pre-built fixtures is an untested seam; lock it with a golden-path integration test through the real composition | `faa6e25` (#3635) + `a2fda59` (#3634) |

## Triage notes

- Five learning-proposal issues (#3643–#3647) produced four docs: #3646 and #3647 describe the same "untested integration seam" lesson from consecutive PRs in one arc, so they're consolidated into one doc rather than left to drift apart.
- `per-owner-installation-tokens` is cross-linked to the existing `credential-mint-time-permission-scoping` doc — related but distinct (rotation-vs-permission isolation vs the installation boundary), so kept separate, not folded in.

## Notes

- All four are knowledge-track (`problem_type: best_practice`, `applies_when`), consistent with the `best-practices/` corpus convention.
- Content is first-hand from the merged, already-reviewed PRs, not paraphrased machine drafts.

---

Closes #3643
Closes #3644
Closes #3645
Closes #3646
Closes #3647
