### PR TITLE
docs: clarify cross-repo dispatch trust boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ If you need to re-approve after reopening a closed goal issue, reopening automat
 
 Each dispatch carries only the universal `prompt` input — no `correlation_id` or other custom input, since target repos are autonomous and only guarantee `prompt`. The correlation id and a per-item nonce ride inside the prompt itself; the worker reports completion by posting a receipt comment on the coordination issue, which a periodic tracker verifies (author, correlation id, and `hash(nonce)`) before resolving the item.
 
-The nonce binds a receipt to its item: the coordination issue stores only `hash(nonce)`, and the raw nonce reaches the worker only through the prompt. One caveat worth stating plainly — a repo running Fro Bot with `OPENCODE_PROMPT_ARTIFACT` enabled publishes the rendered prompt (raw nonce included) as a downloadable Actions artifact. Where that's set on a target, item-level nonce isolation falls back to trusting the dispatched worker itself, which is the same trust boundary the loop already assumes: every worker is a Fro Bot agent.
+The nonce binds a receipt to its item: the coordination issue stores only `hash(nonce)`, and the raw nonce reaches the worker only through the prompt. One caveat worth stating plainly — a target repo running Fro Bot with `OPENCODE_PROMPT_ARTIFACT` enabled publishes the rendered prompt (raw nonce included) as a downloadable Actions artifact. Where that's set on a target, item-level nonce isolation falls back to trusting that target's worker and its `FRO_BOT_PAT`.
 
 **Why push, not poll.** Tracking used to correlate a dispatched item to its worker run by matching a `correlation_id` against the run name — until target repos turned out to only guarantee a `prompt` input, and GitHub's dispatch API gives you a `204` with no run id back anyway. So the model flipped: the worker already knows how it went, and it already holds a credential that can write back to the coordination issue. The worker posts, a scheduled tracker reads. Tracking never polls PR state or the Actions API for completion; a `pr` URL in a receipt is operator-facing metadata, nothing more.
 
