### PR TITLE
feat(status-truth): graduate plan-consistency corrections

### DIFF
--- a/.github/workflows/status-truth.yaml
+++ b/.github/workflows/status-truth.yaml
@@ -379,10 +379,27 @@ jobs:
           permission-pull-requests: write
           permission-issues: write
 
+      # Mint a separate, strictly read-only app token for fetch/list calls
+      # (existing-PR discovery, terminal-fingerprint issue scan). Keeps the
+      # write token's blast radius limited to the write calls that actually
+      # need it — the fetch path never needs write scope.
+      - name: 🔑 Mint fetch token (read-only)
+        id: fetch-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          # Scope to this repo only — smallest blast radius.
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: read
+          permission-pull-requests: read
+          permission-issues: read
+
       - name: 🛠 Execute status-truth correction PRs
         id: prs
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          STATUS_TRUTH_FETCH_TOKEN: ${{ steps.fetch-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           STATUS_TRUTH_REPORT_PATH: ${{ runner.temp }}/status-truth-report.json
           STATUS_TRUTH_PRS_RESULT_PATH: ${{ runner.temp }}/status-truth-prs-result.json
@@ -416,12 +433,17 @@ jobs:
               echo "| Version rejected | $(jq '.plannedCounts.versionRejected // 0' "$result") |"
               echo "| Opened | $(jq '.executedCounts.opened // 0' "$result") |"
               echo "| Closed | $(jq '.executedCounts.closed // 0' "$result") |"
+              echo "| Rediscovered | $(jq '.executedCounts.rediscovered // 0' "$result") |"
               echo "| Downgraded (execution) | $(jq '.executedCounts.downgraded // 0' "$result") |"
               echo "| Safety refused | $(jq '.executedCounts.safetyRefused // 0' "$result") |"
               echo "| Failed | $(jq '.executedCounts.failed // 0' "$result") |"
               echo "| Branch delete failed | $(jq '.executedCounts.branchDeleteFailed // 0' "$result") |"
               echo "| Would open (dry-run) | $(jq '.executedCounts.wouldOpen // 0' "$result") |"
               echo "| Would close (dry-run) | $(jq '.executedCounts.wouldClose // 0' "$result") |"
+              echo "| Would rediscover (dry-run) | $(jq '.executedCounts.wouldRediscover // 0' "$result") |"
+              echo "| Terminal fingerprints skipped | $(jq '.terminalFingerprintsSkipped // 0' "$result") |"
+              echo "| Terminal fingerprint duplicates | $(jq '.terminalFingerprintDuplicates // 0' "$result") |"
+              echo "| Error | $(jq -r '.error // "none"' "$result") |"
             else
               echo "| Status | (PR execution result unavailable) |"
             fi

--- a/.github/workflows/status-truth.yaml
+++ b/.github/workflows/status-truth.yaml
@@ -362,9 +362,11 @@ jobs:
           path: ${{ runner.temp }}
 
       # Mint a scoped app token only inside this job, only on armed dispatches.
-      # Raised above the open job's issues:write to include contents:write and
-      # pull-requests:write for branch/commit/PR mutations; issues:read covers
-      # live terminal-label lookups on proposal issues.
+      # Adds contents:write and pull-requests:write for branch/commit/PR
+      # mutations. issues:write is required because executeStatusTruthPrActions
+      # closes stale/terminal correction PRs via issues.createComment (PR
+      # comments are Issues API comments); pull-requests:write alone cannot
+      # create the closure comment.
       - name: 🔑 Mint write token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -375,7 +377,7 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           permission-contents: write
           permission-pull-requests: write
-          permission-issues: read
+          permission-issues: write
 
       - name: 🛠 Execute status-truth correction PRs
         id: prs

--- a/README.md
+++ b/README.md
@@ -319,6 +319,8 @@ Applying `status-truth:rejected` or `status-truth:false-positive` to a plan-cons
 
 **Correction PRs (currently disarmed):**
 
+`plan-consistency` is the first graduated claim kind, but graduation alone doesn't open PRs — the repository variable and manual dispatch input below still both have to be set.
+
 The Status Truth workflow can, once armed, open a pull request that applies a proposal's correction directly instead of waiting on a human edit. No PR opens today. Three independent, reviewed keys must all be true at once before one can:
 
 1. The repository variable `STATUS_TRUTH_PRS_ENABLED` is set to `true`.

--- a/docs/plans/2026-07-07-002-feat-status-truth-plan-consistency-graduation-plan.md
+++ b/docs/plans/2026-07-07-002-feat-status-truth-plan-consistency-graduation-plan.md
@@ -124,7 +124,7 @@ The work therefore needs to graduate the kind and complete the same-run report-r
 - The current armed stub behavior is gone; the CLI path exercises real planning/execution while preserving the disarmed no-op and counts-only output contract.
 - Tests prove partial-success recovery: an existing matching correction PR from a prior partially successful run prevents duplicate PR creation and still allows stale/terminal closure planning.
 
-- [ ] **Unit 2: Correct PR job token permissions**
+- [x] **Unit 2: Correct PR job token permissions**
 
 **Goal:** Give the PR execution job exactly the write permissions its executor already needs for stale/terminal PR closure comments.
 

--- a/docs/plans/2026-07-07-002-feat-status-truth-plan-consistency-graduation-plan.md
+++ b/docs/plans/2026-07-07-002-feat-status-truth-plan-consistency-graduation-plan.md
@@ -152,7 +152,7 @@ The work therefore needs to graduate the kind and complete the same-run report-r
 **Verification:**
 - Workflow lint and the parsed workflow test pass; the PR job is still reachable only through the existing arming `if:` gate.
 
-- [ ] **Unit 3: Graduate `plan-consistency` and update operator docs**
+- [x] **Unit 3: Graduate `plan-consistency` and update operator docs**
 
 **Goal:** Add `plan-consistency` to the reviewed graduated set and update tests/docs with the evidence trail.
 

--- a/docs/plans/2026-07-07-002-feat-status-truth-plan-consistency-graduation-plan.md
+++ b/docs/plans/2026-07-07-002-feat-status-truth-plan-consistency-graduation-plan.md
@@ -1,0 +1,216 @@
+---
+title: 'feat: Graduate plan-consistency Status Truth correction PRs'
+type: feat
+status: active
+date: 2026-07-07
+origin: docs/brainstorms/2026-07-03-bounded-correction-pr-execution-requirements.md
+---
+
+# feat: Graduate plan-consistency Status Truth correction PRs
+
+## Overview
+
+Graduate the `plan-consistency` Status Truth claim kind from proposal-only signal to bounded correction PR eligibility. The graduation is backed by real operator evidence: one explicit accepted proposal (#3656) and three resolved-positive historical proposals (#3614–#3616). The change must also finish the PR execution CLI path that the bounded-correction slice intentionally left inert while no claim kinds were graduated.
+
+This does not arm autonomous PR creation by itself. Correction PRs still require all three keys: reviewed graduated kind, repository variable enabled, and a manual workflow dispatch with PR execution requested. This plan exists to make `plan-consistency` graduation meaningful by unblocking the already-designed PR runner; it is not a broader rewrite of Status Truth.
+
+## Problem Frame
+
+Status Truth now has enough evidence to graduate `plan-consistency`, but the runtime path is not functionally complete. `GRADUATED_CLAIM_KINDS` is empty, and `scripts/status-truth-prs.ts` still exits from the armed path after printing `{armed: true, dryRun}`. A one-line set change would be theater: it would make the kind look graduated while armed runs still produce zero correction PR actions.
+
+The work therefore needs to graduate the kind and complete the same-run report-read → plan → execute loop behind the existing arming model.
+
+## Requirements Trace
+
+- R1. Graduate only `plan-consistency`, citing #3656 as the explicit accepted outcome and #3614–#3616 as resolved-positive supporting signal.
+- R2. Preserve the three-key arming model: repository variable, non-empty reviewed graduated set, and manual `open_prs=true` dispatch input.
+- R3. Scheduled runs and normal dry-runs must never open correction PRs.
+- R4. Replace the armed CLI stub with the real same-run pipeline: read report artifact, fetch existing correction PR/proposal state, plan actions, and execute through the existing executor.
+- R5. Keep correction PR writes bounded to the already-built safety model: one-file corrections, allowed paths only, live re-read/re-verification, opaque branch/title metadata, public-output gate, and one-new-open-per-run cap.
+- R6. Fix the App-token mint scope in `.github/workflows/status-truth.yaml`: the `actions/create-github-app-token` step in the PR job must request `permission-issues: write` because `executeStatusTruthPrActions` closes stale/terminal correction PRs by calling `issues.createComment`; job-level `permissions` stay read-only.
+- R7. Update tests to pin both the new graduation evidence and the functional CLI path; no change may rely on manual inspection of workflow logs.
+- R8. Do not set or change the `STATUS_TRUTH_PRS_ENABLED` repository variable and do not dispatch a live PR-opening run as part of implementation.
+- R9. Preserve the public-output contract: stdout, result JSON, step summaries, and failure messages carry only counts and closed-vocabulary reason keys, never report paths, source paths, fingerprints, branch names, PR/proposal identifiers, titles, bodies, or token material.
+- R10. Preserve serialized execution and branch ownership: the existing `status-truth` workflow concurrency group serializes runs, and every write/delete must re-check the bot-owned `status-truth/correction-*` branch pattern before mutation.
+
+## Scope Boundaries
+
+- In scope: `plan-consistency` graduation, PR CLI runner completion, workflow token permission correction, tests, and minimal operator docs.
+- Out of scope: enabling the repo variable, running `open_prs=true`, changing the one-new-open-per-run cap, graduating other claim kinds, adding new correctors, broad Status Truth redesign, automerge, or branch-protection changes.
+- Out of scope: re-litigating the proposal loop, detector claim kinds, or the outcome taxonomy; those are already shipped and verified.
+
+### Deferred to Separate Tasks
+
+- Lifting the one-new-open-per-run cap remains out of scope.
+- Removing `plan-consistency` after a future false-positive remains out of scope and requires a separate reviewed change.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/status-truth-prs.ts` — contains `GRADUATED_CLAIM_KINDS`, `planStatusTruthPrActions`, `executeStatusTruthPrActions`, the corrector/re-verifier registries, and the current stubbed `runPrs()` entry point.
+- `scripts/status-truth-prs.test.ts` — already tests planner and executor behavior with injected `new Set(['plan-consistency'])`; the production constant test currently expects an empty set.
+- `.github/workflows/status-truth.yaml` — hosts the three-job detect/open/prs workflow and the PR job's write-token mint.
+- `scripts/status-truth-proposals.ts` — proposal executor pattern to mirror for label/fetch/plan/execute sequencing and counts-only outputs.
+- `README.md` — documents the Status Truth outcome labels, three-key PR arming model, and graduation policy.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/status-truth-synthetic-self-audit-claim-kinds-2026-07-03.md` — `plan-consistency` is a synthetic self-audit kind; do not add a prose-regex definition for it.
+- `docs/solutions/best-practices/closed-vocabulary-telemetry-keys-from-public-bodies-2026-07-03.md` — outcome counts by kind must stay closed-vocabulary and counts-only.
+- `docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md` — every PR/output surface must pass the existing public-output gate; the gate is the invariant, not intent.
+- `docs/solutions/best-practices/observability-before-structural-change-2026-06-09.md` — the accepted/resolved proposal history is the live evidence justifying this structural step.
+
+## Key Technical Decisions
+
+- Graduate only `plan-consistency`: it has the required explicit accepted proposal (#3656) and already has a bounded corrector/re-verifier.
+- Complete the CLI runner before relying on the graduated set: a set-only change would satisfy documentation but not behavior.
+- Keep arming operationally separate from graduation: implementation changes code only; operators still choose whether to set `STATUS_TRUTH_PRS_ENABLED` and dispatch `open_prs=true`.
+- Use `issues: write` on the PR job's minted GitHub App token, not the job token: pull request comments are Issues API comments, and stale/terminal closure is part of the already-designed executor. `pull-requests: write` alone cannot create the closure comment.
+- Do not update historical plan/requirements docs that described earlier shipped state; cite the new evidence in the new plan, code comments, tests, README, and PR body instead.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should this be a set-only graduation? No. The current `runPrs()` armed path is a stub, so set-only graduation would be functionally inert.
+- Should the repo variable be enabled as part of this change? No. The repository variable is an operational arming key, not part of the reviewed graduation PR.
+
+### Deferred to Implementation
+
+- Exact helper names inside `runPrsCore()`: choose names during implementation, but the seam itself is required.
+
+## Implementation Units
+
+- [x] **Unit 1: Complete the PR execution CLI runner**
+
+**Goal:** Replace the armed `runPrs()` stub with the real same-run report-read, state-fetch, planning, and execution path.
+
+**Requirements:** R2, R3, R4, R5, R7
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `scripts/status-truth-prs.ts`
+- Test: `scripts/status-truth-prs.test.ts`
+
+**Approach:**
+- Keep the disarmed path unchanged: counts-only result and no write-token requirement.
+- Extract an exported, testable `runPrsCore()` seam with explicit dependencies for environment flags, report loading, Octokit/client creation, public-output token loading, existing-PR fetch, terminal-fingerprint fetch, planner, executor, stdout/result writing, and process-exit signaling. `runPrs()` stays a thin environment wrapper.
+- In the armed path, read `STATUS_TRUTH_REPORT_PATH`, parse the same-run detect report, fetch `existingPrs` from open pull requests created by the bot whose head branch starts with `status-truth/correction-` and base is `main`, and fetch `terminalFingerprints` from status-truth proposal issues carrying terminal labels (`status-truth:rejected` or `status-truth:false-positive`) by strict extraction of the existing `<!-- status-truth:fingerprint=<hex> -->` marker format.
+- Terminal fingerprint extraction is fail-closed per issue: malformed, missing, non-hex, or duplicate terminal fingerprints are excluded and counted as skipped/invalid terminal records; they must never suppress another fingerprint by fuzzy matching.
+- Call `planStatusTruthPrActions`, then `executeStatusTruthPrActions`. Existing proposal labels are read only to derive terminal fingerprints; accepted/resolved labels are evidence and outcome math, not terminal suppressors.
+- Preserve counts-only stdout/result JSON and the existing failure posture: missing report, malformed report, unavailable state fetch, or token/public-output load failure fails closed before writes.
+- Mode matrix: scheduled and manual `open_prs=false` skip the PR job; manual `open_prs=true` with the repo variable unset is disarmed counts-only; manual armed dry-run may perform read-only discovery/planning and reports would-act counts with zero mutating calls; manual armed live may mutate only through executor actions after all safety checks.
+
+**Execution note:** Test-first; start with a `runPrsCore()` test that would fail against the current `{armed:true,dryRun}` stub.
+
+**Patterns to follow:**
+- `scripts/status-truth-proposals.ts` `runOpen()` for report/result-path handling and counts-only output.
+- Existing `status-truth-prs` planner/executor tests for injected Octokit shape and per-action accounting.
+
+**Test scenarios:**
+- Integration: armed dry-run with a report containing one graduated `plan-consistency` drift produces planned would-open counts and no mutating API calls.
+- Happy path: armed live mode with one eligible finding calls the executor path and reports opened counts when the mocked executor succeeds.
+- Edge case: disarmed mode still exits counts-only and does not require `STATUS_TRUTH_REPORT_PATH`.
+- Edge case: terminal-label proposal issue contributes its fingerprint to `terminalFingerprints`; accepted/resolved labels do not.
+- Edge case: terminal-label proposal issue with malformed, missing, or non-hex fingerprint marker is ignored and counted, never converted into a terminal suppression.
+- Edge case: existing bot-owned `status-truth/correction-*` PR targeting `main` is passed into planner rediscovery; non-bot, non-main, or non-prefix PRs are ignored.
+- Recovery: if a previous run created the branch/PR but failed later, the next run rediscovers the existing bot-owned correction PR and plans rediscovery/closure rather than opening a duplicate.
+- Error path: missing report path, malformed report, failed state fetch, or failed public-output token load exits non-zero before any mutation.
+- Privacy/output: stdout, result JSON, and error messages contain only counts and reason keys; no source path, report path, fingerprint, branch name, PR/proposal number, title, body, token, or rendered PR body.
+
+**Verification:**
+- The current armed stub behavior is gone; the CLI path exercises real planning/execution while preserving the disarmed no-op and counts-only output contract.
+- Tests prove partial-success recovery: an existing matching correction PR from a prior partially successful run prevents duplicate PR creation and still allows stale/terminal closure planning.
+
+- [ ] **Unit 2: Correct PR job token permissions**
+
+**Goal:** Give the PR execution job exactly the write permissions its executor already needs for stale/terminal PR closure comments.
+
+**Requirements:** R6, R8
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `.github/workflows/status-truth.yaml`
+- Test: `scripts/status-truth-prs.test.ts`
+
+**Approach:**
+- Change only the PR job's `actions/create-github-app-token` inputs from `permission-issues: read` to `permission-issues: write`, preserving repo scoping plus `permission-contents: write` and `permission-pull-requests: write`.
+- Do not change job-level default permissions or the detect/open credential split.
+- Add an automated workflow assertion, mirroring `scripts/wiki-lint-issues.test.ts`, that parses `.github/workflows/status-truth.yaml` and pins the PR job App-token inputs (`contents: write`, `pull-requests: write`, `issues: write`) plus the read-only job token permissions.
+
+**Patterns to follow:**
+- Existing open job's scoped token mint for proposal issues.
+- Existing comments in `.github/workflows/status-truth.yaml` that explain credential boundaries.
+
+**Test scenarios:**
+- Workflow contract: parsed workflow test finds the PR job App-token step and asserts `permission-issues: write`, `permission-pull-requests: write`, `permission-contents: write`, repo scoping, and job-level `permissions.contents: read`.
+- Regression: workflow `if:` still requires repo variable, workflow_dispatch event, and `open_prs == 'true'`.
+
+**Verification:**
+- Workflow lint and the parsed workflow test pass; the PR job is still reachable only through the existing arming `if:` gate.
+
+- [ ] **Unit 3: Graduate `plan-consistency` and update operator docs**
+
+**Goal:** Add `plan-consistency` to the reviewed graduated set and update tests/docs with the evidence trail.
+
+**Requirements:** R1, R2, R7, R8
+
+**Dependencies:** Units 1–2
+
+**Files:**
+- Modify: `scripts/status-truth-prs.ts`
+- Modify: `scripts/status-truth-prs.test.ts`
+- Modify: `README.md`
+
+**Approach:**
+- Change `GRADUATED_CLAIM_KINDS` to include exactly `plan-consistency`.
+- Update the production JSDoc and the exported-constant test to cite #3656 as explicit accepted evidence and #3614–#3616 as resolved-positive support.
+- Keep README's three-key arming language intact; add a terse note that `plan-consistency` is the first graduated kind, while PR creation still requires the variable and manual dispatch input.
+
+**Execution note:** Test-first for the exported constant and arming behavior.
+
+**Patterns to follow:**
+- Existing tests that inject `new Set(['plan-consistency'])` for planner behavior.
+- README Status Truth section's terse operator-facing label/arming style.
+
+**Test scenarios:**
+- Happy path: `GRADUATED_CLAIM_KINDS` contains exactly `plan-consistency`.
+- Safety: `isPrExecutionArmed` remains false unless repo variable, dispatch input, and non-empty graduated set are all true.
+- Regression: scheduled/default dispatch assumptions remain documented and unaffected.
+
+**Verification:**
+- Full repo gate passes; no workflow variable is set and no PR-opening run is dispatched.
+
+## System-Wide Impact
+
+- **Interaction graph:** Status Truth detect/open behavior stays unchanged. Only the PR execution job becomes functionally capable when all arming keys are present.
+- **Error propagation:** Failures before safety validation perform no writes. Failures after an individual action succeeds are partial-success states: earlier writes are not rolled back, later failures are counted, and the next run must rediscover/close/update through existing idempotent branch and PR checks.
+- **State lifecycle risks:** Correction PR branches and stale PR closure are bounded by opaque branch names, bot ownership checks, workflow-level `status-truth` concurrency, branch-collision fail-closed behavior, and close/delete safeguards.
+- **Partial-success recovery:** The runner does not roll back already-created branches or PRs. Recovery is by rediscovery: subsequent runs identify matching bot-owned correction PRs and avoid duplicates, then close/delete through the normal stale/terminal path when appropriate.
+- **API surface parity:** The CLI result remains counts-only JSON; the workflow summary can continue reading the same result shape.
+- **Integration coverage:** The critical integration seam is `runPrs()` calling the existing planner/executor, not the planner in isolation.
+- **Unchanged invariants:** No automerge, no direct `main` writes, no scheduled PR execution, no repo variable change, no broad claim-kind graduation.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| Set-only graduation creates a false sense of functionality | Unit 1 completes the runner before Unit 3 graduates the kind. |
+| Permission widening surprises reviewers | Limit the change to the PR job's minted token and explain Issues API comments require `issues: write`. |
+| A future armed run opens an unexpected PR | Three-key arming remains; implementation does not set the repo variable or dispatch with `open_prs=true`. |
+| Public PR surfaces leak sensitive identifiers | Reuse existing public-output gate and opaque branch/title machinery; no new rendered fields. |
+
+## Documentation / Operational Notes
+
+- After this lands, `plan-consistency` is PR-eligible only when operators deliberately arm the workflow with both the repo variable and manual dispatch input.
+- A future operator rehearsal can use `open_prs=true` with `dry_run=true` to prove would-act counts before any live PR creation; that rehearsal is not part of this implementation.
+
+## Sources & References
+
+- Origin document: [docs/brainstorms/2026-07-03-bounded-correction-pr-execution-requirements.md](../brainstorms/2026-07-03-bounded-correction-pr-execution-requirements.md)
+- Foundation plan: [docs/plans/2026-07-03-001-feat-bounded-correction-pr-execution-plan.md](2026-07-03-001-feat-bounded-correction-pr-execution-plan.md)
+- Accepted evidence: [#3656](https://github.com/fro-bot/.github/issues/3656)
+- Supporting resolved-positive proposals: [#3614](https://github.com/fro-bot/.github/issues/3614), [#3615](https://github.com/fro-bot/.github/issues/3615), [#3616](https://github.com/fro-bot/.github/issues/3616)

--- a/scripts/status-truth-prs.test.ts
+++ b/scripts/status-truth-prs.test.ts
@@ -19,6 +19,7 @@ import type {
   ExecuteStatusTruthPrActionsInput,
   ExistingStatusTruthPr,
   PlanStatusTruthPrActionsInput,
+  RunPrsCoreDeps,
   StatusTruthPrAction,
   StatusTruthPrOctokitClient,
 } from './status-truth-prs.ts'
@@ -28,10 +29,14 @@ import {createHash} from 'node:crypto'
 import {describe, expect, it, vi} from 'vitest'
 import {
   executeStatusTruthPrActions,
+  extractTerminalFingerprint,
+  fetchExistingCorrectionPrs,
+  fetchTerminalFingerprints,
   GRADUATED_CLAIM_KINDS,
   planStatusTruthPrActions,
   PR_BRANCH_PREFIX,
   PR_TITLE_PREFIX,
+  runPrsCore,
 } from './status-truth-prs.ts'
 
 // Mirrors the production digest derivation so tests stay in sync without
@@ -1123,6 +1128,42 @@ describe('execution shell: createRef 422 collision policy', () => {
   })
 })
 
+describe('execution shell: close-pr ordering (closure before comment)', () => {
+  it('closes the PR and attempts branch delete even when posting the comment fails', async () => {
+    const action = makeClosePrAction()
+    const octokit = makeMockOctokit({
+      issues: {
+        createComment: vi.fn(async () => {
+          throw new Error('comment API failure')
+        }),
+      },
+    })
+
+    const result = await executeStatusTruthPrActions(makeExecuteInput({actions: [action], octokit}))
+
+    expect(octokit.rest.pulls.update).toHaveBeenCalled()
+    expect(octokit.rest.git.deleteRef).toHaveBeenCalled()
+    expect(result.counts.closed).toBe(1)
+    expect(result.counts.failed).toBe(0)
+  })
+
+  it('closes the PR even when the comment fails the public-output gate', async () => {
+    const action = makeClosePrAction()
+    const octokit = makeMockOctokit()
+    // Unloaded tokens force applyPublicOutputGate to block unconditionally
+    // (fail-closed), guaranteeing the comment gate fails for this test.
+    const unloadedTokens: PublicOutputTokens = {loaded: false, error: 'test: forced gate failure'}
+
+    const result = await executeStatusTruthPrActions(
+      makeExecuteInput({actions: [action], octokit, publicOutputTokens: unloadedTokens}),
+    )
+
+    expect(octokit.rest.pulls.update).toHaveBeenCalled()
+    expect(octokit.rest.issues.createComment).not.toHaveBeenCalled()
+    expect(result.counts.closed).toBe(1)
+  })
+})
+
 describe('execution shell: deleteRef 422 non-fatal', () => {
   it('counts the failure and continues when deleteRef 422s (already gone)', async () => {
     const action = makeClosePrAction()
@@ -1319,5 +1360,672 @@ describe('additional invariants', () => {
 
     expect(result.counts.pathForbidden).toBe(0)
     expect(result.counts.prActionsPlanned).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// runPrsCore() seam — same-run report-read, state-fetch, plan, execute
+// ---------------------------------------------------------------------------
+
+function makeTerminalFingerprintIssue(fingerprint: string, label: string) {
+  return {
+    number: 501,
+    labels: [{name: 'status-truth'}, {name: label}],
+    body: `<!-- status-truth:fingerprint=${fingerprint} -->\n\nbody text`,
+  }
+}
+
+function makeFetchClientStub(
+  overrides: {
+    prs?: readonly {
+      number: number
+      state: string
+      head: {ref: string}
+      base: {ref: string}
+      user: {login?: string | null} | null
+    }[]
+    issues?: readonly {number: number; labels: readonly {name?: string | null}[]; body?: string | null}[]
+  } = {},
+) {
+  const prs = overrides.prs ?? []
+  const issues = overrides.issues ?? []
+  return {
+    rest: {
+      pulls: {
+        list: vi.fn(async ({page}: {page: number}) => ({data: page === 1 ? prs : []})),
+      },
+      issues: {
+        listForRepo: vi.fn(async ({page}: {page: number}) => ({data: page === 1 ? issues : []})),
+      },
+    },
+  }
+}
+
+function makeRunPrsCoreDeps(overrides: Partial<RunPrsCoreDeps> = {}): RunPrsCoreDeps {
+  return {
+    env: {},
+    graduatedClaimKinds: new Set(['plan-consistency']),
+    readReport: vi.fn(async () => {
+      throw new Error('readReport not stubbed')
+    }),
+    loadPublicOutputTokens: vi.fn(async () => makeLoadedTokens()),
+    createFetchClient: vi.fn(async () => makeFetchClientStub() as never),
+    createWriteClient: vi.fn(async () => makeMockOctokit()),
+    writeStdout: vi.fn(),
+    writeStderr: vi.fn(),
+    writeResultFile: vi.fn(async () => undefined),
+    setExitCode: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('runPrsCore: disarmed mode', () => {
+  it('exits counts-only and does not require a report path or report read', async () => {
+    const readReport = vi.fn(async () => {
+      throw new Error('must not be called when disarmed')
+    })
+    const deps = makeRunPrsCoreDeps({
+      env: {},
+      readReport,
+    })
+
+    const result = await runPrsCore(deps)
+
+    expect(result.armed).toBe(false)
+    expect(readReport).not.toHaveBeenCalled()
+    expect(deps.setExitCode).not.toHaveBeenCalled()
+    expect(deps.writeStdout).toHaveBeenCalledTimes(1)
+    const stdoutArg = vi.mocked(deps.writeStdout).mock.calls[0]?.[0] as string
+    expect(stdoutArg).toContain('"armed":false')
+  })
+})
+
+describe('runPrsCore: armed dry-run', () => {
+  it('plans and reports would-open counts for a graduated plan-consistency drift with zero mutating calls', async () => {
+    const finding = makeDriftedFinding({fingerprint: 'abc123def456abcd', kind: 'plan-consistency'})
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const writeClient = makeMockOctokit()
+    const fetchClient = makeFetchClientStub()
+
+    const deps = makeRunPrsCoreDeps({
+      env: {
+        STATUS_TRUTH_PRS_ENABLED: 'true',
+        STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true',
+        STATUS_TRUTH_DRY_RUN: 'true',
+        STATUS_TRUTH_REPORT_PATH: '/tmp/report.json',
+        GITHUB_REPOSITORY: 'fro-bot/.github',
+      },
+      readReport: vi.fn(async () => ({valid: true as const, report})),
+      createFetchClient: vi.fn(async () => fetchClient as never),
+      createWriteClient: vi.fn(async () => writeClient),
+    })
+
+    const result = await runPrsCore(deps)
+
+    expect(result.armed).toBe(true)
+    expect(result.dryRun).toBe(true)
+    expect(result.plannedCounts.prActionsPlanned).toBe(1)
+    expect(result.executedCounts.wouldOpen).toBe(1)
+    expect(result.executedCounts.opened).toBe(0)
+
+    // Zero mutating calls in dry-run.
+    expect(writeClient.rest.git.createRef).not.toHaveBeenCalled()
+    expect(writeClient.rest.repos.createOrUpdateFileContents).not.toHaveBeenCalled()
+    expect(writeClient.rest.pulls.create).not.toHaveBeenCalled()
+    expect(writeClient.rest.pulls.update).not.toHaveBeenCalled()
+    expect(writeClient.rest.git.deleteRef).not.toHaveBeenCalled()
+  })
+})
+
+describe('runPrsCore: armed live mode', () => {
+  it('executes the open-pr action for one eligible plan-consistency finding and reports opened=1 when the mocked write client succeeds', async () => {
+    const finding = makeDriftedFinding({fingerprint: 'abc123def456abcd', kind: 'plan-consistency'})
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const writeClient = makeMockOctokit()
+    const fetchClient = makeFetchClientStub()
+
+    const deps = makeRunPrsCoreDeps({
+      env: {
+        STATUS_TRUTH_PRS_ENABLED: 'true',
+        STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true',
+        STATUS_TRUTH_REPORT_PATH: '/tmp/report.json',
+        GITHUB_REPOSITORY: 'fro-bot/.github',
+      },
+      readReport: vi.fn(async () => ({valid: true as const, report})),
+      createFetchClient: vi.fn(async () => fetchClient as never),
+      createWriteClient: vi.fn(async () => writeClient),
+    })
+
+    const result = await runPrsCore(deps)
+
+    expect(result.armed).toBe(true)
+    expect(result.dryRun).toBe(false)
+    expect(result.plannedCounts.prActionsPlanned).toBe(1)
+    expect(result.executedCounts.opened).toBe(1)
+    expect(result.executedCounts.failed).toBe(0)
+    expect(result.executedCounts.safetyRefused).toBe(0)
+
+    // Confirms the executor path actually ran mutating calls (not just planned).
+    expect(writeClient.rest.git.createRef).toHaveBeenCalledTimes(1)
+    expect(writeClient.rest.repos.createOrUpdateFileContents).toHaveBeenCalledTimes(1)
+    expect(writeClient.rest.pulls.create).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('runPrsCore: terminal fingerprint extraction', () => {
+  it('contributes a terminal fingerprint from a strictly-marked rejected/false-positive issue; accepted/resolved do not', async () => {
+    const rejectedFp = 'aaaa1111bbbb2222'
+    const falsePositiveFp = 'cccc3333dddd4444'
+    const acceptedFp = 'eeee5555ffff6666'
+    const resolvedFp = '1111222233334444'
+
+    const issues = [
+      makeTerminalFingerprintIssue(rejectedFp, 'status-truth:rejected'),
+      makeTerminalFingerprintIssue(falsePositiveFp, 'status-truth:false-positive'),
+      makeTerminalFingerprintIssue(acceptedFp, 'status-truth:accepted'),
+      makeTerminalFingerprintIssue(resolvedFp, 'status-truth:resolved'),
+    ]
+
+    const fetchClient = makeFetchClientStub({issues})
+    const terminals = await fetchTerminalFingerprints({
+      client: fetchClient as never,
+      owner: 'fro-bot',
+      repo: '.github',
+    })
+
+    expect(terminals.fingerprints.has(rejectedFp)).toBe(true)
+    expect(terminals.fingerprints.has(falsePositiveFp)).toBe(true)
+    expect(terminals.fingerprints.has(acceptedFp)).toBe(false)
+    expect(terminals.fingerprints.has(resolvedFp)).toBe(false)
+  })
+
+  it('excludes malformed, missing, non-hex, or duplicate terminal fingerprints and never suppresses via fuzzy matching', () => {
+    // Malformed: uppercase hex is not valid per the strict marker pattern.
+    expect(extractTerminalFingerprint('<!-- status-truth:fingerprint=ABCDEF -->')).toBeNull()
+    // Missing marker entirely.
+    expect(extractTerminalFingerprint('no marker here')).toBeNull()
+    // Non-hex characters.
+    expect(extractTerminalFingerprint('<!-- status-truth:fingerprint=zzzznothex -->')).toBeNull()
+    // Empty value.
+    expect(extractTerminalFingerprint('<!-- status-truth:fingerprint= -->')).toBeNull()
+    // Valid.
+    expect(extractTerminalFingerprint('<!-- status-truth:fingerprint=abc123 -->')).toBe('abc123')
+  })
+
+  it('counts duplicate terminal fingerprints across issues as skipped/invalid and does not suppress from either', async () => {
+    const dupFp = 'abc123def456abcd'
+    const issues = [
+      makeTerminalFingerprintIssue(dupFp, 'status-truth:rejected'),
+      makeTerminalFingerprintIssue(dupFp, 'status-truth:false-positive'),
+    ]
+    const fetchClient = makeFetchClientStub({issues})
+    const terminals = await fetchTerminalFingerprints({
+      client: fetchClient as never,
+      owner: 'fro-bot',
+      repo: '.github',
+    })
+
+    // Duplicate fingerprint across two terminal issues is excluded (fail-closed on
+    // ambiguity) — never trusted for suppression from either source.
+    expect(terminals.fingerprints.has(dupFp)).toBe(false)
+    expect(terminals.skippedInvalid).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe('fetchExistingCorrectionPrs: unfiltered candidate fetch', () => {
+  it('returns every open-against-main PR as a candidate with botOwned/branch/digest metadata, deferring rediscovery gating to the planner', async () => {
+    // This fetch is intentionally unfiltered by bot-ownership or branch-prefix
+    // criteria (see the function's doc comment) — it returns raw candidate
+    // records so the planner can independently gate rediscovery. Do not read
+    // this test as "the fetcher filters"; it asserts the fetcher preserves
+    // exactly the metadata the planner needs to do its own gating.
+    const fingerprint = 'abc123def456abcd'
+    const opaqueDigest = testDeriveOpaqueDigest(fingerprint)
+    const matchingPr = {
+      number: 42,
+      state: 'open',
+      head: {ref: `${PR_BRANCH_PREFIX}${opaqueDigest}`},
+      base: {ref: 'main'},
+      user: {login: 'fro-bot[bot]'},
+    }
+    const nonBotPr = {
+      number: 43,
+      state: 'open',
+      head: {ref: `${PR_BRANCH_PREFIX}otherdigest12345`},
+      base: {ref: 'main'},
+      user: {login: 'random-user'},
+    }
+    const nonPrefixPr = {
+      number: 45,
+      state: 'open',
+      head: {ref: 'some-other-branch'},
+      base: {ref: 'main'},
+      user: {login: 'fro-bot[bot]'},
+    }
+
+    const fetchClient = makeFetchClientStub({prs: [matchingPr, nonBotPr, nonPrefixPr]})
+    const existingPrs = await fetchExistingCorrectionPrs({
+      client: fetchClient as never,
+      owner: 'fro-bot',
+      repo: '.github',
+    })
+
+    // All three are returned as candidates — the fetcher does not filter.
+    expect(existingPrs).toHaveLength(3)
+
+    const found = existingPrs.find(pr => pr.number === 42)
+    expect(found?.botOwned).toBe(true)
+    expect(found?.headBranch).toBe(`${PR_BRANCH_PREFIX}${opaqueDigest}`)
+    expect(found?.baseBranch).toBe('main')
+    expect(found?.opaqueDigest).toBe(opaqueDigest)
+
+    const nonBot = existingPrs.find(pr => pr.number === 43)
+    expect(nonBot?.botOwned).toBe(false)
+
+    const nonPrefix = existingPrs.find(pr => pr.number === 45)
+    expect(nonPrefix?.opaqueDigest).toBe('')
+  })
+})
+
+describe('runPrsCore: planner gates rediscovery on bot ownership, base branch, and prefix', () => {
+  it('does not rediscover a same-digest, same-branch-prefix PR that is not bot-owned; plans a fresh open instead', async () => {
+    const fingerprint = 'abc123def456abcd'
+    const opaqueDigest = testDeriveOpaqueDigest(fingerprint)
+    const finding = makeDriftedFinding({fingerprint, kind: 'plan-consistency'})
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    // Candidate PR matches digest and branch prefix and base, but is NOT
+    // bot-owned — the planner must refuse to treat it as a rediscovery.
+    const nonBotCandidate = {
+      number: 43,
+      state: 'open',
+      head: {ref: `${PR_BRANCH_PREFIX}${opaqueDigest}`},
+      base: {ref: 'main'},
+      user: {login: 'random-user'},
+    }
+    const fetchClient = makeFetchClientStub({prs: [nonBotCandidate]})
+    const writeClient = makeMockOctokit()
+
+    const deps = makeRunPrsCoreDeps({
+      env: {
+        STATUS_TRUTH_PRS_ENABLED: 'true',
+        STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true',
+        STATUS_TRUTH_DRY_RUN: 'true',
+        STATUS_TRUTH_REPORT_PATH: '/tmp/report.json',
+        GITHUB_REPOSITORY: 'fro-bot/.github',
+      },
+      readReport: vi.fn(async () => ({valid: true as const, report})),
+      createFetchClient: vi.fn(async () => fetchClient as never),
+      createWriteClient: vi.fn(async () => writeClient),
+    })
+
+    const result = await runPrsCore(deps)
+
+    // A fresh open-pr action is planned (not a rediscover), because the
+    // candidate fails the bot-ownership gate.
+    expect(result.plannedCounts.prActionsPlanned).toBe(1)
+    expect(result.executedCounts.wouldOpen).toBe(1)
+  })
+})
+
+describe('runPrsCore: partial-success recovery', () => {
+  it('rediscovers an existing matching correction PR from a prior partial run and still allows stale/terminal closure planning', async () => {
+    const fingerprint = 'abc123def456abcd'
+    const opaqueDigest = testDeriveOpaqueDigest(fingerprint)
+    const finding = makeDriftedFinding({fingerprint, kind: 'plan-consistency'})
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+
+    const existingPr = {
+      number: 77,
+      state: 'open',
+      head: {ref: `${PR_BRANCH_PREFIX}${opaqueDigest}`},
+      base: {ref: 'main'},
+      user: {login: 'fro-bot[bot]'},
+    }
+    const fetchClient = makeFetchClientStub({prs: [existingPr]})
+    const writeClient = makeMockOctokit()
+
+    const deps = makeRunPrsCoreDeps({
+      env: {
+        STATUS_TRUTH_PRS_ENABLED: 'true',
+        STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true',
+        STATUS_TRUTH_DRY_RUN: 'true',
+        STATUS_TRUTH_REPORT_PATH: '/tmp/report.json',
+        GITHUB_REPOSITORY: 'fro-bot/.github',
+      },
+      readReport: vi.fn(async () => ({valid: true as const, report})),
+      createFetchClient: vi.fn(async () => fetchClient as never),
+      createWriteClient: vi.fn(async () => writeClient),
+    })
+
+    const result = await runPrsCore(deps)
+
+    // No duplicate open-pr planned; rediscovery instead.
+    expect(result.plannedCounts.prActionsPlanned).toBe(1)
+    expect(result.executedCounts.wouldOpen).toBe(0)
+  })
+})
+
+describe('runPrsCore: error paths exit non-zero before mutation', () => {
+  it('exits non-zero when the report path is missing', async () => {
+    const writeClient = makeMockOctokit()
+    const deps = makeRunPrsCoreDeps({
+      env: {
+        STATUS_TRUTH_PRS_ENABLED: 'true',
+        STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true',
+      },
+      createWriteClient: vi.fn(async () => writeClient),
+    })
+
+    await runPrsCore(deps)
+
+    expect(deps.setExitCode).toHaveBeenCalledWith(1)
+    expect(writeClient.rest.pulls.create).not.toHaveBeenCalled()
+  })
+
+  it('exits non-zero when the report is malformed', async () => {
+    const writeClient = makeMockOctokit()
+    const deps = makeRunPrsCoreDeps({
+      env: {
+        STATUS_TRUTH_PRS_ENABLED: 'true',
+        STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true',
+        STATUS_TRUTH_REPORT_PATH: '/tmp/report.json',
+      },
+      readReport: vi.fn(async () => ({valid: false as const, reason: 'artifact validation failed'})),
+      createWriteClient: vi.fn(async () => writeClient),
+    })
+
+    await runPrsCore(deps)
+
+    expect(deps.setExitCode).toHaveBeenCalledWith(1)
+    expect(writeClient.rest.pulls.create).not.toHaveBeenCalled()
+  })
+
+  it('exits non-zero when the existing-state fetch fails in live (non-dry-run) mode', async () => {
+    const report = makeReport()
+    const writeClient = makeMockOctokit()
+    const deps = makeRunPrsCoreDeps({
+      env: {
+        STATUS_TRUTH_PRS_ENABLED: 'true',
+        STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true',
+        STATUS_TRUTH_REPORT_PATH: '/tmp/report.json',
+        GITHUB_REPOSITORY: 'fro-bot/.github',
+      },
+      readReport: vi.fn(async () => ({valid: true as const, report})),
+      createFetchClient: vi.fn(async () => {
+        throw new Error('state fetch failed')
+      }),
+      createWriteClient: vi.fn(async () => writeClient),
+    })
+
+    await runPrsCore(deps)
+
+    expect(deps.setExitCode).toHaveBeenCalledWith(1)
+    expect(writeClient.rest.pulls.create).not.toHaveBeenCalled()
+  })
+
+  it('exits non-zero when the public-output token load fails', async () => {
+    const report = makeReport()
+    const writeClient = makeMockOctokit()
+    const deps = makeRunPrsCoreDeps({
+      env: {
+        STATUS_TRUTH_PRS_ENABLED: 'true',
+        STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true',
+        STATUS_TRUTH_REPORT_PATH: '/tmp/report.json',
+        GITHUB_REPOSITORY: 'fro-bot/.github',
+      },
+      readReport: vi.fn(async () => ({valid: true as const, report})),
+      loadPublicOutputTokens: vi.fn(async () => {
+        throw new Error('token load failed')
+      }),
+      createWriteClient: vi.fn(async () => writeClient),
+    })
+
+    await runPrsCore(deps)
+
+    expect(deps.setExitCode).toHaveBeenCalledWith(1)
+    expect(writeClient.rest.pulls.create).not.toHaveBeenCalled()
+  })
+})
+
+describe('runPrsCore: output privacy', () => {
+  it('stdout and error messages contain only counts and reason keys, never paths/fingerprints/branch/PR identifiers/tokens', async () => {
+    const fingerprint = 'abc123def456abcd'
+    const finding = makeDriftedFinding({fingerprint, kind: 'plan-consistency', path: 'docs/plans/example.md'})
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const fetchClient = makeFetchClientStub()
+    const writeClient = makeMockOctokit()
+
+    const deps = makeRunPrsCoreDeps({
+      env: {
+        STATUS_TRUTH_PRS_ENABLED: 'true',
+        STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true',
+        STATUS_TRUTH_DRY_RUN: 'true',
+        STATUS_TRUTH_REPORT_PATH: '/secret/path/report.json',
+        GITHUB_REPOSITORY: 'fro-bot/.github',
+      },
+      readReport: vi.fn(async () => ({valid: true as const, report})),
+      createFetchClient: vi.fn(async () => fetchClient as never),
+      createWriteClient: vi.fn(async () => writeClient),
+    })
+
+    await runPrsCore(deps)
+
+    const stdoutCalls = vi.mocked(deps.writeStdout).mock.calls.map(c => c[0])
+    const stderrCalls = vi.mocked(deps.writeStderr).mock.calls.map(c => c[0])
+    const allOutput = [...stdoutCalls, ...stderrCalls].join('\n')
+
+    expect(allOutput).not.toContain('/secret/path/report.json')
+    expect(allOutput).not.toContain('docs/plans/example.md')
+    expect(allOutput).not.toContain(fingerprint)
+    expect(allOutput).not.toContain(PR_BRANCH_PREFIX)
+    expect(allOutput).not.toContain('example.md')
+  })
+})
+
+describe('runPrsCore: dry-run does not require a write client', () => {
+  it('still returns counts/would-act with no crash when createWriteClient throws in dry-run', async () => {
+    const finding = makeDriftedFinding({fingerprint: 'abc123def456abcd', kind: 'plan-consistency'})
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const fetchClient = makeFetchClientStub()
+    const createWriteClient = vi.fn(async (): Promise<StatusTruthPrOctokitClient> => {
+      throw new Error('write client creation must not be attempted in dry-run')
+    })
+
+    const deps = makeRunPrsCoreDeps({
+      env: {
+        STATUS_TRUTH_PRS_ENABLED: 'true',
+        STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true',
+        STATUS_TRUTH_DRY_RUN: 'true',
+        STATUS_TRUTH_REPORT_PATH: '/tmp/report.json',
+        GITHUB_REPOSITORY: 'fro-bot/.github',
+      },
+      readReport: vi.fn(async () => ({valid: true as const, report})),
+      createFetchClient: vi.fn(async () => fetchClient as never),
+      createWriteClient,
+    })
+
+    const result = await runPrsCore(deps)
+
+    expect(deps.setExitCode).not.toHaveBeenCalledWith(1)
+    expect(result.armed).toBe(true)
+    expect(result.dryRun).toBe(true)
+    expect(result.executedCounts.wouldOpen).toBe(1)
+    expect(result.executedCounts.opened).toBe(0)
+  })
+})
+
+describe('runPrsCore: error paths still write counts-only JSON to stdout/result', () => {
+  it('writes a parseable JSON result with no sensitive strings when the report path is missing', async () => {
+    const deps = makeRunPrsCoreDeps({
+      env: {
+        STATUS_TRUTH_PRS_ENABLED: 'true',
+        STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true',
+      },
+    })
+
+    await runPrsCore(deps)
+
+    expect(deps.setExitCode).toHaveBeenCalledWith(1)
+    expect(deps.writeStdout).toHaveBeenCalledTimes(1)
+    const stdoutArg = vi.mocked(deps.writeStdout).mock.calls[0]?.[0] as string
+    expect(() => {
+      JSON.parse(stdoutArg)
+    }).not.toThrow()
+    const parsed = JSON.parse(stdoutArg) as Record<string, unknown>
+    expect(parsed.armed).toBe(true)
+    expect(stdoutArg).not.toContain('STATUS_TRUTH_REPORT_PATH')
+  })
+
+  it('writes a parseable JSON result with no sensitive strings when the token load fails', async () => {
+    const report = makeReport()
+    const deps = makeRunPrsCoreDeps({
+      env: {
+        STATUS_TRUTH_PRS_ENABLED: 'true',
+        STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true',
+        STATUS_TRUTH_REPORT_PATH: '/secret/path/report.json',
+        GITHUB_REPOSITORY: 'fro-bot/.github',
+      },
+      readReport: vi.fn(async () => ({valid: true as const, report})),
+      loadPublicOutputTokens: vi.fn(async () => {
+        throw new Error('token load failed')
+      }),
+    })
+
+    await runPrsCore(deps)
+
+    expect(deps.setExitCode).toHaveBeenCalledWith(1)
+    expect(deps.writeStdout).toHaveBeenCalledTimes(1)
+    const stdoutArg = vi.mocked(deps.writeStdout).mock.calls[0]?.[0] as string
+    expect(() => {
+      JSON.parse(stdoutArg)
+    }).not.toThrow()
+    const parsed = JSON.parse(stdoutArg) as Record<string, unknown>
+    expect(parsed.armed).toBe(true)
+    expect(stdoutArg).not.toContain('/secret/path/report.json')
+  })
+})
+
+describe('executeStatusTruthPrActions: dry-run wouldRediscover count', () => {
+  it('counts rediscover-pr actions separately from wouldOpen/wouldClose', async () => {
+    const digest = testDeriveOpaqueDigest('abc123def456abcd')
+    const rediscoverAction: Extract<StatusTruthPrAction, {type: 'rediscover-pr'}> = {
+      type: 'rediscover-pr',
+      existingPrNumber: 77,
+      opaqueDigest: digest,
+    }
+    const octokit = makeMockOctokit()
+
+    const result = await executeStatusTruthPrActions(
+      makeExecuteInput({actions: [rediscoverAction], octokit, dryRun: true}),
+    )
+
+    expect(result.counts.wouldRediscover).toBe(1)
+    expect(result.counts.wouldOpen).toBe(0)
+  })
+})
+
+describe('runPrsCore: dry-run wouldRediscover for existing matching correction PR', () => {
+  it('reports wouldRediscover=1 and wouldOpen=0', async () => {
+    const fingerprint = 'abc123def456abcd'
+    const opaqueDigest = testDeriveOpaqueDigest(fingerprint)
+    const finding = makeDriftedFinding({fingerprint, kind: 'plan-consistency'})
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const existingPr = {
+      number: 77,
+      state: 'open',
+      head: {ref: `${PR_BRANCH_PREFIX}${opaqueDigest}`},
+      base: {ref: 'main'},
+      user: {login: 'fro-bot[bot]'},
+    }
+    const fetchClient = makeFetchClientStub({prs: [existingPr]})
+    const writeClient = makeMockOctokit()
+
+    const deps = makeRunPrsCoreDeps({
+      env: {
+        STATUS_TRUTH_PRS_ENABLED: 'true',
+        STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true',
+        STATUS_TRUTH_DRY_RUN: 'true',
+        STATUS_TRUTH_REPORT_PATH: '/tmp/report.json',
+        GITHUB_REPOSITORY: 'fro-bot/.github',
+      },
+      readReport: vi.fn(async () => ({valid: true as const, report})),
+      createFetchClient: vi.fn(async () => fetchClient as never),
+      createWriteClient: vi.fn(async () => writeClient),
+    })
+
+    const result = await runPrsCore(deps)
+
+    expect(result.executedCounts.wouldRediscover).toBe(1)
+    expect(result.executedCounts.wouldOpen).toBe(0)
+  })
+})
+
+describe('fetchTerminalFingerprints: includes open issues', () => {
+  it('contributes a terminal fingerprint from an open issue carrying a terminal label', async () => {
+    const openTerminalFp = 'ffff9999eeee8888'
+    const issues = [makeTerminalFingerprintIssue(openTerminalFp, 'status-truth:rejected')]
+    const fetchClient = {
+      rest: {
+        pulls: {list: vi.fn(async () => ({data: []}))},
+        issues: {
+          listForRepo: vi.fn(async (params: {state: string; page: number}) => ({
+            data: params.state === 'all' && params.page === 1 ? issues : [],
+          })),
+        },
+      },
+    }
+
+    const terminals = await fetchTerminalFingerprints({
+      client: fetchClient as never,
+      owner: 'fro-bot',
+      repo: '.github',
+    })
+
+    expect(terminals.fingerprints.has(openTerminalFp)).toBe(true)
+    expect(fetchClient.rest.issues.listForRepo).toHaveBeenCalledWith(expect.objectContaining({state: 'all'}))
+  })
+})
+
+describe('fetchTerminalFingerprints: duplicateCount observability', () => {
+  it('reports a numeric duplicateCount without leaking raw fingerprints', async () => {
+    const dupFp = 'abc123def456abcd'
+    const issues = [
+      makeTerminalFingerprintIssue(dupFp, 'status-truth:rejected'),
+      makeTerminalFingerprintIssue(dupFp, 'status-truth:false-positive'),
+    ]
+    const fetchClient = makeFetchClientStub({issues})
+
+    const terminals = await fetchTerminalFingerprints({
+      client: fetchClient as never,
+      owner: 'fro-bot',
+      repo: '.github',
+    })
+
+    expect(terminals.duplicateCount).toBe(1)
+    expect(JSON.stringify(terminals.duplicateCount)).not.toContain(dupFp)
   })
 })

--- a/scripts/status-truth-prs.test.ts
+++ b/scripts/status-truth-prs.test.ts
@@ -36,6 +36,7 @@ import {
   fetchExistingCorrectionPrs,
   fetchTerminalFingerprints,
   GRADUATED_CLAIM_KINDS,
+  isPrExecutionArmed,
   planStatusTruthPrActions,
   PR_BRANCH_PREFIX,
   PR_TITLE_PREFIX,
@@ -225,12 +226,67 @@ describe('happy path: graduated claim kind', () => {
     }
   })
 
-  it('GRADUATED_CLAIM_KINDS export is a readonly set (intentionally empty in Phase 1)', () => {
+  it('GRADUATED_CLAIM_KINDS export contains exactly plan-consistency (graduated on #3656 + #3614-#3616 evidence)', () => {
     expect(GRADUATED_CLAIM_KINDS).toBeDefined()
     expect(typeof GRADUATED_CLAIM_KINDS).toBe('object')
-    // Phase 1: no claim kinds are graduated yet; set is empty by design.
-    // To graduate a kind, add it via a reviewed repo change after Phase 1 signal.
-    expect(GRADUATED_CLAIM_KINDS.size).toBe(0)
+    expect(GRADUATED_CLAIM_KINDS.size).toBe(1)
+    expect(GRADUATED_CLAIM_KINDS.has('plan-consistency')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isPrExecutionArmed: three-key arming gate
+// ---------------------------------------------------------------------------
+
+describe('isPrExecutionArmed', () => {
+  it('is armed only when repo variable, dispatch input, and graduated set are all true/non-empty', () => {
+    expect(
+      isPrExecutionArmed({
+        prsEnabledVar: 'true',
+        dispatchInputVar: 'true',
+        graduatedClaimKinds: GRADUATED_CLAIM_KINDS,
+      }),
+    ).toBe(true)
+  })
+
+  it('stays false when the repo variable is missing', () => {
+    expect(
+      isPrExecutionArmed({
+        prsEnabledVar: undefined,
+        dispatchInputVar: 'true',
+        graduatedClaimKinds: new Set(['plan-consistency']),
+      }),
+    ).toBe(false)
+  })
+
+  it('stays false when the dispatch input is missing', () => {
+    expect(
+      isPrExecutionArmed({
+        prsEnabledVar: 'true',
+        dispatchInputVar: undefined,
+        graduatedClaimKinds: new Set(['plan-consistency']),
+      }),
+    ).toBe(false)
+  })
+
+  it('stays false when the graduated set is empty, even with both other keys true', () => {
+    expect(
+      isPrExecutionArmed({
+        prsEnabledVar: 'true',
+        dispatchInputVar: 'true',
+        graduatedClaimKinds: new Set(),
+      }),
+    ).toBe(false)
+  })
+
+  it('stays false when all three keys are absent/false/empty', () => {
+    expect(
+      isPrExecutionArmed({
+        prsEnabledVar: undefined,
+        dispatchInputVar: undefined,
+        graduatedClaimKinds: new Set(),
+      }),
+    ).toBe(false)
   })
 })
 

--- a/scripts/status-truth-prs.test.ts
+++ b/scripts/status-truth-prs.test.ts
@@ -26,7 +26,10 @@ import type {
 import type {PublicOutputTokens} from './status-truth-public-output.ts'
 import {Buffer} from 'node:buffer'
 import {createHash} from 'node:crypto'
+import {readFileSync} from 'node:fs'
+import {resolve} from 'node:path'
 import {describe, expect, it, vi} from 'vitest'
+import {parse} from 'yaml'
 import {
   executeStatusTruthPrActions,
   extractTerminalFingerprint,
@@ -2027,5 +2030,71 @@ describe('fetchTerminalFingerprints: duplicateCount observability', () => {
 
     expect(terminals.duplicateCount).toBe(1)
     expect(JSON.stringify(terminals.duplicateCount)).not.toContain(dupFp)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Workflow contract: PR job App-token permission scope
+// ---------------------------------------------------------------------------
+
+/** Narrow the parsed YAML to the shape we index into, without any broad cast. */
+function assertStatusTruthWorkflow(value: unknown): asserts value is {
+  jobs: Record<
+    string,
+    {
+      if?: string
+      permissions?: Record<string, string>
+      steps: {name?: string; uses?: string; with?: Record<string, string>}[]
+    }
+  >
+} {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    !('jobs' in value) ||
+    typeof (value as Record<string, unknown>).jobs !== 'object'
+  ) {
+    throw new TypeError('status-truth.yaml does not have expected shape: missing jobs object')
+  }
+}
+
+describe('workflow contract: PR job app-token permissions', () => {
+  const workflowPath = resolve(import.meta.dirname, '../.github/workflows/status-truth.yaml')
+  const parsed: unknown = parse(readFileSync(workflowPath, 'utf8'))
+  assertStatusTruthWorkflow(parsed)
+  const prsJob = parsed.jobs.prs
+
+  it('has a prs job with a Mint write token step using create-github-app-token', () => {
+    expect(prsJob).toBeDefined()
+    const appTokenStep = prsJob?.steps.find(s => s.uses?.includes('actions/create-github-app-token'))
+    expect(appTokenStep).toBeDefined()
+  })
+
+  it('mints the PR job app-token with issues: write (required for stale/terminal closure comments)', () => {
+    const appTokenStep = prsJob?.steps.find(s => s.uses?.includes('actions/create-github-app-token'))
+    expect(appTokenStep?.with?.['permission-issues']).toBe('write')
+  })
+
+  it('mints the PR job app-token with pull-requests: write and contents: write', () => {
+    const appTokenStep = prsJob?.steps.find(s => s.uses?.includes('actions/create-github-app-token'))
+    expect(appTokenStep?.with?.['permission-pull-requests']).toBe('write')
+    expect(appTokenStep?.with?.['permission-contents']).toBe('write')
+  })
+
+  it('keeps the PR job app-token scoped to this repository only', () => {
+    const appTokenStep = prsJob?.steps.find(s => s.uses?.includes('actions/create-github-app-token'))
+    const expectedRepositoryScope = '$' + '{{ github.event.repository.name }}'
+    expect(appTokenStep?.with?.repositories).toBe(expectedRepositoryScope)
+  })
+
+  it('keeps the PR job-level permissions read-only (contents: read)', () => {
+    expect(prsJob?.permissions).toEqual({contents: 'read'})
+  })
+
+  it('keeps the PR job if: gated on the repo variable, workflow_dispatch, and open_prs input', () => {
+    expect(prsJob?.if).toContain('vars.STATUS_TRUTH_PRS_ENABLED')
+    expect(prsJob?.if).toContain("== 'true'")
+    expect(prsJob?.if).toContain("github.event_name == 'workflow_dispatch'")
+    expect(prsJob?.if).toContain("github.event.inputs.open_prs == 'true'")
   })
 })

--- a/scripts/status-truth-prs.test.ts
+++ b/scripts/status-truth-prs.test.ts
@@ -21,6 +21,7 @@ import type {
   PlanStatusTruthPrActionsInput,
   RunPrsCoreDeps,
   StatusTruthPrAction,
+  StatusTruthPrFetchClient,
   StatusTruthPrOctokitClient,
 } from './status-truth-prs.ts'
 import type {PublicOutputTokens} from './status-truth-public-output.ts'
@@ -28,9 +29,11 @@ import {Buffer} from 'node:buffer'
 import {createHash} from 'node:crypto'
 import {readFileSync} from 'node:fs'
 import {resolve} from 'node:path'
+import process from 'node:process'
 import {describe, expect, it, vi} from 'vitest'
 import {parse} from 'yaml'
 import {
+  buildEnvBackedRunPrsCoreDeps,
   executeStatusTruthPrActions,
   extractTerminalFingerprint,
   fetchExistingCorrectionPrs,
@@ -40,8 +43,10 @@ import {
   planStatusTruthPrActions,
   PR_BRANCH_PREFIX,
   PR_TITLE_PREFIX,
+  runPrs,
   runPrsCore,
 } from './status-truth-prs.ts'
+import * as publicOutputModule from './status-truth-public-output.ts'
 
 // Mirrors the production digest derivation so tests stay in sync without
 // importing the private helper.
@@ -934,6 +939,7 @@ function makeOpenPrAction(overrides: Partial<Extract<StatusTruthPrAction, {type:
     opaqueDigest: digest,
     path: 'docs/plans/example-plan.md',
     kind: 'plan-consistency',
+    fingerprint: 'abc123def456abcd',
     ...overrides,
   }
 }
@@ -1250,7 +1256,7 @@ describe('execution shell: pulls.create isolated failure', () => {
     const octokit = makeMockOctokit({
       pulls: {
         create: vi.fn(async () => {
-          throw new Error('API failure')
+          throw new Error('API failure: token=super-secret-value')
         }),
         update: vi.fn(async () => ({data: {number: 101}})),
       },
@@ -1263,21 +1269,187 @@ describe('execution shell: pulls.create isolated failure', () => {
   })
 })
 
-describe('execution shell: privacy gate on rendered surfaces', () => {
-  it('aborts the open-pr action when the rendered PR body fails the public-output gate', async () => {
+describe('execution shell: action-failure diagnostics', () => {
+  it('emits a privacy-safe open-pr diagnostic with action type, error-class, and numeric status, never raw message text', async () => {
     const action = makeOpenPrAction()
+    const octokit = makeMockOctokit({
+      pulls: {
+        create: vi.fn(async () => {
+          throw Object.assign(new Error('super-secret-message-should-not-leak'), {status: 500})
+        }),
+        update: vi.fn(async () => ({data: {number: 101}})),
+      },
+    })
+    const writeStderr = vi.fn<(text: string) => void>()
+
+    const result = await executeStatusTruthPrActions(makeExecuteInput({actions: [action], octokit, writeStderr}))
+
+    expect(result.counts.failed).toBe(1)
+    expect(writeStderr).toHaveBeenCalled()
+    const diagnostic = vi
+      .mocked(writeStderr)
+      .mock.calls.map(c => c[0])
+      .join('\n')
+    expect(diagnostic).toContain('action=open-pr')
+    expect(diagnostic).toContain('error-class=action-failure')
+    expect(diagnostic).toContain('status=500')
+    expect(diagnostic).not.toContain('super-secret-message-should-not-leak')
+  })
+
+  it('emits a privacy-safe close-pr diagnostic without a status when the error carries none, never raw message text', async () => {
+    const action = makeClosePrAction()
+    const octokit = makeMockOctokit({
+      pulls: {
+        create: vi.fn(async () => ({data: {number: 101}})),
+        update: vi.fn(async () => {
+          throw new Error('super-secret-message-should-not-leak')
+        }),
+      },
+    })
+    const writeStderr = vi.fn<(text: string) => void>()
+
+    const result = await executeStatusTruthPrActions(makeExecuteInput({actions: [action], octokit, writeStderr}))
+
+    expect(result.counts.failed).toBe(1)
+    const diagnostic = vi
+      .mocked(writeStderr)
+      .mock.calls.map(c => c[0])
+      .join('\n')
+    expect(diagnostic).toContain('action=close-pr')
+    expect(diagnostic).toContain('error-class=action-failure')
+    expect(diagnostic).not.toContain('status=')
+    expect(diagnostic).not.toContain('super-secret-message-should-not-leak')
+  })
+})
+
+describe('execution shell: downgrade classification for live-content 404', () => {
+  it('classifies a 404 on live base-branch getContent as downgraded, not failed', async () => {
+    const action = makeOpenPrAction()
+    const octokit = makeMockOctokit({
+      repos: {
+        getContent: vi.fn(async () => {
+          throw Object.assign(new Error('Not Found'), {status: 404})
+        }),
+        createOrUpdateFileContents: vi.fn(async () => ({data: {commit: {sha: 'commit-sha-1'}}})),
+      },
+    })
+
+    const result = await executeStatusTruthPrActions(makeExecuteInput({actions: [action], octokit}))
+
+    expect(result.counts.downgraded).toBe(1)
+    expect(result.counts.failed).toBe(0)
+    expect(octokit.rest.git.createRef).not.toHaveBeenCalled()
+  })
+
+  it('re-throws (counts as failed) a non-404 API error on live-content getContent', async () => {
+    const action = makeOpenPrAction()
+    const octokit = makeMockOctokit({
+      repos: {
+        getContent: vi.fn(async () => {
+          throw Object.assign(new Error('Internal Server Error'), {status: 500})
+        }),
+        createOrUpdateFileContents: vi.fn(async () => ({data: {commit: {sha: 'commit-sha-1'}}})),
+      },
+    })
+
+    const result = await executeStatusTruthPrActions(makeExecuteInput({actions: [action], octokit}))
+
+    expect(result.counts.failed).toBe(1)
+    expect(result.counts.downgraded).toBe(0)
+  })
+
+  it('classifies a branch-collision getContent 404 as safetyRefused, not failed', async () => {
+    const action = makeOpenPrAction()
+    const octokit = makeMockOctokit({
+      git: {
+        getRef: vi.fn(async () => ({data: {object: {sha: 'base-sha-1'}}})),
+        createRef: vi.fn(async () => {
+          throw Object.assign(new Error('Reference already exists'), {status: 422})
+        }),
+        deleteRef: vi.fn(async () => undefined),
+      },
+      repos: {
+        getContent: vi.fn(async (params: {ref?: string}) => {
+          if (params.ref === action.opaqueBranchName) {
+            throw Object.assign(new Error('Not Found'), {status: 404})
+          }
+          return {
+            data: {
+              content: Buffer.from(STALE_PLAN_CONTENT, 'utf8').toString('base64'),
+              encoding: 'base64',
+              sha: 'blob-sha-1',
+            },
+          }
+        }),
+        createOrUpdateFileContents: vi.fn(async () => ({data: {commit: {sha: 'commit-sha-1'}}})),
+      },
+    })
+
+    const result = await executeStatusTruthPrActions(makeExecuteInput({actions: [action], octokit}))
+
+    expect(result.counts.safetyRefused).toBe(1)
+    expect(result.counts.failed).toBe(0)
+    expect(octokit.rest.pulls.create).not.toHaveBeenCalled()
+  })
+})
+
+describe('execution shell: corrector-returning-null and decodeGetContentResponse-null downgrades', () => {
+  it('downgrades when the corrector returns null for the live content', async () => {
+    const action = makeOpenPrAction({kind: 'plan-consistency', path: 'docs/plans/no-status-line.md'})
+    const noStatusLineContent = '# A plan with no status line at all\n'
+    const octokit = makeMockOctokit({
+      repos: {
+        getContent: vi.fn(async () => ({
+          data: {
+            content: Buffer.from(noStatusLineContent, 'utf8').toString('base64'),
+            encoding: 'base64',
+            sha: 'blob-sha-x',
+          },
+        })),
+        createOrUpdateFileContents: vi.fn(async () => ({data: {commit: {sha: 'commit-sha-1'}}})),
+      },
+    })
+
+    const result = await executeStatusTruthPrActions(makeExecuteInput({actions: [action], octokit}))
+
+    expect(result.counts.downgraded).toBe(1)
+    expect(result.counts.opened).toBe(0)
+    expect(octokit.rest.git.createRef).not.toHaveBeenCalled()
+  })
+
+  it('downgrades when decodeGetContentResponse returns null (missing content field)', async () => {
+    const action = makeOpenPrAction()
+    const octokit = makeMockOctokit({
+      repos: {
+        getContent: vi.fn(async () => ({
+          data: {sha: 'blob-sha-y'},
+        })),
+        createOrUpdateFileContents: vi.fn(async () => ({data: {commit: {sha: 'commit-sha-1'}}})),
+      },
+    })
+
+    const result = await executeStatusTruthPrActions(makeExecuteInput({actions: [action], octokit}))
+
+    expect(result.counts.downgraded).toBe(1)
+    expect(result.counts.opened).toBe(0)
+    expect(octokit.rest.git.createRef).not.toHaveBeenCalled()
+  })
+})
+
+describe('execution shell: privacy gate on rendered surfaces', () => {
+  it('threads the action fingerprint into the title/body gate calls (public-output gate symmetry)', async () => {
+    const action = makeOpenPrAction({fingerprint: 'abc123def456abcd'})
     const octokit = makeMockOctokit()
+    const gateSpy = vi.spyOn(publicOutputModule, 'applyPublicOutputGate')
 
-    const result = await executeStatusTruthPrActions(
-      makeExecuteInput({actions: [action], octokit, publicOutputTokens: makeBlockingTokens()}),
-    )
+    await executeStatusTruthPrActions(makeExecuteInput({actions: [action], octokit}))
 
-    // opaqueTitle/body here do not literally contain 'private-repo-name', so this
-    // exercises the gate pass-through path; the safety net still requires zero
-    // writes on any gate failure. Assert the gate ran (no crash) and, when the
-    // fixed body/title strings do not trip the blocking tokens, the action still
-    // succeeds — proving the gate call site exists in the write path.
-    expect(result.counts.opened + result.counts.safetyRefused).toBeGreaterThanOrEqual(0)
+    const titleCall = gateSpy.mock.calls.find(([params]) => params.surface === 'pr-title')
+    const bodyCall = gateSpy.mock.calls.find(([params]) => params.surface === 'pr-body')
+    expect(titleCall?.[0].fingerprint).toBe('abc123def456abcd')
+    expect(bodyCall?.[0].fingerprint).toBe('abc123def456abcd')
+
+    gateSpy.mockRestore()
   })
 })
 
@@ -1426,11 +1598,12 @@ describe('additional invariants', () => {
 // runPrsCore() seam — same-run report-read, state-fetch, plan, execute
 // ---------------------------------------------------------------------------
 
-function makeTerminalFingerprintIssue(fingerprint: string, label: string) {
+function makeTerminalFingerprintIssue(fingerprint: string, label: string, login = 'fro-bot[bot]') {
   return {
     number: 501,
     labels: [{name: 'status-truth'}, {name: label}],
     body: `<!-- status-truth:fingerprint=${fingerprint} -->\n\nbody text`,
+    user: {login},
   }
 }
 
@@ -1443,21 +1616,30 @@ function makeFetchClientStub(
       base: {ref: string}
       user: {login?: string | null} | null
     }[]
-    issues?: readonly {number: number; labels: readonly {name?: string | null}[]; body?: string | null}[]
+    issues?: readonly {
+      number: number
+      labels: readonly {name?: string | null}[]
+      body?: string | null
+      user?: {login?: string | null} | null
+    }[]
+    alwaysFullPrPages?: boolean
+    alwaysFullIssuePages?: boolean
   } = {},
-) {
+): StatusTruthPrFetchClient {
   const prs = overrides.prs ?? []
   const issues = overrides.issues ?? []
   return {
     rest: {
       pulls: {
-        list: vi.fn(async ({page}: {page: number}) => ({data: page === 1 ? prs : []})),
+        list: vi.fn(async ({page}: {page: number}) => ({data: overrides.alwaysFullPrPages || page === 1 ? prs : []})),
       },
       issues: {
-        listForRepo: vi.fn(async ({page}: {page: number}) => ({data: page === 1 ? issues : []})),
+        listForRepo: vi.fn(async ({page}: {page: number}) => ({
+          data: overrides.alwaysFullIssuePages || page === 1 ? issues : [],
+        })),
       },
     },
-  }
+  } as unknown as StatusTruthPrFetchClient
 }
 
 function makeRunPrsCoreDeps(overrides: Partial<RunPrsCoreDeps> = {}): RunPrsCoreDeps {
@@ -1468,7 +1650,7 @@ function makeRunPrsCoreDeps(overrides: Partial<RunPrsCoreDeps> = {}): RunPrsCore
       throw new Error('readReport not stubbed')
     }),
     loadPublicOutputTokens: vi.fn(async () => makeLoadedTokens()),
-    createFetchClient: vi.fn(async () => makeFetchClientStub() as never),
+    createFetchClient: vi.fn(async () => makeFetchClientStub()),
     createWriteClient: vi.fn(async () => makeMockOctokit()),
     writeStdout: vi.fn(),
     writeStderr: vi.fn(),
@@ -1519,7 +1701,7 @@ describe('runPrsCore: armed dry-run', () => {
         GITHUB_REPOSITORY: 'fro-bot/.github',
       },
       readReport: vi.fn(async () => ({valid: true as const, report})),
-      createFetchClient: vi.fn(async () => fetchClient as never),
+      createFetchClient: vi.fn(async () => fetchClient),
       createWriteClient: vi.fn(async () => writeClient),
     })
 
@@ -1559,7 +1741,7 @@ describe('runPrsCore: armed live mode', () => {
         GITHUB_REPOSITORY: 'fro-bot/.github',
       },
       readReport: vi.fn(async () => ({valid: true as const, report})),
-      createFetchClient: vi.fn(async () => fetchClient as never),
+      createFetchClient: vi.fn(async () => fetchClient),
       createWriteClient: vi.fn(async () => writeClient),
     })
 
@@ -1595,7 +1777,7 @@ describe('runPrsCore: terminal fingerprint extraction', () => {
 
     const fetchClient = makeFetchClientStub({issues})
     const terminals = await fetchTerminalFingerprints({
-      client: fetchClient as never,
+      client: fetchClient,
       owner: 'fro-bot',
       repo: '.github',
     })
@@ -1627,7 +1809,7 @@ describe('runPrsCore: terminal fingerprint extraction', () => {
     ]
     const fetchClient = makeFetchClientStub({issues})
     const terminals = await fetchTerminalFingerprints({
-      client: fetchClient as never,
+      client: fetchClient,
       owner: 'fro-bot',
       repo: '.github',
     })
@@ -1672,7 +1854,7 @@ describe('fetchExistingCorrectionPrs: unfiltered candidate fetch', () => {
 
     const fetchClient = makeFetchClientStub({prs: [matchingPr, nonBotPr, nonPrefixPr]})
     const existingPrs = await fetchExistingCorrectionPrs({
-      client: fetchClient as never,
+      client: fetchClient,
       owner: 'fro-bot',
       repo: '.github',
     })
@@ -1725,7 +1907,7 @@ describe('runPrsCore: planner gates rediscovery on bot ownership, base branch, a
         GITHUB_REPOSITORY: 'fro-bot/.github',
       },
       readReport: vi.fn(async () => ({valid: true as const, report})),
-      createFetchClient: vi.fn(async () => fetchClient as never),
+      createFetchClient: vi.fn(async () => fetchClient),
       createWriteClient: vi.fn(async () => writeClient),
     })
 
@@ -1767,7 +1949,7 @@ describe('runPrsCore: partial-success recovery', () => {
         GITHUB_REPOSITORY: 'fro-bot/.github',
       },
       readReport: vi.fn(async () => ({valid: true as const, report})),
-      createFetchClient: vi.fn(async () => fetchClient as never),
+      createFetchClient: vi.fn(async () => fetchClient),
       createWriteClient: vi.fn(async () => writeClient),
     })
 
@@ -1881,7 +2063,7 @@ describe('runPrsCore: output privacy', () => {
         GITHUB_REPOSITORY: 'fro-bot/.github',
       },
       readReport: vi.fn(async () => ({valid: true as const, report})),
-      createFetchClient: vi.fn(async () => fetchClient as never),
+      createFetchClient: vi.fn(async () => fetchClient),
       createWriteClient: vi.fn(async () => writeClient),
     })
 
@@ -1920,7 +2102,7 @@ describe('runPrsCore: dry-run does not require a write client', () => {
         GITHUB_REPOSITORY: 'fro-bot/.github',
       },
       readReport: vi.fn(async () => ({valid: true as const, report})),
-      createFetchClient: vi.fn(async () => fetchClient as never),
+      createFetchClient: vi.fn(async () => fetchClient),
       createWriteClient,
     })
 
@@ -2032,7 +2214,7 @@ describe('runPrsCore: dry-run wouldRediscover for existing matching correction P
         GITHUB_REPOSITORY: 'fro-bot/.github',
       },
       readReport: vi.fn(async () => ({valid: true as const, report})),
-      createFetchClient: vi.fn(async () => fetchClient as never),
+      createFetchClient: vi.fn(async () => fetchClient),
       createWriteClient: vi.fn(async () => writeClient),
     })
 
@@ -2059,7 +2241,7 @@ describe('fetchTerminalFingerprints: includes open issues', () => {
     }
 
     const terminals = await fetchTerminalFingerprints({
-      client: fetchClient as never,
+      client: fetchClient,
       owner: 'fro-bot',
       repo: '.github',
     })
@@ -2079,13 +2261,326 @@ describe('fetchTerminalFingerprints: duplicateCount observability', () => {
     const fetchClient = makeFetchClientStub({issues})
 
     const terminals = await fetchTerminalFingerprints({
-      client: fetchClient as never,
+      client: fetchClient,
       owner: 'fro-bot',
       repo: '.github',
     })
 
     expect(terminals.duplicateCount).toBe(1)
     expect(JSON.stringify(terminals.duplicateCount)).not.toContain(dupFp)
+  })
+})
+
+describe('executeStatusTruthPrActions: live-mode rediscovered count', () => {
+  it('counts rediscover-pr actions as rediscovered in live mode instead of silently dropping them', async () => {
+    const digest = testDeriveOpaqueDigest('abc123def456abcd')
+    const rediscoverAction: Extract<StatusTruthPrAction, {type: 'rediscover-pr'}> = {
+      type: 'rediscover-pr',
+      existingPrNumber: 77,
+      opaqueDigest: digest,
+    }
+    const octokit = makeMockOctokit()
+
+    const result = await executeStatusTruthPrActions(makeExecuteInput({actions: [rediscoverAction], octokit}))
+
+    expect(result.counts.rediscovered).toBe(1)
+    expect(result.counts.opened).toBe(0)
+    expect(result.counts.failed).toBe(0)
+  })
+})
+
+describe('fetchTerminalFingerprints: pagination cap', () => {
+  it('fails closed (throws) when the terminal-fingerprint fetch would exceed the page cap', async () => {
+    const fetchClient = makeFetchClientStub({
+      alwaysFullIssuePages: true,
+      issues: Array.from({length: 100}, (_v, i) => ({
+        number: i,
+        labels: [{name: 'status-truth'}],
+        body: null,
+        user: {login: 'fro-bot[bot]'},
+      })),
+    })
+
+    await expect(fetchTerminalFingerprints({client: fetchClient, owner: 'fro-bot', repo: '.github'})).rejects.toThrow()
+  })
+})
+
+describe('fetchExistingCorrectionPrs: pagination cap', () => {
+  it('fails closed (throws) when the existing-PR fetch would exceed the page cap', async () => {
+    const fetchClient = makeFetchClientStub({
+      alwaysFullPrPages: true,
+      prs: Array.from({length: 100}, (_v, i) => ({
+        number: i,
+        state: 'open',
+        head: {ref: `${PR_BRANCH_PREFIX}deadbeefdeadbeef`},
+        base: {ref: 'main'},
+        user: {login: 'fro-bot[bot]'},
+      })),
+    })
+
+    await expect(fetchExistingCorrectionPrs({client: fetchClient, owner: 'fro-bot', repo: '.github'})).rejects.toThrow()
+  })
+})
+
+describe('runPrsCore: pagination cap exceeded in live mode is treated as a fetch failure', () => {
+  it('exits non-zero with error-class=fetch-failure when a fetch hits the pagination cap in live mode', async () => {
+    const report = makeReport()
+    const cappedFetchClient = makeFetchClientStub({
+      alwaysFullIssuePages: true,
+      issues: Array.from({length: 100}, (_v, i) => ({
+        number: i,
+        labels: [{name: 'status-truth'}, {name: 'status-truth:rejected'}],
+        body: null,
+        user: {login: 'fro-bot[bot]'},
+      })),
+    })
+    const writeClient = makeMockOctokit()
+
+    const deps = makeRunPrsCoreDeps({
+      env: {
+        STATUS_TRUTH_PRS_ENABLED: 'true',
+        STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true',
+        STATUS_TRUTH_REPORT_PATH: '/tmp/report.json',
+        GITHUB_REPOSITORY: 'fro-bot/.github',
+      },
+      readReport: vi.fn(async () => ({valid: true as const, report})),
+      createFetchClient: vi.fn(async () => cappedFetchClient),
+      createWriteClient: vi.fn(async () => writeClient),
+    })
+
+    const result = await runPrsCore(deps)
+
+    expect(deps.setExitCode).toHaveBeenCalledWith(1)
+    expect(result.error).toBe('fetch-failure')
+    expect(writeClient.rest.pulls.create).not.toHaveBeenCalled()
+  })
+})
+
+describe('runPrsCore: PrsResult error field on early-failure paths', () => {
+  it('sets error=missing-report when the report path is absent', async () => {
+    const deps = makeRunPrsCoreDeps({
+      env: {STATUS_TRUTH_PRS_ENABLED: 'true', STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true'},
+    })
+    const result = await runPrsCore(deps)
+    expect(result.error).toBe('missing-report')
+  })
+
+  it('sets error=report-failure when the report is invalid', async () => {
+    const deps = makeRunPrsCoreDeps({
+      env: {
+        STATUS_TRUTH_PRS_ENABLED: 'true',
+        STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true',
+        STATUS_TRUTH_REPORT_PATH: '/tmp/report.json',
+      },
+      readReport: vi.fn(async () => ({valid: false as const, reason: 'artifact validation failed'})),
+    })
+    const result = await runPrsCore(deps)
+    expect(result.error).toBe('report-failure')
+  })
+
+  it('sets error=token-load-failure when public-output token loading fails', async () => {
+    const report = makeReport()
+    const deps = makeRunPrsCoreDeps({
+      env: {
+        STATUS_TRUTH_PRS_ENABLED: 'true',
+        STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true',
+        STATUS_TRUTH_REPORT_PATH: '/tmp/report.json',
+      },
+      readReport: vi.fn(async () => ({valid: true as const, report})),
+      loadPublicOutputTokens: vi.fn(async () => {
+        throw new Error('token load failed')
+      }),
+    })
+    const result = await runPrsCore(deps)
+    expect(result.error).toBe('token-load-failure')
+  })
+
+  it('sets error=fetch-failure when existing-state fetch fails in live mode', async () => {
+    const report = makeReport()
+    const deps = makeRunPrsCoreDeps({
+      env: {
+        STATUS_TRUTH_PRS_ENABLED: 'true',
+        STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true',
+        STATUS_TRUTH_REPORT_PATH: '/tmp/report.json',
+        GITHUB_REPOSITORY: 'fro-bot/.github',
+      },
+      readReport: vi.fn(async () => ({valid: true as const, report})),
+      createFetchClient: vi.fn(async () => {
+        throw new Error('fetch failed')
+      }),
+    })
+    const result = await runPrsCore(deps)
+    expect(result.error).toBe('fetch-failure')
+  })
+
+  it('sets error=write-client-failure when write-client creation fails in live mode', async () => {
+    const report = makeReport()
+    const fetchClient = makeFetchClientStub()
+    const deps = makeRunPrsCoreDeps({
+      env: {
+        STATUS_TRUTH_PRS_ENABLED: 'true',
+        STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true',
+        STATUS_TRUTH_REPORT_PATH: '/tmp/report.json',
+        GITHUB_REPOSITORY: 'fro-bot/.github',
+      },
+      readReport: vi.fn(async () => ({valid: true as const, report})),
+      createFetchClient: vi.fn(async () => fetchClient),
+      createWriteClient: vi.fn(async () => {
+        throw new Error('write client creation failed')
+      }),
+    })
+    const result = await runPrsCore(deps)
+    expect(result.error).toBe('write-client-failure')
+  })
+
+  it('omits error on a successful armed run', async () => {
+    const finding = makeDriftedFinding({fingerprint: 'abc123def456abcd', kind: 'plan-consistency'})
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const fetchClient = makeFetchClientStub()
+    const writeClient = makeMockOctokit()
+    const deps = makeRunPrsCoreDeps({
+      env: {
+        STATUS_TRUTH_PRS_ENABLED: 'true',
+        STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true',
+        STATUS_TRUTH_DRY_RUN: 'true',
+        STATUS_TRUTH_REPORT_PATH: '/tmp/report.json',
+        GITHUB_REPOSITORY: 'fro-bot/.github',
+      },
+      readReport: vi.fn(async () => ({valid: true as const, report})),
+      createFetchClient: vi.fn(async () => fetchClient),
+      createWriteClient: vi.fn(async () => writeClient),
+    })
+    const result = await runPrsCore(deps)
+    expect(result.error).toBeUndefined()
+  })
+})
+
+describe('runPrs: top-level catch-all for unexpected exceptions', () => {
+  it('emits error=unexpected, exit code 1, and a parseable counts-only result when runPrsCore throws unexpectedly', async () => {
+    // readReport throws directly (rather than returning a ReadReportResult),
+    // which is outside runPrsCore's anticipated failure branches and
+    // propagates up to the top-level catch-all in runPrs().
+    const deps = makeRunPrsCoreDeps({
+      env: {
+        STATUS_TRUTH_PRS_ENABLED: 'true',
+        STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true',
+        STATUS_TRUTH_REPORT_PATH: '/tmp/report.json',
+      },
+      readReport: vi.fn(() => {
+        throw new TypeError('exotic unexpected failure')
+      }),
+    })
+
+    const result = await runPrs(deps)
+
+    expect(deps.setExitCode).toHaveBeenCalledWith(1)
+    expect(result.error).toBe('unexpected')
+    expect(deps.writeStdout).toHaveBeenCalled()
+    const stdoutArg = vi.mocked(deps.writeStdout).mock.calls.at(-1)?.[0] as string
+    expect(() => {
+      JSON.parse(stdoutArg)
+    }).not.toThrow()
+    expect(stdoutArg).not.toContain('exotic unexpected failure')
+  })
+
+  it('delegates to runPrsCore and returns its result on the normal (non-throwing) path', async () => {
+    const deps = makeRunPrsCoreDeps({env: {}})
+    const result = await runPrs(deps)
+    expect(result.armed).toBe(false)
+  })
+})
+
+describe('runPrsCore: dry-run fetch failure degrades to empty state (would-act counts, no exit code)', () => {
+  it('does not set a non-zero exit code and still reports would-act counts when the fetch fails in dry-run', async () => {
+    const finding = makeDriftedFinding({fingerprint: 'abc123def456abcd', kind: 'plan-consistency'})
+    const report = makeReport({
+      findings: [finding],
+      counts: {total: 1, current: 0, drifted: 1, unresolved: 0, unsafe: 0, proposal_eligible: 1},
+    })
+    const deps = makeRunPrsCoreDeps({
+      env: {
+        STATUS_TRUTH_PRS_ENABLED: 'true',
+        STATUS_TRUTH_PRS_DISPATCH_INPUT: 'true',
+        STATUS_TRUTH_DRY_RUN: 'true',
+        STATUS_TRUTH_REPORT_PATH: '/tmp/report.json',
+        GITHUB_REPOSITORY: 'fro-bot/.github',
+      },
+      readReport: vi.fn(async () => ({valid: true as const, report})),
+      createFetchClient: vi.fn(async () => {
+        throw new Error('fetch failed')
+      }),
+    })
+
+    const result = await runPrsCore(deps)
+
+    expect(deps.setExitCode).not.toHaveBeenCalled()
+    expect(result.dryRun).toBe(true)
+    expect(result.error).toBeUndefined()
+    // With empty existingPrs/terminalFingerprints, the graduated finding still
+    // plans a fresh open-pr action, reported as would-open in dry-run.
+    expect(result.executedCounts.wouldOpen).toBe(1)
+  })
+})
+
+describe('runPrsCore: writeResultFile path', () => {
+  it('omits the writeResultFile call when the result path env var is unset', async () => {
+    const writeResultFile = vi.fn(async () => undefined)
+    const deps = makeRunPrsCoreDeps({env: {}, writeResultFile})
+
+    await runPrsCore(deps)
+
+    expect(writeResultFile).not.toHaveBeenCalled()
+  })
+
+  it('invokes writeResultFile exactly once with parseable JSON when a result path is configured', async () => {
+    const writeResultFile = vi.fn<(json: string) => Promise<void>>(async () => undefined)
+    const deps = makeRunPrsCoreDeps({
+      env: {STATUS_TRUTH_PRS_RESULT_PATH: '/tmp/status-truth-prs-result.json'},
+      writeResultFile,
+    })
+
+    await runPrsCore(deps)
+
+    expect(writeResultFile).toHaveBeenCalledTimes(1)
+    const jsonArg = vi.mocked(writeResultFile).mock.calls[0]?.[0] as string
+    expect(() => {
+      JSON.parse(jsonArg)
+    }).not.toThrow()
+  })
+})
+
+describe('fetchTerminalFingerprints: bot-authorship narrowing', () => {
+  it('ignores a human-authored issue carrying a terminal label and marker (no impersonation of bot suppression)', async () => {
+    const humanFp = 'deadbeefdeadbeef'
+    const issues = [makeTerminalFingerprintIssue(humanFp, 'status-truth:rejected', 'random-human')]
+    const fetchClient = makeFetchClientStub({issues})
+
+    const terminals = await fetchTerminalFingerprints({client: fetchClient, owner: 'fro-bot', repo: '.github'})
+
+    expect(terminals.fingerprints.has(humanFp)).toBe(false)
+  })
+
+  it('accepts a bot-authored issue (fro-bot[bot]) carrying a terminal label and marker', async () => {
+    const botFp = 'beefdeadbeefdead'
+    const issues = [makeTerminalFingerprintIssue(botFp, 'status-truth:rejected', 'fro-bot[bot]')]
+    const fetchClient = makeFetchClientStub({issues})
+
+    const terminals = await fetchTerminalFingerprints({client: fetchClient, owner: 'fro-bot', repo: '.github'})
+
+    expect(terminals.fingerprints.has(botFp)).toBe(true)
+  })
+
+  it('accepts a bot-authored issue (bare fro-bot login) carrying a terminal label and marker', async () => {
+    const botFp = 'cafefeedcafefeed'
+    const issues = [makeTerminalFingerprintIssue(botFp, 'status-truth:false-positive', 'fro-bot')]
+    const fetchClient = makeFetchClientStub({issues})
+
+    const terminals = await fetchTerminalFingerprints({client: fetchClient, owner: 'fro-bot', repo: '.github'})
+
+    expect(terminals.fingerprints.has(botFp)).toBe(true)
   })
 })
 
@@ -2100,7 +2595,7 @@ function assertStatusTruthWorkflow(value: unknown): asserts value is {
     {
       if?: string
       permissions?: Record<string, string>
-      steps: {name?: string; uses?: string; with?: Record<string, string>}[]
+      steps: {name?: string; uses?: string; with?: Record<string, string>; env?: Record<string, string>}[]
     }
   >
 } {
@@ -2152,5 +2647,62 @@ describe('workflow contract: PR job app-token permissions', () => {
     expect(prsJob?.if).toContain("== 'true'")
     expect(prsJob?.if).toContain("github.event_name == 'workflow_dispatch'")
     expect(prsJob?.if).toContain("github.event.inputs.open_prs == 'true'")
+  })
+})
+
+describe('workflow contract: separate read-only fetch token', () => {
+  const workflowPath = resolve(import.meta.dirname, '../.github/workflows/status-truth.yaml')
+  const parsed: unknown = parse(readFileSync(workflowPath, 'utf8'))
+  assertStatusTruthWorkflow(parsed)
+  const prsJob = parsed.jobs.prs
+
+  it('mints a second, read-only app-token step distinct from the write-token step', () => {
+    const appTokenSteps = prsJob?.steps.filter(s => s.uses?.includes('actions/create-github-app-token')) ?? []
+    expect(appTokenSteps.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('scopes the fetch token to read-only permissions (contents, pull-requests, issues)', () => {
+    const fetchTokenStep = prsJob?.steps.find(
+      s => s.uses?.includes('actions/create-github-app-token') && s.name?.toLowerCase().includes('fetch'),
+    )
+    expect(fetchTokenStep).toBeDefined()
+    expect(fetchTokenStep?.with?.['permission-contents']).toBe('read')
+    expect(fetchTokenStep?.with?.['permission-pull-requests']).toBe('read')
+    expect(fetchTokenStep?.with?.['permission-issues']).toBe('read')
+  })
+
+  it('scopes the fetch token to this repository only, matching the write token', () => {
+    const fetchTokenStep = prsJob?.steps.find(
+      s => s.uses?.includes('actions/create-github-app-token') && s.name?.toLowerCase().includes('fetch'),
+    )
+    const expectedRepositoryScope = '$' + '{{ github.event.repository.name }}'
+    expect(fetchTokenStep?.with?.repositories).toBe(expectedRepositoryScope)
+  })
+
+  it('passes the fetch token to the execute step via STATUS_TRUTH_FETCH_TOKEN, distinct from GITHUB_TOKEN', () => {
+    const executeStep = prsJob?.steps.find(s => s.name?.includes('Execute status-truth correction PRs'))
+    expect(executeStep?.env?.STATUS_TRUTH_FETCH_TOKEN).toBeDefined()
+    expect(executeStep?.env?.GITHUB_TOKEN).toBeDefined()
+    expect(executeStep?.env?.STATUS_TRUTH_FETCH_TOKEN).not.toBe(executeStep?.env?.GITHUB_TOKEN)
+  })
+})
+
+describe('env-backed PR runner deps', () => {
+  it('requires STATUS_TRUTH_FETCH_TOKEN for fetch clients and does not fall back to GITHUB_TOKEN', async () => {
+    const originalFetchToken = process.env.STATUS_TRUTH_FETCH_TOKEN
+    const originalGithubToken = process.env.GITHUB_TOKEN
+    try {
+      delete process.env.STATUS_TRUTH_FETCH_TOKEN
+      process.env.GITHUB_TOKEN = 'write-token-only'
+
+      const deps = buildEnvBackedRunPrsCoreDeps()
+
+      await expect(deps.createFetchClient()).rejects.toThrow('required token is missing')
+    } finally {
+      if (originalFetchToken === undefined) delete process.env.STATUS_TRUTH_FETCH_TOKEN
+      else process.env.STATUS_TRUTH_FETCH_TOKEN = originalFetchToken
+      if (originalGithubToken === undefined) delete process.env.GITHUB_TOKEN
+      else process.env.GITHUB_TOKEN = originalGithubToken
+    }
   })
 })

--- a/scripts/status-truth-prs.ts
+++ b/scripts/status-truth-prs.ts
@@ -219,6 +219,12 @@ export interface OpenPrAction {
   readonly path: string
   /** Claim kind — selects the corrector/re-verifier the shell must run. */
   readonly kind: string
+  /**
+   * Source fingerprint, threaded through so execution-shell gate calls carry
+   * the same `fingerprint` context the planner used (public-output gate
+   * symmetry). Never rendered verbatim into any public surface.
+   */
+  readonly fingerprint: string
 }
 
 /**
@@ -656,6 +662,7 @@ export function planStatusTruthPrActions(input: PlanStatusTruthPrActionsInput): 
       opaqueDigest,
       path: finding.path,
       kind: finding.kind,
+      fingerprint,
     })
     prActionsPlanned++
     openPrsPlanned++
@@ -815,6 +822,7 @@ export interface StatusTruthPrFetchClient {
           readonly number: number
           readonly labels: readonly (string | {readonly name?: string | null})[]
           readonly body?: string | null
+          readonly user?: {readonly login?: string | null} | null
         }[]
       }>
     }
@@ -830,6 +838,13 @@ export interface ExecuteStatusTruthPrActionsInput {
   /** When true: read-only calls permitted, zero mutating calls, would-act counts. */
   readonly dryRun: boolean
   readonly publicOutputTokens: PublicOutputTokens
+  /**
+   * Privacy-safe diagnostic sink for action-level failures. Defaults to a
+   * no-op when omitted (e.g. in existing tests that don't assert on it).
+   * Never receives raw error message text or bodies — only action type,
+   * a closed-vocabulary error-class, and a numeric API status when present.
+   */
+  readonly writeStderr?: (text: string) => void
 }
 
 /** Counts-only result of the PR execution shell. */
@@ -840,6 +855,8 @@ export interface ExecuteStatusTruthPrActionsCounts {
   readonly safetyRefused: number
   readonly failed: number
   readonly branchDeleteFailed: number
+  /** Live mode: rediscover-pr actions observed (no mutation — count only, replaces silent drop). */
+  readonly rediscovered: number
   /** Dry-run: would-open count (no mutation performed). */
   readonly wouldOpen: number
   /** Dry-run: would-close count (no mutation performed). */
@@ -866,6 +883,31 @@ function isApiStatus(error: unknown, status: number): boolean {
   )
 }
 
+/** Extract a numeric API status code from an error, if present. Never extracts message text. */
+function extractApiStatus(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null || !('status' in error)) return undefined
+  const status = (error as {status: unknown}).status
+  return typeof status === 'number' ? status : undefined
+}
+
+/**
+ * Emit a privacy-safe diagnostic line for an action-level execution failure:
+ * action type + closed-vocabulary error-class + numeric API status (when
+ * available). Never includes error message text, response bodies, or any
+ * other raw error content.
+ */
+function emitActionFailureDiagnostic(params: {
+  writeStderr: (text: string) => void
+  actionType: 'open-pr' | 'close-pr'
+  error: unknown
+}): void {
+  const status = extractApiStatus(params.error)
+  const statusSuffix = status === undefined ? '' : ` status=${status}`
+  params.writeStderr(
+    `status-truth-prs: action failed: action=${params.actionType} error-class=action-failure${statusSuffix}\n`,
+  )
+}
+
 /**
  * Execute planned status-truth correction PR actions with independent
  * per-action safety validation. The shell never trusts planner output:
@@ -884,7 +926,7 @@ function isApiStatus(error: unknown, status: number): boolean {
 export async function executeStatusTruthPrActions(
   input: ExecuteStatusTruthPrActionsInput,
 ): Promise<ExecuteStatusTruthPrActionsResult> {
-  const {octokit, owner, repo, actions, dryRun, publicOutputTokens} = input
+  const {octokit, owner, repo, actions, dryRun, publicOutputTokens, writeStderr = () => undefined} = input
 
   if (dryRun) {
     let wouldOpen = 0
@@ -904,6 +946,7 @@ export async function executeStatusTruthPrActions(
         safetyRefused: 0,
         failed: 0,
         branchDeleteFailed: 0,
+        rediscovered: 0,
         wouldOpen,
         wouldClose,
         wouldRediscover,
@@ -917,9 +960,15 @@ export async function executeStatusTruthPrActions(
   let safetyRefused = 0
   let failed = 0
   let branchDeleteFailed = 0
+  let rediscovered = 0
 
   for (const action of actions) {
-    if (action.type === 'open-pr') {
+    if (action.type === 'rediscover-pr') {
+      // Rediscovery performs no mutation — the existing PR already represents
+      // the correction. Live mode surfaces this as an explicit count instead
+      // of silently dropping the action.
+      rediscovered++
+    } else if (action.type === 'open-pr') {
       try {
         // 1. Branch-pattern validation for the current fingerprint (R11c).
         if (!branchMatchesCorrectionPattern(action.opaqueBranchName, action.opaqueDigest)) {
@@ -934,9 +983,20 @@ export async function executeStatusTruthPrActions(
           continue
         }
 
-        // 2. Live re-read of the target file from the base branch.
-        const liveResponse = await octokit.rest.repos.getContent({owner, repo, path: action.path})
-        const liveData = liveResponse.data
+        // 2. Live re-read of the target file from the base branch. A 404 means
+        // the file no longer exists on the live base branch — this is a
+        // legitimate downgrade (the claim is stale), not an execution failure.
+        let liveData: {content?: string; encoding?: string; sha: string}
+        try {
+          const liveResponse = await octokit.rest.repos.getContent({owner, repo, path: action.path})
+          liveData = liveResponse.data
+        } catch (getContentError: unknown) {
+          if (isApiStatus(getContentError, 404)) {
+            downgraded++
+            continue
+          }
+          throw getContentError
+        }
         const liveContent = decodeGetContentResponse(liveData)
         if (liveContent === null) {
           downgraded++
@@ -961,7 +1021,7 @@ export async function executeStatusTruthPrActions(
           surface: 'pr-title',
           content: action.opaqueTitle,
           tokens: publicOutputTokens,
-          fingerprint: undefined,
+          fingerprint: action.fingerprint,
         })
         if (!titleGate.allowed) {
           safetyRefused++
@@ -972,7 +1032,7 @@ export async function executeStatusTruthPrActions(
           surface: 'pr-body',
           content: bodyContent,
           tokens: publicOutputTokens,
-          fingerprint: undefined,
+          fingerprint: action.fingerprint,
         })
         if (!bodyGate.allowed) {
           safetyRefused++
@@ -1002,13 +1062,25 @@ export async function executeStatusTruthPrActions(
             safetyRefused++
             continue
           }
-          const existingTipContentResponse = await octokit.rest.repos.getContent({
-            owner,
-            repo,
-            path: action.path,
-            ref: action.opaqueBranchName,
-          })
-          const existingTipContent = decodeGetContentResponse(existingTipContentResponse.data)
+          let existingTipContent: string | null
+          try {
+            const existingTipContentResponse = await octokit.rest.repos.getContent({
+              owner,
+              repo,
+              path: action.path,
+              ref: action.opaqueBranchName,
+            })
+            existingTipContent = decodeGetContentResponse(existingTipContentResponse.data)
+          } catch (existingTipError: unknown) {
+            if (isApiStatus(existingTipError, 404)) {
+              // The colliding branch exists but no longer carries this file —
+              // ambiguous state, not a real API failure. Refuse safely rather
+              // than guessing or force-overwriting.
+              safetyRefused++
+              continue
+            }
+            throw existingTipError
+          }
           if (existingTipContent === null || existingTipContent !== correctedContent) {
             safetyRefused++
             continue
@@ -1054,8 +1126,9 @@ export async function executeStatusTruthPrActions(
           base: CORRECTION_BASE_BRANCH,
         })
         opened++
-      } catch {
+      } catch (error: unknown) {
         failed++
+        emitActionFailureDiagnostic({writeStderr, actionType: 'open-pr', error})
       }
     } else if (action.type === 'close-pr') {
       try {
@@ -1106,8 +1179,9 @@ export async function executeStatusTruthPrActions(
         } catch {
           branchDeleteFailed++
         }
-      } catch {
+      } catch (error: unknown) {
         failed++
+        emitActionFailureDiagnostic({writeStderr, actionType: 'close-pr', error})
       }
     }
   }
@@ -1121,6 +1195,7 @@ export async function executeStatusTruthPrActions(
       safetyRefused,
       failed,
       branchDeleteFailed,
+      rediscovered,
       wouldOpen: 0,
       wouldClose: 0,
       wouldRediscover: 0,
@@ -1170,6 +1245,17 @@ export interface FetchTerminalFingerprintsResult {
   readonly duplicateCount: number
 }
 
+/** Maximum pages fetched by pagination loops (10 pages @ 100/page = 1000 items). Fail closed if exceeded. */
+const MAX_FETCH_PAGES = 10
+
+/** Thrown when a pagination loop hits {@link MAX_FETCH_PAGES} without exhausting results. */
+class PaginationCapExceededError extends Error {
+  constructor() {
+    super('pagination cap exceeded')
+    this.name = 'PaginationCapExceededError'
+  }
+}
+
 /**
  * Fetch terminal fingerprints from status-truth proposal issues carrying a
  * terminal outcome label (`status-truth:rejected` or `status-truth:false-positive`).
@@ -1199,6 +1285,7 @@ export async function fetchTerminalFingerprints(params: {
 
   let page = 1
   for (;;) {
+    if (page > MAX_FETCH_PAGES) throw new PaginationCapExceededError()
     const response = await client.rest.issues.listForRepo({
       owner,
       repo,
@@ -1208,6 +1295,12 @@ export async function fetchTerminalFingerprints(params: {
       page,
     })
     for (const issue of response.data) {
+      // Narrow suppression to bot-authored proposal issues only. A
+      // human-authored issue carrying copied labels/markers must never be
+      // accepted as a terminal-outcome source — that would let anyone
+      // suppress a claim by opening a look-alike issue.
+      if (!BOT_LOGINS.has(issue.user?.login ?? '')) continue
+
       const labelNames = issue.labels.map(l => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean)
       const hasTerminalLabel = labelNames.some(l => TERMINAL_OUTCOME_LABELS.has(l))
       if (!hasTerminalLabel) continue
@@ -1260,6 +1353,7 @@ export async function fetchExistingCorrectionPrs(params: {
 
   let page = 1
   for (;;) {
+    if (page > MAX_FETCH_PAGES) throw new PaginationCapExceededError()
     const response = await client.rest.pulls.list({
       owner,
       repo,
@@ -1315,12 +1409,22 @@ export function isPrExecutionArmed(params: {
   return params.prsEnabledVar === 'true' && params.dispatchInputVar === 'true' && params.graduatedClaimKinds.size > 0
 }
 
+/** Closed vocabulary of early-failure reasons surfaced on {@link PrsResult}. Never raw error text. */
+export type PrsResultError =
+  'missing-report' | 'report-failure' | 'token-load-failure' | 'fetch-failure' | 'write-client-failure' | 'unexpected'
+
 /** Counts-only result written to stdout and STATUS_TRUTH_PRS_RESULT_PATH. */
 export interface PrsResult {
   readonly armed: boolean
   readonly dryRun: boolean
   readonly plannedCounts: PlanStatusTruthPrActionsCounts
   readonly executedCounts: ExecuteStatusTruthPrActionsCounts
+  /** Closed-vocabulary failure reason, present only on a non-success early-exit path. */
+  readonly error?: PrsResultError
+  /** Malformed/invalid/duplicate terminal fingerprints skipped this run (counts-only). */
+  readonly terminalFingerprintsSkipped?: number
+  /** Distinct terminal fingerprints observed on more than one terminal issue this run (counts-only). */
+  readonly terminalFingerprintDuplicates?: number
 }
 
 type OctokitConstructor = new (params: {
@@ -1343,13 +1447,24 @@ async function loadOctokitConstructor(): Promise<OctokitConstructor> {
   return Octokit as unknown as OctokitConstructor
 }
 
-async function createOctokitFromEnv(): Promise<StatusTruthPrOctokitClient> {
-  const token = process.env.GITHUB_TOKEN
+/**
+ * Build an Octokit client authenticated with the given token.
+ *
+ * Fetch calls use `STATUS_TRUTH_FETCH_TOKEN` (a dedicated read-only app token
+ * minted for fetch/list calls). Write calls use `GITHUB_TOKEN` directly (the
+ * scoped write token). These channels intentionally do not fall back to each
+ * other.
+ */
+async function createOctokitFromToken(token: string | undefined): Promise<StatusTruthPrOctokitClient> {
   if (token === undefined || token === '') {
-    throw new Error('status-truth-prs: GITHUB_TOKEN is required in the environment')
+    throw new Error('status-truth-prs: required token is missing from the environment')
   }
   const LoadedOctokit = await loadOctokitConstructor()
   return new LoadedOctokit({auth: token, request: {timeout: 10_000}, log: NOOP_LOG})
+}
+
+async function createOctokitFromEnv(): Promise<StatusTruthPrOctokitClient> {
+  return createOctokitFromToken(process.env.GITHUB_TOKEN)
 }
 
 /** Report-read result: mirrors the `validateStatusTruthArtifact` discriminated union. */
@@ -1394,6 +1509,7 @@ const EMPTY_EXECUTED_COUNTS: ExecuteStatusTruthPrActionsCounts = {
   safetyRefused: 0,
   failed: 0,
   branchDeleteFailed: 0,
+  rediscovered: 0,
   wouldOpen: 0,
   wouldClose: 0,
   wouldRediscover: 0,
@@ -1508,13 +1624,14 @@ export async function runPrsCore(deps: RunPrsCoreDeps): Promise<PrsResult> {
   }
 
   if (reportPath === undefined || reportPath === '') {
-    deps.writeStderr('status-truth-prs: STATUS_TRUTH_REPORT_PATH is required\n')
+    deps.writeStderr('status-truth-prs: STATUS_TRUTH_REPORT_PATH is required: error-class=missing-report\n')
     deps.setExitCode(1)
     const result: PrsResult = {
       armed: true,
       dryRun,
       plannedCounts: EMPTY_PLANNED_COUNTS,
       executedCounts: EMPTY_EXECUTED_COUNTS,
+      error: 'missing-report',
     }
     await writeResultAndStdout({result, resultPath, deps})
     return result
@@ -1529,6 +1646,7 @@ export async function runPrsCore(deps: RunPrsCoreDeps): Promise<PrsResult> {
       dryRun,
       plannedCounts: EMPTY_PLANNED_COUNTS,
       executedCounts: EMPTY_EXECUTED_COUNTS,
+      error: 'report-failure',
     }
     await writeResultAndStdout({result, resultPath, deps})
     return result
@@ -1546,6 +1664,7 @@ export async function runPrsCore(deps: RunPrsCoreDeps): Promise<PrsResult> {
       dryRun,
       plannedCounts: EMPTY_PLANNED_COUNTS,
       executedCounts: EMPTY_EXECUTED_COUNTS,
+      error: 'token-load-failure',
     }
     await writeResultAndStdout({result, resultPath, deps})
     return result
@@ -1555,6 +1674,8 @@ export async function runPrsCore(deps: RunPrsCoreDeps): Promise<PrsResult> {
 
   let existingPrs: ExistingStatusTruthPr[] = []
   let terminalFingerprints: ReadonlySet<string> = new Set<string>()
+  let terminalFingerprintsSkipped = 0
+  let terminalFingerprintDuplicates = 0
 
   try {
     const fetchClient = await deps.createFetchClient()
@@ -1564,6 +1685,8 @@ export async function runPrsCore(deps: RunPrsCoreDeps): Promise<PrsResult> {
     ])
     existingPrs = prs
     terminalFingerprints = terminals.fingerprints
+    terminalFingerprintsSkipped = terminals.skippedInvalid
+    terminalFingerprintDuplicates = terminals.duplicateCount
   } catch {
     if (!dryRun) {
       deps.writeStderr('status-truth-prs: existing state fetch failed: error-class=fetch-failure\n')
@@ -1573,6 +1696,7 @@ export async function runPrsCore(deps: RunPrsCoreDeps): Promise<PrsResult> {
         dryRun,
         plannedCounts: EMPTY_PLANNED_COUNTS,
         executedCounts: EMPTY_EXECUTED_COUNTS,
+        error: 'fetch-failure',
       }
       await writeResultAndStdout({result, resultPath, deps})
       return result
@@ -1603,13 +1727,16 @@ export async function runPrsCore(deps: RunPrsCoreDeps): Promise<PrsResult> {
     try {
       writeClient = await deps.createWriteClient()
     } catch {
-      deps.writeStderr('status-truth-prs: write client creation failed: error-class=token-load-failure\n')
+      deps.writeStderr('status-truth-prs: write client creation failed: error-class=write-client-failure\n')
       deps.setExitCode(1)
       const result: PrsResult = {
         armed: true,
         dryRun,
         plannedCounts: planResult.counts,
         executedCounts: EMPTY_EXECUTED_COUNTS,
+        error: 'write-client-failure',
+        terminalFingerprintsSkipped,
+        terminalFingerprintDuplicates,
       }
       await writeResultAndStdout({result, resultPath, deps})
       return result
@@ -1623,6 +1750,7 @@ export async function runPrsCore(deps: RunPrsCoreDeps): Promise<PrsResult> {
     actions: planResult.actions,
     dryRun,
     publicOutputTokens,
+    writeStderr: deps.writeStderr,
   })
 
   const result: PrsResult = {
@@ -1630,6 +1758,8 @@ export async function runPrsCore(deps: RunPrsCoreDeps): Promise<PrsResult> {
     dryRun,
     plannedCounts: planResult.counts,
     executedCounts: executeResult.counts,
+    terminalFingerprintsSkipped,
+    terminalFingerprintDuplicates,
   }
   await writeResultAndStdout({result, resultPath, deps})
   return result
@@ -1644,7 +1774,8 @@ export async function runPrsCore(deps: RunPrsCoreDeps): Promise<PrsResult> {
  * - STATUS_TRUTH_DRY_RUN: set to 'true' for dry-run mode (optional)
  * - STATUS_TRUTH_PRS_ENABLED: repository variable arming key (required to be 'true' to arm)
  * - STATUS_TRUTH_PRS_DISPATCH_INPUT: manual dispatch input arming key (required to be 'true' to arm)
- * - GITHUB_TOKEN: write-scoped app token for branch/PR mutations and read-only listing
+ * - STATUS_TRUTH_FETCH_TOKEN: read-scoped app token for existing PR/proposal listing
+ * - GITHUB_TOKEN: write-scoped app token for branch/PR mutations
  * - GITHUB_REPOSITORY: `owner/repo` (defaults to fro-bot/.github)
  *
  * Behavior:
@@ -1655,8 +1786,8 @@ export async function runPrsCore(deps: RunPrsCoreDeps): Promise<PrsResult> {
  * Thin environment wrapper around {@link runPrsCore}; all real I/O boundaries live there as
  * injected dependencies.
  */
-async function runPrs(): Promise<void> {
-  await runPrsCore({
+export function buildEnvBackedRunPrsCoreDeps(): RunPrsCoreDeps {
+  return {
     env: process.env,
     graduatedClaimKinds: GRADUATED_CLAIM_KINDS,
     readReport: async () => {
@@ -1692,7 +1823,8 @@ async function runPrs(): Promise<void> {
       ])
       return makePublicOutputTokens({privateTokens, redactedCanonicalIds})
     },
-    createFetchClient: async () => (await createOctokitFromEnv()) as unknown as StatusTruthPrFetchClient,
+    createFetchClient: async () =>
+      (await createOctokitFromToken(process.env.STATUS_TRUTH_FETCH_TOKEN)) as unknown as StatusTruthPrFetchClient,
     createWriteClient: async () => createOctokitFromEnv(),
     writeStdout: text => process.stdout.write(text),
     writeStderr: text => process.stderr.write(text),
@@ -1705,9 +1837,48 @@ async function runPrs(): Promise<void> {
     setExitCode: code => {
       process.exitCode = code
     },
-  })
+  }
+}
+
+/**
+ * Top-level catch-all wrapper around {@link runPrsCore}.
+ *
+ * `runPrsCore` already handles every anticipated failure path (missing
+ * report, invalid report, token load failure, fetch failure, write-client
+ * failure) with its own counts-only JSON result and `error` code. This
+ * wrapper exists for genuinely unexpected exceptions — e.g. a bug in the
+ * planner/executor, an unhandled rejection deep in a dependency — so the
+ * process never exits with a raw stack trace or uncaught error reaching
+ * stdout/stderr. Exported for testability; production use supplies real
+ * env-backed deps via {@link buildEnvBackedRunPrsCoreDeps}.
+ */
+export async function runPrs(deps: RunPrsCoreDeps): Promise<PrsResult> {
+  try {
+    return await runPrsCore(deps)
+  } catch {
+    deps.setExitCode(1)
+    const result: PrsResult = {
+      armed: false,
+      dryRun: deps.env.STATUS_TRUTH_DRY_RUN === 'true',
+      plannedCounts: EMPTY_PLANNED_COUNTS,
+      executedCounts: EMPTY_EXECUTED_COUNTS,
+      error: 'unexpected',
+    }
+    const resultJson = `${JSON.stringify(result)}\n`
+    deps.writeStdout(resultJson)
+    deps.writeStderr('status-truth-prs: unexpected failure: error-class=unexpected\n')
+    const resultPath = deps.env.STATUS_TRUTH_PRS_RESULT_PATH
+    if (resultPath !== undefined && resultPath !== '') {
+      try {
+        await deps.writeResultFile(resultJson)
+      } catch {
+        deps.writeStderr('status-truth-prs: could not write result: error-class=write-failure\n')
+      }
+    }
+    return result
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  await runPrs()
+  await runPrs(buildEnvBackedRunPrsCoreDeps())
 }

--- a/scripts/status-truth-prs.ts
+++ b/scripts/status-truth-prs.ts
@@ -74,13 +74,15 @@ const OPAQUE_DIGEST_NAMESPACE = 'status-truth-pr'
  * Claim kinds that have graduated to PR-eligible status.
  *
  * A claim kind graduates when it has demonstrated sufficient accuracy signal
- * (accepted/rejected outcomes from proposal issues). This set is intentionally
- * empty in Phase 1 — no claim kinds are graduated until Phase 1 produces signal.
+ * (accepted/rejected outcomes from proposal issues).
  *
- * To graduate a claim kind: add it to this set in a reviewed repo change after
- * Phase 1 accuracy data supports it.
+ * `plan-consistency` graduated first: explicit `status-truth:accepted` on
+ * #3656, with #3614-#3616 as supporting resolved-positive outcomes.
+ *
+ * To graduate another claim kind: add it to this set in a reviewed repo
+ * change after equivalent accepted evidence exists.
  */
-export const GRADUATED_CLAIM_KINDS: ReadonlySet<string> = new Set<string>()
+export const GRADUATED_CLAIM_KINDS: ReadonlySet<string> = new Set<string>(['plan-consistency'])
 
 // ---------------------------------------------------------------------------
 // Path authorization

--- a/scripts/status-truth-prs.ts
+++ b/scripts/status-truth-prs.ts
@@ -772,6 +772,53 @@ export interface StatusTruthPrOctokitClient {
   }
 }
 
+/** Shape of a single pull request returned by `pulls.list`. */
+export interface PrListItem {
+  readonly number: number
+  readonly state: string
+  readonly head: {readonly ref: string}
+  readonly base: {readonly ref: string}
+  readonly user: {readonly login?: string | null} | null
+}
+
+/**
+ * List-capable Octokit client used to fetch existing open correction PRs and
+ * terminal-labeled proposal issues before planning. Separate from
+ * {@link StatusTruthPrOctokitClient} (the write shell) so each seam only
+ * declares the surfaces it actually calls; production Octokit instances
+ * satisfy both structurally.
+ */
+export interface StatusTruthPrFetchClient {
+  readonly rest: {
+    readonly pulls: {
+      readonly list: (params: {
+        owner: string
+        repo: string
+        state: 'open' | 'closed' | 'all'
+        base?: string
+        per_page: number
+        page: number
+      }) => Promise<{data: readonly PrListItem[]}>
+    }
+    readonly issues: {
+      readonly listForRepo: (params: {
+        owner: string
+        repo: string
+        labels: string
+        state: 'open' | 'closed' | 'all'
+        per_page: number
+        page: number
+      }) => Promise<{
+        data: readonly {
+          readonly number: number
+          readonly labels: readonly (string | {readonly name?: string | null})[]
+          readonly body?: string | null
+        }[]
+      }>
+    }
+  }
+}
+
 /** Input to the PR execution shell. */
 export interface ExecuteStatusTruthPrActionsInput {
   readonly octokit: StatusTruthPrOctokitClient
@@ -795,6 +842,8 @@ export interface ExecuteStatusTruthPrActionsCounts {
   readonly wouldOpen: number
   /** Dry-run: would-close count (no mutation performed). */
   readonly wouldClose: number
+  /** Dry-run: would-rediscover count (no mutation performed). */
+  readonly wouldRediscover: number
 }
 
 /** Result of the PR execution shell. */
@@ -838,9 +887,11 @@ export async function executeStatusTruthPrActions(
   if (dryRun) {
     let wouldOpen = 0
     let wouldClose = 0
+    let wouldRediscover = 0
     for (const action of actions) {
       if (action.type === 'open-pr') wouldOpen++
       else if (action.type === 'close-pr') wouldClose++
+      else if (action.type === 'rediscover-pr') wouldRediscover++
     }
     return {
       dryRun: true,
@@ -853,6 +904,7 @@ export async function executeStatusTruthPrActions(
         branchDeleteFailed: 0,
         wouldOpen,
         wouldClose,
+        wouldRediscover,
       },
     }
   }
@@ -1010,29 +1062,37 @@ export async function executeStatusTruthPrActions(
           continue
         }
 
-        const comment =
-          action.reason === 'terminal-label'
-            ? 'Closing: linked proposal received a terminal outcome label.'
-            : 'Drift cleared. Closing this correction PR.'
-        const commentGate = applyPublicOutputGate({
-          surface: 'proposal-comment',
-          content: comment,
-          tokens: publicOutputTokens,
-          fingerprint: undefined,
-        })
-        if (!commentGate.allowed) {
-          safetyRefused++
-          continue
-        }
-
-        await octokit.rest.issues.createComment({
-          owner,
-          repo,
-          issue_number: action.prNumber,
-          body: commentGate.sanitizedContent,
-        })
+        // Closure happens first: if the best-effort comment below fails or
+        // is gated, the PR must still be closed rather than left open
+        // waiting on a non-essential courtesy comment.
         await octokit.rest.pulls.update({owner, repo, pull_number: action.prNumber, state: 'closed'})
         closed++
+
+        // Best-effort, non-fatal courtesy comment. Gate failure or API
+        // failure here must never undo the closure or count as a failed
+        // action — the PR is already closed.
+        try {
+          const comment =
+            action.reason === 'terminal-label'
+              ? 'Closing: linked proposal received a terminal outcome label.'
+              : 'Drift cleared. Closing this correction PR.'
+          const commentGate = applyPublicOutputGate({
+            surface: 'proposal-comment',
+            content: comment,
+            tokens: publicOutputTokens,
+            fingerprint: undefined,
+          })
+          if (commentGate.allowed) {
+            await octokit.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: action.prNumber,
+              body: commentGate.sanitizedContent,
+            })
+          }
+        } catch {
+          // Non-fatal: the PR is already closed.
+        }
 
         if (!branchMatchesCorrectionPattern(action.branch, action.opaqueDigest)) {
           // Unreachable given the guard above, but re-validated per R11c
@@ -1052,8 +1112,177 @@ export async function executeStatusTruthPrActions(
 
   return {
     dryRun: false,
-    counts: {opened, closed, downgraded, safetyRefused, failed, branchDeleteFailed, wouldOpen: 0, wouldClose: 0},
+    counts: {
+      opened,
+      closed,
+      downgraded,
+      safetyRefused,
+      failed,
+      branchDeleteFailed,
+      wouldOpen: 0,
+      wouldClose: 0,
+      wouldRediscover: 0,
+    },
   }
+}
+
+// ---------------------------------------------------------------------------
+// Same-run state fetch: existing correction PRs + terminal fingerprints
+// ---------------------------------------------------------------------------
+
+/** Bot login identifiers recognized as owning correction PRs/comments. */
+const BOT_LOGINS: ReadonlySet<string> = new Set(['fro-bot', 'fro-bot[bot]'])
+
+/** Strict marker pattern for extracting a terminal fingerprint from an issue body. Lowercase hex only. */
+const TERMINAL_FINGERPRINT_MARKER_PATTERN = /<!-- status-truth:fingerprint=([a-f0-9]+) -->/u
+
+/** Terminal outcome labels whose presence contributes a fingerprint to the suppression set. */
+const TERMINAL_OUTCOME_LABELS: ReadonlySet<string> = new Set(['status-truth:rejected', 'status-truth:false-positive'])
+
+/**
+ * Strictly extract a terminal fingerprint from an issue body's hidden marker.
+ *
+ * Returns null for missing body, missing marker, or a marker whose captured
+ * value is empty or contains non-hex characters (the regex itself only
+ * captures `[a-f0-9]+`, so any match is already lowercase hex; malformed
+ * uppercase/mixed markers simply fail to match and return null).
+ *
+ * Exported for testability. Fail-closed: any ambiguity returns null rather
+ * than guessing or fuzzy-matching a nearby value.
+ */
+export function extractTerminalFingerprint(body: string | null | undefined): string | null {
+  if (body === null || body === undefined || body === '') return null
+  const match = TERMINAL_FINGERPRINT_MARKER_PATTERN.exec(body)
+  if (match === null) return null
+  const value = match[1]
+  if (value === undefined || value === '') return null
+  return value
+}
+
+/** Result of fetching terminal fingerprints: the valid set plus a skipped/invalid count. */
+export interface FetchTerminalFingerprintsResult {
+  readonly fingerprints: ReadonlySet<string>
+  /** Malformed, missing, non-hex, or duplicate terminal fingerprints — excluded and counted. */
+  readonly skippedInvalid: number
+  /** Count of distinct fingerprints observed on more than one terminal issue (never the raw values). */
+  readonly duplicateCount: number
+}
+
+/**
+ * Fetch terminal fingerprints from status-truth proposal issues carrying a
+ * terminal outcome label (`status-truth:rejected` or `status-truth:false-positive`).
+ *
+ * Fail-closed per issue: a fingerprint that is malformed, missing, non-hex, or a
+ * duplicate of another terminal fingerprint is excluded from the returned set and
+ * counted as skipped/invalid. A duplicate is excluded from BOTH occurrences —
+ * ambiguity between two terminal issues claiming the same fingerprint must never
+ * be resolved by picking one arbitrarily, and must never suppress by fuzzy
+ * matching a prefix or substring.
+ *
+ * Accepted/resolved and other non-terminal labels never contribute to this set;
+ * only issues carrying a recognized terminal label are considered at all.
+ *
+ * Exported for testability.
+ */
+export async function fetchTerminalFingerprints(params: {
+  client: StatusTruthPrFetchClient
+  owner: string
+  repo: string
+}): Promise<FetchTerminalFingerprintsResult> {
+  const {client, owner, repo} = params
+  const perPage = 100
+  const seenOnce = new Set<string>()
+  const duplicates = new Set<string>()
+  let skippedInvalid = 0
+
+  let page = 1
+  for (;;) {
+    const response = await client.rest.issues.listForRepo({
+      owner,
+      repo,
+      labels: 'status-truth',
+      state: 'all',
+      per_page: perPage,
+      page,
+    })
+    for (const issue of response.data) {
+      const labelNames = issue.labels.map(l => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean)
+      const hasTerminalLabel = labelNames.some(l => TERMINAL_OUTCOME_LABELS.has(l))
+      if (!hasTerminalLabel) continue
+
+      const fingerprint = extractTerminalFingerprint(issue.body)
+      if (fingerprint === null) {
+        skippedInvalid++
+        continue
+      }
+
+      if (seenOnce.has(fingerprint)) {
+        duplicates.add(fingerprint)
+      } else {
+        seenOnce.add(fingerprint)
+      }
+    }
+    if (response.data.length < perPage) break
+    page++
+  }
+
+  const fingerprints = new Set<string>()
+  for (const fp of seenOnce) {
+    if (duplicates.has(fp)) {
+      skippedInvalid++
+      continue
+    }
+    fingerprints.add(fp)
+  }
+
+  return {fingerprints, skippedInvalid, duplicateCount: duplicates.size}
+}
+
+/**
+ * Fetch existing open correction PRs (any head branch/base/owner) so the planner
+ * can independently gate rediscovery on bot ownership, base branch, and the
+ * opaque branch-name prefix. This fetch is intentionally unfiltered by those
+ * criteria — the shell trusts the planner's own re-checks, mirroring the R11c
+ * "every write primitive re-validates" posture applied one layer up.
+ *
+ * Exported for testability.
+ */
+export async function fetchExistingCorrectionPrs(params: {
+  client: StatusTruthPrFetchClient
+  owner: string
+  repo: string
+}): Promise<ExistingStatusTruthPr[]> {
+  const {client, owner, repo} = params
+  const perPage = 100
+  const prs: ExistingStatusTruthPr[] = []
+
+  let page = 1
+  for (;;) {
+    const response = await client.rest.pulls.list({
+      owner,
+      repo,
+      state: 'open',
+      base: BASE_BRANCH,
+      per_page: perPage,
+      page,
+    })
+    for (const pr of response.data) {
+      const headBranch = pr.head.ref
+      const opaqueDigest = headBranch.startsWith(PR_BRANCH_PREFIX) ? headBranch.slice(PR_BRANCH_PREFIX.length) : ''
+      prs.push({
+        number: pr.number,
+        state: pr.state === 'closed' ? 'closed' : 'open',
+        headBranch,
+        baseBranch: pr.base.ref,
+        opaqueDigest,
+        botOwned: BOT_LOGINS.has(pr.user?.login ?? ''),
+      })
+    }
+    if (response.data.length < perPage) break
+    page++
+  }
+
+  return prs
 }
 
 // ---------------------------------------------------------------------------
@@ -1121,89 +1350,360 @@ async function createOctokitFromEnv(): Promise<StatusTruthPrOctokitClient> {
   return new LoadedOctokit({auth: token, request: {timeout: 10_000}, log: NOOP_LOG})
 }
 
+/** Report-read result: mirrors the `validateStatusTruthArtifact` discriminated union. */
+export type ReadReportResult = {valid: true; report: StatusTruthJsonReport} | {valid: false; reason: string}
+
 /**
- * CLI entry point for the status-truth PR execution step.
+ * Explicit dependency seam for {@link runPrsCore}.
  *
- * Environment variables:
- * - STATUS_TRUTH_REPORT_PATH: path to the JSON report artifact from the detect step (required)
- * - STATUS_TRUTH_PRS_RESULT_PATH: path to write the counts-only result JSON (optional)
- * - STATUS_TRUTH_DRY_RUN: set to 'true' for dry-run mode (optional)
- * - STATUS_TRUTH_PRS_ENABLED: repository variable arming key (required to be 'true' to arm)
- * - STATUS_TRUTH_PRS_DISPATCH_INPUT: manual dispatch input arming key (required to be 'true' to arm)
- * - GITHUB_TOKEN: write-scoped app token for branch/PR mutations (required unless dry-run/disarmed)
- *
- * Behavior:
- * - Re-checks arming at startup; disarmed → counts-only exit (defense in depth).
- * - stdout/stderr carry counts only; no raw claim text, source paths, fingerprints, or tokens.
- *
- * Strip-only safe: no parameter properties, enums, or namespaces.
+ * Every I/O boundary — environment flags, report loading, Octokit/client
+ * creation, public-output token loading, existing-PR fetch, terminal-
+ * fingerprint fetch, stdout/result writing, and process-exit signaling — is
+ * injected here so `runPrsCore` is fully testable without touching the real
+ * filesystem, network, or process globals. `runPrs()` is a thin wrapper that
+ * supplies the real environment-backed implementations.
  */
-async function runPrs(): Promise<void> {
-  const reportPath = process.env.STATUS_TRUTH_REPORT_PATH
-  const resultPath = process.env.STATUS_TRUTH_PRS_RESULT_PATH
-  const dryRun = process.env.STATUS_TRUTH_DRY_RUN === 'true'
+export interface RunPrsCoreDeps {
+  readonly env: Readonly<Record<string, string | undefined>>
+  readonly graduatedClaimKinds: ReadonlySet<string>
+  readonly readReport: () => Promise<ReadReportResult>
+  readonly loadPublicOutputTokens: () => Promise<PublicOutputTokens>
+  readonly createFetchClient: () => Promise<StatusTruthPrFetchClient>
+  readonly createWriteClient: () => Promise<StatusTruthPrOctokitClient>
+  readonly writeStdout: (text: string) => void
+  readonly writeStderr: (text: string) => void
+  readonly writeResultFile: (json: string) => Promise<void>
+  readonly setExitCode: (code: number) => void
+}
+
+const EMPTY_PLANNED_COUNTS: PlanStatusTruthPrActionsCounts = {
+  prActionsPlanned: 0,
+  downgradedToProposalOnly: 0,
+  pathForbidden: 0,
+  privacyGateBlocked: 0,
+  overflow: 0,
+  versionRejected: 0,
+}
+
+const EMPTY_EXECUTED_COUNTS: ExecuteStatusTruthPrActionsCounts = {
+  opened: 0,
+  closed: 0,
+  downgraded: 0,
+  safetyRefused: 0,
+  failed: 0,
+  branchDeleteFailed: 0,
+  wouldOpen: 0,
+  wouldClose: 0,
+  wouldRediscover: 0,
+}
+
+/**
+ * Stub write client used only for dry-run. Dry-run performs zero mutating
+ * calls (executeStatusTruthPrActions returns before touching `octokit` in
+ * its dry-run branch), so this stub's methods must never actually be
+ * invoked; each throws defensively if that invariant is ever violated.
+ */
+const NOOP_WRITE_CLIENT: StatusTruthPrOctokitClient = {
+  rest: {
+    repos: {
+      getContent: () => {
+        throw new Error('dry-run write client must not be called')
+      },
+      createOrUpdateFileContents: () => {
+        throw new Error('dry-run write client must not be called')
+      },
+    },
+    git: {
+      getRef: () => {
+        throw new Error('dry-run write client must not be called')
+      },
+      createRef: () => {
+        throw new Error('dry-run write client must not be called')
+      },
+      deleteRef: () => {
+        throw new Error('dry-run write client must not be called')
+      },
+    },
+    pulls: {
+      create: () => {
+        throw new Error('dry-run write client must not be called')
+      },
+      update: () => {
+        throw new Error('dry-run write client must not be called')
+      },
+    },
+    issues: {
+      createComment: () => {
+        throw new Error('dry-run write client must not be called')
+      },
+    },
+  },
+}
+
+/**
+ * Split a `owner/repo` GITHUB_REPOSITORY value into its parts.
+ * Falls back to the fro-bot/.github default when absent or malformed.
+ */
+function splitGithubRepository(githubRepository: string | undefined): {owner: string; repo: string} {
+  const value = githubRepository ?? 'fro-bot/.github'
+  const slashIndex = value.indexOf('/')
+  if (slashIndex === -1) return {owner: value, repo: '.github'}
+  return {owner: value.slice(0, slashIndex), repo: value.slice(slashIndex + 1)}
+}
+
+async function writeResultAndStdout(params: {
+  result: PrsResult
+  resultPath: string | undefined
+  deps: Pick<RunPrsCoreDeps, 'writeStdout' | 'writeResultFile' | 'writeStderr'>
+}): Promise<void> {
+  const {result, resultPath, deps} = params
+  const resultJson = `${JSON.stringify(result)}\n`
+  deps.writeStdout(resultJson)
+  if (resultPath !== undefined && resultPath !== '') {
+    try {
+      await deps.writeResultFile(resultJson)
+    } catch {
+      deps.writeStderr('status-truth-prs: could not write result: error-class=write-failure\n')
+    }
+  }
+}
+
+/**
+ * Testable core of the PR execution CLI step.
+ *
+ * Same-run pipeline (armed path only — disarmed exits immediately below):
+ * 1. Re-check three-key arming; disarmed → counts-only exit, no report required.
+ * 2. Read and validate `STATUS_TRUTH_REPORT_PATH`'s artifact; malformed/missing → exit 1.
+ * 3. Load public-output tokens (fail-closed on load failure) → exit 1 on failure.
+ * 4. Fetch existing bot-owned open correction PRs and terminal proposal
+ *    fingerprints; a live-mode fetch failure exits 1 before any planning
+ *    or writes (dry-run degrades to empty state on fetch failure, matching
+ *    the existing proposals CLI's dry-run posture).
+ * 5. Plan (`planStatusTruthPrActions`) and execute (`executeStatusTruthPrActions`).
+ * 6. Write counts-only stdout/result JSON; never source paths, fingerprints,
+ *    branch names, PR/proposal numbers, titles, bodies, or tokens.
+ */
+export async function runPrsCore(deps: RunPrsCoreDeps): Promise<PrsResult> {
+  const reportPath = deps.env.STATUS_TRUTH_REPORT_PATH
+  const resultPath = deps.env.STATUS_TRUTH_PRS_RESULT_PATH
+  const dryRun = deps.env.STATUS_TRUTH_DRY_RUN === 'true'
 
   const armed = isPrExecutionArmed({
-    prsEnabledVar: process.env[PRS_ENABLED_VAR],
-    dispatchInputVar: process.env[PRS_DISPATCH_INPUT_VAR],
-    graduatedClaimKinds: GRADUATED_CLAIM_KINDS,
+    prsEnabledVar: deps.env[PRS_ENABLED_VAR],
+    dispatchInputVar: deps.env[PRS_DISPATCH_INPUT_VAR],
+    graduatedClaimKinds: deps.graduatedClaimKinds,
   })
-
-  const emptyPlannedCounts: PlanStatusTruthPrActionsCounts = {
-    prActionsPlanned: 0,
-    downgradedToProposalOnly: 0,
-    pathForbidden: 0,
-    privacyGateBlocked: 0,
-    overflow: 0,
-    versionRejected: 0,
-  }
-  const emptyExecutedCounts: ExecuteStatusTruthPrActionsCounts = {
-    opened: 0,
-    closed: 0,
-    downgraded: 0,
-    safetyRefused: 0,
-    failed: 0,
-    branchDeleteFailed: 0,
-    wouldOpen: 0,
-    wouldClose: 0,
-  }
 
   if (!armed) {
     const result: PrsResult = {
       armed: false,
       dryRun,
-      plannedCounts: emptyPlannedCounts,
-      executedCounts: emptyExecutedCounts,
+      plannedCounts: EMPTY_PLANNED_COUNTS,
+      executedCounts: EMPTY_EXECUTED_COUNTS,
     }
-    const resultJson = `${JSON.stringify(result)}\n`
-    process.stdout.write(resultJson)
-    if (resultPath !== undefined && resultPath !== '') {
-      const {writeFile} = await import('node:fs/promises')
-      try {
-        await writeFile(resultPath, resultJson, {flag: 'w'})
-      } catch {
-        process.stderr.write('status-truth-prs: could not write result: error-class=write-failure\n')
-      }
-    }
-    return
+    await writeResultAndStdout({result, resultPath, deps})
+    return result
   }
 
   if (reportPath === undefined || reportPath === '') {
-    process.stderr.write('status-truth-prs: STATUS_TRUTH_REPORT_PATH is required\n')
-    process.exitCode = 1
-    return
+    deps.writeStderr('status-truth-prs: STATUS_TRUTH_REPORT_PATH is required\n')
+    deps.setExitCode(1)
+    const result: PrsResult = {
+      armed: true,
+      dryRun,
+      plannedCounts: EMPTY_PLANNED_COUNTS,
+      executedCounts: EMPTY_EXECUTED_COUNTS,
+    }
+    await writeResultAndStdout({result, resultPath, deps})
+    return result
   }
 
-  // Armed path is exercised only against a graduated, reviewed kind set;
-  // this slice ships GRADUATED_CLAIM_KINDS empty (R2), so the full
-  // report-read/plan/execute pipeline is deliberately out of scope for the
-  // CLI entry point beyond wiring — Unit 4 completes workflow integration.
-  // The write-scoped client is minted here (never in detect/open) so mint-time
-  // scoping is exercised even while GRADUATED_CLAIM_KINDS stays empty.
-  if (!dryRun) {
-    await createOctokitFromEnv()
+  const readResult = await deps.readReport()
+  if (!readResult.valid) {
+    deps.writeStderr('status-truth-prs: could not read or validate report artifact: error-class=report-failure\n')
+    deps.setExitCode(1)
+    const result: PrsResult = {
+      armed: true,
+      dryRun,
+      plannedCounts: EMPTY_PLANNED_COUNTS,
+      executedCounts: EMPTY_EXECUTED_COUNTS,
+    }
+    await writeResultAndStdout({result, resultPath, deps})
+    return result
   }
-  process.stdout.write(`${JSON.stringify({armed: true, dryRun})}\n`)
+  const {report} = readResult
+
+  let publicOutputTokens: PublicOutputTokens
+  try {
+    publicOutputTokens = await deps.loadPublicOutputTokens()
+  } catch {
+    deps.writeStderr('status-truth-prs: privacy token load failed: error-class=token-load-failure\n')
+    deps.setExitCode(1)
+    const result: PrsResult = {
+      armed: true,
+      dryRun,
+      plannedCounts: EMPTY_PLANNED_COUNTS,
+      executedCounts: EMPTY_EXECUTED_COUNTS,
+    }
+    await writeResultAndStdout({result, resultPath, deps})
+    return result
+  }
+
+  const {owner, repo} = splitGithubRepository(deps.env.GITHUB_REPOSITORY)
+
+  let existingPrs: ExistingStatusTruthPr[] = []
+  let terminalFingerprints: ReadonlySet<string> = new Set<string>()
+
+  try {
+    const fetchClient = await deps.createFetchClient()
+    const [prs, terminals] = await Promise.all([
+      fetchExistingCorrectionPrs({client: fetchClient, owner, repo}),
+      fetchTerminalFingerprints({client: fetchClient, owner, repo}),
+    ])
+    existingPrs = prs
+    terminalFingerprints = terminals.fingerprints
+  } catch {
+    if (!dryRun) {
+      deps.writeStderr('status-truth-prs: existing state fetch failed: error-class=fetch-failure\n')
+      deps.setExitCode(1)
+      const result: PrsResult = {
+        armed: true,
+        dryRun,
+        plannedCounts: EMPTY_PLANNED_COUNTS,
+        executedCounts: EMPTY_EXECUTED_COUNTS,
+      }
+      await writeResultAndStdout({result, resultPath, deps})
+      return result
+    }
+    // Dry-run: non-fatal — proceed with empty state (would-act counts may
+    // over-estimate opens, but zero mutating calls occur either way).
+  }
+
+  const planResult = planStatusTruthPrActions({
+    report,
+    graduatedClaimKinds: deps.graduatedClaimKinds,
+    existingPrs,
+    publicOutputTokens,
+    maxPrsPerRun: 1,
+    enabled: true,
+    terminalFingerprints,
+  })
+
+  // Dry-run performs zero mutating calls (see executeStatusTruthPrActions'
+  // dry-run branch, which returns before touching `octokit` at all), so a
+  // real write client/token is neither required nor created here — only
+  // live mode needs one, and only live mode's failure to create one is
+  // fatal.
+  let writeClient: StatusTruthPrOctokitClient
+  if (dryRun) {
+    writeClient = NOOP_WRITE_CLIENT
+  } else {
+    try {
+      writeClient = await deps.createWriteClient()
+    } catch {
+      deps.writeStderr('status-truth-prs: write client creation failed: error-class=token-load-failure\n')
+      deps.setExitCode(1)
+      const result: PrsResult = {
+        armed: true,
+        dryRun,
+        plannedCounts: planResult.counts,
+        executedCounts: EMPTY_EXECUTED_COUNTS,
+      }
+      await writeResultAndStdout({result, resultPath, deps})
+      return result
+    }
+  }
+
+  const executeResult = await executeStatusTruthPrActions({
+    octokit: writeClient,
+    owner,
+    repo,
+    actions: planResult.actions,
+    dryRun,
+    publicOutputTokens,
+  })
+
+  const result: PrsResult = {
+    armed: true,
+    dryRun,
+    plannedCounts: planResult.counts,
+    executedCounts: executeResult.counts,
+  }
+  await writeResultAndStdout({result, resultPath, deps})
+  return result
+}
+
+/**
+ * CLI entry point for the status-truth PR execution step.
+ *
+ * Environment variables:
+ * - STATUS_TRUTH_REPORT_PATH: path to the JSON report artifact from the detect step (required when armed)
+ * - STATUS_TRUTH_PRS_RESULT_PATH: path to write the counts-only result JSON (optional)
+ * - STATUS_TRUTH_DRY_RUN: set to 'true' for dry-run mode (optional)
+ * - STATUS_TRUTH_PRS_ENABLED: repository variable arming key (required to be 'true' to arm)
+ * - STATUS_TRUTH_PRS_DISPATCH_INPUT: manual dispatch input arming key (required to be 'true' to arm)
+ * - GITHUB_TOKEN: write-scoped app token for branch/PR mutations and read-only listing
+ * - GITHUB_REPOSITORY: `owner/repo` (defaults to fro-bot/.github)
+ *
+ * Behavior:
+ * - Re-checks arming at startup; disarmed → counts-only exit (defense in depth), no report required.
+ * - stdout/stderr carry counts only; no raw claim text, source paths, fingerprints, branch names,
+ *   PR/proposal numbers, titles, bodies, or tokens.
+ *
+ * Thin environment wrapper around {@link runPrsCore}; all real I/O boundaries live there as
+ * injected dependencies.
+ */
+async function runPrs(): Promise<void> {
+  await runPrsCore({
+    env: process.env,
+    graduatedClaimKinds: GRADUATED_CLAIM_KINDS,
+    readReport: async () => {
+      const reportPath = process.env.STATUS_TRUTH_REPORT_PATH
+      if (reportPath === undefined || reportPath === '') {
+        return {valid: false, reason: 'missing report path'}
+      }
+      const {readFile} = await import('node:fs/promises')
+      let rawJson: string
+      try {
+        rawJson = await readFile(reportPath, 'utf8')
+      } catch {
+        return {valid: false, reason: 'read-failure'}
+      }
+      let rawParsed: unknown
+      try {
+        rawParsed = JSON.parse(rawJson)
+      } catch {
+        return {valid: false, reason: 'parse-failure'}
+      }
+      const {validateStatusTruthArtifact} = await import('./status-truth-detect.ts')
+      const validation = validateStatusTruthArtifact(rawParsed)
+      if (!validation.valid) return {valid: false, reason: validation.reason}
+      return {valid: true, report: validation.report}
+    },
+    loadPublicOutputTokens: async () => {
+      const {loadPrivateTokensFromDisk} = await import('./capture-learnings-privacy.ts')
+      const {loadRedactedCanonicalIdsFromDisk} = await import('./status-truth-proposals.ts')
+      const {makePublicOutputTokens} = await import('./status-truth-public-output.ts')
+      const [privateTokens, redactedCanonicalIds] = await Promise.all([
+        loadPrivateTokensFromDisk(),
+        loadRedactedCanonicalIdsFromDisk(),
+      ])
+      return makePublicOutputTokens({privateTokens, redactedCanonicalIds})
+    },
+    createFetchClient: async () => (await createOctokitFromEnv()) as unknown as StatusTruthPrFetchClient,
+    createWriteClient: async () => createOctokitFromEnv(),
+    writeStdout: text => process.stdout.write(text),
+    writeStderr: text => process.stderr.write(text),
+    writeResultFile: async json => {
+      const resultPath = process.env.STATUS_TRUTH_PRS_RESULT_PATH
+      if (resultPath === undefined || resultPath === '') return
+      const {writeFile} = await import('node:fs/promises')
+      await writeFile(resultPath, json, {flag: 'w'})
+    },
+    setExitCode: code => {
+      process.exitCode = code
+    },
+  })
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {


### PR DESCRIPTION
## Summary

- graduate `plan-consistency` as the first Status Truth correction-PR claim kind
- wire the correction PR runner through same-run report parsing, state discovery, planning, and execution
- split read/write App tokens for correction runs and document the reviewed arming model

## Verification

- `pnpm bootstrap && pnpm check-types && pnpm lint && pnpm test`
- `pnpm exec actionlint .github/workflows/status-truth.yaml`
- focused pre-PR review of runner/error/privacy paths

## Notes

This does not enable autonomous correction PRs by itself. The repository variable and manual `open_prs=true` dispatch remain required.