@@ -371,7 +371,7 @@ The nonce binds a receipt to its item: the coordination issue stores only `hash(
 
 **When an item gets stuck wrong.** First-authentic-receipt-wins is a deliberate anti-spoof choice, but it means a bad early receipt (or your own mistake) can lock an item somewhere you don't want it. There's no undo command for that yet — the fix is editing the coordination issue's state marker comment directly to correct the item's status.
 
-**What's still open.** Every worker authenticates as the same shared `FRO_BOT_PAT`, so this is a shared-trust-boundary design, not per-item authorization — a compromised PAT can still forge a receipt for any item whose nonce it can obtain. Scoping receipt tokens per dispatch, per coordination issue, is planned hardening, not yet shipped.
+**What's still open.** Every worker authenticates with the `FRO_BOT_PAT` available to that target repo, so this is a shared worker-trust design, not per-item authorization. A compromised target worker or PAT can still forge a receipt for any item whose nonce it can obtain. GitHub does not provide an issue-scoped receipt token, and pushing a separate token through the dispatch prompt would only move the leak. Further hardening requires a real target-side policy change or a receipt broker, not control-plane theater.
 
 ## Development
 

--- a/docs/plans/2026-07-04-002-feat-cross-repo-dispatch-push-tracking-plan.md
+++ b/docs/plans/2026-07-04-002-feat-cross-repo-dispatch-push-tracking-plan.md
@@ -98,10 +98,11 @@ See origin: docs/brainstorms/2026-07-04-cross-repo-dispatch-tracking-push-model-
 
 ### Deferred to Separate Tasks
 
-- Confused-deputy hardening (HARD follow-up, not optional) — replacing `FRO_BOT_PAT` authorship with a
-  per-dispatch, coordination-issue-scoped receipt token so a compromised org-wide PAT can no longer
-  author receipts. Filed as a tracked fro-bot/.github issue + smart note BEFORE this ships. v1 accepts
-  the residual risk explicitly (shared-trust-boundary: all workers are `fro-bot` agents).
+- Confused-deputy residual — worker receipts use the `FRO_BOT_PAT` available to the target repo. GitHub
+  does not provide issue-scoped receipt tokens, and sending a separate token through the prompt would
+  only move the leak. Further hardening needs a real target-side policy change or receipt broker, not
+  coordinator-only code. v1 accepts the residual explicitly: dispatched workers are trusted Fro Bot
+  agents.
 - Worker-side receipt channel (drift mitigation) — a bundled skill or runtime receipt template in the
   fro-bot/agent repo so the receipt is generated from structured data rather than prompt prose. This
   is the real fix if live drift stays high after v1; tracked as a follow-up (its own brainstorm/plan,
@@ -536,7 +537,7 @@ production composition, and document the push-model architecture.
   resolves on the next track pass.
 - This test must fail if any unit regresses the contract (the standing anti-recurrence test).
 - Update the README: push model, receipt contract + region format, three-gate trust, SLA,
-  needs-attention, and the deferred token-scoping note.
+  needs-attention, and the shared worker-trust residual.
 
 **Execution note:** Start from the realistic-receipt golden-path test (contract-first), mirroring the
 decomposition golden-path test that caught wall #3.
@@ -588,7 +589,7 @@ fails on any contract regression; README reflects the shipped design.
 |------|------------|
 | Worker drifts from the receipt format (wall-#3 class) — the highest-likelihood failure, evidenced on live #3633 | Prompt-only formatting is best-effort, not a correctness guarantee: delimited region + literal example + self-validate REDUCE drift; a drifted marker is `unparseable-receipt` (visible, never silent success); and the diagnostic run-lookup makes the residual `needs-attention` actionable ("ran but didn't report") so drift is triaged, not silent. A worker-side receipt channel is the tracked next step if drift stays high. |
 | Cross-item receipt forgery reading the public marker | Hash-bound nonce (R6): the public marker stores only `hash(nonce)`; the raw nonce is prompt-only; track verifies `hash(receipt.nonce)`. Preimage resistance means reading the marker yields nothing forgeable. |
-| Confused-deputy: ANY holder of `FRO_BOT_PAT` (every org workflow/agent that uses it, or a leaked PAT) can author receipts | NOT closed in v1. This is shared-trust-boundary security, not item-level authorization: the hash gate stops one worker forging ANOTHER item's receipt, but a compromised PAT can forge receipts for items whose nonce it holds. Accepted for v1 only because all workers are trusted `fro-bot` agents. Hard follow-up (tracked issue + smart note): mint a per-dispatch, coordination-issue-scoped receipt token instead of reusing the org-wide PAT. |
+| Confused-deputy: ANY holder of a target repo's `FRO_BOT_PAT` can author receipts | NOT closed in v1. This is shared worker-trust security, not item-level authorization: the hash gate stops one worker forging ANOTHER item's receipt from marker state alone, but a compromised worker/PAT can forge receipts for items whose nonce it has. GitHub does not provide issue-scoped receipt tokens, and prompt-delivered tokens are theater. Further hardening requires target-side policy or a receipt broker. |
 | Worker cannot resolve/write the coordination issue | Prompt carries structured `owner`/`repo`/`number` + canonical URL and a self-check echoing the resolved destination; `FRO_BOT_PAT` verified to carry cross-repo issue-write (gateway-rollout-tracker precedent); Unit 6 asserts the authored identity passes `FROBOT_COMMENT_AUTHORS`. |
 | Premature `failed` locks an item | First-terminal-wins is deliberate anti-spoof; operator manual-override via marker edit documented. |
 | Unit 5 sequencing pulls run-lookup out of a live resolver | Unit 5 explicitly depends on Unit 4's receipt-first rewire; run-lookup is DEMOTED (diagnostic-only), not deleted, preserving crash recovery; full green suite gate + golden-path test prove receipt-only closure. |
@@ -600,9 +601,7 @@ fails on any contract regression; README reflects the shipped design.
 ## Documentation / Operational Notes
 
 - README/architecture doc updated (Unit 6): push model, receipt + region format, three-gate trust,
-  24h SLA, `needs-attention` semantics, operator override, deferred token-scoping.
-- File the confused-deputy token-scoping hardening as a tracked fro-bot/.github issue with a smart
-  note before shipping.
+  24h SLA, `needs-attention` semantics, operator override, and the shared worker-trust residual.
 - Rehearsal issue #3633 (checklist intact, stale marker cleared, labels present) is the live canary
   to re-exercise once this lands — it will exercise the receipt path for the first time in production.
 - Legacy-marker migration: any in-flight marker that stored a RAW `nonce` (the prior schema) is

--- a/docs/solutions/best-practices/worker-authored-hash-bound-receipts-2026-07-06.md
+++ b/docs/solutions/best-practices/worker-authored-hash-bound-receipts-2026-07-06.md
@@ -48,8 +48,8 @@ posted over a public channel. Gate acceptance on **three** checks:
 3. **Hash-bound nonce** — `hash(receipt.nonce)` equals the item's stored `nonceHash`.
 
 Only the **hash** of the nonce ever appears in the public marker; the raw nonce is delivered to the
-worker prompt-only (a dispatch input, never public). Reading the public marker therefore yields
-nothing forgeable — a worker for item B cannot forge item A's receipt. Resolution is
+worker through the prompt, not as its own dispatch input. Reading the public marker therefore yields
+nothing forgeable — a worker for item B cannot forge item A's receipt from marker state alone. Resolution is
 **earliest-authentic-receipt-wins**: the raw nonce becomes public the instant the real worker posts
 its receipt, so a later replay of that now-public nonce must not be able to flip an already-resolved
 item.
@@ -95,5 +95,7 @@ Nonce spec that made the gate sound: minted from `randomBytes(32).toString('base
   companion parse-tolerance invariant for the same receipts
 - `docs/solutions/best-practices/per-owner-installation-tokens-2026-07-06.md` — the credential
   topology the dispatch half depends on
-- Known residual: shared-PAT receipt authorship is a confused-deputy boundary (tracked in
-  fro-bot/.github#3637), closed only by a per-dispatch, issue-scoped receipt token
+- Known residual: worker receipt authorship is a shared-trust boundary. GitHub does not provide an
+  issue-scoped receipt token, and passing a separate token through the prompt would only move the
+  secret. Further hardening requires target-side policy or a receipt broker, not coordinator-only
+  code.


### PR DESCRIPTION
## Summary

- Clarifies the A3 cross-repo dispatch trust boundary after the production rehearsal.
- Removes the inaccurate per-dispatch / issue-scoped receipt-token path from README and plan docs.
- Documents the real residual: worker receipts trust the target repo's Fro Bot worker and `FRO_BOT_PAT`; further hardening requires target-side policy or a receipt broker, not coordinator-only code.

## Verification

- `pnpm bootstrap && pnpm check-types && pnpm lint && pnpm test`
