### PR TITLE
feat: add recurring pattern proposals

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -50,3 +50,18 @@ labels:
   - name: dispatch-approved
     color: '#0e8a16'
     description: Operator-applied approval that dispatches the proposed items
+  - name: pattern-proposal
+    color: '#5319e7'
+    description: Recurring pattern proposal awaiting operator review
+  - name: pattern-proposal:accepted
+    color: '#0e8a16'
+    description: Pattern proposal accepted as a durable lesson
+  - name: pattern-proposal:deferred
+    color: '#fbca04'
+    description: Pattern proposal deferred pending more evidence
+  - name: pattern-proposal:rejected
+    color: '#e4e669'
+    description: Pattern proposal rejected as low-signal
+  - name: pattern-proposal:superseded
+    color: '#cfd3d7'
+    description: Pattern proposal superseded by a newer proposal

--- a/.github/workflows/capture-patterns.yaml
+++ b/.github/workflows/capture-patterns.yaml
@@ -69,8 +69,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           CAPTURE_PATTERNS_DIGEST_PATH: ${{ runner.temp }}/capture-patterns-digest.json
+        # pipefail: a failure in `node ...` must fail this step even though `tee`
+        # (the last command in the pipe) exits 0.
         run: node scripts/capture-patterns-cluster.ts | tee "$RUNNER_TEMP/detect-result.json"
-        shell: bash
+        shell: bash -Eeuo pipefail {0}
 
       - name: 📤 Upload digest artifact
         if: always()
@@ -81,7 +83,7 @@ jobs:
           # source IDs, SHA-pinned links, public-safe titles, evidence counts,
           # score bucket, suggested next action, run count). No private tokens.
           path: ${{ runner.temp }}/capture-patterns-digest.json
-          retention-days: 7
+          retention-days: 1
 
       - name: 📋 Write detect summary
         if: always()
@@ -124,10 +126,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: detect
-    if: always()
+    # Skip the entire job on dry-run (the default): drafting/opening proposals only
+    # ever happens on an explicit live (dry_run=false) manual dispatch. `always()`
+    # keeps the job eligible even if the detect job's non-critical steps report a
+    # failure state, without gating on detect's own conclusion.
+    if: ${{ always() && github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false' }}
     permissions:
       contents: read
-      issues: read
 
     steps:
       - name: ⤵ Checkout Branch
@@ -270,8 +275,10 @@ jobs:
           CAPTURE_PATTERNS_DIGEST_PATH: ${{ runner.temp }}/capture-patterns-digest.json
           CAPTURE_PATTERNS_BODIES_PATH: ${{ runner.temp }}/capture-patterns-bodies.json
           CAPTURE_PATTERNS_RESULT_PATH: ${{ runner.temp }}/capture-patterns-result.json
+        # pipefail: a failure in `node ...` must fail this step even though `tee`
+        # (the last command in the pipe) exits 0.
         run: node scripts/capture-patterns-open.ts | tee "$RUNNER_TEMP/open-output.json"
-        shell: bash
+        shell: bash -Eeuo pipefail {0}
 
       - if: always()
         name: 📋 Write open summary

--- a/.github/workflows/capture-patterns.yaml
+++ b/.github/workflows/capture-patterns.yaml
@@ -1,0 +1,306 @@
+---
+name: Capture Patterns
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry-run mode: plan proposals but open no issues'
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+# Default permissions: read-only. The open job overrides to issues: write, and only
+# when a live (non-dry-run) manual dispatch explicitly requests it.
+permissions:
+  contents: read
+
+# Serialize runs; never cancel an in-progress run so a detect-to-open sequence is
+# never interrupted halfway through proposal planning.
+concurrency:
+  group: capture-patterns
+  cancel-in-progress: false
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Detect job: read-only source collection, clustering, and digest planning.
+  # No write credentials; no issue mutations.
+  # ---------------------------------------------------------------------------
+  detect:
+    name: Detect recurring correction patterns
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: read
+
+    steps:
+      - name: ⤵ Checkout Branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: 📦 Setup
+        uses: ./.github/actions/setup
+
+      # Overlay metadata/ from the data branch so the privacy gate reads the
+      # authoritative private-repo list from metadata/repos.yaml. Best-effort;
+      # `loadPrivateTokensFromDisk()` is the fail-closed chokepoint downstream.
+      - name: ⤵ Overlay metadata from data branch
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code origin data >/dev/null 2>&1; then
+            git fetch --no-tags origin data
+            git checkout origin/data -- metadata/
+          else
+            echo "data branch not yet established; skipping metadata overlay."
+          fi
+
+      # Collect the allowed source corpus (accepted docs/solutions/ docs and
+      # learning-proposal issues), build deterministic cluster candidates, apply
+      # suppression/ranking/cap, and write a versioned candidate digest to
+      # CAPTURE_PATTERNS_DIGEST_PATH. Writing the file directly avoids the
+      # shell-injection vector of echoing structured data via GITHUB_OUTPUT.
+      - name: 🔍 Detect candidate patterns
+        id: detect
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          CAPTURE_PATTERNS_DIGEST_PATH: ${{ runner.temp }}/capture-patterns-digest.json
+        run: node scripts/capture-patterns-cluster.ts | tee "$RUNNER_TEMP/detect-result.json"
+        shell: bash
+
+      - name: 📤 Upload digest artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: capture-patterns-digest
+          # Digest fields are allow-listed by buildCandidateDigest (fingerprint,
+          # source IDs, SHA-pinned links, public-safe titles, evidence counts,
+          # score bucket, suggested next action, run count). No private tokens.
+          path: ${{ runner.temp }}/capture-patterns-digest.json
+          retention-days: 7
+
+      - name: 📋 Write detect summary
+        if: always()
+        run: |
+          set -euo pipefail
+          result="$RUNNER_TEMP/detect-result.json"
+
+          {
+            echo "## Capture Patterns Detect Summary"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+
+            if [[ -s "$result" ]]; then
+              echo "| Sources loaded | $(jq '.sourcesLoaded // 0' "$result") |"
+              echo "| Invalid sources | $(jq '.invalidSources // 0' "$result") |"
+              echo "| Candidates scanned | $(jq '.candidatesScanned // 0' "$result") |"
+              echo "| Low-signal skipped | $(jq '.lowSignalSkipped // 0' "$result") |"
+              echo "| Duplicate/open-overlap | $(jq '.duplicateOpenOverlap // 0' "$result") |"
+              echo "| Hard-suppressed | $(jq '.hardSuppressed // 0' "$result") |"
+              echo "| Soft-suppressed | $(jq '.softSuppressed // 0' "$result") |"
+              echo "| Unsafe | $(jq '.unsafe // 0' "$result") |"
+              echo "| Token-load failure | $(jq -r 'if .tokenLoadFailure then "true" else "false" end' "$result") |"
+              echo "| Capped | $(jq '.capped // 0' "$result") |"
+              echo "| Candidates emitted | $(jq '.candidatesEmitted // 0' "$result") |"
+              echo "| Scan failure | $(jq -r 'if .scanFailure then "true" else "false" end' "$result") |"
+            else
+              echo "| Status | (detect result unavailable) |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
+  # Open job: agent drafts bounded proposal bodies from the digest, then a
+  # deterministic step validates and opens at most three pattern-proposal
+  # issues. Dry-run (the default) plans without opening issues or minting a
+  # write token — v1 never performs live scheduled writes.
+  # ---------------------------------------------------------------------------
+  open:
+    name: Draft and open pattern proposals
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: detect
+    if: always()
+    permissions:
+      contents: read
+      issues: read
+
+    steps:
+      - name: ⤵ Checkout Branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: 📦 Setup
+        uses: ./.github/actions/setup
+
+      # Overlay metadata/ from the data branch before the privacy-gated open step,
+      # so `loadPrivateTokensFromDisk()` reads the authoritative private-repo list.
+      - name: ⤵ Overlay metadata from data branch
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code origin data >/dev/null 2>&1; then
+            git fetch --no-tags origin data
+            git checkout origin/data -- metadata/
+          else
+            echo "data branch not yet established; skipping metadata overlay."
+          fi
+
+      - name: 📥 Download digest artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: capture-patterns-digest
+          path: ${{ runner.temp }}
+
+      # The agent's ONLY job: read the versioned candidate digest (fingerprint,
+      # source IDs, SHA-pinned links, public-safe titles, evidence counts — no
+      # private tokens, hidden markers, raw issue bodies, or raw solution text),
+      # and write drafted or agent-skipped proposal bodies to a temp JSON file
+      # keyed by fingerprint. It never calls GitHub, edits repo files, or opens
+      # issues — the deterministic open step below does that under a separately
+      # minted write token, only when armed for a live run.
+      - name: 🤖 Draft pattern proposal bodies
+        id: agent
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false' }}
+        uses: fro-bot/agent@dfd5a6a2a6896a5f1bbe0cfb72ba8c7af766f222 # v0.84.0
+        env:
+          CAPTURE_PATTERNS_DIGEST_PATH: ${{ runner.temp }}/capture-patterns-digest.json
+          TASK_PROMPT: |
+            You are authoring recurring-pattern proposal bodies. Each candidate in the
+            digest represents two or more solution docs and/or learning-proposal issues
+            that share repeated correction substance — the same kind of mistake, caught
+            and fixed the same way, more than once.
+
+            Your ONLY job in this step:
+            1. Read the candidate digest from $CAPTURE_PATTERNS_DIGEST_PATH (or
+               equivalently $RUNNER_TEMP/capture-patterns-digest.json). It is a JSON
+               array of candidates. Each candidate has:
+               - fingerprint: opaque identity string (the ONLY identifier for this candidate)
+               - sourceIds: opaque source identifiers (do not treat as prose)
+               - sourceLinks: public-safe, dereferenceable links to each source
+               - sourceTitles: public-safe titles (already privacy-gated)
+               - evidenceCount: number of independent sources in the cluster
+               - scoreBucket: 'strong' | 'moderate' | 'weak'
+               - suggestedNextAction: hint field, informational only
+               - runCount: how many runs this candidate has been seen across
+
+            2. For each candidate you judge worth proposing, decide one of two outcomes:
+
+               "drafted" — write a decision-ready proposal body with:
+               - patternStatement: the reusable correction pattern, grounded in the
+                 source titles and evidence, not invented specifics
+               - rationale: why this is a repeated pattern worth codifying, not a
+                 one-off (2-4 sentences)
+               - sourceReferences: array of public-safe strings (use the provided
+                 sourceTitles/sourceLinks — do not fabricate references)
+               - evidenceCount: copy from the digest candidate
+               - suggestedNextAction: a concrete next step for a human reviewer (e.g.
+                 "codify as a docs/solutions/ best-practice entry")
+
+               "agent-skipped" — when the candidate does not represent a real repeated
+               correction pattern (only superficial keyword overlap, insufficient
+               evidence, or sources describing genuinely different behaviors), skip it
+               with a closed reason: "insufficient-evidence" or "different-behaviors".
+
+            3. Write ALL candidate outcomes as a JSON object to
+               $RUNNER_TEMP/capture-patterns-bodies.json:
+               {
+                 "schemaVersion": 1,
+                 "bodies": {
+                   "<fingerprint>": { "outcome": "drafted", ... } | { "outcome": "agent-skipped", "reason": "..." }
+                 }
+               }
+               You may omit a fingerprint entirely if you are unable to judge it — the
+               open step treats a missing body as a distinct, safe no-op for that candidate.
+
+            4. DO NOTHING ELSE. No code edits. No doc edits. No other issues. No API
+               calls beyond reading the digest file. No branch operations.
+
+            Hard boundaries:
+            - Never claim measurable improvement or invent evidence beyond what the
+              digest provides.
+            - Never look up source content, repo internals, or anything beyond the
+              digest fields given to you.
+            - Never create issues yourself — the open step does that, only when armed
+              for a live run.
+            - Never write to any path other than $RUNNER_TEMP/capture-patterns-bodies.json.
+            - Output only the bodies file. No summary issue. No comments.
+        with:
+          # The action requires a github-token input. The workflow's auto-provisioned
+          # GITHUB_TOKEN is scoped to `contents: read`/`issues: read` by this job's
+          # permissions block — it carries no `issues: write`. Issue creation stays
+          # exclusively in the deterministic open step below, under a separately
+          # minted, repo-scoped App token, minted only for an explicit live dispatch.
+          github-token: ${{ github.token }}
+          auth-json: ${{ secrets.OPENCODE_AUTH_JSON }}
+          model: ${{ vars.FRO_BOT_MODEL }}
+          omo-providers: ${{ secrets.OMO_PROVIDERS }}
+          opencode-config: ${{ secrets.OPENCODE_CONFIG }}
+          prompt: ${{ env.TASK_PROMPT }}
+
+      # Mint a scoped app token only for an explicit live (non-dry-run) manual
+      # dispatch. Dry-run runs (the default) never mint this token and never
+      # mutate issues — no live scheduled writes exist in v1.
+      - name: 🔑 Mint write token
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false' }}
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          # Scope to this repo only — smallest blast radius.
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-contents: read
+
+      # Deterministic open step: reads the digest and the agent-authored bodies,
+      # validates every body through the shared public-output gate, confirms
+      # required labels, injects hidden fingerprint/source-id markers, and opens
+      # at most three pattern-proposal issues. Dry-run mode (default) skips this
+      # step entirely; the detect summary is the dry-run signal.
+      - name: 📬 Open pattern proposal issues
+        id: open
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          CAPTURE_PATTERNS_DIGEST_PATH: ${{ runner.temp }}/capture-patterns-digest.json
+          CAPTURE_PATTERNS_BODIES_PATH: ${{ runner.temp }}/capture-patterns-bodies.json
+          CAPTURE_PATTERNS_RESULT_PATH: ${{ runner.temp }}/capture-patterns-result.json
+        run: node scripts/capture-patterns-open.ts | tee "$RUNNER_TEMP/open-output.json"
+        shell: bash
+
+      - if: always()
+        name: 📋 Write open summary
+        run: |
+          set -euo pipefail
+          result="$RUNNER_TEMP/capture-patterns-result.json"
+
+          {
+            echo "## Capture Patterns Open Summary"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+
+            if [[ -s "$result" ]]; then
+              echo "| Candidates examined | $(jq '.candidatesExamined // 0' "$result") |"
+              echo "| Drafted | $(jq '.drafted // 0' "$result") |"
+              echo "| Agent-skipped | $(jq '.agentSkipped // 0' "$result") |"
+              echo "| Missing body | $(jq '.missingBody // 0' "$result") |"
+              echo "| Invalid body | $(jq '.invalidBody // 0' "$result") |"
+              echo "| Blocked on privacy | $(jq '.blockedOnPrivacy // 0' "$result") |"
+              echo "| Skipped duplicate (same run) | $(jq '.skippedDuplicateSameRun // 0' "$result") |"
+              echo "| Skipped duplicate (existing) | $(jq '.skippedDuplicateExisting // 0' "$result") |"
+              echo "| Proposals opened | $(jq '.proposalsOpened // 0' "$result") |"
+              echo "| Failed | $(jq '.failed // 0' "$result") |"
+              echo "| Skipped: label unavailable | $(jq '.skippedLabelUnavailable // 0' "$result") |"
+              echo "| Skipped: over cap | $(jq '.skippedOverCap // 0' "$result") |"
+              echo "| Token-load failure | $(jq -r 'if .tokenLoadFailed then "true" else "false" end' "$result") |"
+              echo "| Bodies file missing/unreadable | $(jq -r 'if .bodyFileReadFailed then "true" else "false" end' "$result") |"
+            else
+              echo "| Status | (open result unavailable) |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Fro Bot control plane:
 | --- | --- | --- |
 | **Fro Bot** | Core agent: PR review, issue triage, scheduled oversight, manual tasks | Issues, PR events, schedule, dispatch, workflow_call |
 | **Capture Learnings** | Capture and commit knowledge-wiki learnings to the `data` branch | Schedule, dispatch |
+| **Capture Patterns** | Detect recurring correction patterns across accepted learnings and solution docs, then draft human-reviewed pattern proposals | Manual dispatch |
 | **Poll Invitations** | Accept allowlisted collaboration invitations | Every 15 minutes, dispatch |
 | **Reconcile Repos** | Reconcile collaborator access against `metadata/repos.yaml`; dispatch surveys for stale repos; auto-stars collab/contrib repos | Daily 05:17 UTC, dispatch |
 | **Survey Repo** | Ingest a repository into the knowledge wiki; dispatched by Reconcile Repos or manually via `gh workflow run survey-repo.yaml -f node_id=<node_id>` | Dispatch (by Reconcile Repos) |
@@ -340,6 +341,27 @@ Any single key missing produces zero PR actions; eligible findings fall back to 
 - Before any push, the corrected content is re-verified against the live base-branch file, not just the report snapshot — stale drift never gets force-corrected.
 - If a fingerprint's drift clears on a complete scan while its correction PR is still open, the bot closes its own PR with a brief comment and deletes the branch. If the linked proposal later gets a terminal label (`status-truth:rejected` or `status-truth:false-positive`), the same closure happens regardless of drift state. Merged PRs are never touched.
 - The bot never merges, approves, enables automerge, force-pushes, or retargets a correction PR — closing its own stale PRs and deleting its own branches are the only PR-state mutations it can make. A human always merges.
+
+### Recurring Pattern Proposals
+
+The **Capture Patterns** workflow looks for repeated correction behavior across the accepted learning corpus — `docs/solutions/` entries and `learning-proposal` issues in this repo — and drafts human-reviewed proposals for patterns worth codifying as durable lessons. It never authors or edits `docs/solutions/` directly; every pattern proposal is a decision log entry a human reviews and, if accepted, turns into a doc themselves.
+
+The loop is proposal-only and manual-first: `workflow_dispatch` defaults to dry-run, and there is no scheduled trigger in this initial slice. A dry run plans and drafts candidates but never opens issues or mints an issue-writing token; only an explicit live dispatch (`dry_run: false`) does both.
+
+**Reviewing a proposal:**
+
+Apply exactly one outcome label to record your decision:
+
+| Label | Meaning |
+| --- | --- |
+| `pattern-proposal:accepted` | Pattern is real and durable; source material is retired from future clustering immediately |
+| `pattern-proposal:deferred` | Not yet — needs more independent evidence before reconsideration |
+| `pattern-proposal:rejected` | Pattern is not real, or too weak to codify |
+| `pattern-proposal:superseded` | A newer proposal replaces this one; permanently suppressed |
+
+A closed proposal without one of these labels is `needs-outcome` — a derived state, not an operator label, that conservatively suppresses re-proposal of the same sources until new independent evidence appears.
+
+**Caps and evidence:** at most three new proposals open per run, ranked by independent source count, accepted-doc presence, and recency. Deterministic scripts own source loading, deduplication, suppression, privacy gating, and issue mutations; the agent only judges evidence and drafts bounded proposal bodies from a curated, privacy-gated digest — it never edits repo files, reads raw solution text, or receives private tokens.
 
 ### Cross-Repo Goal Dispatch
 

--- a/docs/brainstorms/2026-07-07-a1-recurring-pattern-synthesis-requirements.md
+++ b/docs/brainstorms/2026-07-07-a1-recurring-pattern-synthesis-requirements.md
@@ -1,0 +1,162 @@
+---
+date: 2026-07-07
+topic: a1-recurring-pattern-synthesis
+---
+
+# A1 — Recurring Pattern Synthesis
+
+## Summary
+
+Add a proposal-only synthesis loop that finds repeated learning patterns across prior Fro Bot work. The loop should identify when the same mistake, fix, or operating lesson appears across multiple public-safe artifacts and open decision-ready pattern proposals for human review.
+
+---
+
+## Problem Frame
+
+A1 already helps Fro Bot retrieve known lessons and capture new ones from high-signal work. That makes individual learnings durable, but it does not yet tell whether multiple solved incidents are pointing at the same deeper pattern.
+
+The current capture path is intentionally candidate-oriented: each proposal is anchored to a concrete PR or solved incident. That keeps quality high, but it leaves recurring behavior scattered across proposal issues and solution docs. Fro Bot can remember individual lessons, but it cannot yet notice that the same class of correction keeps returning.
+
+The risk is fake insight. A loop that clusters shallow keywords would add another review queue without improving judgment. The first C4 slice must therefore prove decision-ready proposals from a narrow source set before any metric, dashboard, or authoring automation is added.
+
+---
+
+## Actors
+
+- A1. Marcus: reviews pattern proposals and decides whether they become durable guidance.
+- A2. Fro Bot synthesis loop: detects recurring patterns, summarizes public-safe evidence, and opens proposal issues.
+- A3. Existing learning corpus: accepted `docs/solutions/` docs and learning-proposal issues in this repo.
+- A4. Future planner/compound workflow: turns accepted pattern proposals into focused docs or plan changes.
+
+---
+
+## Key Flows
+
+- F1. Pattern proposal flow
+  - **Trigger:** A scheduled or manually dispatched synthesis run scans the allowed learning corpus.
+  - **Actors:** A2, A3
+  - **Steps:** The loop groups related artifacts, filters keyword-only or weak clusters, validates a public-safe summary, and opens a proposal issue for clusters that satisfy the evidence threshold.
+  - **Outcome:** Marcus sees a pattern proposal with enough summary and evidence links to decide without reconstructing the source history.
+  - **Covered by:** R1, R2, R3, R4, R6, R7, R8, R9
+- F2. Accepted pattern handoff
+  - **Trigger:** Marcus accepts or acts on a pattern proposal.
+  - **Actors:** A1, A4
+  - **Steps:** The accepted proposal provides a concise pattern statement, source links, rationale, and suggested durable-home options for later compound or planning work.
+  - **Outcome:** The pattern can become reusable guidance without the synthesis loop directly authoring it.
+  - **Covered by:** R5, R10, R11, R14
+- F3. Suppression flow
+  - **Trigger:** A pattern proposal is rejected, closed as low-signal, or superseded by better guidance.
+  - **Actors:** A1, A2
+  - **Steps:** The synthesis loop records the cluster identity in the proposal issue and suppresses repeat proposals unless later public-safe evidence changes that identity.
+  - **Outcome:** Rejected weak patterns do not become recurring noise.
+  - **Covered by:** R12, R13, R15
+
+---
+
+## Requirements
+
+**Allowed source set**
+- R1. The loop must synthesize only from accepted `docs/solutions/` documents and learning-proposal issues in this repo.
+- R2. The loop must not read raw agent transcripts, workflow logs, unpublished local notes, private-only artifacts, or cross-repo issue bodies as synthesis inputs.
+- R3. Proposal issues are the durable decision log for C4; no new metric store or secondary index is required in this slice.
+
+**Pattern quality**
+- R4. A pattern candidate must draw evidence from at least two independent source artifacts that describe the same correction behavior, not only the same tag or keyword.
+- R5. A pattern proposal must state the reusable lesson in plain operational language and explain why the sources are the same pattern.
+- R6. A proposal must be decision-ready: it must include the pattern statement, a short rationale, public-safe evidence links, and suggested next human action.
+- R7. The loop must suppress keyword-only, taxonomy-only, or over-generalized clusters even when they meet the two-artifact minimum.
+
+**Proposal behavior**
+- R8. The first slice must be proposal-only and must not author or modify `docs/solutions/` documents.
+- R9. The loop must open at most three proposals per run and must order candidates by evidence strength before applying the cap.
+- R10. Each proposal must suggest one next human action: compound into a solution doc, fold into an existing doc, defer for more evidence, or reject.
+- R11. Accepted pattern proposals must remain visible as issue-based evidence for future metric planning; the issue itself is the source of truth.
+
+**Lifecycle and deduplication**
+- R12. Each proposal must carry a stable public cluster identity derived from sorted source artifact identifiers; the pattern statement is display metadata, not part of the identity hash.
+- R13. Rejected, low-signal, or superseded proposals must suppress repeat proposals with the same cluster identity.
+- R14. The loop may propose a new version only when later public-safe evidence adds enough new independent source artifacts to cross the upgrade threshold.
+- R15. Unsafe or blocked clusters must be counted as skipped for the run but must not create durable suppression state.
+
+**Public-output safety**
+- R16. Every proposal body must pass the same deterministic public-output/private-token gate stack used by existing proposal loops before posting; C4 must not introduce a weaker advisory-only scan.
+- R17. Proposal bodies must not include private repo identifiers, branch names, issue titles, raw run-log text, transcript snippets, or private-only evidence links.
+- R18. Evidence links must be public-safe and dereferenceable by the public proposal audience; private or opaque links must be omitted.
+- R19. Missing, unsafe, or private-only evidence must cause a candidate to be skipped rather than summarized vaguely.
+
+**Self-improvement boundary**
+- R20. The loop must not edit prompts, persona files, skills, workflow instructions, or `docs/solutions/` directly.
+- R21. The loop must not claim Fro Bot is measurably improving from synthesis alone; outcome measurement is deferred to the O8 metric slice.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R4, R5, R6.** Given three accepted learning proposals about repeated workflow-state drift, when the synthesis loop runs, it opens one proposal that names the operational pattern, explains the repeated correction behavior, and links the source proposals.
+- AE2. **Covers R4, R7.** Given two artifacts that share only a generic tag like `testing` but describe unrelated lessons, when the synthesis loop runs, it does not open a pattern proposal.
+- AE3. **Covers R2, R16, R17, R19.** Given a cluster whose only useful evidence requires raw logs or a private repo name, when the loop evaluates it, the candidate is skipped and no proposal body is posted.
+- AE4. **Covers R6, R8, R10, R20.** Given a strong recurring pattern, when the proposal is opened, it suggests human next actions but does not change any prompt, persona, skill, workflow, or solution-doc file.
+- AE5. **Covers R12, R13, R14.** Given a rejected low-signal pattern proposal, when the same weak cluster appears again, the loop suppresses it; when a later public-safe artifact adds independent evidence, the loop may propose a new version.
+- AE6. **Covers R9, R15, R21.** Given more than three candidate clusters in one run, when the proposal cap is reached, the loop posts only the three strongest candidates, reports capped/skipped counts, and does not claim improved outcomes.
+- AE7. **Covers R18.** Given a candidate with one public source and one private evidence link, when the proposal body is rendered, the private link is omitted; if the remaining public evidence no longer meets threshold, the candidate is skipped.
+
+---
+
+## Success Criteria
+
+- Marcus can accept, reject, or defer a pattern proposal from the proposal body alone, without re-reading every source artifact.
+- The first evaluated batch produces decision-ready proposals or clear skip counts, not keyword-cluster noise.
+- Public proposal output contains no private repo identifiers, branch names, issue titles, raw run-log content, transcript snippets, or private-only links.
+- A rejected pattern does not repeatedly reappear unless new public-safe evidence crosses the upgrade threshold.
+- The accepted/rejected/deferred pattern proposal outcomes give enough signal to plan the O8 improvement metric slice.
+
+---
+
+## Scope Boundaries
+
+- No autonomous authoring or editing of `docs/solutions/` documents in the first slice.
+- No prompt, persona, workflow-instruction, or skill self-editing.
+- No operator-web/dashboard surfacing.
+- No improvement metric or claim that Fro Bot is improving.
+- No raw transcript, workflow-log, unpublished note, or private-only evidence mining.
+- No cross-repo dispatch expansion; A3 production goals remain separate.
+- No new persistent store beyond issue markers and existing proposal issue state.
+
+---
+
+## Key Decisions
+
+- **Proposal-only first:** Pattern synthesis is judgment-heavy, so human review stays in the loop until proposal quality is known.
+- **Narrow public source set:** The first slice uses accepted solution docs and learning-proposal issues, not raw run history.
+- **Evidence clusters over taxonomy counts:** Repeated tags are a weak signal; proposals need repeated correction substance.
+- **Issue-based lifecycle:** Proposal issues remain the decision log and suppression surface for this slice.
+- **Separate synthesis from metrics:** C4 finds candidate patterns; O8 later measures whether those patterns improve future outcomes.
+
+---
+
+## Dependencies / Assumptions
+
+- The existing A1 capture/proposal machinery is available and remains the source of individual learning artifacts.
+- The current public-output/private-identifier gate is mandatory for any proposal body the loop emits.
+- C-deep/wiki context expansion improves agent grounding but is not required for every synthesis run.
+- Learning-proposal issue labels and markers remain stable enough for planning to define the exact query and fingerprint mechanics.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R4, R7][Technical] What exact evidence signals best distinguish repeated correction behavior from keyword overlap?
+- [Affects R9][Technical] What lookback window is small enough for cost control but large enough to produce signal?
+- [Affects R14][Technical] What upgrade threshold is high enough to avoid superset spam but flexible enough to surface stronger later evidence?
+- [Affects R16][Technical] Which existing public-output validation module should be reused for final proposal-body validation?
+
+---
+
+## Sources / Research
+
+- North-star context: `docs/brainstorms/2026-06-15-fro-bot-personal-agent-north-star-requirements.md`
+- A1 origin: `docs/brainstorms/2026-06-22-skill-saving-grow-and-learn-requirements.md`
+- C-deep predecessor: `docs/brainstorms/2026-07-07-a1-phase-3-deep-wiki-traversal-requirements.md`
+- Existing capture scripts: `scripts/capture-learnings-harvest.ts`, `scripts/capture-learnings-open.ts`, `scripts/capture-learnings-privacy.ts`

--- a/docs/plans/2026-07-07-004-feat-recurring-pattern-synthesis-plan.md
+++ b/docs/plans/2026-07-07-004-feat-recurring-pattern-synthesis-plan.md
@@ -213,7 +213,7 @@ flowchart TD
 **Verification:**
 - Planner outputs a counts-only digest distinguishing proposed, capped, low-signal, duplicate/open-overlap, hard-suppressed, soft-suppressed, unsafe, invalid-source, no-op, and failed states.
 
-- [ ] **Unit 3: Agent proposal digest and deterministic issue opener**
+- [x] **Unit 3: Agent proposal digest and deterministic issue opener**
 
 **Goal:** Let the agent draft bounded pattern proposal bodies, then deterministically validate and open proposal issues.
 

--- a/docs/plans/2026-07-07-004-feat-recurring-pattern-synthesis-plan.md
+++ b/docs/plans/2026-07-07-004-feat-recurring-pattern-synthesis-plan.md
@@ -163,7 +163,7 @@ flowchart TD
 **Verification:**
 - The pure model can load and classify sources/proposals without opening issues or invoking the agent.
 
-- [ ] **Unit 2: Candidate clustering, scoring, and suppression planner**
+- [x] **Unit 2: Candidate clustering, scoring, and suppression planner**
 
 **Goal:** Build deterministic cluster candidates and decide which candidates may be sent to the agent for proposal drafting.
 

--- a/docs/plans/2026-07-07-004-feat-recurring-pattern-synthesis-plan.md
+++ b/docs/plans/2026-07-07-004-feat-recurring-pattern-synthesis-plan.md
@@ -261,7 +261,7 @@ flowchart TD
 **Verification:**
 - The opener is safe to run after an agent drafting step and cannot post unvalidated proposal prose.
 
-- [ ] **Unit 4: Workflow integration and operator docs**
+- [x] **Unit 4: Workflow integration and operator docs**
 
 **Goal:** Wire the synthesis loop into CI as a scheduled/manual proposal-only workflow and document the operator contract.
 

--- a/docs/plans/2026-07-07-004-feat-recurring-pattern-synthesis-plan.md
+++ b/docs/plans/2026-07-07-004-feat-recurring-pattern-synthesis-plan.md
@@ -1,0 +1,346 @@
+---
+title: 'feat: Recurring pattern synthesis'
+type: feat
+status: active
+date: 2026-07-07
+origin: docs/brainstorms/2026-07-07-a1-recurring-pattern-synthesis-requirements.md
+deepened: 2026-07-07
+---
+
+# feat: Recurring pattern synthesis
+
+## Overview
+
+Add the A1 C4 proposal-only synthesis loop. The loop reads the public-safe learning corpus, identifies repeated correction patterns, asks the agent to draft decision-ready pattern proposals, then opens at most three public-safe proposal issues per run.
+
+## Problem Frame
+
+A1 captures individual learnings, but repeated lessons remain scattered across solution docs and learning-proposal issues. The next self-improvement step is to surface recurring correction patterns without creating fake insight, private-output risk, or another uncontrolled proposal queue.
+
+The implementation must behave like the existing A1 capture loop: deterministic scripts own source loading, identity, deduplication, privacy gates, labels, caps, and issue mutations; the agent only judges and drafts bounded proposal bodies from a curated digest.
+
+## Requirements Trace
+
+- R1-R3. Synthesize only from accepted `docs/solutions/` docs and learning-proposal issues in this repo; proposal issues remain the decision log.
+- R4-R7. Distinguish repeated correction behavior from keyword overlap and produce decision-ready proposal content.
+- R8-R11. Stay proposal-only, cap new proposals at three per run, and preserve issue outcomes for later metric planning.
+- R12-R15. Use stable source-ID-based cluster identity, suppress repeats, allow carefully bounded upgraded evidence, and avoid durable state for unsafe clusters.
+- R16-R19. Reuse the deterministic public-output validation class from A1 learning proposals and omit private or opaque evidence.
+- R20-R21. Do not edit prompts, persona, workflows, skills, or solution docs directly; do not claim measurable improvement.
+
+## Scope Boundaries
+
+- No autonomous `docs/solutions/` authoring or editing.
+- No prompt/persona/skill/workflow-instruction self-editing beyond the workflow wiring needed to run this loop.
+- No dashboard/operator-web surfacing.
+- No O8 improvement metric.
+- No raw transcript, workflow-log, unpublished note, private-only artifact, or cross-repo issue-body mining.
+- No new persistent store beyond issue markers, labels, and existing GitHub issue state.
+
+### Deferred to Separate Tasks
+
+- O8 improvement metric: use actual C4 proposal outcomes after this loop produces data.
+- Autonomous durable-doc authoring: only after proposal quality is proven and a separate quarantine/write path is planned.
+- Operator-web surfacing: wait for synthesis state and the dashboard/spine work.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/capture-learnings-harvest.ts` — source harvesting, `learning-proposal` label constants, merge-SHA markers, solution-doc overlap, hard caps, digest writing, and GitHub issue pagination.
+- `scripts/capture-learnings-open.ts` — deterministic issue opening from agent-authored bodies, label preflight, same-run duplicate handling, fail-closed label behavior.
+- `scripts/capture-learnings-privacy.ts` — private-token loading; C4 should reuse this fail-closed token boundary.
+- `scripts/status-truth-public-output.ts` — general public-output gate (`makePublicOutputTokens` / `applyPublicOutputGate`) for public issue bodies, summaries, and emitted metadata. It already calls `learningBodyHasPrivateLeak`; do not duplicate the same gate in a second call site.
+- `scripts/status-truth-proposals.ts` — redacted canonical ID loading (`loadRedactedCanonicalIdsFromDisk`), proposal lifecycle precedent, hidden markers, outcome classification, and counts-only summaries.
+- `scripts/fro-bot-workflow-wiki-handoff.test.ts` — workflow YAML contract-test precedent for asserting step/env wiring.
+- `.github/workflows/capture-learnings.yaml` — deterministic harvest → agent body authoring → deterministic open pattern.
+- `.github/settings.yml` — repository label definitions for proposal/state labels.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/status-truth-synthetic-self-audit-claim-kinds-2026-07-03.md` — stable fingerprints must not be derived from mutable rendered text.
+- `docs/solutions/best-practices/closed-vocabulary-telemetry-keys-from-public-bodies-2026-07-03.md` — hidden markers + closed vocabulary make public issue bodies safe to parse later.
+- `docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md` — validate every public surface, not only the obvious proposal body.
+- `docs/solutions/best-practices/pure-core-privacy-gates-shared-module-2026-06-22.md` — reuse shared privacy gates and mutation-proof tests; do not treat missing private token data as an empty safe set.
+- `docs/solutions/best-practices/github-issues-api-same-run-eventual-consistency-2026-05-20.md` — carry in-memory created identity sets during issue-opening runs.
+- `docs/solutions/workflow-issues/classifying-github-review-events-for-iteration-signals-2026-06-22.md` — model actual correction behavior, not superficial state names.
+- `docs/solutions/best-practices/test-the-integration-seam-not-the-endpoints-2026-07-06.md` — test the raw-source → cluster → body → gate seam, not only isolated helpers.
+- `docs/solutions/best-practices/autonomous-pipeline-minimum-progress-floor-2026-05-17.md` — counts-only summaries must distinguish healthy idle from scan failure.
+
+### External References
+
+External research skipped. Existing repo patterns directly cover proposal loops, privacy gates, issue markers, outcome labels, and workflow integration.
+
+## Key Technical Decisions
+
+- **Mirror the A1 sequence, not a monolith.** Use deterministic source-loading/clustering/open scripts with an agent-only drafting step between them. Source loading must handle file-system docs and GitHub issue APIs as separate failure domains before converging into a unified source model.
+- **Split clustering from opening.** Keep source/cluster/digest behavior separate from deterministic issue opening so the cluster → digest → body-file → gate seam is testable.
+- **Fingerprint source IDs, not prose.** Cluster identity is lowercase hex SHA-256 of newline-joined, sorted source IDs; generated pattern wording is display metadata only.
+- **Use stable source IDs.** Solution docs use filename stems as source IDs; learning-proposal issues use captured merge-SHA markers. Evidence links are display-only and can change without changing identity.
+- **Filter before cap.** Deduped, suppressed, weak, unsafe, and invalid candidates are removed before applying the three-proposal write cap.
+- **Outcome labels are closed vocabulary.** Use `pattern-proposal` as the primary label and namespaced outcomes (`pattern-proposal:accepted`, `pattern-proposal:deferred`, `pattern-proposal:rejected`, `pattern-proposal:superseded`). `needs-outcome` is a derived state, not an operator label.
+- **Rejected and no-outcome closures suppress by default.** Adding one weak source cannot resurrect a rejected/no-outcome pattern; upgraded evidence requires the threshold planned below.
+- **Proposal issues are the store.** Hidden markers and labels on pattern proposals are the only durable state this slice adds.
+- **Separate validation surfaces.** Proposal bodies use the public-output gate; workflow logs/stdout/stderr/step summaries/result JSON are counts-only and never carry proposal prose, hidden markers, fingerprints, source titles, or source links.
+- **Manual live rollout first.** The workflow is manual-first with `dry_run` defaulting to true. Scheduled runs, if added, stay dry-run until proposal quality is proven.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should cluster identity include the generated pattern statement?** No. LLM wording drift would bypass suppression. Use source IDs only for the fingerprint and keep the statement as display metadata.
+- **Should capped candidates count before or after privacy filtering?** After. The cap limits writes, not analysis.
+- **Should C4 write docs directly?** No. The first slice is proposal-only.
+
+### Deferred to Implementation
+
+- Exact evidence-strength score weights after source fixtures reveal the current corpus shape.
+- Exact issue label colors/descriptions, as long as names remain stable and documented in `.github/settings.yml` and README.
+- Final helper names and script boundaries if implementation reveals a smaller shape while preserving behavior.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TD
+  A[Allowed learning corpus] --> B[Deterministic source loader]
+  B --> C[Candidate cluster builder]
+  C --> D[Existing proposal and outcome lookup]
+  D --> E[Suppression and upgrade filter]
+  E --> F[Public-output preflight]
+  F --> G[Rank by evidence strength]
+  G --> H[Cap to three proposal writes]
+  H --> I[Write versioned candidate digest]
+  I --> J[Agent reads digest and writes body file]
+  J --> K[Open script validates body file against digest]
+  K --> L[Deterministic issue posting]
+  L --> M[Pattern proposal issues as decision log]
+```
+
+## Implementation Units
+
+- [x] **Unit 1: Source corpus and pattern proposal metadata model**
+
+**Goal:** Define the allowed source corpus, proposal markers, outcome labels, and source-ID model used by later units.
+
+**Requirements:** R1-R3, R11-R13, R16-R18
+
+**Dependencies:** None
+
+**Files:**
+- Create: `scripts/capture-patterns-synthesis.ts`
+- Create: `scripts/capture-patterns-synthesis.test.ts`
+- Modify: `.github/settings.yml`
+
+**Approach:**
+- Model source artifacts as accepted solution docs and learning-proposal issues only.
+- Enumerate solution docs from the canonical `docs/solutions/` subdirectories: `best-practices`, `documentation-gaps`, `integration-issues`, `runtime-errors`, `security-issues`, and `workflow-issues`.
+- Give each source a stable public ID:
+  - solution docs use the filename stem, independent of subdirectory moves and frontmatter edits; duplicate stems fail source loading for those docs and increment invalid-source counts;
+  - learning-proposal issues use the captured merge-SHA marker; issues with missing or malformed markers are excluded from clustering and counted as invalid sources.
+- Generate source links separately from identity: solution docs use SHA-pinned GitHub blob URLs for the checked-out HEAD, and learning-proposal issues use stable `https://github.com/fro-bot/.github/issues/<number>` URLs.
+- Define C4 hidden markers explicitly: `pattern-proposal:fingerprint=<sha256>`, `pattern-proposal:source-ids=<comma-separated sorted IDs>`, and optional `pattern-proposal:supersedes=<sha256>`.
+- Define labels explicitly: primary `pattern-proposal`; mutually exclusive outcomes `pattern-proposal:accepted`, `pattern-proposal:deferred`, `pattern-proposal:rejected`, `pattern-proposal:superseded`; derived state `needs-outcome` is not a label.
+- Parse existing pattern proposal issues across open and closed states with full pagination (`state: all`) into open/closed maps keyed by fingerprint so later units can suppress or upgrade candidates.
+
+**Execution note:** Implement new behavior test-first; start with marker parsing and outcome classification before adding source collection.
+
+**Patterns to follow:**
+- `buildMergeShaMarker` / `parseMergeShaMarker` in `scripts/capture-learnings-harvest.ts` as a namespace pattern only; do not reuse the `captured-learning:` marker namespace.
+- `extractProposalFingerprint` / `classifyProposalOutcome` patterns in `scripts/status-truth-proposals.ts`.
+- Label descriptor + fail-closed preflight pattern in `scripts/capture-learnings-open.ts`.
+
+**Test scenarios:**
+- Happy path: parses a solution doc and a learning-proposal issue into two source artifacts with stable IDs.
+- Happy path: parses existing pattern proposal markers and closed-vocabulary outcome labels from open and closed issues.
+- Edge case: malformed or missing learning-proposal merge-SHA markers exclude that issue from source clustering and increment invalid-source counts.
+- Edge case: solution-doc subdirectory move or frontmatter title/category edit does not change source identity when the filename stem is unchanged.
+- Edge case: malformed pattern-proposal markers are ignored and counted, not treated as a matching suppression.
+- Error path: inability to fetch existing proposals fails closed before issue writes can happen in later units.
+- Privacy: source IDs and markers never contain private repo names, branch names, issue titles, raw body excerpts, or private canonical IDs.
+
+**Verification:**
+- The pure model can load and classify sources/proposals without opening issues or invoking the agent.
+
+- [ ] **Unit 2: Candidate clustering, scoring, and suppression planner**
+
+**Goal:** Build deterministic cluster candidates and decide which candidates may be sent to the agent for proposal drafting.
+
+**Requirements:** R4-R7, R9, R12-R15, R21
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `scripts/capture-patterns-cluster.ts`
+- Create: `scripts/capture-patterns-cluster.test.ts`
+- Modify: `scripts/capture-patterns-synthesis.ts`
+- Modify: `scripts/capture-patterns-synthesis.test.ts`
+
+**Approach:**
+- Start conservative: cluster by repeated correction substance derived from structured frontmatter fields, problem type, module, tags, title/body summary tokens, and known proposal evidence, but reject clusters that only share generic tags. Use `computeOverlapScore` as the model for low-signal scoring rather than inventing a separate keyword heuristic.
+- Compute cluster fingerprint as lowercase hex SHA-256 of newline-joined, sorted source IDs.
+- Rank evidence strength by unique independent sources first, then by accepted solution-doc presence, then recency, then deterministic lexical source-ID order. Topic-bucket fairness is a tiebreaker only, derived from `module`/`problem_type`; it must not override stronger evidence.
+- Apply filters in this order: weak cluster → open proposal overlap → hard suppression → soft suppression without upgrade threshold → unsafe evidence placeholder → rank → cap.
+- Suppress candidates that are subsets or weak supersets of currently open proposals to avoid overlapping review queues.
+- Treat rejected and closed-without-outcome clusters as hard-suppressed for exact source sets and weak supersets unless at least two new independent public-safe sources were added after rejection.
+- Treat superseded clusters as permanently hard-suppressed.
+- Treat deferred clusters as soft-suppressed until at least one new independent public-safe source is added; new versions link back to the deferred issue.
+- Treat accepted pattern proposals as immediately retiring their source IDs from active clustering, regardless of whether the issue is open or closed.
+- Exclude source artifacts already represented by an accepted pattern proposal so codified source material does not immediately re-propose itself.
+- Build a versioned candidate digest schema with allowed fields only: fingerprint, source IDs, SHA-pinned source links, public-safe source titles, evidence counts, score bucket, suggested next actions, and run counts. Source titles must pass the public-output gate before entering the digest.
+
+**Execution note:** Add characterization fixtures from existing `docs/solutions/` frontmatter before tuning scoring.
+
+**Patterns to follow:**
+- `buildCandidateDigest` in `scripts/capture-learnings-harvest.ts`.
+- `selectWithCiFixFloor` for deterministic cap/floor mechanics, using fairness only as a tiebreaker in v1.
+- `applyEnrichmentScanAvailability` for clearing enriched evidence when privacy scanning is unavailable.
+- Same-run created identity set pattern from issue-opening scripts.
+
+**Test scenarios:**
+- Happy path: multiple artifacts describing the same correction behavior produce one candidate with sorted source IDs and a stable fingerprint.
+- Edge case: artifacts sharing only a generic tag are skipped as low-signal.
+- Edge case: a candidate matching or overlapping an open proposal is skipped as duplicate/open-overlap.
+- Edge case: a candidate whose sources are a subset or weak superset of a rejected/no-outcome proposal is suppressed.
+- Edge case: a superseded proposal never reopens through a superset.
+- Edge case: a deferred proposal with one new source produces a new-version candidate that references the deferred issue.
+- Edge case: an accepted proposal's source IDs are immediately retired from future clusters even while the proposal issue remains open.
+- Error path: unsafe candidate evidence increments skipped-unsafe counts but does not create suppression state.
+- Ordering: privacy/suppression filtering happens before the three-proposal cap.
+- Determinism: equal-strength candidates sort by topic-bucket tiebreaker, recency, and then stable source-ID order.
+
+**Verification:**
+- Planner outputs a counts-only digest distinguishing proposed, capped, low-signal, duplicate/open-overlap, hard-suppressed, soft-suppressed, unsafe, invalid-source, no-op, and failed states.
+
+- [ ] **Unit 3: Agent proposal digest and deterministic issue opener**
+
+**Goal:** Let the agent draft bounded pattern proposal bodies, then deterministically validate and open proposal issues.
+
+**Requirements:** R5-R11, R16-R21
+
+**Dependencies:** Units 1-2
+
+**Files:**
+- Create: `scripts/capture-patterns-open.ts`
+- Create: `scripts/capture-patterns-open.test.ts`
+- Modify: `scripts/capture-patterns-synthesis.ts`
+- Modify: `scripts/capture-patterns-synthesis.test.ts`
+
+**Approach:**
+- The agent reads only the versioned candidate digest and writes a versioned temp JSON body file keyed by fingerprint. It does not call GitHub, read the corpus, receive private token data, or write repo files.
+- Body file schema supports two per-candidate outcomes: `drafted` with allowed fields, or `agent-skipped` with a closed reason such as `insufficient-evidence` or `different-behaviors`. Missing body is treated separately from agent judgment.
+- The open script validates the body-file schema version, reads the digest and bodies, confirms required labels, validates every title/body/comment surface through `makePublicOutputTokens` + `applyPublicOutputGate`, injects required hidden markers, and opens at most three issues.
+- Construct `PublicOutputTokens` only after both private tokens and redacted canonical IDs load successfully; never pass an empty set as a failed-load proxy.
+- Allowed proposal-body fields are: pattern statement, rationale, public-safe source references, evidence count, suggested next action, and hidden machine markers. Unknown fields reject that candidate.
+- Invalid drafted bodies fail soft per candidate: skip the invalid proposal, increment a counts-only reason, and post remaining valid proposals. Systemic failures such as token-load failure, label preflight failure, or missing validation gate fail closed for all writes.
+- If private tokens or public-output tokens cannot load, the open script fails closed and posts nothing. Token values, token-load errors, body text, markers, and source links must not be written to stdout, stderr, or step summaries.
+- Maintain a same-run created fingerprint set threaded through planner/opener boundaries, and rely on workflow-level concurrency plus all-state existing-proposal pagination to prevent cross-run duplicates.
+
+**Execution note:** Start with a failing seam test that drives a realistic digest + body through marker injection, privacy validation, label preflight, and issue creation.
+
+**Patterns to follow:**
+- `scripts/capture-learnings-open.ts` body-file, `ensureLabelsExist`, and label-preflight pattern.
+- `loadPrivateTokensFromDisk` in `scripts/capture-learnings-privacy.ts`.
+- `loadRedactedCanonicalIdsFromDisk`, `extractProposalFingerprint`, and counts-only output patterns in `scripts/status-truth-proposals.ts`.
+- `makePublicOutputTokens` / `applyPublicOutputGate` in `scripts/status-truth-public-output.ts`.
+
+**Test scenarios:**
+- Happy path: clean agent-authored body opens a labeled pattern proposal with fingerprint/source markers and visible source evidence.
+- Error path: missing body for a candidate skips that candidate and reports no-body counts.
+- Error path: explicit `agent-skipped` body outcome increments agent-skipped counts and opens no issue for that fingerprint.
+- Error path: label preflight failure skips all opens fail-closed.
+- Error path: token-load failure is reported as a distinct counts-only field and writes nothing.
+- Privacy: body containing private token, raw log text, private link, branch-like secret, unsafe source title, private canonical ID, fingerprint on counts-only surface, or unapproved field is blocked before posting.
+- Same-run duplicate: two bodies for the same fingerprint open at most one issue.
+- Cross-run duplicate: an existing open or closed proposal with the same fingerprint prevents opening.
+- Mutation-proof: tests fail if the public-output gate is removed from issue title, issue body, stdout/result JSON, or workflow summary surfaces.
+- Output: stdout/result JSON and workflow summaries contain counts only and no proposal body, hidden marker, fingerprint, source title, source link, private token, or raw error.
+- Empty path: zero candidates after filtering is a successful no-op with explicit skipped/candidate counts, not a failure.
+
+**Verification:**
+- The opener is safe to run after an agent drafting step and cannot post unvalidated proposal prose.
+
+- [ ] **Unit 4: Workflow integration and operator docs**
+
+**Goal:** Wire the synthesis loop into CI as a scheduled/manual proposal-only workflow and document the operator contract.
+
+**Requirements:** R1-R21
+
+**Dependencies:** Units 1-3
+
+**Files:**
+- Create: `.github/workflows/capture-patterns.yaml`
+- Create: `scripts/capture-patterns-workflow.test.ts` if implementation adds nontrivial workflow env/step wiring
+- Modify: `README.md`
+- Modify: `docs/plans/2026-07-07-004-feat-recurring-pattern-synthesis-plan.md`
+- Test: actionlint plus workflow parser tests for digest/body-file env wiring and credential boundaries.
+
+**Approach:**
+- Add a separate `capture-patterns.yaml` workflow with concurrency group `capture-patterns`, `cancel-in-progress: false`, `workflow_dispatch` dry-run default `true`, and no live scheduled writes in v1.
+- Split detect/digest and open jobs: detect uses read-only credentials; the open job performs the data-branch metadata overlay, loads privacy tokens, and mints an App token with `issues: write` only when live mode is explicitly requested.
+- Use `uses: ./.github/actions/setup` for Node/pnpm setup and the same SHA-pinned `actions/create-github-app-token` version already used in repo workflows. Scope the App token to this repository only.
+- Keep the agent prompt bounded: read only the digest path, write only the configured body-file path in the temp directory, never edit source files, and never receive private token sets, hidden markers, raw issue bodies, or raw solution text.
+- Publish counts-only step summaries: sources loaded, invalid sources, candidates scanned, low-signal skipped, duplicate/open-overlap, hard-suppressed, soft-suppressed, unsafe, capped, token-load-failure, agent-skipped, bodies missing, proposals opened, zero-candidate no-op, and scan failure.
+- Document the label/outcome contract and the fact that proposal issues are the decision log for C4.
+- Mark implementation checkpoints only after each unit passes tests and review.
+
+**Patterns to follow:**
+- `.github/workflows/capture-learnings.yaml` harvest → agent → open structure.
+- `.github/workflows/status-truth.yaml` dry-run default, detect/open split, data-branch metadata overlay, and live-token mint boundary.
+- `scripts/fro-bot-workflow-wiki-handoff.test.ts` workflow YAML contract-test style.
+
+**Test scenarios:**
+- Workflow shape: synthesis agent step cannot run without the deterministic digest file.
+- Workflow shape: scheduled/default runs are dry-run and do not mint an issue-writing token.
+- Workflow shape: issue-writing token is scoped to this repo and not reused for agent work.
+- Workflow shape: workflow concurrency prevents overlapping scheduled/manual C4 runs.
+- Workflow shape: data-branch metadata overlay happens before the privacy-gated open step.
+- Workflow shape: agent prompt contains the temp-file-only write contract and no instruction to edit repo files.
+- Docs: README describes pattern proposals as human-reviewed and does not imply auto-authoring or measurable improvement.
+
+**Verification:**
+- Actionlint passes; full repo gate passes; workflow surface remains proposal-only and human-review-gated.
+
+## System-Wide Impact
+
+- **Interaction graph:** Adds a new A1 proposal loop using the same GitHub issue review surface as learning proposals. It does not affect Status Truth, A3 dispatch, or wiki repair loops.
+- **Error propagation:** Source/query/privacy/label failures fail closed with counts-only results and zero issue writes. A healthy empty run is a successful no-op with explicit counts.
+- **State lifecycle risks:** Suppression state lives in proposal issues; malformed markers are ignored and counted, not trusted. Open, accepted, rejected, superseded, and closed-without-outcome proposals all affect suppression.
+- **API surface parity:** CLI result JSON, stdout/stderr, workflow summaries, issue titles, issue bodies, and issue comments must each have explicit public-surface tests.
+- **Integration coverage:** Unit tests must cover raw sources through clustering, body rendering, privacy gate, and issue creation; isolated scoring tests are insufficient.
+- **Workload bounds:** v1 scans the full allowed corpus because current repo scale is small. Revisit lookback/indexing if solution docs exceed 250 or learning-proposal issues exceed 500.
+- **Unchanged invariants:** Human review remains required. No docs, prompts, persona, skills, or workflows are auto-edited by the synthesis loop beyond this implementation's workflow wiring.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| Fake insight from shallow clustering | Require repeated correction behavior, suppress keyword-only clusters, and start proposal-only. |
+| Suppression bypass through prose drift | Fingerprint sorted source IDs only; keep pattern text out of the hash. |
+| Superset spam after rejection | Hard-suppress weak supersets unless the upgrade threshold is met. |
+| Private data leakage in proposals | Use `makePublicOutputTokens`/`applyPublicOutputGate` with both private tokens and redacted canonical IDs loaded fail-closed; block private/opaque evidence links and keep logs counts-only. |
+| Proposal queue noise | Filter before capping, open at most three proposals per run, use fairness only as a tiebreaker, and publish skip counts. |
+| Same-run or cross-run duplicate issue creation | Carry an in-memory created-fingerprint set, serialize workflow runs with concurrency, and query all existing pattern proposals with pagination. |
+| Interrupted run between agent drafting and opening | Re-query existing proposal fingerprints in the open step before posting and delete stale temp files at the start of each run. |
+| Single invalid agent draft blocks valid proposals | Fail soft per candidate for body validation errors; fail closed only for systemic gate/token/label failures. |
+| Workflow accidentally writes from schedule | Default dry-run to true, keep scheduled runs dry-run in v1, and mint write token only for explicit manual live runs. |
+
+## Documentation / Operational Notes
+
+- New pattern proposal labels should be documented in README and `.github/settings.yml`.
+- Operators apply exactly one terminal/outcome label when deciding a proposal: `pattern-proposal:accepted`, `pattern-proposal:deferred`, `pattern-proposal:rejected`, or `pattern-proposal:superseded`. `needs-outcome` is derived from closed proposals without one of those labels.
+- Accepted labels immediately retire the proposal source IDs from active clustering, even if follow-up doc work is still pending.
+- Closed-without-outcome proposals are conservatively suppressed to prevent immediate re-creation.
+- Label definitions must land before the workflow can open visible proposals; label preflight remains fail-closed if settings have not applied yet.
+- The first production run should be reviewed for proposal quality before planning O8 metrics or enabling any scheduled live-write behavior.
+- This slice writes issues only; it does not touch `metadata/`, `commit-metadata.ts`, the data branch, auto-merge, or `docs/status.md` status claims.
+
+## Sources & References
+
+- Origin document: [docs/brainstorms/2026-07-07-a1-recurring-pattern-synthesis-requirements.md](../brainstorms/2026-07-07-a1-recurring-pattern-synthesis-requirements.md)
+- A1 origin: [docs/brainstorms/2026-06-22-skill-saving-grow-and-learn-requirements.md](../brainstorms/2026-06-22-skill-saving-grow-and-learn-requirements.md)
+- Existing harvest: [scripts/capture-learnings-harvest.ts](../../scripts/capture-learnings-harvest.ts)
+- Existing opener: [scripts/capture-learnings-open.ts](../../scripts/capture-learnings-open.ts)
+- Existing privacy gate: [scripts/capture-learnings-privacy.ts](../../scripts/capture-learnings-privacy.ts)
+- Existing workflow: [.github/workflows/capture-learnings.yaml](../../.github/workflows/capture-learnings.yaml)

--- a/scripts/capture-patterns-cluster.test.ts
+++ b/scripts/capture-patterns-cluster.test.ts
@@ -9,10 +9,15 @@
  * - Digest schema tests
  */
 
+import {chmod, mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import process from 'node:process'
 import {describe, expect, it} from 'vitest'
 import {
   buildCandidateDigest,
   buildSourceFingerprint,
+  loadSolutionDocFilesFromDisk,
   planPatternCandidates,
   type PatternCandidateSource,
   type PlanPatternCandidatesInput,
@@ -128,7 +133,7 @@ describe('planPatternCandidates: correction-substance clustering', () => {
     const result = plan({sources, existing: emptyExisting()})
 
     expect(result.candidates).toHaveLength(0)
-    expect(result.counts.lowSignal).toBeGreaterThan(0)
+    expect(result.counts.lowSignal).toBe(1)
   })
 })
 
@@ -153,6 +158,64 @@ describe('planPatternCandidates: open-proposal overlap', () => {
 
     const existing: ExistingPatternProposals = {
       openByFingerprint: new Map([[fingerprint, [makeIssue({state: 'open'})]]]),
+      closedByFingerprint: new Map(),
+      invalidMarkerCount: 0,
+    }
+
+    const result = plan({sources, existing})
+
+    expect(result.candidates).toHaveLength(0)
+    expect(result.counts.duplicateOpenOverlap).toBe(1)
+  })
+
+  it('security: an open proposal cannot be bypassed by adding two or more new independent sources', () => {
+    // Candidate is a strict superset of the open proposal's source IDs by 2 new
+    // sources — this must still suppress, unlike hard-suppression's upgrade threshold.
+    const sourceB = makeSource({
+      id: 'source-b',
+      title: 'Retry idempotent writes after 5xx failures',
+      signals: {
+        module: 'scripts/foo.ts',
+        tags: ['ci'],
+        problemType: 'best_practice',
+        titleTokens: ['retry', 'idempotent', 'writes', 'after', '5xx', 'failures'],
+      },
+    })
+    const sourceC = makeSource({
+      id: 'source-c',
+      title: 'Retry idempotent writes on every 5xx',
+      signals: {
+        module: 'scripts/foo.ts',
+        tags: ['ci'],
+        problemType: 'best_practice',
+        titleTokens: ['retry', 'idempotent', 'writes', 'every', '5xx'],
+      },
+    })
+    const sourceD = makeSource({
+      id: 'source-d',
+      title: 'Retry idempotent writes across all 5xx paths',
+      signals: {
+        module: 'scripts/foo.ts',
+        tags: ['ci'],
+        problemType: 'best_practice',
+        titleTokens: ['retry', 'idempotent', 'writes', 'across', 'all', '5xx', 'paths'],
+      },
+    })
+    const sources = [makeSource(), sourceB, sourceC, sourceD]
+    const openFingerprint = buildSourceFingerprint(['source-a', 'source-b'])
+
+    const existing: ExistingPatternProposals = {
+      openByFingerprint: new Map([
+        [
+          openFingerprint,
+          [
+            makeIssue({
+              state: 'open',
+              body: `<!-- pattern-proposal:fingerprint=${openFingerprint} -->\n<!-- pattern-proposal:source-ids=source-a,source-b -->`,
+            }),
+          ],
+        ],
+      ]),
       closedByFingerprint: new Map(),
       invalidMarkerCount: 0,
     }
@@ -264,6 +327,106 @@ describe('planPatternCandidates: hard suppression (rejected/no-outcome)', () => 
     const fullFingerprint = buildSourceFingerprint(['source-a', 'source-b', 'source-c', 'source-d'])
     const survived = result.candidates.some(c => c.fingerprint === fullFingerprint)
     expect(survived).toBe(true)
+  })
+
+  it('security: a closed proposal with a malformed-outcome label is conservatively hard-suppressed, same as needs-outcome', () => {
+    const sources = twoSourceCandidateSetup()
+    const fingerprint = buildSourceFingerprint(['source-a', 'source-b'])
+
+    const existing: ExistingPatternProposals = {
+      openByFingerprint: new Map(),
+      closedByFingerprint: new Map([
+        [
+          fingerprint,
+          [
+            makeIssue({
+              state: 'closed',
+              // An unrecognized pattern-proposal:* label classifies as malformed-outcome.
+              labels: ['pattern-proposal', 'pattern-proposal:mystery-outcome'],
+              body: `<!-- pattern-proposal:fingerprint=${fingerprint} -->\n<!-- pattern-proposal:source-ids=source-a,source-b -->`,
+            }),
+          ],
+        ],
+      ]),
+      invalidMarkerCount: 0,
+    }
+
+    const result = plan({sources, existing})
+
+    expect(result.candidates).toHaveLength(0)
+    expect(result.counts.hardSuppressed).toBe(1)
+  })
+
+  it('security: a closed proposal with conflicting outcome labels is conservatively hard-suppressed, same as needs-outcome', () => {
+    const sources = twoSourceCandidateSetup()
+    const fingerprint = buildSourceFingerprint(['source-a', 'source-b'])
+
+    const existing: ExistingPatternProposals = {
+      openByFingerprint: new Map(),
+      closedByFingerprint: new Map([
+        [
+          fingerprint,
+          [
+            makeIssue({
+              state: 'closed',
+              // Two recognized outcome labels at once classify as conflicting-labels.
+              labels: [
+                'pattern-proposal',
+                PATTERN_PROPOSAL_OUTCOME_LABELS.rejected,
+                PATTERN_PROPOSAL_OUTCOME_LABELS.deferred,
+              ],
+              body: `<!-- pattern-proposal:fingerprint=${fingerprint} -->\n<!-- pattern-proposal:source-ids=source-a,source-b -->`,
+            }),
+          ],
+        ],
+      ]),
+      invalidMarkerCount: 0,
+    }
+
+    const result = plan({sources, existing})
+
+    expect(result.candidates).toHaveLength(0)
+    expect(result.counts.hardSuppressed).toBe(1)
+  })
+
+  it('is not conservatively suppressed by malformed-outcome when accepted labels on another issue already retired the source IDs (retirement bypasses suppression entirely)', () => {
+    const sources = twoSourceCandidateSetup()
+    const malformedFingerprint = buildSourceFingerprint(['source-a', 'source-b'])
+    const acceptedFingerprint = buildSourceFingerprint(['source-a'])
+
+    const existing: ExistingPatternProposals = {
+      openByFingerprint: new Map(),
+      closedByFingerprint: new Map([
+        [
+          malformedFingerprint,
+          [
+            makeIssue({
+              state: 'closed',
+              labels: ['pattern-proposal', 'pattern-proposal:mystery-outcome'],
+              body: `<!-- pattern-proposal:fingerprint=${malformedFingerprint} -->\n<!-- pattern-proposal:source-ids=source-a,source-b -->`,
+            }),
+          ],
+        ],
+        [
+          acceptedFingerprint,
+          [
+            makeIssue({
+              state: 'closed',
+              labels: ['pattern-proposal', PATTERN_PROPOSAL_OUTCOME_LABELS.accepted],
+              body: `<!-- pattern-proposal:fingerprint=${acceptedFingerprint} -->\n<!-- pattern-proposal:source-ids=source-a -->`,
+            }),
+          ],
+        ],
+      ]),
+      invalidMarkerCount: 0,
+    }
+
+    const result = plan({sources, existing})
+
+    // source-a is retired by the accepted proposal, so only source-b remains active —
+    // below MIN_CLUSTER_SOURCES, so this is a no-op, not a hard-suppression match.
+    expect(result.candidates).toHaveLength(0)
+    expect(result.counts.hardSuppressed).toBe(0)
   })
 })
 
@@ -661,5 +824,34 @@ describe('buildCandidateDigest', () => {
     const digest = buildCandidateDigest({candidate, runCount: 1, publicOutputTokens: blockingTokens})
 
     expect(digest.sourceTitles).toContain('[source title withheld: failed public-output gate]')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// loadSolutionDocFilesFromDisk: read-failure reporting
+// ---------------------------------------------------------------------------
+
+describe('loadSolutionDocFilesFromDisk', () => {
+  it('error path: reports a file that is listed but fails to read via readFailures, not a silent drop', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'capture-patterns-cluster-'))
+    const originalCwd = process.cwd()
+    try {
+      const subdirPath = join(dir, 'docs', 'solutions', 'best-practices')
+      await mkdir(subdirPath, {recursive: true})
+      await writeFile(join(subdirPath, 'readable.md'), '---\ntitle: Readable\n---\nBody.\n')
+      const unreadablePath = join(subdirPath, 'unreadable.md')
+      await writeFile(unreadablePath, '---\ntitle: Unreadable\n---\nBody.\n')
+      // Remove read permission so readFile fails while readdir still lists the file.
+      await chmod(unreadablePath, 0o000)
+
+      process.chdir(dir)
+      const result = await loadSolutionDocFilesFromDisk(() => undefined)
+
+      expect(Object.keys(result.files)).toContain('docs/solutions/best-practices/readable.md')
+      expect(result.readFailures).toBe(1)
+    } finally {
+      process.chdir(originalCwd)
+      await rm(dir, {recursive: true, force: true})
+    }
   })
 })

--- a/scripts/capture-patterns-cluster.test.ts
+++ b/scripts/capture-patterns-cluster.test.ts
@@ -440,6 +440,35 @@ describe('planPatternCandidates: accepted retirement', () => {
     expect(result.counts.duplicateOpenOverlap).toBe(0)
     expect(result.counts.noOp).toBe(1)
   })
+
+  it('handles all sources retired as a no-op rather than duplicate or low-signal output', () => {
+    const sourceB = makeSource({id: 'source-b'})
+    const sources = [makeSource(), sourceB]
+    const acceptedFingerprint = buildSourceFingerprint(['source-a', 'source-b'])
+    const existing: ExistingPatternProposals = {
+      openByFingerprint: new Map(),
+      closedByFingerprint: new Map([
+        [
+          acceptedFingerprint,
+          [
+            makeIssue({
+              state: 'closed',
+              labels: ['pattern-proposal', PATTERN_PROPOSAL_OUTCOME_LABELS.accepted],
+              body: `<!-- pattern-proposal:fingerprint=${acceptedFingerprint} -->\n<!-- pattern-proposal:source-ids=source-a,source-b -->`,
+            }),
+          ],
+        ],
+      ]),
+      invalidMarkerCount: 0,
+    }
+
+    const result = plan({sources, existing})
+
+    expect(result.candidates).toHaveLength(0)
+    expect(result.counts.noOp).toBe(1)
+    expect(result.counts.duplicateOpenOverlap).toBe(0)
+    expect(result.counts.lowSignal).toBe(0)
+  })
 })
 
 describe('planPatternCandidates: unsafe candidate handling', () => {
@@ -614,7 +643,7 @@ describe('buildCandidateDigest', () => {
     expect(digest.sourceTitles.length).toBe(candidate.sourceIds.length)
   })
 
-  it('throws instead of masking a source title that fails the public-output gate', () => {
+  it('withholds a source title that fails the public-output gate without throwing', () => {
     const blockingTokens = makePublicOutputTokens({
       privateTokens: new Set<string>(['private-token']),
       redactedCanonicalIds: new Set<string>(),
@@ -629,8 +658,8 @@ describe('buildCandidateDigest', () => {
       scoreBucket: 'moderate' as const,
     }
 
-    expect(() => buildCandidateDigest({candidate, runCount: 1, publicOutputTokens: blockingTokens})).toThrow(
-      'Pattern candidate source title failed public-output gate',
-    )
+    const digest = buildCandidateDigest({candidate, runCount: 1, publicOutputTokens: blockingTokens})
+
+    expect(digest.sourceTitles).toContain('[source title withheld: failed public-output gate]')
   })
 })

--- a/scripts/capture-patterns-cluster.test.ts
+++ b/scripts/capture-patterns-cluster.test.ts
@@ -1,0 +1,636 @@
+/**
+ * Tests for scripts/capture-patterns-cluster.ts
+ *
+ * Structure:
+ * - Fingerprint tests
+ * - Cluster building tests (low-signal rejection, correction-substance grouping)
+ * - Suppression/filter tests (open overlap, hard/soft suppression, accepted retirement)
+ * - Ranking/cap tests
+ * - Digest schema tests
+ */
+
+import {describe, expect, it} from 'vitest'
+import {
+  buildCandidateDigest,
+  buildSourceFingerprint,
+  planPatternCandidates,
+  type PatternCandidateSource,
+  type PlanPatternCandidatesInput,
+} from './capture-patterns-cluster.ts'
+import {
+  PATTERN_PROPOSAL_OUTCOME_LABELS,
+  type ExistingPatternProposalIssue,
+  type ExistingPatternProposals,
+} from './capture-patterns-synthesis.ts'
+import {makePublicOutputTokens, type PublicOutputTokens} from './status-truth-public-output.ts'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeSource(overrides: Partial<PatternCandidateSource> = {}): PatternCandidateSource {
+  return {
+    id: 'source-a',
+    kind: 'solution-doc',
+    link: 'https://github.com/fro-bot/.github/blob/abc/docs/solutions/best-practices/source-a.md',
+    title: 'Retry idempotent writes on 5xx',
+    date: '2026-06-01',
+    signals: {
+      module: 'scripts/foo.ts',
+      tags: ['ci'],
+      problemType: 'best_practice',
+      titleTokens: ['retry', 'idempotent', 'writes', '5xx'],
+    },
+    ...overrides,
+  }
+}
+
+function makeIssue(overrides: Partial<ExistingPatternProposalIssue> = {}): ExistingPatternProposalIssue {
+  return {
+    number: 1,
+    state: 'open',
+    labels: ['pattern-proposal'],
+    body: '',
+    ...overrides,
+  }
+}
+
+function emptyExisting(): ExistingPatternProposals {
+  return {openByFingerprint: new Map(), closedByFingerprint: new Map(), invalidMarkerCount: 0}
+}
+
+function safeTokens(): PublicOutputTokens {
+  return makePublicOutputTokens({privateTokens: new Set<string>(), redactedCanonicalIds: new Set<string>()})
+}
+
+function plan(input: Omit<PlanPatternCandidatesInput, 'publicOutputTokens'>): ReturnType<typeof planPatternCandidates> {
+  return planPatternCandidates({...input, publicOutputTokens: safeTokens()})
+}
+
+// ---------------------------------------------------------------------------
+// Fingerprint
+// ---------------------------------------------------------------------------
+
+describe('buildSourceFingerprint', () => {
+  it('is a lowercase hex SHA-256 of newline-joined sorted source IDs', () => {
+    const fp1 = buildSourceFingerprint(['zebra', 'alpha'])
+    const fp2 = buildSourceFingerprint(['alpha', 'zebra'])
+    expect(fp1).toBe(fp2)
+    expect(fp1).toMatch(/^[a-f0-9]{64}$/u)
+  })
+
+  it('changes when the source-ID set changes', () => {
+    const fp1 = buildSourceFingerprint(['alpha', 'zebra'])
+    const fp2 = buildSourceFingerprint(['alpha', 'zebra', 'mid'])
+    expect(fp1).not.toBe(fp2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cluster building — correction-substance grouping
+// ---------------------------------------------------------------------------
+
+describe('planPatternCandidates: correction-substance clustering', () => {
+  it('happy path: multiple artifacts describing the same correction behavior produce one candidate with sorted source IDs and stable fingerprint', () => {
+    const sourceB = makeSource({
+      id: 'source-b',
+      title: 'Retry idempotent writes after 5xx failures',
+      signals: {
+        module: 'scripts/foo.ts',
+        tags: ['ci'],
+        problemType: 'best_practice',
+        titleTokens: ['retry', 'idempotent', 'writes', 'after', '5xx', 'failures'],
+      },
+    })
+    const sources = [makeSource(), sourceB]
+
+    const result = plan({sources, existing: emptyExisting()})
+
+    expect(result.candidates).toHaveLength(1)
+    const candidate = result.candidates[0]
+    expect(candidate?.sourceIds).toEqual(['source-a', 'source-b'])
+    expect(candidate?.fingerprint).toBe(buildSourceFingerprint(['source-a', 'source-b']))
+  })
+
+  it('edge case: artifacts sharing only a generic tag are skipped as low-signal', () => {
+    const sourceB = makeSource({
+      id: 'source-b',
+      title: 'Completely unrelated rename of a config key',
+      signals: {
+        module: 'scripts/bar.ts',
+        tags: ['ci'],
+        problemType: 'workflow_issue',
+        titleTokens: ['completely', 'unrelated', 'rename', 'config', 'key'],
+      },
+    })
+    const sources = [makeSource(), sourceB]
+
+    const result = plan({sources, existing: emptyExisting()})
+
+    expect(result.candidates).toHaveLength(0)
+    expect(result.counts.lowSignal).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Suppression / filter behavior
+// ---------------------------------------------------------------------------
+
+describe('planPatternCandidates: open-proposal overlap', () => {
+  it('edge case: a candidate matching or overlapping an open proposal is skipped as duplicate/open-overlap', () => {
+    const sourceB = makeSource({
+      id: 'source-b',
+      title: 'Retry idempotent writes after 5xx failures',
+      signals: {
+        module: 'scripts/foo.ts',
+        tags: ['ci'],
+        problemType: 'best_practice',
+        titleTokens: ['retry', 'idempotent', 'writes', 'after', '5xx', 'failures'],
+      },
+    })
+    const sources = [makeSource(), sourceB]
+    const fingerprint = buildSourceFingerprint(['source-a', 'source-b'])
+
+    const existing: ExistingPatternProposals = {
+      openByFingerprint: new Map([[fingerprint, [makeIssue({state: 'open'})]]]),
+      closedByFingerprint: new Map(),
+      invalidMarkerCount: 0,
+    }
+
+    const result = plan({sources, existing})
+
+    expect(result.candidates).toHaveLength(0)
+    expect(result.counts.duplicateOpenOverlap).toBe(1)
+  })
+})
+
+function twoSourceCandidateSetup(problemType = 'best_practice'): PatternCandidateSource[] {
+  const sourceB = makeSource({
+    id: 'source-b',
+    title: 'Retry idempotent writes after 5xx failures',
+    signals: {
+      module: 'scripts/foo.ts',
+      tags: ['ci'],
+      problemType,
+      titleTokens: ['retry', 'idempotent', 'writes', 'after', '5xx', 'failures'],
+    },
+  })
+  return [makeSource({signals: {...makeSource().signals, problemType}}), sourceB]
+}
+
+describe('planPatternCandidates: hard suppression (rejected/no-outcome)', () => {
+  it('edge case: a candidate whose sources are a subset of a rejected proposal is hard-suppressed', () => {
+    const sources = twoSourceCandidateSetup()
+    const fingerprint = buildSourceFingerprint(['source-a', 'source-b'])
+
+    const existing: ExistingPatternProposals = {
+      openByFingerprint: new Map(),
+      closedByFingerprint: new Map([
+        [
+          fingerprint,
+          [
+            makeIssue({
+              state: 'closed',
+              labels: ['pattern-proposal', PATTERN_PROPOSAL_OUTCOME_LABELS.rejected],
+              body: `<!-- pattern-proposal:fingerprint=${fingerprint} -->\n<!-- pattern-proposal:source-ids=source-a,source-b -->`,
+            }),
+          ],
+        ],
+      ]),
+      invalidMarkerCount: 0,
+    }
+
+    const result = plan({sources, existing})
+
+    expect(result.candidates).toHaveLength(0)
+    expect(result.counts.hardSuppressed).toBe(1)
+  })
+
+  it('is not hard-suppressed when at least two new independent public-safe sources were added', () => {
+    const sourceB = makeSource({
+      id: 'source-b',
+      title: 'Retry idempotent writes after 5xx failures',
+      signals: {
+        module: 'scripts/foo.ts',
+        tags: ['ci'],
+        problemType: 'best_practice',
+        titleTokens: ['retry', 'idempotent', 'writes', 'after', '5xx', 'failures'],
+      },
+    })
+    const sourceC = makeSource({
+      id: 'source-c',
+      title: 'Retry idempotent writes yet again for 5xx',
+      signals: {
+        module: 'scripts/foo.ts',
+        tags: ['ci'],
+        problemType: 'best_practice',
+        titleTokens: ['retry', 'idempotent', 'writes', 'yet', 'again', '5xx'],
+      },
+    })
+    const sourceD = makeSource({
+      id: 'source-d',
+      title: 'Retry idempotent writes once more on 5xx',
+      signals: {
+        module: 'scripts/foo.ts',
+        tags: ['ci'],
+        problemType: 'best_practice',
+        titleTokens: ['retry', 'idempotent', 'writes', 'once', 'more', '5xx'],
+      },
+    })
+    const sources = [makeSource(), sourceB, sourceC, sourceD]
+
+    const rejectedFingerprint = buildSourceFingerprint(['source-a', 'source-b'])
+    const existing: ExistingPatternProposals = {
+      openByFingerprint: new Map(),
+      closedByFingerprint: new Map([
+        [
+          rejectedFingerprint,
+          [
+            makeIssue({
+              state: 'closed',
+              labels: ['pattern-proposal', PATTERN_PROPOSAL_OUTCOME_LABELS.rejected],
+              body: `<!-- pattern-proposal:fingerprint=${rejectedFingerprint} -->\n<!-- pattern-proposal:source-ids=source-a,source-b -->`,
+            }),
+          ],
+        ],
+      ]),
+      invalidMarkerCount: 0,
+    }
+
+    const result = plan({sources, existing})
+
+    // The full 4-source cluster has 2 new sources (c, d) beyond the rejected set (a, b) —
+    // this must NOT be hard-suppressed.
+    const fullFingerprint = buildSourceFingerprint(['source-a', 'source-b', 'source-c', 'source-d'])
+    const survived = result.candidates.some(c => c.fingerprint === fullFingerprint)
+    expect(survived).toBe(true)
+  })
+})
+
+describe('planPatternCandidates: superseded suppression', () => {
+  it('edge case: a superseded proposal never reopens through a superset', () => {
+    const sources = [
+      makeSource(),
+      makeSource({
+        id: 'source-b',
+        title: 'Retry idempotent writes after 5xx failures',
+        signals: {
+          module: 'scripts/foo.ts',
+          tags: ['ci'],
+          problemType: 'best_practice',
+          titleTokens: ['retry', 'idempotent', 'writes', 'after', '5xx', 'failures'],
+        },
+      }),
+    ]
+    const fingerprint = buildSourceFingerprint(['source-a', 'source-b'])
+
+    const existing: ExistingPatternProposals = {
+      openByFingerprint: new Map(),
+      closedByFingerprint: new Map([
+        [
+          fingerprint,
+          [
+            makeIssue({
+              state: 'closed',
+              labels: ['pattern-proposal', PATTERN_PROPOSAL_OUTCOME_LABELS.superseded],
+              body: `<!-- pattern-proposal:fingerprint=${fingerprint} -->\n<!-- pattern-proposal:source-ids=source-a,source-b -->`,
+            }),
+          ],
+        ],
+      ]),
+      invalidMarkerCount: 0,
+    }
+
+    const result = plan({sources, existing})
+
+    expect(result.candidates).toHaveLength(0)
+    expect(result.counts.hardSuppressed).toBe(1)
+  })
+})
+
+describe('planPatternCandidates: deferred soft suppression', () => {
+  it('edge case: a deferred proposal with one new source produces a new-version candidate referencing the deferred issue', () => {
+    const sourceB = makeSource({
+      id: 'source-b',
+      title: 'Retry idempotent writes after 5xx failures',
+      signals: {
+        module: 'scripts/foo.ts',
+        tags: ['ci'],
+        problemType: 'best_practice',
+        titleTokens: ['retry', 'idempotent', 'writes', 'after', '5xx', 'failures'],
+      },
+    })
+    const sourceC = makeSource({
+      id: 'source-c',
+      title: 'Retry idempotent writes yet again for 5xx',
+      signals: {
+        module: 'scripts/foo.ts',
+        tags: ['ci'],
+        problemType: 'best_practice',
+        titleTokens: ['retry', 'idempotent', 'writes', 'yet', 'again', '5xx'],
+      },
+    })
+    const sources = [makeSource(), sourceB, sourceC]
+
+    const deferredFingerprint = buildSourceFingerprint(['source-a', 'source-b'])
+    const existing: ExistingPatternProposals = {
+      openByFingerprint: new Map(),
+      closedByFingerprint: new Map([
+        [
+          deferredFingerprint,
+          [
+            makeIssue({
+              number: 99,
+              state: 'closed',
+              labels: ['pattern-proposal', PATTERN_PROPOSAL_OUTCOME_LABELS.deferred],
+              body: `<!-- pattern-proposal:fingerprint=${deferredFingerprint} -->\n<!-- pattern-proposal:source-ids=source-a,source-b -->`,
+            }),
+          ],
+        ],
+      ]),
+      invalidMarkerCount: 0,
+    }
+
+    const result = plan({sources, existing})
+
+    const fullFingerprint = buildSourceFingerprint(['source-a', 'source-b', 'source-c'])
+    const candidate = result.candidates.find(c => c.fingerprint === fullFingerprint)
+    expect(candidate).toBeDefined()
+    expect(candidate?.supersedes).toBe(deferredFingerprint)
+  })
+
+  it('soft-suppresses a deferred proposal with no new sources (exact set)', () => {
+    const sources = [
+      makeSource(),
+      makeSource({
+        id: 'source-b',
+        title: 'Retry idempotent writes after 5xx failures',
+        signals: {
+          module: 'scripts/foo.ts',
+          tags: ['ci'],
+          problemType: 'best_practice',
+          titleTokens: ['retry', 'idempotent', 'writes', 'after', '5xx', 'failures'],
+        },
+      }),
+    ]
+    const fingerprint = buildSourceFingerprint(['source-a', 'source-b'])
+
+    const existing: ExistingPatternProposals = {
+      openByFingerprint: new Map(),
+      closedByFingerprint: new Map([
+        [
+          fingerprint,
+          [
+            makeIssue({
+              state: 'closed',
+              labels: ['pattern-proposal', PATTERN_PROPOSAL_OUTCOME_LABELS.deferred],
+              body: `<!-- pattern-proposal:fingerprint=${fingerprint} -->\n<!-- pattern-proposal:source-ids=source-a,source-b -->`,
+            }),
+          ],
+        ],
+      ]),
+      invalidMarkerCount: 0,
+    }
+
+    const result = plan({sources, existing})
+
+    expect(result.candidates).toHaveLength(0)
+    expect(result.counts.softSuppressed).toBe(1)
+  })
+})
+
+describe('planPatternCandidates: accepted retirement', () => {
+  it('edge case: an accepted proposal source IDs are immediately retired from future clusters even while open', () => {
+    const sourceB = makeSource({
+      id: 'source-b',
+      title: 'Retry idempotent writes after 5xx failures',
+      signals: {
+        module: 'scripts/foo.ts',
+        tags: ['ci'],
+        problemType: 'best_practice',
+        titleTokens: ['retry', 'idempotent', 'writes', 'after', '5xx', 'failures'],
+      },
+    })
+    const sources = [makeSource(), sourceB]
+
+    // Source A already codified via an accepted proposal (issue still open per plan text:
+    // "regardless of whether the issue is open or closed").
+    const acceptedFingerprint = buildSourceFingerprint(['source-a'])
+    const existing: ExistingPatternProposals = {
+      openByFingerprint: new Map([
+        [
+          acceptedFingerprint,
+          [
+            makeIssue({
+              state: 'open',
+              labels: ['pattern-proposal', PATTERN_PROPOSAL_OUTCOME_LABELS.accepted],
+              body: `<!-- pattern-proposal:fingerprint=${acceptedFingerprint} -->\n<!-- pattern-proposal:source-ids=source-a -->`,
+            }),
+          ],
+        ],
+      ]),
+      closedByFingerprint: new Map(),
+      invalidMarkerCount: 0,
+    }
+
+    const result = plan({sources, existing})
+
+    // source-a is retired; only source-b remains, insufficient for a cluster (needs >= 2).
+    expect(result.candidates).toHaveLength(0)
+    expect(result.counts.duplicateOpenOverlap).toBe(0)
+    expect(result.counts.noOp).toBe(1)
+  })
+})
+
+describe('planPatternCandidates: unsafe candidate handling', () => {
+  it('error path: unsafe candidate evidence increments skipped-unsafe counts but does not create suppression state', () => {
+    const unsafeTitle = `Retry idempotent writes ghp_${'a'.repeat(40)}`
+    const sourceB = makeSource({
+      id: 'source-b',
+      title: unsafeTitle,
+      signals: {
+        module: 'scripts/foo.ts',
+        tags: ['ci'],
+        problemType: 'best_practice',
+        titleTokens: ['retry', 'idempotent', 'writes'],
+      },
+    })
+    const sources = [makeSource(), sourceB]
+
+    const result = plan({sources, existing: emptyExisting()})
+
+    expect(result.candidates).toHaveLength(0)
+    expect(result.counts.unsafe).toBe(1)
+  })
+})
+
+describe('planPatternCandidates: filter-before-cap ordering', () => {
+  it('filters candidates before applying the three-proposal cap', () => {
+    // Build 4 well-formed clusters; suppress 2 of them via open-overlap so only 2 remain,
+    // both under the cap of 3 — confirms cap is applied post-filter, not pre-filter.
+    const TOPIC_WORDS = [
+      ['aardvark', 'brambling', 'catapult'],
+      ['dewdrop', 'echelon', 'foxglove'],
+      ['gargoyle', 'hazelnut', 'ibis'],
+      ['jackal', 'kestrel', 'lanyard'],
+    ]
+
+    function pairFor(n: number): PatternCandidateSource[] {
+      const base = `pair${n}`
+      const words = TOPIC_WORDS[n - 1] ?? ['unknown']
+      return [
+        makeSource({
+          id: `${base}-a`,
+          title: `${words.join(' ')} first`,
+          signals: {
+            module: `scripts/mod${n}.ts`,
+            tags: [`topic${n}`],
+            problemType: `best_practice_${n}`,
+            titleTokens: [...words, 'first'],
+          },
+        }),
+        makeSource({
+          id: `${base}-b`,
+          title: `${words.join(' ')} second`,
+          signals: {
+            module: `scripts/mod${n}.ts`,
+            tags: [`topic${n}`],
+            problemType: `best_practice_${n}`,
+            titleTokens: [...words, 'second'],
+          },
+        }),
+      ]
+    }
+
+    const sources = [...pairFor(1), ...pairFor(2), ...pairFor(3), ...pairFor(4)]
+    const suppressedFingerprint = buildSourceFingerprint(['pair1-a', 'pair1-b'])
+
+    const existing: ExistingPatternProposals = {
+      openByFingerprint: new Map([[suppressedFingerprint, [makeIssue({state: 'open'})]]]),
+      closedByFingerprint: new Map(),
+      invalidMarkerCount: 0,
+    }
+
+    const result = plan({sources, existing, cap: 3})
+
+    expect(result.counts.duplicateOpenOverlap).toBe(1)
+    expect(result.candidates.length).toBeLessThanOrEqual(3)
+    expect(result.candidates.some(c => c.fingerprint === suppressedFingerprint)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Deterministic ordering
+// ---------------------------------------------------------------------------
+
+describe('planPatternCandidates: deterministic tie order', () => {
+  it('orders equal-strength candidates by recency then stable source-ID order', () => {
+    const TIE_TOPIC_WORDS = [
+      ['marmoset', 'nightjar', 'ocelot'],
+      ['periwinkle', 'quokka', 'ravenous'],
+    ]
+
+    function pairFor(n: number, date: string): PatternCandidateSource[] {
+      const base = `set${n}`
+      const words = TIE_TOPIC_WORDS[n - 1] ?? ['unknown']
+      return [
+        makeSource({
+          id: `${base}-a`,
+          title: `${words.join(' ')} alpha`,
+          date,
+          signals: {
+            module: `scripts/mod${n}.ts`,
+            tags: [`topic${n}`],
+            problemType: `best_practice_${n}`,
+            titleTokens: [...words, 'alpha'],
+          },
+        }),
+        makeSource({
+          id: `${base}-b`,
+          title: `${words.join(' ')} beta`,
+          date,
+          signals: {
+            module: `scripts/mod${n}.ts`,
+            tags: [`topic${n}`],
+            problemType: `best_practice_${n}`,
+            titleTokens: [...words, 'beta'],
+          },
+        }),
+      ]
+    }
+
+    const older = pairFor(1, '2026-01-01')
+    const newer = pairFor(2, '2026-06-01')
+    const sources = [...older, ...newer]
+
+    const result = plan({sources, existing: emptyExisting(), cap: 1})
+
+    expect(result.candidates).toHaveLength(1)
+    expect(result.candidates[0]?.sourceIds).toEqual(['set2-a', 'set2-b'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Digest schema
+// ---------------------------------------------------------------------------
+
+describe('buildCandidateDigest', () => {
+  it('contains only allowed fields and validates public-safe titles', () => {
+    const sourceB = makeSource({
+      id: 'source-b',
+      title: 'Retry idempotent writes after 5xx failures',
+      signals: {
+        module: 'scripts/foo.ts',
+        tags: ['ci'],
+        problemType: 'best_practice',
+        titleTokens: ['retry', 'idempotent', 'writes', 'after', '5xx', 'failures'],
+      },
+    })
+    const sources = [makeSource(), sourceB]
+
+    const result = plan({sources, existing: emptyExisting()})
+    expect(result.candidates).toHaveLength(1)
+    const candidate = result.candidates[0]
+    if (candidate === undefined) throw new Error('expected a candidate')
+
+    const digest = buildCandidateDigest({candidate, runCount: 1, publicOutputTokens: safeTokens()})
+
+    const allowedKeys = new Set([
+      'fingerprint',
+      'sourceIds',
+      'sourceLinks',
+      'sourceTitles',
+      'evidenceCount',
+      'scoreBucket',
+      'suggestedNextAction',
+      'runCount',
+      'supersedes',
+    ])
+    for (const key of Object.keys(digest)) {
+      expect(allowedKeys.has(key)).toBe(true)
+    }
+    expect(digest.fingerprint).toBe(candidate.fingerprint)
+    expect(digest.sourceIds).toEqual(candidate.sourceIds)
+    expect(digest.sourceTitles.length).toBe(candidate.sourceIds.length)
+  })
+
+  it('throws instead of masking a source title that fails the public-output gate', () => {
+    const blockingTokens = makePublicOutputTokens({
+      privateTokens: new Set<string>(['private-token']),
+      redactedCanonicalIds: new Set<string>(),
+    })
+    const candidate = {
+      fingerprint: buildSourceFingerprint(['source-a', 'source-b']),
+      sourceIds: ['source-a', 'source-b'],
+      sources: [
+        makeSource({id: 'source-a', title: 'Retry private-token safely'}),
+        makeSource({id: 'source-b', title: 'Retry idempotent writes after 5xx failures'}),
+      ],
+      scoreBucket: 'moderate' as const,
+    }
+
+    expect(() => buildCandidateDigest({candidate, runCount: 1, publicOutputTokens: blockingTokens})).toThrow(
+      'Pattern candidate source title failed public-output gate',
+    )
+  })
+})

--- a/scripts/capture-patterns-cluster.ts
+++ b/scripts/capture-patterns-cluster.ts
@@ -11,13 +11,22 @@
  * Strip-only safe: no parameter properties, enums, or namespaces.
  */
 
+import type {Dirent} from 'node:fs'
 import {createHash} from 'node:crypto'
+import {readdir, readFile, writeFile} from 'node:fs/promises'
+import process from 'node:process'
 
 import {
   classifyPatternProposalOutcome,
+  collectLearningProposalSources,
+  collectSolutionDocSources,
+  fetchExistingPatternProposals,
   parsePatternProposalSourceIds,
+  SOLUTION_SUBDIRS,
   type ExistingPatternProposalIssue,
   type ExistingPatternProposals,
+  type LearningProposalIssueInput,
+  type PatternProposalOctokitClient,
   type PatternSourceSignals,
 } from './capture-patterns-synthesis.ts'
 import {applyPublicOutputGate, type PublicOutputTokens} from './status-truth-public-output.ts'
@@ -600,4 +609,201 @@ export function buildCandidateDigest(input: BuildCandidateDigestInput): PatternC
   }
 
   return digest
+}
+
+// ---------------------------------------------------------------------------
+// Entry point (detect/digest step: collect sources, plan candidates, write digest)
+// ---------------------------------------------------------------------------
+
+/** Counts-only run summary written to stdout and CAPTURE_PATTERNS_RESULT_PATH. */
+export interface PatternDetectResult {
+  sourcesLoaded: number
+  invalidSources: number
+  candidatesScanned: number
+  lowSignalSkipped: number
+  duplicateOpenOverlap: number
+  hardSuppressed: number
+  softSuppressed: number
+  unsafe: number
+  capped: number
+  candidatesEmitted: number
+  tokenLoadFailure: boolean
+  scanFailure: boolean
+}
+
+async function loadSolutionDocFilesFromDisk(): Promise<Record<string, string>> {
+  const files: Record<string, string> = {}
+
+  for (const subdir of SOLUTION_SUBDIRS) {
+    const dirPath = `docs/solutions/${subdir}`
+    let entries: Dirent[]
+
+    try {
+      entries = await readdir(dirPath, {withFileTypes: true})
+    } catch {
+      continue
+    }
+
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.md')) continue
+      const path = `${dirPath}/${entry.name}`
+      try {
+        files[path] = await readFile(path, 'utf8')
+      } catch {
+        process.stderr.write(`capture-patterns-cluster: could not read file (path: ${path})\n`)
+      }
+    }
+  }
+
+  return files
+}
+
+/** Minimal shape of an issue returned by `paginate(listForRepo)` for learning-proposal collection. */
+interface RawLearningProposalIssue {
+  readonly number: number
+  readonly body?: string | null
+  readonly title?: string | null
+  readonly created_at?: string
+  readonly labels?: readonly (string | {readonly name?: string | null})[]
+}
+
+/** Octokit surface needed for detect: paginated issue listing plus pattern-proposal reads. */
+interface PatternDetectOctokitClient extends PatternProposalOctokitClient {
+  readonly paginate: (fn: unknown, params: Record<string, unknown>) => Promise<RawLearningProposalIssue[]>
+}
+
+async function fetchLearningProposalIssuesFromRepo(
+  octokit: PatternDetectOctokitClient,
+  owner: string,
+  repo: string,
+): Promise<LearningProposalIssueInput[]> {
+  const raw = await octokit.paginate(octokit.rest.issues.listForRepo, {
+    owner,
+    repo,
+    state: 'all',
+    labels: 'learning-proposal',
+    per_page: 100,
+  })
+
+  return raw.map(issue => ({
+    number: issue.number,
+    body: issue.body,
+    title: issue.title ?? '',
+    createdAt: issue.created_at ?? '',
+    labels: (issue.labels ?? []).map(l => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean),
+  }))
+}
+
+async function writePatternDigestFile(digestCandidates: PatternCandidateDigest[]): Promise<void> {
+  const digestPath = process.env.CAPTURE_PATTERNS_DIGEST_PATH
+  if (digestPath !== undefined && digestPath !== '') {
+    await writeFile(digestPath, `${JSON.stringify(digestCandidates)}\n`, {flag: 'w'})
+  }
+}
+
+/**
+ * CLI entry point for the detect/digest step: collects the allowed source corpus
+ * (solution docs + learning-proposal issues), plans deterministic cluster candidates,
+ * and writes a versioned candidate digest to CAPTURE_PATTERNS_DIGEST_PATH.
+ *
+ * Best-effort: any error falls back to an empty digest and exit 0 — this step must
+ * never fail the workflow. Errors are logged as counts-only, never with message text
+ * that could leak content.
+ */
+async function main(): Promise<void> {
+  const owner = 'fro-bot'
+  const repo = '.github'
+
+  const result: PatternDetectResult = {
+    sourcesLoaded: 0,
+    invalidSources: 0,
+    candidatesScanned: 0,
+    lowSignalSkipped: 0,
+    duplicateOpenOverlap: 0,
+    hardSuppressed: 0,
+    softSuppressed: 0,
+    unsafe: 0,
+    capped: 0,
+    candidatesEmitted: 0,
+    tokenLoadFailure: false,
+    scanFailure: false,
+  }
+
+  let digestCandidates: PatternCandidateDigest[] = []
+
+  try {
+    const {createOctokitFromEnv} = await import('./capture-learnings-harvest.ts')
+    const {loadPrivateTokensFromDisk} = await import('./capture-learnings-privacy.ts')
+    const {loadRedactedCanonicalIdsFromDisk} = await import('./status-truth-proposals.ts')
+    const {makePublicOutputTokens} = await import('./status-truth-public-output.ts')
+
+    const octokit = (await createOctokitFromEnv()) as unknown as PatternDetectOctokitClient
+    const headSha = process.env.GITHUB_SHA ?? ''
+
+    const [solutionFiles, learningProposalIssues, existing] = await Promise.all([
+      loadSolutionDocFilesFromDisk(),
+      fetchLearningProposalIssuesFromRepo(octokit, owner, repo),
+      fetchExistingPatternProposals({octokit, owner, repo}),
+    ])
+
+    const solutionSources = collectSolutionDocSources(solutionFiles, headSha)
+    const learningSources = collectLearningProposalSources(learningProposalIssues)
+
+    result.sourcesLoaded = solutionSources.sources.length + learningSources.sources.length
+    result.invalidSources = solutionSources.invalidCount + learningSources.invalidCount
+
+    let publicOutputTokens: PublicOutputTokens
+    try {
+      const [privateTokens, redactedCanonicalIds] = await Promise.all([
+        loadPrivateTokensFromDisk(),
+        loadRedactedCanonicalIdsFromDisk(),
+      ])
+      publicOutputTokens = makePublicOutputTokens({privateTokens, redactedCanonicalIds})
+    } catch {
+      result.tokenLoadFailure = true
+      publicOutputTokens = {loaded: false, error: 'token load failed'}
+    }
+
+    const sources: PatternCandidateSource[] = [...solutionSources.sources, ...learningSources.sources]
+
+    const plan = planPatternCandidates({sources, existing, publicOutputTokens})
+
+    result.candidatesScanned =
+      plan.counts.proposed +
+      plan.counts.capped +
+      plan.counts.lowSignal +
+      plan.counts.duplicateOpenOverlap +
+      plan.counts.hardSuppressed +
+      plan.counts.softSuppressed +
+      plan.counts.unsafe
+    result.lowSignalSkipped = plan.counts.lowSignal
+    result.duplicateOpenOverlap = plan.counts.duplicateOpenOverlap
+    result.hardSuppressed = plan.counts.hardSuppressed
+    result.softSuppressed = plan.counts.softSuppressed
+    result.unsafe = plan.counts.unsafe
+    result.capped = plan.counts.capped
+    result.candidatesEmitted = plan.candidates.length
+
+    digestCandidates = plan.candidates.map(candidate =>
+      buildCandidateDigest({candidate, runCount: 1, publicOutputTokens}),
+    )
+
+    await writePatternDigestFile(digestCandidates)
+  } catch (error: unknown) {
+    const errorName = error instanceof Error ? error.name : 'unknown'
+    process.stderr.write(`capture-patterns-cluster: unexpected error (${errorName}), falling back to empty digest\n`)
+    result.scanFailure = true
+    digestCandidates = []
+    try {
+      await writePatternDigestFile(digestCandidates)
+    } catch {
+      // ignore
+    }
+  }
+
+  process.stdout.write(`${JSON.stringify(result)}\n`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
 }

--- a/scripts/capture-patterns-cluster.ts
+++ b/scripts/capture-patterns-cluster.ts
@@ -298,16 +298,35 @@ function rankCandidates(candidates: PatternCandidate[]): PatternCandidate[] {
 interface ClosedSuppressionRecord {
   fingerprint: string
   sourceIds: Set<string>
-  outcome: 'rejected' | 'needs-outcome' | 'superseded' | 'deferred'
+  outcome: 'rejected' | 'needs-outcome' | 'superseded' | 'deferred' | 'malformed-outcome' | 'conflicting-labels'
   issueNumber: number
 }
+
+/**
+ * Outcomes treated as conservatively suppressed (same bucket as `needs-outcome`):
+ * an ambiguous or malformed closed outcome must never be read as "safe to re-propose"
+ * without new independent evidence.
+ */
+const CONSERVATIVE_SUPPRESSION_OUTCOMES = new Set([
+  'rejected',
+  'needs-outcome',
+  'malformed-outcome',
+  'conflicting-labels',
+])
 
 function resolveClosedSuppressionRecords(existing: ExistingPatternProposals): ClosedSuppressionRecord[] {
   const records: ClosedSuppressionRecord[] = []
   for (const [fingerprint, issues] of existing.closedByFingerprint) {
     for (const issue of issues) {
       const outcome = classifyPatternProposalOutcome(issue)
-      if (outcome !== 'rejected' && outcome !== 'needs-outcome' && outcome !== 'superseded' && outcome !== 'deferred') {
+      if (
+        outcome !== 'rejected' &&
+        outcome !== 'needs-outcome' &&
+        outcome !== 'superseded' &&
+        outcome !== 'deferred' &&
+        outcome !== 'malformed-outcome' &&
+        outcome !== 'conflicting-labels'
+      ) {
         continue
       }
       const sourceIds = parsePatternProposalSourceIds(issue.body ?? '') ?? []
@@ -404,12 +423,8 @@ export function planPatternCandidates(input: PlanPatternCandidatesInput): Patter
   const activeSources = input.sources.filter(s => !retiredSourceIds.has(s.id))
 
   const rawClusters = buildRawClusters(activeSources)
-  const totalPairsConsidered = countCandidatePairs(activeSources)
-  const weakClusterCount = totalPairsConsidered > 0 ? Math.max(0, activeSources.length - rawClusters.flat().length) : 0
-  counts.lowSignal +=
-    weakClusterCount === 0 && rawClusters.length === 0 && activeSources.length >= MIN_CLUSTER_SOURCES ? 1 : 0
-  // Simpler, precise low-signal accounting: any activeSources not part of a surviving
-  // cluster, when there were at least 2 sources to compare, is attributable to weak overlap.
+  // Low-signal accounting: at least two sources were available to compare but none
+  // survived clustering (weak overlap only) — counted once per run, not per source.
   if (activeSources.length >= MIN_CLUSTER_SOURCES && rawClusters.length === 0) {
     counts.lowSignal = 1
   }
@@ -435,7 +450,10 @@ export function planPatternCandidates(input: PlanPatternCandidatesInput): Patter
       for (const issues of input.existing.openByFingerprint.values()) {
         for (const issue of issues) {
           const openIds = new Set(parsePatternProposalSourceIds(issue.body ?? '') ?? [])
-          if (isSubsetOrWeakSuperset(candidateIds, openIds)) {
+          // Any exact, subset, or superset overlap with a still-open proposal suppresses
+          // the candidate unconditionally — an open proposal is not yet resolved, so
+          // adding new sources must never bypass it while it remains open.
+          if (hasAnyIdOverlap(candidateIds, openIds)) {
             overlapsOpen = true
             break
           }
@@ -455,8 +473,7 @@ export function planPatternCandidates(input: PlanPatternCandidatesInput): Patter
     const candidateIds = new Set(candidate.sourceIds)
     let hardSuppressed = false
     for (const record of closedRecords) {
-      if (record.outcome !== 'rejected' && record.outcome !== 'needs-outcome' && record.outcome !== 'superseded')
-        continue
+      if (record.outcome === 'deferred') continue
       if (record.outcome === 'superseded') {
         // Superseded: permanently hard-suppressed for exact/subset/superset matches.
         if (
@@ -468,7 +485,9 @@ export function planPatternCandidates(input: PlanPatternCandidatesInput): Patter
         }
         continue
       }
-      // rejected / needs-outcome: subset or weak superset unless >= 2 new sources.
+      if (!CONSERVATIVE_SUPPRESSION_OUTCOMES.has(record.outcome)) continue
+      // rejected / needs-outcome / malformed-outcome / conflicting-labels: conservatively
+      // treated as suppressed — subset or weak superset unless >= 2 new sources.
       if (isSubsetOrWeakSuperset(candidateIds, record.sourceIds)) {
         hardSuppressed = true
         break
@@ -540,9 +559,17 @@ function isExactOrSuperset(candidateIds: Set<string>, referenceIds: Set<string>)
   return [...referenceIds].every(id => candidateIds.has(id))
 }
 
-function countCandidatePairs(sources: PatternCandidateSource[]): number {
-  const n = sources.length
-  return n < 2 ? 0 : (n * (n - 1)) / 2
+/**
+ * True when candidateIds and referenceIds are an exact match, or either is a subset of
+ * the other. Used for open-proposal overlap suppression, where any such relation must
+ * suppress the candidate unconditionally — no upgrade-threshold bypass while the
+ * referenced proposal remains open.
+ */
+function hasAnyIdOverlap(candidateIds: Set<string>, referenceIds: Set<string>): boolean {
+  if (referenceIds.size === 0 || candidateIds.size === 0) return false
+  const candidateSubsetOfReference = [...candidateIds].every(id => referenceIds.has(id))
+  const referenceSubsetOfCandidate = [...referenceIds].every(id => candidateIds.has(id))
+  return candidateSubsetOfReference || referenceSubsetOfCandidate
 }
 
 // ---------------------------------------------------------------------------
@@ -631,8 +658,24 @@ export interface PatternDetectResult {
   scanFailure: boolean
 }
 
-async function loadSolutionDocFilesFromDisk(): Promise<Record<string, string>> {
+/** Result of loading solution-doc files from disk: contents plus unreadable-file count. */
+export interface LoadSolutionDocFilesResult {
+  files: Record<string, string>
+  /** Count of files that were listed but could not be read (e.g. permission/IO error). */
+  readFailures: number
+}
+
+/**
+ * Load solution-doc file contents from disk. A directory-listing failure is treated as
+ * "no files in that subdir" (best-effort), but a file that is listed and then fails to
+ * read is a real corpus gap: it is reported via `readFailures` so callers fold it into
+ * `invalidSources` rather than silently dropping evidence.
+ */
+export async function loadSolutionDocFilesFromDisk(
+  writeStderr: (message: string) => void = message => process.stderr.write(message),
+): Promise<LoadSolutionDocFilesResult> {
   const files: Record<string, string> = {}
+  let readFailures = 0
 
   for (const subdir of SOLUTION_SUBDIRS) {
     const dirPath = `docs/solutions/${subdir}`
@@ -650,12 +693,13 @@ async function loadSolutionDocFilesFromDisk(): Promise<Record<string, string>> {
       try {
         files[path] = await readFile(path, 'utf8')
       } catch {
-        process.stderr.write(`capture-patterns-cluster: could not read file (path: ${path})\n`)
+        readFailures += 1
+        writeStderr(`capture-patterns-cluster: could not read file (path: ${path})\n`)
       }
     }
   }
 
-  return files
+  return {files, readFailures}
 }
 
 /** Minimal shape of an issue returned by `paginate(listForRepo)` for learning-proposal collection. */
@@ -694,11 +738,20 @@ async function fetchLearningProposalIssuesFromRepo(
   }))
 }
 
+/**
+ * Write the candidate digest to CAPTURE_PATTERNS_DIGEST_PATH.
+ *
+ * Fail-closed contract: a missing/empty digest path is a configuration error, not a
+ * silent no-op — the caller must know the digest was never persisted so the run result
+ * reflects a scan failure rather than reporting emitted candidates that were never
+ * written anywhere.
+ */
 async function writePatternDigestFile(digestCandidates: PatternCandidateDigest[]): Promise<void> {
   const digestPath = process.env.CAPTURE_PATTERNS_DIGEST_PATH
-  if (digestPath !== undefined && digestPath !== '') {
-    await writeFile(digestPath, `${JSON.stringify(digestCandidates)}\n`, {flag: 'w'})
+  if (digestPath === undefined || digestPath === '') {
+    throw new Error('capture-patterns-cluster: CAPTURE_PATTERNS_DIGEST_PATH is required to persist the digest')
   }
+  await writeFile(digestPath, `${JSON.stringify(digestCandidates)}\n`, {flag: 'w'})
 }
 
 /**
@@ -709,6 +762,11 @@ async function writePatternDigestFile(digestCandidates: PatternCandidateDigest[]
  * Best-effort: any error falls back to an empty digest and exit 0 — this step must
  * never fail the workflow. Errors are logged as counts-only, never with message text
  * that could leak content.
+ *
+ * Token-load ordering: the privacy token load is attempted BEFORE any GitHub API call.
+ * If it fails, no API calls are made at all (a failed load must never gate access to
+ * data it was supposed to redact) and the run writes an empty digest/counts with
+ * `tokenLoadFailure: true`.
  */
 async function main(): Promise<void> {
   const owner = 'fro-bot'
@@ -732,25 +790,9 @@ async function main(): Promise<void> {
   let digestCandidates: PatternCandidateDigest[] = []
 
   try {
-    const {createOctokitFromEnv} = await import('./capture-learnings-harvest.ts')
     const {loadPrivateTokensFromDisk} = await import('./capture-learnings-privacy.ts')
     const {loadRedactedCanonicalIdsFromDisk} = await import('./status-truth-proposals.ts')
     const {makePublicOutputTokens} = await import('./status-truth-public-output.ts')
-
-    const octokit = (await createOctokitFromEnv()) as unknown as PatternDetectOctokitClient
-    const headSha = process.env.GITHUB_SHA ?? ''
-
-    const [solutionFiles, learningProposalIssues, existing] = await Promise.all([
-      loadSolutionDocFilesFromDisk(),
-      fetchLearningProposalIssuesFromRepo(octokit, owner, repo),
-      fetchExistingPatternProposals({octokit, owner, repo}),
-    ])
-
-    const solutionSources = collectSolutionDocSources(solutionFiles, headSha)
-    const learningSources = collectLearningProposalSources(learningProposalIssues)
-
-    result.sourcesLoaded = solutionSources.sources.length + learningSources.sources.length
-    result.invalidSources = solutionSources.invalidCount + learningSources.invalidCount
 
     let publicOutputTokens: PublicOutputTokens
     try {
@@ -760,9 +802,31 @@ async function main(): Promise<void> {
       ])
       publicOutputTokens = makePublicOutputTokens({privateTokens, redactedCanonicalIds})
     } catch {
+      // Token load failed before any GitHub API call was made: skip all API calls and
+      // write an empty digest/counts. Logs stay counts-only.
       result.tokenLoadFailure = true
-      publicOutputTokens = {loaded: false, error: 'token load failed'}
+      await writePatternDigestFile([])
+      process.stdout.write(`${JSON.stringify(result)}\n`)
+      return
     }
+
+    const {createOctokitFromEnv} = await import('./capture-learnings-harvest.ts')
+    const octokit = (await createOctokitFromEnv()) as unknown as PatternDetectOctokitClient
+    const headSha = process.env.GITHUB_SHA ?? ''
+
+    const [solutionDocs, learningProposalIssues, existing] = await Promise.all([
+      loadSolutionDocFilesFromDisk(),
+      fetchLearningProposalIssuesFromRepo(octokit, owner, repo),
+      fetchExistingPatternProposals({octokit, owner, repo}),
+    ])
+
+    const solutionSources = collectSolutionDocSources(solutionDocs.files, headSha)
+    const learningSources = collectLearningProposalSources(learningProposalIssues)
+
+    result.sourcesLoaded = solutionSources.sources.length + learningSources.sources.length
+    // Files that were listed but failed to read are a real corpus gap, not a silent
+    // drop — fold them into invalidSources alongside malformed/duplicate sources.
+    result.invalidSources = solutionSources.invalidCount + learningSources.invalidCount + solutionDocs.readFailures
 
     const sources: PatternCandidateSource[] = [...solutionSources.sources, ...learningSources.sources]
 

--- a/scripts/capture-patterns-cluster.ts
+++ b/scripts/capture-patterns-cluster.ts
@@ -581,10 +581,7 @@ export function buildCandidateDigest(input: BuildCandidateDigestInput): PatternC
       tokens,
       fingerprint: input.candidate.fingerprint,
     })
-    if (!gate.allowed) {
-      throw new Error('Pattern candidate source title failed public-output gate')
-    }
-    return gate.sanitizedContent
+    return gate.allowed ? gate.sanitizedContent : '[source title withheld: failed public-output gate]'
   })
 
   const digest: PatternCandidateDigest = {

--- a/scripts/capture-patterns-cluster.ts
+++ b/scripts/capture-patterns-cluster.ts
@@ -1,0 +1,606 @@
+/**
+ * Candidate clustering, scoring, and suppression planner for recurring pattern synthesis.
+ *
+ * Pure core: `planPatternCandidates` builds deterministic cluster candidates from source
+ * artifacts and existing pattern-proposal state, then decides which candidates may be
+ * sent to the agent for proposal drafting. No I/O — all data is injected.
+ *
+ * Filter order (fixed): weak cluster -> open-proposal overlap -> hard suppression ->
+ * soft suppression (without upgrade threshold) -> unsafe evidence placeholder -> rank -> cap.
+ *
+ * Strip-only safe: no parameter properties, enums, or namespaces.
+ */
+
+import {createHash} from 'node:crypto'
+
+import {
+  classifyPatternProposalOutcome,
+  parsePatternProposalSourceIds,
+  type ExistingPatternProposalIssue,
+  type ExistingPatternProposals,
+  type PatternSourceSignals,
+} from './capture-patterns-synthesis.ts'
+import {applyPublicOutputGate, type PublicOutputTokens} from './status-truth-public-output.ts'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum candidates emitted per run (before opener applies its own cap). */
+const DEFAULT_CAP = 3
+
+/**
+ * Minimum shared correction-substance score (inclusive) for two sources to cluster
+ * together. Modeled on `computeOverlapScore` in capture-learnings-harvest.ts, but tuned
+ * so that a single generic signal (a shared tag, or a bare problem_type match with no
+ * title-token or module overlap) can never clear the bar on its own — real repeated
+ * correction substance requires multiple shared signals or overlapping title tokens.
+ */
+const CLUSTER_OVERLAP_THRESHOLD = 30
+
+/** Minimum candidate cluster size (in unique sources) to avoid single-source noise. */
+const MIN_CLUSTER_SOURCES = 2
+
+/** Number of new independent public-safe sources required to upgrade past hard suppression. */
+const HARD_SUPPRESSION_UPGRADE_THRESHOLD = 2
+
+/** Number of new independent public-safe sources required to lift soft (deferred) suppression. */
+const SOFT_SUPPRESSION_UPGRADE_THRESHOLD = 1
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
+
+/** Minimal source shape the planner clusters over. */
+export interface PatternCandidateSource {
+  id: string
+  kind: 'solution-doc' | 'learning-proposal'
+  link: string
+  title: string
+  date: string
+  signals: PatternSourceSignals
+}
+
+/** Evidence/score bucket, coarse and deterministic. */
+export type PatternCandidateScoreBucket = 'strong' | 'moderate' | 'weak'
+
+/** A built cluster candidate ready for suppression filtering and ranking. */
+export interface PatternCandidate {
+  fingerprint: string
+  sourceIds: string[]
+  sources: PatternCandidateSource[]
+  scoreBucket: PatternCandidateScoreBucket
+  /** Fingerprint of a deferred proposal this candidate is a new version of, if any. */
+  supersedes?: string
+}
+
+/** Counts-only telemetry for the planner. No prose, fingerprints, or titles. */
+export interface PatternPlannerCounts {
+  proposed: number
+  capped: number
+  lowSignal: number
+  duplicateOpenOverlap: number
+  hardSuppressed: number
+  softSuppressed: number
+  unsafe: number
+  invalidSource: number
+  noOp: number
+  failed: number
+}
+
+/** Result of `planPatternCandidates`. */
+export interface PatternPlannerResult {
+  candidates: PatternCandidate[]
+  counts: PatternPlannerCounts
+}
+
+// ---------------------------------------------------------------------------
+// Fingerprint
+// ---------------------------------------------------------------------------
+
+/**
+ * Cluster fingerprint: lowercase hex SHA-256 of newline-joined, sorted source IDs.
+ * Identity is source-ID-based only — generated pattern wording is never hashed.
+ */
+export function buildSourceFingerprint(sourceIds: readonly string[]): string {
+  const sorted = [...sourceIds].sort((a, b) => a.localeCompare(b))
+  return createHash('sha256').update(sorted.join('\n')).digest('hex')
+}
+
+// ---------------------------------------------------------------------------
+// Correction-substance overlap scoring (models computeOverlapScore)
+// ---------------------------------------------------------------------------
+
+/**
+ * Score shared correction substance between two sources' structured signals.
+ *
+ * - Exact non-empty problem_type match: 100 points (strong signal).
+ * - Each shared tag token: 10 points.
+ * - Each shared module token (path split on separators, len >= 3): 10 points.
+ * - Each shared title token: 10 points.
+ *
+ * A single shared generic tag alone (10 points) never clears CLUSTER_OVERLAP_THRESHOLD.
+ * Pure function: no I/O.
+ */
+function computeSourceOverlapScore(a: PatternSourceSignals, b: PatternSourceSignals): number {
+  let score = 0
+
+  if (a.problemType !== '' && a.problemType === b.problemType) {
+    score += 100
+  }
+
+  const aTags = new Set(a.tags.map(t => t.toLowerCase()))
+  for (const tag of b.tags) {
+    if (aTags.has(tag.toLowerCase())) score += 10
+  }
+
+  const moduleTokens = (signals: PatternSourceSignals) =>
+    signals.module
+      .toLowerCase()
+      .split(/[/.\-_]/u)
+      .filter(t => t.length >= 3)
+  const aModuleTokens = new Set(moduleTokens(a))
+  for (const token of moduleTokens(b)) {
+    if (aModuleTokens.has(token)) score += 10
+  }
+
+  const aTitleTokens = new Set(a.titleTokens.map(t => t.toLowerCase()))
+  for (const token of b.titleTokens) {
+    if (aTitleTokens.has(token.toLowerCase())) score += 10
+  }
+
+  return score
+}
+
+// ---------------------------------------------------------------------------
+// Cluster building (union-find over pairwise overlap)
+// ---------------------------------------------------------------------------
+
+function findRoot(parent: Map<string, string>, id: string): string {
+  let current = id
+  while (parent.get(current) !== current) {
+    const next = parent.get(current)
+    if (next === undefined) break
+    current = next
+  }
+  return current
+}
+
+function unionIds(parent: Map<string, string>, a: string, b: string): void {
+  const rootA = findRoot(parent, a)
+  const rootB = findRoot(parent, b)
+  if (rootA !== rootB) {
+    parent.set(rootA, rootB)
+  }
+}
+
+/**
+ * Group sources into clusters by pairwise correction-substance overlap
+ * (union-find), then reject clusters that are too small or whose *combined*
+ * pairwise overlap never exceeds a single shared generic tag.
+ */
+function buildRawClusters(sources: PatternCandidateSource[]): PatternCandidateSource[][] {
+  const parent = new Map<string, string>()
+  for (const source of sources) parent.set(source.id, source.id)
+
+  // Track whether any pair within an eventual cluster crossed the overlap threshold.
+  const strongPairs = new Set<string>()
+
+  for (let i = 0; i < sources.length; i++) {
+    for (let j = i + 1; j < sources.length; j++) {
+      const sourceI = sources[i]
+      const sourceJ = sources[j]
+      if (sourceI === undefined || sourceJ === undefined) continue
+      const score = computeSourceOverlapScore(sourceI.signals, sourceJ.signals)
+      if (score >= CLUSTER_OVERLAP_THRESHOLD) {
+        unionIds(parent, sourceI.id, sourceJ.id)
+        strongPairs.add(sourceI.id)
+        strongPairs.add(sourceJ.id)
+      }
+    }
+  }
+
+  const groups = new Map<string, PatternCandidateSource[]>()
+  for (const source of sources) {
+    const root = findRoot(parent, source.id)
+    const existing = groups.get(root) ?? []
+    existing.push(source)
+    groups.set(root, existing)
+  }
+
+  const clusters: PatternCandidateSource[][] = []
+  for (const group of groups.values()) {
+    if (group.length < MIN_CLUSTER_SOURCES) continue
+    // Reject clusters where no member ever crossed the strong-overlap threshold with
+    // another member (defensive; union-find only merges on threshold crossing, but this
+    // guards against isolated members riding along via transitive same-root merges).
+    const hasStrongMember = group.some(s => strongPairs.has(s.id))
+    if (!hasStrongMember) continue
+    clusters.push([...group].sort((a, b) => a.id.localeCompare(b.id)))
+  }
+
+  return clusters
+}
+
+// ---------------------------------------------------------------------------
+// Score bucket + evidence strength ranking
+// ---------------------------------------------------------------------------
+
+function scoreBucketFor(sources: PatternCandidateSource[]): PatternCandidateScoreBucket {
+  const uniqueSourceCount = new Set(sources.map(s => s.id)).size
+  const hasAcceptedGradeEvidence = sources.some(s => s.kind === 'solution-doc')
+  if (uniqueSourceCount >= 3 && hasAcceptedGradeEvidence) return 'strong'
+  if (uniqueSourceCount >= 2) return 'moderate'
+  return 'weak'
+}
+
+function mostRecentDate(sources: PatternCandidateSource[]): string {
+  let latest = ''
+  for (const source of sources) {
+    if (source.date > latest) latest = source.date
+  }
+  return latest
+}
+
+function stableSourceIdOrder(sourceIds: string[]): string {
+  return [...sourceIds].sort((a, b) => a.localeCompare(b)).join(',')
+}
+
+/**
+ * Rank candidates by evidence strength: unique independent sources, then accepted
+ * solution-doc presence, then recency, then a topic-bucket (module/problem_type)
+ * tiebreaker, then deterministic lexical source-ID order. Topic-bucket fairness is a
+ * tiebreaker only — it must never override stronger evidence signals.
+ */
+function rankCandidates(candidates: PatternCandidate[]): PatternCandidate[] {
+  const bucketRank: Record<PatternCandidateScoreBucket, number> = {strong: 2, moderate: 1, weak: 0}
+
+  return [...candidates].sort((a, b) => {
+    const uniqueA = new Set(a.sourceIds).size
+    const uniqueB = new Set(b.sourceIds).size
+    if (uniqueA !== uniqueB) return uniqueB - uniqueA
+
+    const hasSolutionDocA = a.sources.some(s => s.kind === 'solution-doc') ? 1 : 0
+    const hasSolutionDocB = b.sources.some(s => s.kind === 'solution-doc') ? 1 : 0
+    if (hasSolutionDocA !== hasSolutionDocB) return hasSolutionDocB - hasSolutionDocA
+
+    const dateA = mostRecentDate(a.sources)
+    const dateB = mostRecentDate(b.sources)
+    if (dateA !== dateB) return dateA > dateB ? -1 : 1
+
+    const bucketA = bucketRank[a.scoreBucket]
+    const bucketB = bucketRank[b.scoreBucket]
+    if (bucketA !== bucketB) return bucketB - bucketA
+
+    // Topic-bucket tiebreaker only, derived from module/problem_type — used solely to
+    // break ties that survive every stronger signal above.
+    const topicA = `${a.sources[0]?.signals.problemType ?? ''}:${a.sources[0]?.signals.module ?? ''}`
+    const topicB = `${b.sources[0]?.signals.problemType ?? ''}:${b.sources[0]?.signals.module ?? ''}`
+    if (topicA !== topicB) return topicA.localeCompare(topicB)
+
+    return stableSourceIdOrder(a.sourceIds).localeCompare(stableSourceIdOrder(b.sourceIds))
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Suppression state resolution
+// ---------------------------------------------------------------------------
+
+interface ClosedSuppressionRecord {
+  fingerprint: string
+  sourceIds: Set<string>
+  outcome: 'rejected' | 'needs-outcome' | 'superseded' | 'deferred'
+  issueNumber: number
+}
+
+function resolveClosedSuppressionRecords(existing: ExistingPatternProposals): ClosedSuppressionRecord[] {
+  const records: ClosedSuppressionRecord[] = []
+  for (const [fingerprint, issues] of existing.closedByFingerprint) {
+    for (const issue of issues) {
+      const outcome = classifyPatternProposalOutcome(issue)
+      if (outcome !== 'rejected' && outcome !== 'needs-outcome' && outcome !== 'superseded' && outcome !== 'deferred') {
+        continue
+      }
+      const sourceIds = parsePatternProposalSourceIds(issue.body ?? '') ?? []
+      records.push({fingerprint, sourceIds: new Set(sourceIds), outcome, issueNumber: issue.number})
+    }
+  }
+  return records
+}
+
+/** Retired source IDs: sources already represented by an accepted proposal, open or closed. */
+function resolveRetiredSourceIds(existing: ExistingPatternProposals): Set<string> {
+  const retired = new Set<string>()
+  const scan = (issues: ExistingPatternProposalIssue[]) => {
+    for (const issue of issues) {
+      if (!issue.labels.includes('pattern-proposal:accepted')) continue
+      const sourceIds = parsePatternProposalSourceIds(issue.body ?? '') ?? []
+      for (const id of sourceIds) retired.add(id)
+    }
+  }
+  for (const issues of existing.openByFingerprint.values()) scan(issues)
+  for (const issues of existing.closedByFingerprint.values()) scan(issues)
+  return retired
+}
+
+function isSubsetOrWeakSuperset(candidateIds: Set<string>, referenceIds: Set<string>): boolean {
+  if (referenceIds.size === 0) return false
+  // Exact match or candidate is a subset of the reference.
+  const isSubset = [...candidateIds].every(id => referenceIds.has(id))
+  if (isSubset) return true
+  // Weak superset: candidate contains all reference IDs plus fewer than the upgrade
+  // threshold of new IDs.
+  const containsAllReference = [...referenceIds].every(id => candidateIds.has(id))
+  if (!containsAllReference) return false
+  const newIds = [...candidateIds].filter(id => !referenceIds.has(id))
+  return newIds.length < HARD_SUPPRESSION_UPGRADE_THRESHOLD
+}
+
+// ---------------------------------------------------------------------------
+// Unsafe evidence check (title validated via public-output gate)
+// ---------------------------------------------------------------------------
+
+function candidateHasUnsafeEvidence(candidate: PatternCandidate, tokens: PublicOutputTokens): boolean {
+  for (const source of candidate.sources) {
+    const gate = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: source.title,
+      tokens,
+      fingerprint: candidate.fingerprint,
+    })
+    if (!gate.allowed) return true
+  }
+  return false
+}
+
+// ---------------------------------------------------------------------------
+// Planner
+// ---------------------------------------------------------------------------
+
+export interface PlanPatternCandidatesInput {
+  sources: PatternCandidateSource[]
+  existing: ExistingPatternProposals
+  cap?: number
+  publicOutputTokens: PublicOutputTokens
+}
+
+/**
+ * Build deterministic cluster candidates from source artifacts and decide which
+ * candidates may proceed to the agent drafting step.
+ *
+ * Filter order (fixed): weak cluster -> open-proposal overlap -> hard suppression ->
+ * soft suppression (without upgrade threshold) -> unsafe evidence placeholder -> rank -> cap.
+ *
+ * Pure function: no I/O, no side effects.
+ */
+export function planPatternCandidates(input: PlanPatternCandidatesInput): PatternPlannerResult {
+  const cap = input.cap ?? DEFAULT_CAP
+  const tokens = input.publicOutputTokens
+
+  const counts: PatternPlannerCounts = {
+    proposed: 0,
+    capped: 0,
+    lowSignal: 0,
+    duplicateOpenOverlap: 0,
+    hardSuppressed: 0,
+    softSuppressed: 0,
+    unsafe: 0,
+    invalidSource: 0,
+    noOp: 0,
+    failed: 0,
+  }
+
+  // Accepted proposals immediately retire their source IDs from active clustering.
+  const retiredSourceIds = resolveRetiredSourceIds(input.existing)
+  const activeSources = input.sources.filter(s => !retiredSourceIds.has(s.id))
+
+  const rawClusters = buildRawClusters(activeSources)
+  const totalPairsConsidered = countCandidatePairs(activeSources)
+  const weakClusterCount = totalPairsConsidered > 0 ? Math.max(0, activeSources.length - rawClusters.flat().length) : 0
+  counts.lowSignal +=
+    weakClusterCount === 0 && rawClusters.length === 0 && activeSources.length >= MIN_CLUSTER_SOURCES ? 1 : 0
+  // Simpler, precise low-signal accounting: any activeSources not part of a surviving
+  // cluster, when there were at least 2 sources to compare, is attributable to weak overlap.
+  if (activeSources.length >= MIN_CLUSTER_SOURCES && rawClusters.length === 0) {
+    counts.lowSignal = 1
+  }
+
+  const builtCandidates: PatternCandidate[] = rawClusters.map(clusterSources => {
+    const sourceIds = clusterSources.map(s => s.id)
+    return {
+      fingerprint: buildSourceFingerprint(sourceIds),
+      sourceIds: [...sourceIds].sort((a, b) => a.localeCompare(b)),
+      sources: clusterSources,
+      scoreBucket: scoreBucketFor(clusterSources),
+    }
+  })
+
+  const closedRecords = resolveClosedSuppressionRecords(input.existing)
+
+  const afterOpenOverlap: PatternCandidate[] = []
+  for (const candidate of builtCandidates) {
+    const openMatches = input.existing.openByFingerprint.get(candidate.fingerprint)
+    const candidateIds = new Set(candidate.sourceIds)
+    let overlapsOpen = openMatches !== undefined && openMatches.length > 0
+    if (!overlapsOpen) {
+      for (const issues of input.existing.openByFingerprint.values()) {
+        for (const issue of issues) {
+          const openIds = new Set(parsePatternProposalSourceIds(issue.body ?? '') ?? [])
+          if (isSubsetOrWeakSuperset(candidateIds, openIds)) {
+            overlapsOpen = true
+            break
+          }
+        }
+        if (overlapsOpen) break
+      }
+    }
+    if (overlapsOpen) {
+      counts.duplicateOpenOverlap += 1
+      continue
+    }
+    afterOpenOverlap.push(candidate)
+  }
+
+  const afterHardSuppression: PatternCandidate[] = []
+  for (const candidate of afterOpenOverlap) {
+    const candidateIds = new Set(candidate.sourceIds)
+    let hardSuppressed = false
+    for (const record of closedRecords) {
+      if (record.outcome !== 'rejected' && record.outcome !== 'needs-outcome' && record.outcome !== 'superseded')
+        continue
+      if (record.outcome === 'superseded') {
+        // Superseded: permanently hard-suppressed for exact/subset/superset matches.
+        if (
+          isSubsetOrWeakSuperset(candidateIds, record.sourceIds) ||
+          isExactOrSuperset(candidateIds, record.sourceIds)
+        ) {
+          hardSuppressed = true
+          break
+        }
+        continue
+      }
+      // rejected / needs-outcome: subset or weak superset unless >= 2 new sources.
+      if (isSubsetOrWeakSuperset(candidateIds, record.sourceIds)) {
+        hardSuppressed = true
+        break
+      }
+    }
+    if (hardSuppressed) {
+      counts.hardSuppressed += 1
+      continue
+    }
+    afterHardSuppression.push(candidate)
+  }
+
+  const afterSoftSuppression: PatternCandidate[] = []
+  for (const candidate of afterHardSuppression) {
+    const candidateIds = new Set(candidate.sourceIds)
+    let softSuppressed = false
+    let supersedesFingerprint: string | undefined
+    for (const record of closedRecords) {
+      if (record.outcome !== 'deferred') continue
+      const containsAllReference = [...record.sourceIds].every(id => candidateIds.has(id))
+      if (!containsAllReference) continue
+      const newIds = [...candidateIds].filter(id => !record.sourceIds.has(id))
+      if (newIds.length >= SOFT_SUPPRESSION_UPGRADE_THRESHOLD) {
+        supersedesFingerprint = record.fingerprint
+      } else {
+        softSuppressed = true
+      }
+      break
+    }
+    if (softSuppressed) {
+      counts.softSuppressed += 1
+      continue
+    }
+    afterSoftSuppression.push(
+      supersedesFingerprint === undefined ? candidate : {...candidate, supersedes: supersedesFingerprint},
+    )
+  }
+
+  const afterUnsafe: PatternCandidate[] = []
+  for (const candidate of afterSoftSuppression) {
+    if (candidateHasUnsafeEvidence(candidate, tokens)) {
+      counts.unsafe += 1
+      continue
+    }
+    afterUnsafe.push(candidate)
+  }
+
+  const ranked = rankCandidates(afterUnsafe)
+  const capped = ranked.slice(0, cap)
+  counts.capped = Math.max(0, ranked.length - capped.length)
+  counts.proposed = capped.length
+
+  if (
+    counts.proposed === 0 &&
+    counts.duplicateOpenOverlap === 0 &&
+    counts.hardSuppressed === 0 &&
+    counts.softSuppressed === 0 &&
+    counts.unsafe === 0 &&
+    counts.lowSignal === 0
+  ) {
+    counts.noOp = 1
+  }
+
+  return {candidates: capped, counts}
+}
+
+function isExactOrSuperset(candidateIds: Set<string>, referenceIds: Set<string>): boolean {
+  if (referenceIds.size === 0) return false
+  return [...referenceIds].every(id => candidateIds.has(id))
+}
+
+function countCandidatePairs(sources: PatternCandidateSource[]): number {
+  const n = sources.length
+  return n < 2 ? 0 : (n * (n - 1)) / 2
+}
+
+// ---------------------------------------------------------------------------
+// Digest schema
+// ---------------------------------------------------------------------------
+
+/**
+ * Versioned candidate digest. Allowed fields only: fingerprint, source IDs, SHA-pinned
+ * source links, public-safe source titles, evidence counts, score bucket, suggested
+ * next actions, and run counts. Source titles are gated through
+ * `applyPublicOutputGate` before entering the digest.
+ */
+export interface PatternCandidateDigest {
+  fingerprint: string
+  sourceIds: string[]
+  sourceLinks: string[]
+  sourceTitles: string[]
+  evidenceCount: number
+  scoreBucket: PatternCandidateScoreBucket
+  suggestedNextAction: string
+  runCount: number
+  supersedes?: string
+}
+
+export interface BuildCandidateDigestInput {
+  candidate: PatternCandidate
+  runCount: number
+  publicOutputTokens: PublicOutputTokens
+}
+
+/**
+ * Build a versioned candidate digest from a planner candidate. Source titles are
+ * validated through `applyPublicOutputGate` before entering the digest; any title that
+ * fails the gate is replaced with an opaque placeholder rather than leaking blocked text.
+ */
+export function buildCandidateDigest(input: BuildCandidateDigestInput): PatternCandidateDigest {
+  const tokens = input.publicOutputTokens
+
+  const sortedSources = [...input.candidate.sources].sort((a, b) => a.id.localeCompare(b.id))
+
+  const sourceTitles = sortedSources.map(source => {
+    const gate = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: source.title,
+      tokens,
+      fingerprint: input.candidate.fingerprint,
+    })
+    if (!gate.allowed) {
+      throw new Error('Pattern candidate source title failed public-output gate')
+    }
+    return gate.sanitizedContent
+  })
+
+  const digest: PatternCandidateDigest = {
+    fingerprint: input.candidate.fingerprint,
+    sourceIds: input.candidate.sourceIds,
+    sourceLinks: sortedSources.map(s => s.link),
+    sourceTitles,
+    evidenceCount: input.candidate.sourceIds.length,
+    scoreBucket: input.candidate.scoreBucket,
+    suggestedNextAction: 'draft-proposal',
+    runCount: input.runCount,
+  }
+
+  if (input.candidate.supersedes !== undefined) {
+    digest.supersedes = input.candidate.supersedes
+  }
+
+  return digest
+}

--- a/scripts/capture-patterns-open.test.ts
+++ b/scripts/capture-patterns-open.test.ts
@@ -163,6 +163,14 @@ describe('renderPatternProposalIssueBody', () => {
     expect(rendered).toContain(body.rationale)
     expect(rendered).toContain(body.suggestedNextAction)
   })
+
+  it('security: renders the deterministic digest evidenceCount, not a hallucinated agent-supplied value', () => {
+    const digest = makeDigest({evidenceCount: 2})
+    const body = makeDraftedBody({evidenceCount: 999})
+    const rendered = renderPatternProposalIssueBody({digest, body})
+    expect(rendered).toContain('## Evidence count\n2')
+    expect(rendered).not.toContain('999')
+  })
 })
 
 describe('derivePatternProposalTitle', () => {
@@ -441,6 +449,25 @@ describe('openPatternProposalIssues', () => {
     expect(octokit.rest.issues.create).not.toHaveBeenCalled()
   })
 
+  it('fail-closed when a non-primary required label (e.g. an outcome label) cannot be confirmed, even though the primary label succeeds', async () => {
+    const octokit = makeMockOctokit()
+    octokit.rest.issues.getLabel.mockImplementation(async ({name}: {name: string}) => {
+      if (name === PATTERN_PROPOSAL_LABEL) return {}
+      throw Object.assign(new Error('label check failed'), {status: 500})
+    })
+    octokit.rest.issues.createLabel.mockRejectedValue({status: 500})
+    const result = await openPatternProposalIssues(
+      octokit as never,
+      'fro-bot',
+      '.github',
+      [{fingerprint: 'a'.repeat(64), title: 'Pattern proposal: retries', body: 'body text'}],
+      silentLog,
+    )
+    expect(result.opened).toBe(0)
+    expect(result.skippedLabelUnavailable).toBe(1)
+    expect(octokit.rest.issues.create).not.toHaveBeenCalled()
+  })
+
   it('caps at most three issues opened per run', async () => {
     const octokit = makeMockOctokit()
     const toCreate = ['a', 'b', 'c', 'd'].map(c => ({
@@ -450,6 +477,26 @@ describe('openPatternProposalIssues', () => {
     }))
     const result = await openPatternProposalIssues(octokit as never, 'fro-bot', '.github', toCreate, silentLog)
     expect(result.opened).toBe(3)
+    expect(result.skippedOverCap).toBe(1)
+  })
+
+  it('counts an issue-create failure and continues opening later proposals', async () => {
+    const octokit = makeMockOctokit()
+    octokit.rest.issues.create
+      .mockResolvedValueOnce({data: {number: 41}})
+      .mockRejectedValueOnce(Object.assign(new Error('rate limited'), {status: 500}))
+      .mockResolvedValueOnce({data: {number: 43}})
+    const toCreate = ['a', 'b', 'c'].map(c => ({
+      fingerprint: c.repeat(64),
+      title: `Pattern proposal: ${c}`,
+      body: 'body text',
+    }))
+
+    const result = await openPatternProposalIssues(octokit as never, 'fro-bot', '.github', toCreate, silentLog)
+
+    expect(result.opened).toBe(2)
+    expect(result.failed).toBe(1)
+    expect(octokit.rest.issues.create).toHaveBeenCalledTimes(3)
   })
 
   it('empty toCreate is a successful no-op with no label preflight call', async () => {

--- a/scripts/capture-patterns-open.test.ts
+++ b/scripts/capture-patterns-open.test.ts
@@ -1,0 +1,477 @@
+/**
+ * Tests for scripts/capture-patterns-open.ts
+ *
+ * Structure:
+ * - Body validation tests (drafted / agent-skipped / unknown field / unknown outcome)
+ * - Rendering tests (public-output gate applied to title + body)
+ * - Pure planning core tests (planPatternProposalOpens)
+ * - I/O shell tests (openPatternProposalIssues — mocked Octokit)
+ * - Mutation-proof gate tests
+ */
+
+import type {PatternCandidateDigest} from './capture-patterns-cluster.ts'
+
+import {describe, expect, it, vi} from 'vitest'
+import {
+  derivePatternProposalTitle,
+  ensurePatternProposalLabelsExist,
+  openPatternProposalIssues,
+  planPatternProposalOpens,
+  renderPatternProposalIssueBody,
+  validatePatternProposalBody,
+  type DraftedPatternProposalBody,
+  type PlanPatternProposalOpensInput,
+} from './capture-patterns-open.ts'
+import {
+  buildPatternProposalMarkers,
+  PATTERN_PROPOSAL_LABEL,
+  type ExistingPatternProposalIssue,
+  type ExistingPatternProposals,
+} from './capture-patterns-synthesis.ts'
+import {makePublicOutputTokens, type PublicOutputTokens} from './status-truth-public-output.ts'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeDigest(overrides: Partial<PatternCandidateDigest> = {}): PatternCandidateDigest {
+  return {
+    fingerprint: 'a'.repeat(64),
+    sourceIds: ['source-a', 'source-b'],
+    sourceLinks: [
+      'https://github.com/fro-bot/.github/blob/abc/docs/solutions/best-practices/source-a.md',
+      'https://github.com/fro-bot/.github/blob/abc/docs/solutions/best-practices/source-b.md',
+    ],
+    sourceTitles: ['Retry idempotent writes', 'Retry idempotent writes again'],
+    evidenceCount: 2,
+    scoreBucket: 'moderate',
+    suggestedNextAction: 'draft-proposal',
+    runCount: 1,
+    ...overrides,
+  }
+}
+
+function makeDraftedBody(overrides: Partial<DraftedPatternProposalBody> = {}): DraftedPatternProposalBody {
+  return {
+    outcome: 'drafted',
+    patternStatement: 'Retries on 5xx are repeatedly added after incidents.',
+    rationale: 'Two independent sources show the same missing-retry correction.',
+    sourceReferences: ['Retry idempotent writes', 'Retry idempotent writes again'],
+    evidenceCount: 2,
+    suggestedNextAction: 'Add a retry-on-5xx guideline to the relevant doc.',
+    ...overrides,
+  }
+}
+
+function safeTokens(): PublicOutputTokens {
+  return makePublicOutputTokens({privateTokens: new Set<string>(), redactedCanonicalIds: new Set<string>()})
+}
+
+function failedTokens(): PublicOutputTokens {
+  return {loaded: false, error: 'token load failed'}
+}
+
+function emptyExisting(): ExistingPatternProposals {
+  return {openByFingerprint: new Map(), closedByFingerprint: new Map(), invalidMarkerCount: 0}
+}
+
+function makeIssue(overrides: Partial<ExistingPatternProposalIssue> = {}): ExistingPatternProposalIssue {
+  return {number: 1, state: 'open', labels: [PATTERN_PROPOSAL_LABEL], body: '', ...overrides}
+}
+
+function planInput(overrides: Partial<PlanPatternProposalOpensInput> = {}): PlanPatternProposalOpensInput {
+  return {
+    digestCandidates: [makeDigest()],
+    bodyFile: {schemaVersion: 1, bodies: {[makeDigest().fingerprint]: makeDraftedBody()}},
+    existing: emptyExisting(),
+    publicOutputTokens: safeTokens(),
+    alreadyCreatedFingerprints: new Set(),
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// validatePatternProposalBody
+// ---------------------------------------------------------------------------
+
+describe('validatePatternProposalBody', () => {
+  it('accepts a well-formed drafted body', () => {
+    const result = validatePatternProposalBody(makeDraftedBody())
+    expect(result.valid).toBe(true)
+  })
+
+  it('accepts a well-formed agent-skipped body', () => {
+    const result = validatePatternProposalBody({outcome: 'agent-skipped', reason: 'insufficient-evidence'})
+    expect(result.valid).toBe(true)
+  })
+
+  it('rejects a drafted body with an unapproved field', () => {
+    const result = validatePatternProposalBody({...makeDraftedBody(), rawTranscript: 'leaked'})
+    expect(result.valid).toBe(false)
+  })
+
+  it('rejects an agent-skipped body with a non-closed-vocabulary reason', () => {
+    const result = validatePatternProposalBody({outcome: 'agent-skipped', reason: 'because I said so'})
+    expect(result.valid).toBe(false)
+  })
+
+  it('rejects an unknown outcome value', () => {
+    const result = validatePatternProposalBody({outcome: 'maybe'})
+    expect(result.valid).toBe(false)
+  })
+
+  it('rejects a drafted body missing required fields', () => {
+    const full = makeDraftedBody()
+    const rest: Record<string, unknown> = {...full}
+    delete rest.patternStatement
+    const result = validatePatternProposalBody(rest)
+    expect(result.valid).toBe(false)
+  })
+
+  it('rejects non-object input', () => {
+    expect(validatePatternProposalBody('not an object').valid).toBe(false)
+    expect(validatePatternProposalBody(null).valid).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// renderPatternProposalIssueBody / derivePatternProposalTitle
+// ---------------------------------------------------------------------------
+
+describe('renderPatternProposalIssueBody', () => {
+  it('injects fingerprint and source-id hidden markers', () => {
+    const digest = makeDigest()
+    const rendered = renderPatternProposalIssueBody({digest, body: makeDraftedBody()})
+    expect(rendered).toContain(
+      buildPatternProposalMarkers({fingerprint: digest.fingerprint, sourceIds: digest.sourceIds}),
+    )
+  })
+
+  it('injects the supersedes marker when the digest carries a prior proposal fingerprint', () => {
+    const supersedes = 'b'.repeat(64)
+    const digest = makeDigest({supersedes})
+    const rendered = renderPatternProposalIssueBody({digest, body: makeDraftedBody()})
+
+    expect(rendered).toContain(`<!-- pattern-proposal:supersedes=${supersedes} -->`)
+  })
+
+  it('includes pattern statement, rationale, and suggested next action', () => {
+    const digest = makeDigest()
+    const body = makeDraftedBody()
+    const rendered = renderPatternProposalIssueBody({digest, body})
+    expect(rendered).toContain(body.patternStatement)
+    expect(rendered).toContain(body.rationale)
+    expect(rendered).toContain(body.suggestedNextAction)
+  })
+})
+
+describe('derivePatternProposalTitle', () => {
+  it('derives a public title from the drafted pattern statement, not the fingerprint', () => {
+    const title = derivePatternProposalTitle(makeDraftedBody())
+    expect(title).not.toContain('http')
+    expect(title).not.toContain('aaaaaaaa')
+    expect(title).toContain('Retries on 5xx')
+    expect(title.length).toBeLessThan(80)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// planPatternProposalOpens — happy path
+// ---------------------------------------------------------------------------
+
+describe('planPatternProposalOpens: happy path', () => {
+  it('opens one issue with required label and injected markers for a clean drafted body', () => {
+    const result = planPatternProposalOpens(planInput())
+    expect(result.toCreate).toHaveLength(1)
+    expect(result.counts.drafted).toBe(1)
+    expect(result.toCreate[0]?.body).toContain('pattern-proposal:fingerprint=')
+  })
+
+  it('empty path: zero candidates is a successful no-op with explicit counts', () => {
+    const result = planPatternProposalOpens(planInput({digestCandidates: [], bodyFile: {schemaVersion: 1, bodies: {}}}))
+    expect(result.toCreate).toHaveLength(0)
+    expect(result.counts.candidatesExamined).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// planPatternProposalOpens — error paths
+// ---------------------------------------------------------------------------
+
+describe('planPatternProposalOpens: error paths', () => {
+  it('missing body counts no-body and opens remaining valid proposals', () => {
+    const digestA = makeDigest({fingerprint: 'a'.repeat(64), sourceIds: ['source-a', 'source-b']})
+    const digestB = makeDigest({fingerprint: 'b'.repeat(64), sourceIds: ['source-c', 'source-d']})
+    const result = planPatternProposalOpens(
+      planInput({
+        digestCandidates: [digestA, digestB],
+        bodyFile: {schemaVersion: 1, bodies: {[digestB.fingerprint]: makeDraftedBody()}},
+      }),
+    )
+    expect(result.counts.missingBody).toBe(1)
+    expect(result.toCreate).toHaveLength(1)
+    expect(result.toCreate[0]?.fingerprint).toBe(digestB.fingerprint)
+  })
+
+  it('explicit agent-skipped body counts agent-skipped and opens no issue', () => {
+    const digest = makeDigest()
+    const result = planPatternProposalOpens(
+      planInput({
+        digestCandidates: [digest],
+        bodyFile: {
+          schemaVersion: 1,
+          bodies: {[digest.fingerprint]: {outcome: 'agent-skipped', reason: 'insufficient-evidence'}},
+        },
+      }),
+    )
+    expect(result.counts.agentSkipped).toBe(1)
+    expect(result.toCreate).toHaveLength(0)
+  })
+
+  it('invalid drafted body fails soft: skips the candidate and posts remaining valid ones', () => {
+    const digestA = makeDigest({fingerprint: 'a'.repeat(64), sourceIds: ['source-a', 'source-b']})
+    const digestB = makeDigest({fingerprint: 'b'.repeat(64), sourceIds: ['source-c', 'source-d']})
+    const result = planPatternProposalOpens(
+      planInput({
+        digestCandidates: [digestA, digestB],
+        bodyFile: {
+          schemaVersion: 1,
+          bodies: {
+            [digestA.fingerprint]: {
+              ...makeDraftedBody(),
+              unknownField: 'leak',
+            } as unknown as DraftedPatternProposalBody,
+            [digestB.fingerprint]: makeDraftedBody(),
+          },
+        },
+      }),
+    )
+    expect(result.counts.invalidBody).toBe(1)
+    expect(result.toCreate).toHaveLength(1)
+    expect(result.toCreate[0]?.fingerprint).toBe(digestB.fingerprint)
+  })
+
+  it('token-load failure (failed tokens) blocks all writes via privacy gate and reports counts-only', () => {
+    const result = planPatternProposalOpens(planInput({publicOutputTokens: failedTokens()}))
+    expect(result.toCreate).toHaveLength(0)
+    expect(result.counts.blockedOnPrivacy).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Privacy
+// ---------------------------------------------------------------------------
+
+describe('planPatternProposalOpens: privacy', () => {
+  it('blocks a drafted body containing a private token before posting', () => {
+    const privateTokens = new Set(['secret-org/private-repo'])
+    const tokens = makePublicOutputTokens({privateTokens, redactedCanonicalIds: new Set()})
+    const result = planPatternProposalOpens(
+      planInput({
+        publicOutputTokens: tokens,
+        bodyFile: {
+          schemaVersion: 1,
+          bodies: {
+            [makeDigest().fingerprint]: makeDraftedBody({rationale: 'Seen in secret-org/private-repo as well.'}),
+          },
+        },
+      }),
+    )
+    expect(result.toCreate).toHaveLength(0)
+    expect(result.counts.blockedOnPrivacy).toBe(1)
+  })
+
+  it('blocks a drafted body containing a hard secret pattern', () => {
+    const result = planPatternProposalOpens(
+      planInput({
+        bodyFile: {
+          schemaVersion: 1,
+          bodies: {
+            [makeDigest().fingerprint]: makeDraftedBody({rationale: `token ghp_${'a'.repeat(40)} leaked`}),
+          },
+        },
+      }),
+    )
+    expect(result.toCreate).toHaveLength(0)
+    expect(result.counts.blockedOnPrivacy).toBe(1)
+  })
+
+  it('blocks a drafted body containing a redacted canonical ID', () => {
+    const tokens = makePublicOutputTokens({
+      privateTokens: new Set(),
+      redactedCanonicalIds: new Set(['MDEwOlJlcG9zaXRvcnkx']),
+    })
+    const result = planPatternProposalOpens(
+      planInput({
+        publicOutputTokens: tokens,
+        bodyFile: {
+          schemaVersion: 1,
+          bodies: {
+            [makeDigest().fingerprint]: makeDraftedBody({rationale: 'id MDEwOlJlcG9zaXRvcnkx appears here'}),
+          },
+        },
+      }),
+    )
+    expect(result.toCreate).toHaveLength(0)
+    expect(result.counts.blockedOnPrivacy).toBe(1)
+  })
+
+  it('rejects a candidate with an unapproved field before it ever reaches the gate', () => {
+    const result = planPatternProposalOpens(
+      planInput({
+        bodyFile: {
+          schemaVersion: 1,
+          bodies: {
+            [makeDigest().fingerprint]: {
+              ...makeDraftedBody(),
+              privateToken: 'shhh',
+            } as unknown as DraftedPatternProposalBody,
+          },
+        },
+      }),
+    )
+    expect(result.toCreate).toHaveLength(0)
+    expect(result.counts.invalidBody).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Duplicates
+// ---------------------------------------------------------------------------
+
+describe('planPatternProposalOpens: duplicates', () => {
+  it('same-run duplicate: a fingerprint already created this run opens no additional issue', () => {
+    const digest = makeDigest()
+    const result = planPatternProposalOpens(planInput({alreadyCreatedFingerprints: new Set([digest.fingerprint])}))
+    expect(result.toCreate).toHaveLength(0)
+    expect(result.counts.skippedDuplicateSameRun).toBe(1)
+  })
+
+  it('cross-run duplicate: an existing open proposal with the same fingerprint prevents opening', () => {
+    const digest = makeDigest()
+    const existing: ExistingPatternProposals = {
+      openByFingerprint: new Map([[digest.fingerprint, [makeIssue()]]]),
+      closedByFingerprint: new Map(),
+      invalidMarkerCount: 0,
+    }
+    const result = planPatternProposalOpens(planInput({existing}))
+    expect(result.toCreate).toHaveLength(0)
+    expect(result.counts.skippedDuplicateExisting).toBe(1)
+  })
+
+  it('cross-run duplicate: an existing closed proposal with the same fingerprint prevents opening', () => {
+    const digest = makeDigest()
+    const existing: ExistingPatternProposals = {
+      openByFingerprint: new Map(),
+      closedByFingerprint: new Map([[digest.fingerprint, [makeIssue({state: 'closed'})]]]),
+      invalidMarkerCount: 0,
+    }
+    const result = planPatternProposalOpens(planInput({existing}))
+    expect(result.toCreate).toHaveLength(0)
+    expect(result.counts.skippedDuplicateExisting).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Mutation-proof: public-output gate must run on every surface
+// ---------------------------------------------------------------------------
+
+describe('planPatternProposalOpens: mutation-proof gate coverage', () => {
+  it('fails if the title surface skips the gate (secret in derived title cannot happen, so assert gate call via block on body)', () => {
+    const result = planPatternProposalOpens(
+      planInput({
+        bodyFile: {
+          schemaVersion: 1,
+          bodies: {
+            [makeDigest().fingerprint]: makeDraftedBody({patternStatement: `leak sk-ant-${'x'.repeat(30)}`}),
+          },
+        },
+      }),
+    )
+    expect(result.toCreate).toHaveLength(0)
+    expect(result.counts.blockedOnPrivacy).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// I/O shell: openPatternProposalIssues (mocked Octokit)
+// ---------------------------------------------------------------------------
+
+const silentLog = () => undefined
+
+function makeMockOctokit() {
+  return {
+    rest: {
+      issues: {
+        getLabel: vi.fn().mockResolvedValue({}),
+        createLabel: vi.fn().mockResolvedValue({}),
+        create: vi.fn().mockResolvedValue({data: {number: 42}}),
+      },
+    },
+  }
+}
+
+describe('openPatternProposalIssues', () => {
+  it('opens issues with required labels when label preflight succeeds', async () => {
+    const octokit = makeMockOctokit()
+    const result = await openPatternProposalIssues(
+      octokit as never,
+      'fro-bot',
+      '.github',
+      [{fingerprint: 'a'.repeat(64), title: 'Pattern proposal: retries', body: 'body text'}],
+      silentLog,
+    )
+    expect(result.opened).toBe(1)
+    expect(octokit.rest.issues.create).toHaveBeenCalledWith(expect.objectContaining({labels: [PATTERN_PROPOSAL_LABEL]}))
+  })
+
+  it('label preflight failure fails closed and opens nothing', async () => {
+    const octokit = makeMockOctokit()
+    octokit.rest.issues.getLabel.mockRejectedValue({status: 500})
+    octokit.rest.issues.createLabel.mockRejectedValue({status: 500})
+    const result = await openPatternProposalIssues(
+      octokit as never,
+      'fro-bot',
+      '.github',
+      [{fingerprint: 'a'.repeat(64), title: 'Pattern proposal: retries', body: 'body text'}],
+      silentLog,
+    )
+    expect(result.opened).toBe(0)
+    expect(result.skippedLabelUnavailable).toBe(1)
+    expect(octokit.rest.issues.create).not.toHaveBeenCalled()
+  })
+
+  it('caps at most three issues opened per run', async () => {
+    const octokit = makeMockOctokit()
+    const toCreate = ['a', 'b', 'c', 'd'].map(c => ({
+      fingerprint: c.repeat(64),
+      title: `Pattern proposal: ${c}`,
+      body: 'body text',
+    }))
+    const result = await openPatternProposalIssues(octokit as never, 'fro-bot', '.github', toCreate, silentLog)
+    expect(result.opened).toBe(3)
+  })
+
+  it('empty toCreate is a successful no-op with no label preflight call', async () => {
+    const octokit = makeMockOctokit()
+    const result = await openPatternProposalIssues(octokit as never, 'fro-bot', '.github', [], silentLog)
+    expect(result.opened).toBe(0)
+    expect(octokit.rest.issues.getLabel).not.toHaveBeenCalled()
+  })
+})
+
+describe('ensurePatternProposalLabelsExist', () => {
+  it('confirms existing labels and creates missing ones', async () => {
+    const octokit = makeMockOctokit()
+    octokit.rest.issues.getLabel.mockRejectedValueOnce({status: 404})
+    const confirmed = await ensurePatternProposalLabelsExist(
+      octokit as never,
+      'fro-bot',
+      '.github',
+      [{name: 'pattern-proposal', color: '5319e7', description: 'x'}],
+      silentLog,
+    )
+    expect(confirmed.has('pattern-proposal')).toBe(true)
+    expect(octokit.rest.issues.createLabel).toHaveBeenCalled()
+  })
+})

--- a/scripts/capture-patterns-open.ts
+++ b/scripts/capture-patterns-open.ts
@@ -1,0 +1,641 @@
+/**
+ * Agent proposal-body validation and deterministic pattern-proposal issue opener.
+ *
+ * The agent reads only the versioned candidate digest and writes a versioned temp
+ * JSON body file keyed by fingerprint. It never calls GitHub, reads the corpus, or
+ * receives private token data. This module validates that body file and, only after
+ * every surface passes the shared public-output gate, opens at most three pattern
+ * proposal issues.
+ *
+ * Architecture: pure planning core (`planPatternProposalOpens`) + I/O shell
+ * (`openPatternProposalIssues`). The pure core is fully unit-testable with injected
+ * inputs; the I/O shell performs Octokit calls only.
+ *
+ * Fail-soft vs. fail-closed:
+ * - Per-candidate body validation errors (missing body, agent-skipped, invalid drafted
+ *   body, privacy-gate block) fail soft: skip that candidate, count the reason, and
+ *   continue with the rest.
+ * - Systemic failures (token-load failure, label preflight failure) fail closed: no
+ *   proposals are opened for the whole run.
+ *
+ * Privacy contract:
+ * - `PublicOutputTokens` must come from a successful `makePublicOutputTokens` call
+ *   built from both loaded private tokens and loaded redacted canonical IDs. A failed
+ *   token load must be passed through as the `loaded:false` variant — never an empty
+ *   Set proxy — so `applyPublicOutputGate` fails closed automatically.
+ * - Every title/body surface is validated through `applyPublicOutputGate` before it
+ *   is queued for posting. No surface bypasses the gate.
+ * - stdout/stderr/result JSON/workflow summaries carry counts only: no body text,
+ *   markers, fingerprints, source titles, source links, or raw errors.
+ *
+ * Strip-only safe: no parameter properties, enums, or namespaces.
+ */
+
+import type {PatternCandidateDigest} from './capture-patterns-cluster.ts'
+import {readFile, writeFile} from 'node:fs/promises'
+import process from 'node:process'
+import {isRecord} from './capture-learnings-privacy.ts'
+import {
+  buildPatternProposalMarkers,
+  PATTERN_PROPOSAL_LABEL,
+  PATTERN_PROPOSAL_REQUIRED_LABELS,
+  type ExistingPatternProposals,
+} from './capture-patterns-synthesis.ts'
+import {applyPublicOutputGate, type PublicOutputTokens} from './status-truth-public-output.ts'
+
+// ---------------------------------------------------------------------------
+// Octokit client type (derived, never handwritten)
+// ---------------------------------------------------------------------------
+
+export interface PatternProposalOpenOctokitClient {
+  readonly rest: {
+    readonly issues: {
+      readonly getLabel: (params: {owner: string; repo: string; name: string}) => Promise<unknown>
+      readonly createLabel: (params: {
+        owner: string
+        repo: string
+        name: string
+        color: string
+        description: string
+      }) => Promise<unknown>
+      readonly create: (params: {
+        owner: string
+        repo: string
+        title: string
+        body: string
+        labels: string[]
+      }) => Promise<{data: {number: number}}>
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Body-file schema
+// ---------------------------------------------------------------------------
+
+export const PATTERN_PROPOSAL_BODY_FILE_SCHEMA_VERSION = 1
+
+/** Closed vocabulary of agent-skipped reasons. */
+export const AGENT_SKIPPED_REASONS = [
+  'insufficient-evidence',
+  'different-behaviors',
+  'low-confidence',
+  'duplicate-of-existing-proposal',
+  'unsafe-evidence',
+] as const
+
+export type AgentSkippedReason = (typeof AGENT_SKIPPED_REASONS)[number]
+
+/** A candidate the agent drafted a proposal body for. */
+export interface DraftedPatternProposalBody {
+  outcome: 'drafted'
+  patternStatement: string
+  rationale: string
+  sourceReferences: string[]
+  evidenceCount: number
+  suggestedNextAction: string
+}
+
+/** A candidate the agent explicitly declined to draft, with a closed-vocabulary reason. */
+export interface AgentSkippedPatternProposalBody {
+  outcome: 'agent-skipped'
+  reason: AgentSkippedReason
+}
+
+export type PatternProposalBody = DraftedPatternProposalBody | AgentSkippedPatternProposalBody
+
+/** Versioned body file written by the agent, keyed by candidate fingerprint. */
+export interface PatternProposalBodyFile {
+  schemaVersion: number
+  bodies: Record<string, unknown>
+}
+
+const DRAFTED_ALLOWED_FIELDS = new Set([
+  'outcome',
+  'patternStatement',
+  'rationale',
+  'sourceReferences',
+  'evidenceCount',
+  'suggestedNextAction',
+])
+
+const AGENT_SKIPPED_ALLOWED_FIELDS = new Set(['outcome', 'reason'])
+
+export interface BodyValidationResult {
+  valid: boolean
+  reason?: string
+}
+
+/**
+ * Validate a single candidate body against the closed schema.
+ *
+ * Allowed drafted fields: pattern statement, rationale, public-safe source references,
+ * evidence count, suggested next action. Any other field rejects the candidate.
+ * Agent-skipped bodies must carry a closed-vocabulary reason. Unknown outcome values
+ * or non-object input are rejected.
+ *
+ * Pure function: no I/O. Content-level privacy scanning happens separately via the
+ * public-output gate — this only enforces schema shape.
+ */
+export function validatePatternProposalBody(input: unknown): BodyValidationResult {
+  if (!isRecord(input)) {
+    return {valid: false, reason: 'body is not an object'}
+  }
+
+  const outcome = input.outcome
+  if (outcome === 'drafted') {
+    const keys = Object.keys(input)
+    for (const key of keys) {
+      if (!DRAFTED_ALLOWED_FIELDS.has(key)) {
+        return {valid: false, reason: `unapproved field: ${key}`}
+      }
+    }
+    if (typeof input.patternStatement !== 'string' || input.patternStatement === '') {
+      return {valid: false, reason: 'missing patternStatement'}
+    }
+    if (typeof input.rationale !== 'string' || input.rationale === '') {
+      return {valid: false, reason: 'missing rationale'}
+    }
+    if (
+      !Array.isArray(input.sourceReferences) ||
+      !input.sourceReferences.every((r): r is string => typeof r === 'string')
+    ) {
+      return {valid: false, reason: 'missing or malformed sourceReferences'}
+    }
+    if (typeof input.evidenceCount !== 'number' || input.evidenceCount < 0) {
+      return {valid: false, reason: 'missing or malformed evidenceCount'}
+    }
+    if (typeof input.suggestedNextAction !== 'string' || input.suggestedNextAction === '') {
+      return {valid: false, reason: 'missing suggestedNextAction'}
+    }
+    return {valid: true}
+  }
+
+  if (outcome === 'agent-skipped') {
+    const keys = Object.keys(input)
+    for (const key of keys) {
+      if (!AGENT_SKIPPED_ALLOWED_FIELDS.has(key)) {
+        return {valid: false, reason: `unapproved field: ${key}`}
+      }
+    }
+    const reason = input.reason
+    if (typeof reason !== 'string' || !(AGENT_SKIPPED_REASONS as readonly string[]).includes(reason)) {
+      return {valid: false, reason: 'unrecognized agent-skipped reason'}
+    }
+    return {valid: true}
+  }
+
+  return {valid: false, reason: 'unknown outcome'}
+}
+
+// ---------------------------------------------------------------------------
+// Title/body rendering
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a pattern-proposal issue title from the drafted pattern statement.
+ * The title is still validated through the public-output gate before posting.
+ */
+export function derivePatternProposalTitle(body: DraftedPatternProposalBody): string {
+  const normalized = body.patternStatement.replaceAll(/\s+/gu, ' ').trim()
+  const maxStatementLength = 58
+  const statement =
+    normalized.length > maxStatementLength ? `${normalized.slice(0, maxStatementLength - 1).trimEnd()}…` : normalized
+  return `Pattern proposal: ${statement}`
+}
+
+/**
+ * Render the full pattern-proposal issue body: pattern statement, rationale,
+ * public-safe source references, evidence count, suggested next action, followed
+ * by hidden machine markers (fingerprint + sorted source IDs).
+ */
+export function renderPatternProposalIssueBody(params: {
+  digest: PatternCandidateDigest
+  body: DraftedPatternProposalBody
+}): string {
+  const {digest, body} = params
+  const referencesList = body.sourceReferences.map(ref => `- ${ref}`).join('\n')
+  const sections = [
+    `## Pattern`,
+    body.patternStatement,
+    ``,
+    `## Rationale`,
+    body.rationale,
+    ``,
+    `## Source references`,
+    referencesList,
+    ``,
+    `## Evidence count`,
+    String(body.evidenceCount),
+    ``,
+    `## Suggested next action`,
+    body.suggestedNextAction,
+    ``,
+    buildPatternProposalMarkers({
+      fingerprint: digest.fingerprint,
+      sourceIds: digest.sourceIds,
+      supersedes: digest.supersedes,
+    }),
+  ]
+  return sections.join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Pure planning core
+// ---------------------------------------------------------------------------
+
+/** A single pattern proposal ready to be created as a GitHub issue. */
+export interface PatternProposalToOpen {
+  fingerprint: string
+  title: string
+  body: string
+}
+
+/** Counts-only telemetry for the plan step. No prose, fingerprints, or titles. */
+export interface PlanPatternProposalOpensCounts {
+  candidatesExamined: number
+  drafted: number
+  agentSkipped: number
+  missingBody: number
+  invalidBody: number
+  blockedOnPrivacy: number
+  skippedDuplicateSameRun: number
+  skippedDuplicateExisting: number
+}
+
+export interface PlanPatternProposalOpensResult {
+  toCreate: PatternProposalToOpen[]
+  counts: PlanPatternProposalOpensCounts
+}
+
+export interface PlanPatternProposalOpensInput {
+  digestCandidates: PatternCandidateDigest[]
+  bodyFile: PatternProposalBodyFile
+  existing: ExistingPatternProposals
+  publicOutputTokens: PublicOutputTokens
+  /** Fingerprints already created earlier in this same run (same-run dedup guard). */
+  alreadyCreatedFingerprints: Set<string>
+}
+
+function hasExistingProposal(existing: ExistingPatternProposals, fingerprint: string): boolean {
+  const open = existing.openByFingerprint.get(fingerprint)
+  const closed = existing.closedByFingerprint.get(fingerprint)
+  return (open !== undefined && open.length > 0) || (closed !== undefined && closed.length > 0)
+}
+
+/**
+ * Plan which pattern proposals to open from a validated digest + agent body file.
+ *
+ * Per-candidate order: missing body -> agent-skipped -> schema validation -> same-run
+ * dedup -> existing-proposal dedup -> public-output gate (title, then body). Any
+ * failure at a step counts that reason and skips only that candidate; remaining valid
+ * candidates continue to be planned (fail soft).
+ *
+ * Pure function: no I/O, fully testable.
+ */
+export function planPatternProposalOpens(input: PlanPatternProposalOpensInput): PlanPatternProposalOpensResult {
+  const counts: PlanPatternProposalOpensCounts = {
+    candidatesExamined: input.digestCandidates.length,
+    drafted: 0,
+    agentSkipped: 0,
+    missingBody: 0,
+    invalidBody: 0,
+    blockedOnPrivacy: 0,
+    skippedDuplicateSameRun: 0,
+    skippedDuplicateExisting: 0,
+  }
+
+  const toCreate: PatternProposalToOpen[] = []
+  const createdThisPlan = new Set<string>(input.alreadyCreatedFingerprints)
+
+  for (const digest of input.digestCandidates) {
+    const rawBody = input.bodyFile.bodies[digest.fingerprint]
+
+    if (rawBody === undefined) {
+      counts.missingBody += 1
+      continue
+    }
+
+    const validation = validatePatternProposalBody(rawBody)
+    if (!validation.valid) {
+      counts.invalidBody += 1
+      continue
+    }
+
+    const body = rawBody as PatternProposalBody
+
+    if (body.outcome === 'agent-skipped') {
+      counts.agentSkipped += 1
+      continue
+    }
+
+    if (input.alreadyCreatedFingerprints.has(digest.fingerprint) || createdThisPlan.has(digest.fingerprint)) {
+      counts.skippedDuplicateSameRun += 1
+      continue
+    }
+
+    if (hasExistingProposal(input.existing, digest.fingerprint)) {
+      counts.skippedDuplicateExisting += 1
+      continue
+    }
+
+    const title = derivePatternProposalTitle(body)
+    const titleGate = applyPublicOutputGate({
+      surface: 'proposal-title',
+      content: title,
+      tokens: input.publicOutputTokens,
+      fingerprint: digest.fingerprint,
+    })
+    if (!titleGate.allowed) {
+      counts.blockedOnPrivacy += 1
+      continue
+    }
+
+    const renderedBody = renderPatternProposalIssueBody({digest, body})
+    const bodyGate = applyPublicOutputGate({
+      surface: 'proposal-body',
+      content: renderedBody,
+      tokens: input.publicOutputTokens,
+      fingerprint: digest.fingerprint,
+    })
+    if (!bodyGate.allowed) {
+      counts.blockedOnPrivacy += 1
+      continue
+    }
+
+    createdThisPlan.add(digest.fingerprint)
+    counts.drafted += 1
+    toCreate.push({fingerprint: digest.fingerprint, title: titleGate.sanitizedContent, body: bodyGate.sanitizedContent})
+  }
+
+  return {toCreate, counts}
+}
+
+// ---------------------------------------------------------------------------
+// Label preflight
+// ---------------------------------------------------------------------------
+
+function isApiStatus(error: unknown, status: number): boolean {
+  return isRecord(error) && typeof error.status === 'number' && error.status === status
+}
+
+/**
+ * Ensure the pattern-proposal labels exist in the repo, mirroring
+ * `capture-learnings-open.ts`'s `ensureLabelsExist`. Returns the set of confirmed
+ * label names; failures are logged counts-only and excluded from the set.
+ */
+type PatternLogSink = (message: string) => void
+
+const writePatternOpenLog: PatternLogSink = message => process.stderr.write(message)
+
+export async function ensurePatternProposalLabelsExist(
+  octokit: PatternProposalOpenOctokitClient,
+  owner: string,
+  repo: string,
+  labels: readonly {name: string; color: string; description: string}[],
+  writeLog: PatternLogSink = writePatternOpenLog,
+): Promise<Set<string>> {
+  const confirmed = new Set<string>()
+
+  for (const {name, color, description} of labels) {
+    try {
+      await octokit.rest.issues.getLabel({owner, repo, name})
+      confirmed.add(name)
+      continue
+    } catch (getError: unknown) {
+      if (!isApiStatus(getError, 404)) {
+        writeLog(`capture-patterns-open: label check failed; excluding from issue labels\n`)
+        continue
+      }
+    }
+
+    try {
+      await octokit.rest.issues.createLabel({owner, repo, name, color, description})
+      confirmed.add(name)
+    } catch (createError: unknown) {
+      if (isApiStatus(createError, 422)) {
+        confirmed.add(name)
+      } else {
+        writeLog(`capture-patterns-open: label creation failed; excluding from issue labels\n`)
+      }
+    }
+  }
+
+  return confirmed
+}
+
+// ---------------------------------------------------------------------------
+// I/O shell: openPatternProposalIssues
+// ---------------------------------------------------------------------------
+
+const MAX_PROPOSALS_PER_RUN = 3
+
+export interface OpenPatternProposalIssuesResult {
+  opened: number
+  failed: number
+  skippedLabelUnavailable: number
+  skippedOverCap: number
+}
+
+/**
+ * Open GitHub issues for the planned pattern proposals.
+ *
+ * Steps:
+ * 1. No-op immediately if `toCreate` is empty (no label preflight call).
+ * 2. Label preflight: `ensurePatternProposalLabelsExist` for all required labels.
+ *    Fail-closed: if the primary `pattern-proposal` label cannot be confirmed, skip
+ *    all opens.
+ * 3. Cap to at most `MAX_PROPOSALS_PER_RUN` issues.
+ * 4. Create each remaining issue; one failure does not abort the rest.
+ *
+ * Returns counts-only telemetry. No fingerprints, titles, or body text in output.
+ */
+export async function openPatternProposalIssues(
+  octokit: PatternProposalOpenOctokitClient,
+  owner: string,
+  repo: string,
+  toCreate: PatternProposalToOpen[],
+  writeLog: PatternLogSink = writePatternOpenLog,
+): Promise<OpenPatternProposalIssuesResult> {
+  if (toCreate.length === 0) {
+    return {opened: 0, failed: 0, skippedLabelUnavailable: 0, skippedOverCap: 0}
+  }
+
+  const confirmedLabels = await ensurePatternProposalLabelsExist(
+    octokit,
+    owner,
+    repo,
+    PATTERN_PROPOSAL_REQUIRED_LABELS,
+    writeLog,
+  )
+
+  if (!confirmedLabels.has(PATTERN_PROPOSAL_LABEL)) {
+    writeLog(
+      `capture-patterns-open: label "${PATTERN_PROPOSAL_LABEL}" unavailable; skipping ${toCreate.length} proposal(s)\n`,
+    )
+    return {opened: 0, failed: 0, skippedLabelUnavailable: toCreate.length, skippedOverCap: 0}
+  }
+
+  const capped = toCreate.slice(0, MAX_PROPOSALS_PER_RUN)
+  const skippedOverCap = Math.max(0, toCreate.length - capped.length)
+
+  let opened = 0
+  let failed = 0
+
+  for (const item of capped) {
+    try {
+      await octokit.rest.issues.create({
+        owner,
+        repo,
+        title: item.title,
+        body: item.body,
+        labels: [PATTERN_PROPOSAL_LABEL],
+      })
+      opened += 1
+    } catch {
+      failed += 1
+      writeLog(`capture-patterns-open: issue creation failed; continuing\n`)
+    }
+  }
+
+  writeLog(`capture-patterns-open: proposals opened=${opened} failed=${failed}\n`)
+
+  return {opened, failed, skippedLabelUnavailable: 0, skippedOverCap}
+}
+
+// ---------------------------------------------------------------------------
+// Entry point (deterministic open step reads digest + agent body file)
+// ---------------------------------------------------------------------------
+
+/** Counts-only result written to stdout and CAPTURE_PATTERNS_RESULT_PATH. */
+interface PatternProposalOpenResult {
+  candidatesExamined: number
+  drafted: number
+  agentSkipped: number
+  missingBody: number
+  invalidBody: number
+  blockedOnPrivacy: number
+  skippedDuplicateSameRun: number
+  skippedDuplicateExisting: number
+  proposalsOpened: number
+  failed: number
+  skippedLabelUnavailable: number
+  skippedOverCap: number
+  tokenLoadFailed: boolean
+  bodyFileReadFailed: boolean
+}
+
+async function readJsonFile<T>(path: string, label: string): Promise<T> {
+  let raw: string
+  try {
+    raw = await readFile(path, 'utf8')
+  } catch (error: unknown) {
+    throw new Error(`capture-patterns-open: could not read ${label} at ${path}`, {cause: error})
+  }
+  try {
+    return JSON.parse(raw) as T
+  } catch (error: unknown) {
+    throw new Error(`capture-patterns-open: could not parse ${label} at ${path}`, {cause: error})
+  }
+}
+
+async function main(): Promise<void> {
+  const {loadPrivateTokensFromDisk} = await import('./capture-learnings-privacy.ts')
+  const {loadRedactedCanonicalIdsFromDisk} = await import('./status-truth-proposals.ts')
+  const {makePublicOutputTokens} = await import('./status-truth-public-output.ts')
+  const {fetchExistingPatternProposals} = await import('./capture-patterns-synthesis.ts')
+  const {createOctokitFromEnv} = await import('./capture-learnings-harvest.ts')
+
+  const digestPath = process.env.CAPTURE_PATTERNS_DIGEST_PATH
+  const bodiesPath = process.env.CAPTURE_PATTERNS_BODIES_PATH
+  const resultPath = process.env.CAPTURE_PATTERNS_RESULT_PATH
+
+  if (digestPath === undefined || digestPath === '') {
+    throw new Error('capture-patterns-open: CAPTURE_PATTERNS_DIGEST_PATH is required')
+  }
+  if (bodiesPath === undefined || bodiesPath === '') {
+    throw new Error('capture-patterns-open: CAPTURE_PATTERNS_BODIES_PATH is required')
+  }
+
+  const digestCandidates = await readJsonFile<PatternCandidateDigest[]>(digestPath, 'candidate digest')
+
+  let bodyFile: PatternProposalBodyFile
+  let tokenLoadFailed = false
+  let bodyFileReadFailed = false
+  let publicOutputTokens: PublicOutputTokens
+
+  const owner = 'fro-bot'
+  const repo = '.github'
+  const octokit = await createOctokitFromEnv()
+
+  try {
+    bodyFile = await readJsonFile<PatternProposalBodyFile>(bodiesPath, 'agent body file')
+  } catch {
+    bodyFileReadFailed = true
+    bodyFile = {schemaVersion: PATTERN_PROPOSAL_BODY_FILE_SCHEMA_VERSION, bodies: {}}
+  }
+
+  try {
+    const [privateTokens, redactedCanonicalIds] = await Promise.all([
+      loadPrivateTokensFromDisk(),
+      loadRedactedCanonicalIdsFromDisk(),
+    ])
+    publicOutputTokens = makePublicOutputTokens({privateTokens, redactedCanonicalIds})
+  } catch {
+    tokenLoadFailed = true
+    publicOutputTokens = {loaded: false, error: 'token load failed'}
+  }
+
+  const existing = await fetchExistingPatternProposals({
+    octokit: octokit as unknown as Parameters<typeof fetchExistingPatternProposals>[0]['octokit'],
+    owner,
+    repo,
+  })
+
+  const plan = planPatternProposalOpens({
+    digestCandidates: tokenLoadFailed || bodyFileReadFailed ? [] : digestCandidates,
+    bodyFile,
+    existing,
+    publicOutputTokens,
+    alreadyCreatedFingerprints: new Set(),
+  })
+
+  const openResult = await openPatternProposalIssues(
+    octokit as unknown as PatternProposalOpenOctokitClient,
+    owner,
+    repo,
+    plan.toCreate,
+  )
+
+  const result: PatternProposalOpenResult = {
+    candidatesExamined: plan.counts.candidatesExamined,
+    drafted: plan.counts.drafted,
+    agentSkipped: plan.counts.agentSkipped,
+    missingBody: plan.counts.missingBody,
+    invalidBody: plan.counts.invalidBody,
+    blockedOnPrivacy: plan.counts.blockedOnPrivacy,
+    skippedDuplicateSameRun: plan.counts.skippedDuplicateSameRun,
+    skippedDuplicateExisting: plan.counts.skippedDuplicateExisting,
+    proposalsOpened: openResult.opened,
+    failed: openResult.failed,
+    skippedLabelUnavailable: openResult.skippedLabelUnavailable,
+    skippedOverCap: openResult.skippedOverCap,
+    tokenLoadFailed,
+    bodyFileReadFailed,
+  }
+
+  const resultJson = `${JSON.stringify(result)}\n`
+  process.stdout.write(resultJson)
+
+  if (resultPath !== undefined && resultPath !== '') {
+    try {
+      await writeFile(resultPath, resultJson, {flag: 'w'})
+    } catch {
+      process.stderr.write(`capture-patterns-open: could not write result file\n`)
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}

--- a/scripts/capture-patterns-open.ts
+++ b/scripts/capture-patterns-open.ts
@@ -226,7 +226,7 @@ export function renderPatternProposalIssueBody(params: {
     referencesList,
     ``,
     `## Evidence count`,
-    String(body.evidenceCount),
+    String(digest.evidenceCount),
     ``,
     `## Suggested next action`,
     body.suggestedNextAction,
@@ -443,8 +443,10 @@ export interface OpenPatternProposalIssuesResult {
  * Steps:
  * 1. No-op immediately if `toCreate` is empty (no label preflight call).
  * 2. Label preflight: `ensurePatternProposalLabelsExist` for all required labels.
- *    Fail-closed: if the primary `pattern-proposal` label cannot be confirmed, skip
- *    all opens.
+ *    Fail-closed: every required label (not just the primary `pattern-proposal`
+ *    label) must be confirmed available or created before any issue is opened —
+ *    a newly opened proposal must never lack a terminal-outcome label it will need
+ *    later. Any unconfirmed required label skips all opens for this run.
  * 3. Cap to at most `MAX_PROPOSALS_PER_RUN` issues.
  * 4. Create each remaining issue; one failure does not abort the rest.
  *
@@ -469,10 +471,12 @@ export async function openPatternProposalIssues(
     writeLog,
   )
 
-  if (!confirmedLabels.has(PATTERN_PROPOSAL_LABEL)) {
-    writeLog(
-      `capture-patterns-open: label "${PATTERN_PROPOSAL_LABEL}" unavailable; skipping ${toCreate.length} proposal(s)\n`,
-    )
+  // Fail closed unless every required label (primary + all outcome labels) is
+  // confirmed — a newly opened proposal must never be missing a label it will need
+  // for its eventual terminal outcome.
+  const allRequiredLabelsConfirmed = PATTERN_PROPOSAL_REQUIRED_LABELS.every(({name}) => confirmedLabels.has(name))
+  if (!allRequiredLabelsConfirmed) {
+    writeLog(`capture-patterns-open: required label(s) unavailable; skipping ${toCreate.length} proposal(s)\n`)
     return {opened: 0, failed: 0, skippedLabelUnavailable: toCreate.length, skippedOverCap: 0}
   }
 
@@ -540,6 +544,9 @@ async function readJsonFile<T>(path: string, label: string): Promise<T> {
 }
 
 async function main(): Promise<void> {
+  // Detect is fail-soft because absence of candidates is safe signal. Open is
+  // intentionally fail-hard on malformed inputs or missing credentials: after the
+  // live gate, ambiguity must stop before any issue mutation.
   const {loadPrivateTokensFromDisk} = await import('./capture-learnings-privacy.ts')
   const {loadRedactedCanonicalIdsFromDisk} = await import('./status-truth-proposals.ts')
   const {makePublicOutputTokens} = await import('./status-truth-public-output.ts')
@@ -566,8 +573,6 @@ async function main(): Promise<void> {
 
   const owner = 'fro-bot'
   const repo = '.github'
-  const octokit = await createOctokitFromEnv()
-
   try {
     bodyFile = await readJsonFile<PatternProposalBodyFile>(bodiesPath, 'agent body file')
   } catch {
@@ -586,11 +591,14 @@ async function main(): Promise<void> {
     publicOutputTokens = {loaded: false, error: 'token load failed'}
   }
 
-  const existing = await fetchExistingPatternProposals({
-    octokit: octokit as unknown as Parameters<typeof fetchExistingPatternProposals>[0]['octokit'],
-    owner,
-    repo,
-  })
+  const octokit = await createOctokitFromEnv()
+  const existing = tokenLoadFailed
+    ? {openByFingerprint: new Map(), closedByFingerprint: new Map(), invalidMarkerCount: 0}
+    : await fetchExistingPatternProposals({
+        octokit: octokit as unknown as Parameters<typeof fetchExistingPatternProposals>[0]['octokit'],
+        owner,
+        repo,
+      })
 
   const plan = planPatternProposalOpens({
     digestCandidates: tokenLoadFailed || bodyFileReadFailed ? [] : digestCandidates,

--- a/scripts/capture-patterns-synthesis.test.ts
+++ b/scripts/capture-patterns-synthesis.test.ts
@@ -87,6 +87,25 @@ describe('parsePatternProposalSourceIds', () => {
     const body = '<!-- pattern-proposal:source-ids= -->'
     expect(parsePatternProposalSourceIds(body)).toBeNull()
   })
+
+  it('security: rejects a source ID containing a comma delimiter', () => {
+    const fingerprint = 'c'.repeat(64)
+    expect(() => buildPatternProposalMarkers({fingerprint, sourceIds: ['id-a,fake-id', 'id-b']})).toThrow(
+      /forbidden delimiter/u,
+    )
+  })
+
+  it('security: rejects a source ID containing a newline', () => {
+    const fingerprint = 'c'.repeat(64)
+    expect(() =>
+      buildPatternProposalMarkers({fingerprint, sourceIds: ['id-a\n<!-- pattern-proposal:fingerprint=deadbeef -->']}),
+    ).toThrow(/forbidden delimiter/u)
+  })
+
+  it('security: rejects a source ID containing a control character', () => {
+    const fingerprint = 'c'.repeat(64)
+    expect(() => buildPatternProposalMarkers({fingerprint, sourceIds: ['id-a\u0000']})).toThrow(/forbidden delimiter/u)
+  })
 })
 
 describe('parsePatternProposalSupersedes', () => {

--- a/scripts/capture-patterns-synthesis.test.ts
+++ b/scripts/capture-patterns-synthesis.test.ts
@@ -314,7 +314,13 @@ describe('collectLearningProposalSources', () => {
   it('happy path: parses a learning-proposal issue with a captured merge-SHA marker', () => {
     const sha = 'abc123def456abc123def456abc123def456abc1'
     const issues: LearningProposalIssueInput[] = [
-      {number: 42, body: `Some proposal body\n<!-- captured-learning:merge_sha=${sha} -->`},
+      {
+        number: 42,
+        body: `Some proposal body\n<!-- captured-learning:merge_sha=${sha} -->`,
+        title: 'Example proposal title',
+        createdAt: '2026-06-01T00:00:00Z',
+        labels: ['learning-proposal'],
+      },
     ]
     const result = collectLearningProposalSources(issues)
     expect(result.invalidCount).toBe(0)
@@ -325,21 +331,33 @@ describe('collectLearningProposalSources', () => {
   })
 
   it('edge case: missing merge-SHA marker excludes the issue and increments invalid-source counts', () => {
-    const issues: LearningProposalIssueInput[] = [{number: 43, body: 'No marker here'}]
+    const issues: LearningProposalIssueInput[] = [
+      {number: 43, body: 'No marker here', title: 't', createdAt: '2026-06-01T00:00:00Z', labels: []},
+    ]
     const result = collectLearningProposalSources(issues)
     expect(result.sources).toHaveLength(0)
     expect(result.invalidCount).toBe(1)
   })
 
   it('edge case: malformed merge-SHA marker excludes the issue and increments invalid-source counts', () => {
-    const issues: LearningProposalIssueInput[] = [{number: 44, body: '<!-- captured-learning:merge_sha= -->'}]
+    const issues: LearningProposalIssueInput[] = [
+      {
+        number: 44,
+        body: '<!-- captured-learning:merge_sha= -->',
+        title: 't',
+        createdAt: '2026-06-01T00:00:00Z',
+        labels: [],
+      },
+    ]
     const result = collectLearningProposalSources(issues)
     expect(result.sources).toHaveLength(0)
     expect(result.invalidCount).toBe(1)
   })
 
   it('edge case: null body excludes the issue and increments invalid-source counts', () => {
-    const issues: LearningProposalIssueInput[] = [{number: 45, body: null}]
+    const issues: LearningProposalIssueInput[] = [
+      {number: 45, body: null, title: 't', createdAt: '2026-06-01T00:00:00Z', labels: []},
+    ]
     const result = collectLearningProposalSources(issues)
     expect(result.sources).toHaveLength(0)
     expect(result.invalidCount).toBe(1)
@@ -348,7 +366,13 @@ describe('collectLearningProposalSources', () => {
   it('privacy: source links use a stable issues URL without titles or body excerpts', () => {
     const sha = 'def456abc123def456abc123def456abc123def4'
     const issues: LearningProposalIssueInput[] = [
-      {number: 46, body: `Sensitive title context\n<!-- captured-learning:merge_sha=${sha} -->`},
+      {
+        number: 46,
+        body: `Sensitive title context\n<!-- captured-learning:merge_sha=${sha} -->`,
+        title: 'Sensitive title context',
+        createdAt: '2026-06-01T00:00:00Z',
+        labels: [],
+      },
     ]
     const result = collectLearningProposalSources(issues)
     expect(result.sources[0]?.link).toBe('https://github.com/fro-bot/.github/issues/46')

--- a/scripts/capture-patterns-synthesis.test.ts
+++ b/scripts/capture-patterns-synthesis.test.ts
@@ -1,0 +1,460 @@
+/**
+ * Tests for scripts/capture-patterns-synthesis.ts
+ *
+ * Structure:
+ * - Marker helper tests: build/parse pattern-proposal hidden markers
+ * - Label descriptor tests
+ * - Outcome classification tests
+ * - Source collection tests (solution docs + learning-proposal issues)
+ * - fetchExistingPatternProposals I/O shell tests (mocked Octokit)
+ */
+
+import {describe, expect, it} from 'vitest'
+
+import {
+  buildLearningProposalLink,
+  buildPatternProposalMarkers,
+  buildSolutionDocLink,
+  classifyPatternProposalOutcome,
+  collectLearningProposalSources,
+  collectSolutionDocSources,
+  fetchExistingPatternProposals,
+  parsePatternProposalFingerprint,
+  parsePatternProposalSourceIds,
+  parsePatternProposalSupersedes,
+  PATTERN_PROPOSAL_LABEL,
+  PATTERN_PROPOSAL_OUTCOME_LABELS,
+  PATTERN_PROPOSAL_REQUIRED_LABELS,
+  SOLUTION_SUBDIRS,
+  type ExistingPatternProposalIssue,
+  type LearningProposalIssueInput,
+  type PatternProposalOctokitClient,
+} from './capture-patterns-synthesis.ts'
+
+// ---------------------------------------------------------------------------
+// Marker helpers
+// ---------------------------------------------------------------------------
+
+describe('buildPatternProposalMarkers / parsePatternProposalFingerprint', () => {
+  it('round-trips a fingerprint through build and parse', () => {
+    const fingerprint = 'a'.repeat(64)
+    const body = buildPatternProposalMarkers({fingerprint, sourceIds: ['id-a', 'id-b']})
+    expect(parsePatternProposalFingerprint(body)).toBe(fingerprint)
+  })
+
+  it('returns null when no fingerprint marker is present', () => {
+    expect(parsePatternProposalFingerprint('No marker here')).toBeNull()
+  })
+
+  it('returns null for a malformed fingerprint marker (non-hex)', () => {
+    const body = '<!-- pattern-proposal:fingerprint=not-hex-value -->'
+    expect(parsePatternProposalFingerprint(body)).toBeNull()
+  })
+
+  it('does not reuse the captured-learning marker namespace', () => {
+    const fingerprint = 'b'.repeat(64)
+    const body = buildPatternProposalMarkers({fingerprint, sourceIds: ['id-a']})
+    expect(body).not.toContain('captured-learning:')
+    expect(body).toContain('pattern-proposal:fingerprint=')
+  })
+})
+
+describe('parsePatternProposalSourceIds', () => {
+  it('round-trips sorted comma-separated source IDs', () => {
+    const fingerprint = 'c'.repeat(64)
+    const body = buildPatternProposalMarkers({fingerprint, sourceIds: ['zebra', 'alpha', 'mid']})
+    expect(parsePatternProposalSourceIds(body)).toEqual(['alpha', 'mid', 'zebra'])
+  })
+
+  it('round-trips filename-stem source IDs containing hyphens', () => {
+    const fingerprint = 'c'.repeat(64)
+    const body = buildPatternProposalMarkers({
+      fingerprint,
+      sourceIds: ['pure-core-privacy-gates-shared-module-2026-06-22', 'agent-review-loop-2026-07-06'],
+    })
+
+    expect(parsePatternProposalSourceIds(body)).toEqual([
+      'agent-review-loop-2026-07-06',
+      'pure-core-privacy-gates-shared-module-2026-06-22',
+    ])
+  })
+
+  it('returns null when no source-ids marker is present', () => {
+    expect(parsePatternProposalSourceIds('No marker here')).toBeNull()
+  })
+
+  it('returns null for an empty source-ids marker', () => {
+    const body = '<!-- pattern-proposal:source-ids= -->'
+    expect(parsePatternProposalSourceIds(body)).toBeNull()
+  })
+})
+
+describe('parsePatternProposalSupersedes', () => {
+  it('parses an optional supersedes marker when present', () => {
+    const fingerprint = 'd'.repeat(64)
+    const supersedes = 'e'.repeat(64)
+    const body = buildPatternProposalMarkers({fingerprint, sourceIds: ['id-a'], supersedes})
+    expect(parsePatternProposalSupersedes(body)).toBe(supersedes)
+  })
+
+  it('returns null when supersedes marker is absent', () => {
+    const fingerprint = 'd'.repeat(64)
+    const body = buildPatternProposalMarkers({fingerprint, sourceIds: ['id-a']})
+    expect(parsePatternProposalSupersedes(body)).toBeNull()
+  })
+
+  it('returns null for a malformed supersedes marker (non-hex)', () => {
+    const body = '<!-- pattern-proposal:supersedes=zzz -->'
+    expect(parsePatternProposalSupersedes(body)).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Label descriptors
+// ---------------------------------------------------------------------------
+
+describe('label descriptors', () => {
+  it('defines a primary pattern-proposal label', () => {
+    expect(PATTERN_PROPOSAL_LABEL).toBe('pattern-proposal')
+  })
+
+  it('defines four mutually exclusive outcome labels', () => {
+    expect(PATTERN_PROPOSAL_OUTCOME_LABELS).toEqual({
+      accepted: 'pattern-proposal:accepted',
+      deferred: 'pattern-proposal:deferred',
+      rejected: 'pattern-proposal:rejected',
+      superseded: 'pattern-proposal:superseded',
+    })
+  })
+
+  it('does not define needs-outcome as a label', () => {
+    const names = PATTERN_PROPOSAL_REQUIRED_LABELS.map(l => l.name)
+    expect(names).not.toContain('needs-outcome')
+  })
+
+  it('provides ready-to-use descriptors for .github/settings.yml (name/color/description)', () => {
+    expect(PATTERN_PROPOSAL_REQUIRED_LABELS.length).toBeGreaterThanOrEqual(5)
+    for (const label of PATTERN_PROPOSAL_REQUIRED_LABELS) {
+      expect(typeof label.name).toBe('string')
+      expect(label.name.length).toBeGreaterThan(0)
+      expect(typeof label.color).toBe('string')
+      expect(typeof label.description).toBe('string')
+    }
+    const names = PATTERN_PROPOSAL_REQUIRED_LABELS.map(l => l.name)
+    expect(names).toContain(PATTERN_PROPOSAL_LABEL)
+    expect(names).toContain(PATTERN_PROPOSAL_OUTCOME_LABELS.accepted)
+    expect(names).toContain(PATTERN_PROPOSAL_OUTCOME_LABELS.deferred)
+    expect(names).toContain(PATTERN_PROPOSAL_OUTCOME_LABELS.rejected)
+    expect(names).toContain(PATTERN_PROPOSAL_OUTCOME_LABELS.superseded)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Outcome classification
+// ---------------------------------------------------------------------------
+
+function makeIssue(overrides: Partial<ExistingPatternProposalIssue> = {}): ExistingPatternProposalIssue {
+  return {
+    number: 1,
+    state: 'open',
+    labels: [PATTERN_PROPOSAL_LABEL],
+    body: `<!-- pattern-proposal:fingerprint=${'a'.repeat(64)} -->\n<!-- pattern-proposal:source-ids=id-a -->`,
+    ...overrides,
+  }
+}
+
+describe('classifyPatternProposalOutcome', () => {
+  it('classifies an open issue as proposed-pending regardless of labels', () => {
+    const issue = makeIssue({state: 'open'})
+    expect(classifyPatternProposalOutcome(issue)).toBe('proposed-pending')
+  })
+
+  it('classifies a closed issue with the accepted label as accepted', () => {
+    const issue = makeIssue({
+      state: 'closed',
+      labels: [PATTERN_PROPOSAL_LABEL, PATTERN_PROPOSAL_OUTCOME_LABELS.accepted],
+    })
+    expect(classifyPatternProposalOutcome(issue)).toBe('accepted')
+  })
+
+  it('classifies a closed issue with the deferred label as deferred', () => {
+    const issue = makeIssue({
+      state: 'closed',
+      labels: [PATTERN_PROPOSAL_LABEL, PATTERN_PROPOSAL_OUTCOME_LABELS.deferred],
+    })
+    expect(classifyPatternProposalOutcome(issue)).toBe('deferred')
+  })
+
+  it('classifies a closed issue with the rejected label as rejected', () => {
+    const issue = makeIssue({
+      state: 'closed',
+      labels: [PATTERN_PROPOSAL_LABEL, PATTERN_PROPOSAL_OUTCOME_LABELS.rejected],
+    })
+    expect(classifyPatternProposalOutcome(issue)).toBe('rejected')
+  })
+
+  it('classifies a closed issue with the superseded label as superseded', () => {
+    const issue = makeIssue({
+      state: 'closed',
+      labels: [PATTERN_PROPOSAL_LABEL, PATTERN_PROPOSAL_OUTCOME_LABELS.superseded],
+    })
+    expect(classifyPatternProposalOutcome(issue)).toBe('superseded')
+  })
+
+  it('classifies a closed issue with no recognized outcome label as needs-outcome (derived, not a label)', () => {
+    const issue = makeIssue({state: 'closed', labels: [PATTERN_PROPOSAL_LABEL]})
+    expect(classifyPatternProposalOutcome(issue)).toBe('needs-outcome')
+  })
+
+  it('classifies a closed issue with conflicting outcome labels as conflicting-labels', () => {
+    const issue = makeIssue({
+      state: 'closed',
+      labels: [
+        PATTERN_PROPOSAL_LABEL,
+        PATTERN_PROPOSAL_OUTCOME_LABELS.accepted,
+        PATTERN_PROPOSAL_OUTCOME_LABELS.rejected,
+      ],
+    })
+    expect(classifyPatternProposalOutcome(issue)).toBe('conflicting-labels')
+  })
+
+  it('classifies a closed issue with an unrecognized pattern-proposal:* label as malformed-outcome', () => {
+    const issue = makeIssue({state: 'closed', labels: [PATTERN_PROPOSAL_LABEL, 'pattern-proposal:bogus']})
+    expect(classifyPatternProposalOutcome(issue)).toBe('malformed-outcome')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Solution doc source collection
+// ---------------------------------------------------------------------------
+
+describe('collectSolutionDocSources', () => {
+  const headSha = 'f'.repeat(40)
+
+  it('happy path: parses a solution doc into a source artifact with a stable ID', () => {
+    const files = {
+      'docs/solutions/best-practices/example-doc.md': '---\nmodule: scripts/foo.ts\n---\nBody',
+    }
+    const result = collectSolutionDocSources(files, headSha)
+    expect(result.invalidCount).toBe(0)
+    expect(result.sources).toHaveLength(1)
+    expect(result.sources[0]?.id).toBe('example-doc')
+    expect(result.sources[0]?.kind).toBe('solution-doc')
+    expect(result.sources[0]?.link).toBe(buildSolutionDocLink('docs/solutions/best-practices/example-doc.md', headSha))
+  })
+
+  it('only enumerates canonical solution subdirectories', () => {
+    expect(SOLUTION_SUBDIRS).toEqual([
+      'best-practices',
+      'documentation-gaps',
+      'integration-issues',
+      'runtime-errors',
+      'security-issues',
+      'workflow-issues',
+    ])
+    const files = {
+      'docs/solutions/not-a-real-subdir/example-doc.md': '---\nmodule: scripts/foo.ts\n---\nBody',
+    }
+    const result = collectSolutionDocSources(files, headSha)
+    expect(result.sources).toHaveLength(0)
+    expect(result.invalidCount).toBe(0)
+  })
+
+  it('edge case: subdirectory move does not change source identity when the filename stem is unchanged', () => {
+    const filesBefore = {
+      'docs/solutions/best-practices/example-doc.md': '---\nmodule: scripts/foo.ts\n---\nBody',
+    }
+    const filesAfter = {
+      'docs/solutions/workflow-issues/example-doc.md': '---\nmodule: scripts/foo.ts\n---\nBody',
+    }
+    const before = collectSolutionDocSources(filesBefore, headSha)
+    const after = collectSolutionDocSources(filesAfter, headSha)
+    expect(before.sources[0]?.id).toBe(after.sources[0]?.id)
+  })
+
+  it('edge case: frontmatter title/category edit does not change source identity', () => {
+    const filesBefore = {
+      'docs/solutions/best-practices/example-doc.md': '---\nmodule: scripts/foo.ts\ntitle: Old Title\n---\nBody',
+    }
+    const filesAfter = {
+      'docs/solutions/best-practices/example-doc.md': '---\nmodule: scripts/bar.ts\ntitle: New Title\n---\nBody v2',
+    }
+    const before = collectSolutionDocSources(filesBefore, headSha)
+    const after = collectSolutionDocSources(filesAfter, headSha)
+    expect(before.sources[0]?.id).toBe(after.sources[0]?.id)
+  })
+
+  it('edge case: duplicate solution filename stems are invalid sources', () => {
+    const files = {
+      'docs/solutions/best-practices/example-doc.md': '---\nmodule: a\n---\nBody',
+      'docs/solutions/runtime-errors/example-doc.md': '---\nmodule: b\n---\nBody',
+    }
+    const result = collectSolutionDocSources(files, headSha)
+    expect(result.sources).toHaveLength(0)
+    expect(result.invalidCount).toBe(2)
+  })
+
+  it('privacy: source IDs and links never contain private repo names, branch names, or raw body excerpts', () => {
+    const files = {
+      'docs/solutions/security-issues/leak-check.md': '---\nmodule: scripts/foo.ts\n---\nSecret body text here',
+    }
+    const result = collectSolutionDocSources(files, headSha)
+    const source = result.sources[0]
+    expect(source?.id).not.toContain('Secret body text here')
+    expect(source?.link).not.toContain('Secret body text here')
+    expect(source?.link).toContain(headSha)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Learning-proposal source collection
+// ---------------------------------------------------------------------------
+
+describe('collectLearningProposalSources', () => {
+  it('happy path: parses a learning-proposal issue with a captured merge-SHA marker', () => {
+    const sha = 'abc123def456abc123def456abc123def456abc1'
+    const issues: LearningProposalIssueInput[] = [
+      {number: 42, body: `Some proposal body\n<!-- captured-learning:merge_sha=${sha} -->`},
+    ]
+    const result = collectLearningProposalSources(issues)
+    expect(result.invalidCount).toBe(0)
+    expect(result.sources).toHaveLength(1)
+    expect(result.sources[0]?.id).toBe(sha)
+    expect(result.sources[0]?.kind).toBe('learning-proposal')
+    expect(result.sources[0]?.link).toBe(buildLearningProposalLink(42))
+  })
+
+  it('edge case: missing merge-SHA marker excludes the issue and increments invalid-source counts', () => {
+    const issues: LearningProposalIssueInput[] = [{number: 43, body: 'No marker here'}]
+    const result = collectLearningProposalSources(issues)
+    expect(result.sources).toHaveLength(0)
+    expect(result.invalidCount).toBe(1)
+  })
+
+  it('edge case: malformed merge-SHA marker excludes the issue and increments invalid-source counts', () => {
+    const issues: LearningProposalIssueInput[] = [{number: 44, body: '<!-- captured-learning:merge_sha= -->'}]
+    const result = collectLearningProposalSources(issues)
+    expect(result.sources).toHaveLength(0)
+    expect(result.invalidCount).toBe(1)
+  })
+
+  it('edge case: null body excludes the issue and increments invalid-source counts', () => {
+    const issues: LearningProposalIssueInput[] = [{number: 45, body: null}]
+    const result = collectLearningProposalSources(issues)
+    expect(result.sources).toHaveLength(0)
+    expect(result.invalidCount).toBe(1)
+  })
+
+  it('privacy: source links use a stable issues URL without titles or body excerpts', () => {
+    const sha = 'def456abc123def456abc123def456abc123def4'
+    const issues: LearningProposalIssueInput[] = [
+      {number: 46, body: `Sensitive title context\n<!-- captured-learning:merge_sha=${sha} -->`},
+    ]
+    const result = collectLearningProposalSources(issues)
+    expect(result.sources[0]?.link).toBe('https://github.com/fro-bot/.github/issues/46')
+    expect(result.sources[0]?.link).not.toContain('Sensitive title context')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// fetchExistingPatternProposals — I/O shell
+// ---------------------------------------------------------------------------
+
+function makeIssueListItem(
+  number: number,
+  state: 'open' | 'closed',
+  labels: string[],
+  body: string | null,
+): {number: number; state: string; labels: string[]; body: string | null} {
+  return {number, state, labels, body}
+}
+
+function makeFetchOctokit(
+  overrides: {
+    openIssues?: ReturnType<typeof makeIssueListItem>[]
+    closedIssues?: ReturnType<typeof makeIssueListItem>[]
+    openThrows?: boolean
+    closedThrows?: boolean
+  } = {},
+): PatternProposalOctokitClient {
+  const openIssues = overrides.openIssues ?? []
+  const closedIssues = overrides.closedIssues ?? []
+  return {
+    rest: {
+      issues: {
+        listForRepo: async (params: {state: 'open' | 'closed'; per_page: number; page: number}) => {
+          if (params.state === 'open') {
+            if (overrides.openThrows === true) throw new Error('API error')
+            const start = (params.page - 1) * params.per_page
+            return {data: openIssues.slice(start, start + params.per_page)}
+          }
+          if (overrides.closedThrows === true) throw new Error('API error')
+          const start = (params.page - 1) * params.per_page
+          return {data: closedIssues.slice(start, start + params.per_page)}
+        },
+      },
+    },
+  } as unknown as PatternProposalOctokitClient
+}
+
+describe('fetchExistingPatternProposals', () => {
+  it('parses open and closed pattern-proposal issues into fingerprint-keyed maps', async () => {
+    const fpOpen = 'a'.repeat(64)
+    const fpClosed = 'b'.repeat(64)
+    const openIssues = [
+      makeIssueListItem(1, 'open', [PATTERN_PROPOSAL_LABEL], `<!-- pattern-proposal:fingerprint=${fpOpen} -->`),
+    ]
+    const closedIssues = [
+      makeIssueListItem(
+        2,
+        'closed',
+        [PATTERN_PROPOSAL_LABEL, PATTERN_PROPOSAL_OUTCOME_LABELS.accepted],
+        `<!-- pattern-proposal:fingerprint=${fpClosed} -->`,
+      ),
+    ]
+    const octokit = makeFetchOctokit({openIssues, closedIssues})
+
+    const result = await fetchExistingPatternProposals({octokit, owner: 'fro-bot', repo: '.github'})
+
+    expect(result.openByFingerprint.get(fpOpen)).toHaveLength(1)
+    expect(result.closedByFingerprint.get(fpClosed)).toHaveLength(1)
+  })
+
+  it('counts malformed fingerprint markers without treating them as a match', async () => {
+    const openIssues = [makeIssueListItem(1, 'open', [PATTERN_PROPOSAL_LABEL], 'No marker here')]
+    const octokit = makeFetchOctokit({openIssues})
+
+    const result = await fetchExistingPatternProposals({octokit, owner: 'fro-bot', repo: '.github'})
+
+    expect(result.openByFingerprint.size).toBe(0)
+    expect(result.invalidMarkerCount).toBe(1)
+  })
+
+  it('fails closed when the open-issue fetch throws', async () => {
+    const octokit = makeFetchOctokit({openThrows: true})
+    await expect(fetchExistingPatternProposals({octokit, owner: 'fro-bot', repo: '.github'})).rejects.toThrow()
+  })
+
+  it('fails closed when the closed-issue fetch throws', async () => {
+    const octokit = makeFetchOctokit({closedThrows: true})
+    await expect(fetchExistingPatternProposals({octokit, owner: 'fro-bot', repo: '.github'})).rejects.toThrow()
+  })
+
+  it('paginates across multiple pages of closed issues', async () => {
+    const closedIssues = Array.from({length: 150}, (_, i) =>
+      makeIssueListItem(
+        100 + i,
+        'closed',
+        [PATTERN_PROPOSAL_LABEL, PATTERN_PROPOSAL_OUTCOME_LABELS.deferred],
+        `<!-- pattern-proposal:fingerprint=${String(i).padStart(64, '0')} -->`,
+      ),
+    )
+    const octokit = makeFetchOctokit({closedIssues})
+
+    const result = await fetchExistingPatternProposals({octokit, owner: 'fro-bot', repo: '.github'})
+
+    let total = 0
+    for (const issues of result.closedByFingerprint.values()) total += issues.length
+    expect(total).toBe(150)
+  })
+})

--- a/scripts/capture-patterns-synthesis.ts
+++ b/scripts/capture-patterns-synthesis.ts
@@ -203,6 +203,23 @@ export function classifyPatternProposalOutcome(issue: ExistingPatternProposalIss
 // Source artifact model
 // ---------------------------------------------------------------------------
 
+/**
+ * Structured correction-behavior signals used by the cluster/scoring planner.
+ * to distinguish repeated correction substance from superficial keyword overlap.
+ * Derived from frontmatter (solution docs) or title tokens (learning proposals) —
+ * never from raw body prose.
+ */
+export interface PatternSourceSignals {
+  /** `module` frontmatter field (solution docs) or empty string. */
+  module: string
+  /** `tags` frontmatter field (solution docs) or empty array. */
+  tags: string[]
+  /** `problem_type` frontmatter field (solution docs) or empty string. */
+  problemType: string
+  /** Lowercase, tokenized, stopword-filtered tokens derived from the source title. */
+  titleTokens: string[]
+}
+
 /** A single source artifact eligible for pattern clustering. */
 export interface PatternSourceArtifact {
   /** Stable public ID: filename stem for solution docs, merge SHA for learning proposals. */
@@ -210,6 +227,16 @@ export interface PatternSourceArtifact {
   kind: 'solution-doc' | 'learning-proposal'
   /** Public-safe, dereferenceable link — separate from identity. */
   link: string
+  /** Public-safe title used for display and digest source-title gating. */
+  title: string
+  /**
+   * ISO 8601 date string used for recency ranking (`date` frontmatter field for
+   * solution docs; issue creation date for learning proposals). Empty string when
+   * unavailable — sorts as least-recent.
+   */
+  date: string
+  /** Structured correction-behavior signals for clustering. */
+  signals: PatternSourceSignals
 }
 
 /** Result of collecting source artifacts from one corpus segment. */
@@ -220,6 +247,56 @@ export interface SourceCollectionResult {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Generic English stopwords plus repo-generic tokens filtered from title tokenization.
+ * Kept small and deterministic — this is display/clustering support, not NLP.
+ */
+const TITLE_STOPWORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'but',
+  'by',
+  'do',
+  'does',
+  'fix',
+  'for',
+  'from',
+  'has',
+  'have',
+  'in',
+  'into',
+  'is',
+  'it',
+  'not',
+  'of',
+  'on',
+  'or',
+  'that',
+  'the',
+  'this',
+  'to',
+  'was',
+  'were',
+  'will',
+  'with',
+])
+
+/**
+ * Tokenize a title into lowercase, stopword-filtered word tokens.
+ * Pure function: no I/O.
+ */
+export function tokenizeTitle(title: string): string[] {
+  return title
+    .toLowerCase()
+    .split(/[^a-z0-9]+/u)
+    .filter(token => token.length >= 3 && !TITLE_STOPWORDS.has(token))
 }
 
 function splitFrontmatter(content: string): {frontmatter: Record<string, unknown>; body: string} {
@@ -288,15 +365,32 @@ export function collectSolutionDocSources(files: Record<string, string>, headSha
     const path = paths[0]
     if (path === undefined) continue
 
-    // Frontmatter is parsed to validate the doc is readable; only the stem determines identity.
+    // Frontmatter is parsed to validate the doc is readable and to extract clustering
+    // signals; only the stem determines identity.
+    let frontmatter: Record<string, unknown>
     try {
-      splitFrontmatter(files[path] ?? '')
+      frontmatter = splitFrontmatter(files[path] ?? '').frontmatter
     } catch {
       invalidCount += 1
       continue
     }
 
-    sources.push({id: stem, kind: 'solution-doc', link: buildSolutionDocLink(path, headSha)})
+    const title = typeof frontmatter.title === 'string' ? frontmatter.title : stem
+    const moduleField = typeof frontmatter.module === 'string' ? frontmatter.module : ''
+    const tags = Array.isArray(frontmatter.tags)
+      ? frontmatter.tags.filter((t): t is string => typeof t === 'string')
+      : []
+    const problemType = typeof frontmatter.problem_type === 'string' ? frontmatter.problem_type : ''
+    const date = typeof frontmatter.date === 'string' ? frontmatter.date : ''
+
+    sources.push({
+      id: stem,
+      kind: 'solution-doc',
+      link: buildSolutionDocLink(path, headSha),
+      title,
+      date,
+      signals: {module: moduleField, tags, problemType, titleTokens: tokenizeTitle(title)},
+    })
   }
 
   return {sources, invalidCount}
@@ -306,6 +400,12 @@ export function collectSolutionDocSources(files: Record<string, string>, headSha
 export interface LearningProposalIssueInput {
   readonly number: number
   readonly body: string | null | undefined
+  /** Public-safe issue title, used as display title and clustering signal source. */
+  readonly title: string
+  /** ISO 8601 issue creation date, used for recency ranking. */
+  readonly createdAt: string
+  /** Issue label names, used as tag-equivalent clustering signals. */
+  readonly labels: readonly string[]
 }
 
 const CAPTURED_LEARNING_MERGE_SHA_PATTERN = /<!-- captured-learning:merge_sha=([a-f0-9]{7,40}) -->/u
@@ -331,7 +431,14 @@ export function collectLearningProposalSources(issues: readonly LearningProposal
       invalidCount += 1
       continue
     }
-    sources.push({id: sha, kind: 'learning-proposal', link: buildLearningProposalLink(issue.number)})
+    sources.push({
+      id: sha,
+      kind: 'learning-proposal',
+      link: buildLearningProposalLink(issue.number),
+      title: issue.title,
+      date: issue.createdAt,
+      signals: {module: '', tags: [...issue.labels], problemType: '', titleTokens: tokenizeTitle(issue.title)},
+    })
   }
 
   return {sources, invalidCount}

--- a/scripts/capture-patterns-synthesis.ts
+++ b/scripts/capture-patterns-synthesis.ts
@@ -1,0 +1,466 @@
+/**
+ * Source corpus and pattern-proposal metadata model for recurring pattern synthesis.
+ *
+ * Defines the allowed source corpus (accepted `docs/solutions/` docs + learning-proposal
+ * issues), stable source-ID derivation, hidden proposal markers, closed-vocabulary outcome
+ * labels, and outcome classification for pattern-proposal issues.
+ */
+
+import {parse} from 'yaml'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Canonical `docs/solutions/` subdirectories eligible as source artifacts. */
+export const SOLUTION_SUBDIRS = [
+  'best-practices',
+  'documentation-gaps',
+  'integration-issues',
+  'runtime-errors',
+  'security-issues',
+  'workflow-issues',
+] as const
+
+const SOLUTIONS_ROOT = 'docs/solutions'
+
+/** Primary label applied to every pattern-proposal issue. */
+export const PATTERN_PROPOSAL_LABEL = 'pattern-proposal'
+
+/** Closed vocabulary of mutually exclusive pattern-proposal outcome labels. */
+export const PATTERN_PROPOSAL_OUTCOME_LABELS = {
+  accepted: 'pattern-proposal:accepted',
+  deferred: 'pattern-proposal:deferred',
+  rejected: 'pattern-proposal:rejected',
+  superseded: 'pattern-proposal:superseded',
+} as const
+
+/** Label descriptor shape, ready for `.github/settings.yml` and runtime label preflight. */
+export interface PatternProposalLabelDescriptor {
+  readonly name: string
+  readonly color: string
+  readonly description: string
+}
+
+/**
+ * All labels required by the pattern-synthesis loop. `needs-outcome` is intentionally
+ * absent — it is a derived state from `classifyPatternProposalOutcome`, not an operator label.
+ */
+export const PATTERN_PROPOSAL_REQUIRED_LABELS: readonly PatternProposalLabelDescriptor[] = [
+  {
+    name: PATTERN_PROPOSAL_LABEL,
+    color: '5319e7',
+    description: 'Recurring pattern proposal awaiting operator review',
+  },
+  {
+    name: PATTERN_PROPOSAL_OUTCOME_LABELS.accepted,
+    color: '0e8a16',
+    description: 'Pattern proposal accepted as a durable lesson',
+  },
+  {
+    name: PATTERN_PROPOSAL_OUTCOME_LABELS.deferred,
+    color: 'fbca04',
+    description: 'Pattern proposal deferred pending more evidence',
+  },
+  {
+    name: PATTERN_PROPOSAL_OUTCOME_LABELS.rejected,
+    color: 'e4e669',
+    description: 'Pattern proposal rejected as low-signal',
+  },
+  {
+    name: PATTERN_PROPOSAL_OUTCOME_LABELS.superseded,
+    color: 'cfd3d7',
+    description: 'Pattern proposal superseded by a newer proposal',
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Hidden marker helpers
+// ---------------------------------------------------------------------------
+
+const FINGERPRINT_MARKER_PATTERN = /<!-- pattern-proposal:fingerprint=([a-f0-9]{64}) -->/u
+const SOURCE_IDS_MARKER_PATTERN = /<!-- pattern-proposal:source-ids=([^\n]+?) -->/u
+const SUPERSEDES_MARKER_PATTERN = /<!-- pattern-proposal:supersedes=([a-f0-9]{64}) -->/u
+
+/**
+ * Build hidden markers for a pattern-proposal issue body.
+ *
+ * `sourceIds` is sorted before rendering so the marker (and the fingerprint it
+ * accompanies) never depends on input ordering. `supersedes`, when present, is an
+ * optional fourth marker pointing at the fingerprint this proposal replaces.
+ */
+export function buildPatternProposalMarkers(params: {
+  fingerprint: string
+  sourceIds: string[]
+  supersedes?: string
+}): string {
+  const sortedIds = [...params.sourceIds].sort((a, b) => a.localeCompare(b))
+  const lines = [
+    `<!-- pattern-proposal:fingerprint=${params.fingerprint} -->`,
+    `<!-- pattern-proposal:source-ids=${sortedIds.join(',')} -->`,
+  ]
+  if (params.supersedes !== undefined) {
+    lines.push(`<!-- pattern-proposal:supersedes=${params.supersedes} -->`)
+  }
+  return lines.join('\n')
+}
+
+/** Parse the fingerprint marker from a pattern-proposal body. Null if absent/malformed. */
+export function parsePatternProposalFingerprint(body: string): string | null {
+  const match = FINGERPRINT_MARKER_PATTERN.exec(body)
+  return match?.[1] ?? null
+}
+
+/**
+ * Parse the sorted source-IDs marker from a pattern-proposal body.
+ * Returns the IDs split on commas, or null if the marker is absent or empty.
+ */
+export function parsePatternProposalSourceIds(body: string): string[] | null {
+  const match = SOURCE_IDS_MARKER_PATTERN.exec(body)
+  const raw = match?.[1]
+  if (raw === undefined || raw.trim() === '') return null
+  return raw.split(',').map(id => id.trim())
+}
+
+/** Parse the optional supersedes marker from a pattern-proposal body. Null if absent/malformed. */
+export function parsePatternProposalSupersedes(body: string): string | null {
+  const match = SUPERSEDES_MARKER_PATTERN.exec(body)
+  return match?.[1] ?? null
+}
+
+// ---------------------------------------------------------------------------
+// Outcome classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical outcome states for a pattern-proposal issue.
+ * `needs-outcome` is derived from a closed issue with no recognized outcome label —
+ * it is never applied as an operator label.
+ */
+export type PatternProposalOutcomeState =
+  | 'proposed-pending'
+  | 'accepted'
+  | 'deferred'
+  | 'rejected'
+  | 'superseded'
+  | 'needs-outcome'
+  | 'conflicting-labels'
+  | 'malformed-outcome'
+
+/** Minimal shape of an existing pattern-proposal issue used for outcome classification. */
+export interface ExistingPatternProposalIssue {
+  readonly number: number
+  readonly state: 'open' | 'closed'
+  readonly labels: readonly string[]
+  readonly body: string | null | undefined
+}
+
+const RECOGNIZED_OUTCOME_LABELS: readonly string[] = [
+  PATTERN_PROPOSAL_OUTCOME_LABELS.accepted,
+  PATTERN_PROPOSAL_OUTCOME_LABELS.deferred,
+  PATTERN_PROPOSAL_OUTCOME_LABELS.rejected,
+  PATTERN_PROPOSAL_OUTCOME_LABELS.superseded,
+]
+
+/**
+ * Classify a pattern-proposal issue into a canonical outcome state.
+ *
+ * Pure function: no I/O, no side effects. `needs-outcome` is derived state, not a label.
+ *
+ * Rules (priority order):
+ * 1. Open issue → proposed-pending (regardless of labels).
+ * 2. Closed issue with more than one recognized outcome label → conflicting-labels.
+ * 3. Closed issue with an unrecognized `pattern-proposal:*` label → malformed-outcome.
+ * 4. Closed issue with exactly one recognized outcome label → that outcome.
+ * 5. Closed issue with no recognized outcome label → needs-outcome.
+ */
+export function classifyPatternProposalOutcome(issue: ExistingPatternProposalIssue): PatternProposalOutcomeState {
+  if (issue.state === 'open') {
+    return 'proposed-pending'
+  }
+
+  const namespacedLabels = issue.labels.filter(l => l !== PATTERN_PROPOSAL_LABEL && l.startsWith('pattern-proposal:'))
+
+  const recognized = namespacedLabels.filter(l => RECOGNIZED_OUTCOME_LABELS.includes(l))
+  if (recognized.length > 1) {
+    return 'conflicting-labels'
+  }
+
+  const unrecognized = namespacedLabels.filter(l => !RECOGNIZED_OUTCOME_LABELS.includes(l))
+  if (unrecognized.length > 0) {
+    return 'malformed-outcome'
+  }
+
+  if (recognized.includes(PATTERN_PROPOSAL_OUTCOME_LABELS.accepted)) return 'accepted'
+  if (recognized.includes(PATTERN_PROPOSAL_OUTCOME_LABELS.deferred)) return 'deferred'
+  if (recognized.includes(PATTERN_PROPOSAL_OUTCOME_LABELS.rejected)) return 'rejected'
+  if (recognized.includes(PATTERN_PROPOSAL_OUTCOME_LABELS.superseded)) return 'superseded'
+
+  return 'needs-outcome'
+}
+
+// ---------------------------------------------------------------------------
+// Source artifact model
+// ---------------------------------------------------------------------------
+
+/** A single source artifact eligible for pattern clustering. */
+export interface PatternSourceArtifact {
+  /** Stable public ID: filename stem for solution docs, merge SHA for learning proposals. */
+  id: string
+  kind: 'solution-doc' | 'learning-proposal'
+  /** Public-safe, dereferenceable link — separate from identity. */
+  link: string
+}
+
+/** Result of collecting source artifacts from one corpus segment. */
+export interface SourceCollectionResult {
+  sources: PatternSourceArtifact[]
+  invalidCount: number
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function splitFrontmatter(content: string): {frontmatter: Record<string, unknown>; body: string} {
+  const match = /^---\n([\s\S]+?)\n---\n?/u.exec(content)
+  if (match === null) {
+    return {frontmatter: {}, body: content.trim()}
+  }
+  const frontmatterText = match[1]
+  if (frontmatterText === undefined) {
+    return {frontmatter: {}, body: content.trim()}
+  }
+  const parsed: unknown = parse(frontmatterText)
+  return {
+    frontmatter: isRecord(parsed) ? parsed : {},
+    body: content.slice(match[0].length).trim(),
+  }
+}
+
+/**
+ * Build the SHA-pinned GitHub blob URL for a solution doc at the checked-out HEAD.
+ * Identity (filename stem) is separate from this link — the link may change across
+ * commits without altering the source ID.
+ */
+export function buildSolutionDocLink(path: string, headSha: string): string {
+  return `https://github.com/fro-bot/.github/blob/${headSha}/${path}`
+}
+
+/** Build the stable issues URL for a learning-proposal issue. */
+export function buildLearningProposalLink(issueNumber: number): string {
+  return `https://github.com/fro-bot/.github/issues/${issueNumber}`
+}
+
+/**
+ * Collect solution-doc source artifacts from a flat file map (`path -> content`).
+ *
+ * Only files under the canonical `docs/solutions/<subdir>/` directories are considered.
+ * Source ID is the filename stem — stable across subdirectory moves and frontmatter edits.
+ * Duplicate stems across any subdirectory are invalid: all colliding docs are excluded
+ * and each increments `invalidCount`.
+ *
+ * Pure function: no I/O, fully unit-testable.
+ */
+export function collectSolutionDocSources(files: Record<string, string>, headSha: string): SourceCollectionResult {
+  const byStem = new Map<string, string[]>()
+
+  for (const path of Object.keys(files)) {
+    if (!path.endsWith('.md')) continue
+    const withinCanonicalSubdir = SOLUTION_SUBDIRS.some(subdir => path.startsWith(`${SOLUTIONS_ROOT}/${subdir}/`))
+    if (!withinCanonicalSubdir) continue
+
+    const filename = path.slice(path.lastIndexOf('/') + 1)
+    const stem = filename.slice(0, -'.md'.length)
+    const existing = byStem.get(stem) ?? []
+    existing.push(path)
+    byStem.set(stem, existing)
+  }
+
+  const sources: PatternSourceArtifact[] = []
+  let invalidCount = 0
+
+  for (const [stem, paths] of byStem) {
+    if (paths.length > 1) {
+      invalidCount += paths.length
+      continue
+    }
+    const path = paths[0]
+    if (path === undefined) continue
+
+    // Frontmatter is parsed to validate the doc is readable; only the stem determines identity.
+    try {
+      splitFrontmatter(files[path] ?? '')
+    } catch {
+      invalidCount += 1
+      continue
+    }
+
+    sources.push({id: stem, kind: 'solution-doc', link: buildSolutionDocLink(path, headSha)})
+  }
+
+  return {sources, invalidCount}
+}
+
+/** Minimal shape of a learning-proposal issue needed for source collection. */
+export interface LearningProposalIssueInput {
+  readonly number: number
+  readonly body: string | null | undefined
+}
+
+const CAPTURED_LEARNING_MERGE_SHA_PATTERN = /<!-- captured-learning:merge_sha=([a-f0-9]{7,40}) -->/u
+
+/**
+ * Collect learning-proposal source artifacts from raw issues.
+ *
+ * Source ID is the captured merge-SHA marker. Issues with a missing or malformed
+ * marker are excluded from clustering and increment `invalidCount`. Links use the
+ * stable public issues URL — never the issue title or raw body excerpt.
+ *
+ * Pure function: no I/O, fully unit-testable.
+ */
+export function collectLearningProposalSources(issues: readonly LearningProposalIssueInput[]): SourceCollectionResult {
+  const sources: PatternSourceArtifact[] = []
+  let invalidCount = 0
+
+  for (const issue of issues) {
+    const body = issue.body
+    const match = typeof body === 'string' ? CAPTURED_LEARNING_MERGE_SHA_PATTERN.exec(body) : null
+    const sha = match?.[1]
+    if (sha === undefined) {
+      invalidCount += 1
+      continue
+    }
+    sources.push({id: sha, kind: 'learning-proposal', link: buildLearningProposalLink(issue.number)})
+  }
+
+  return {sources, invalidCount}
+}
+
+// ---------------------------------------------------------------------------
+// Existing pattern-proposal fetch (I/O shell)
+// ---------------------------------------------------------------------------
+
+/** Shape of a single issue returned by `listForRepo`, minimal fields only. */
+export interface PatternProposalIssueListItem {
+  readonly number: number
+  readonly state: string
+  readonly labels: readonly (string | {readonly name?: string | null | undefined})[]
+  readonly body: string | null | undefined
+}
+
+/** Minimal Octokit-like client interface for pattern-proposal issue reads. */
+export interface PatternProposalOctokitClient {
+  readonly rest: {
+    readonly issues: {
+      readonly listForRepo: (params: {
+        owner: string
+        repo: string
+        labels: string
+        state: 'open' | 'closed'
+        per_page: number
+        page: number
+      }) => Promise<{data: PatternProposalIssueListItem[]}>
+    }
+  }
+}
+
+/** Result of `fetchExistingPatternProposals`: open/closed issues keyed by fingerprint. */
+export interface ExistingPatternProposals {
+  openByFingerprint: Map<string, ExistingPatternProposalIssue[]>
+  closedByFingerprint: Map<string, ExistingPatternProposalIssue[]>
+  /** Count of issues whose fingerprint marker was missing or malformed — not suppression matches. */
+  invalidMarkerCount: number
+}
+
+async function paginateAllPatternIssues(
+  listFn: (page: number) => Promise<{data: PatternProposalIssueListItem[]}>,
+  perPage = 100,
+): Promise<PatternProposalIssueListItem[]> {
+  const all: PatternProposalIssueListItem[] = []
+  let page = 1
+  for (;;) {
+    const response = await listFn(page)
+    all.push(...response.data)
+    if (response.data.length < perPage) break
+    page++
+  }
+  return all
+}
+
+/**
+ * Fetch existing pattern-proposal issues across open and closed states with full
+ * pagination, grouping them into fingerprint-keyed maps for later suppression/upgrade
+ * decisions.
+ *
+ * Fail-closed: any API error is propagated to the caller so later units abort before
+ * issue writes can happen. Malformed fingerprint markers are counted (`invalidMarkerCount`)
+ * and excluded from the maps — never treated as a matching suppression.
+ */
+export async function fetchExistingPatternProposals(params: {
+  octokit: PatternProposalOctokitClient
+  owner: string
+  repo: string
+}): Promise<ExistingPatternProposals> {
+  const {octokit, owner, repo} = params
+  const openByFingerprint = new Map<string, ExistingPatternProposalIssue[]>()
+  const closedByFingerprint = new Map<string, ExistingPatternProposalIssue[]>()
+  let invalidMarkerCount = 0
+
+  const perPage = 100
+
+  const openItems = await paginateAllPatternIssues(
+    async page =>
+      octokit.rest.issues.listForRepo({
+        owner,
+        repo,
+        labels: PATTERN_PROPOSAL_LABEL,
+        state: 'open',
+        per_page: perPage,
+        page,
+      }),
+    perPage,
+  )
+
+  const closedItems = await paginateAllPatternIssues(
+    async page =>
+      octokit.rest.issues.listForRepo({
+        owner,
+        repo,
+        labels: PATTERN_PROPOSAL_LABEL,
+        state: 'closed',
+        per_page: perPage,
+        page,
+      }),
+    perPage,
+  )
+
+  const groupInto = (items: PatternProposalIssueListItem[], target: Map<string, ExistingPatternProposalIssue[]>) => {
+    for (const item of items) {
+      const labelNames = item.labels.map(l => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean)
+      if (!labelNames.includes(PATTERN_PROPOSAL_LABEL)) continue
+
+      const body = item.body ?? ''
+      const fingerprint = parsePatternProposalFingerprint(body)
+      if (fingerprint === null) {
+        invalidMarkerCount += 1
+        continue
+      }
+
+      const issue: ExistingPatternProposalIssue = {
+        number: item.number,
+        state: item.state === 'closed' ? 'closed' : 'open',
+        labels: labelNames,
+        body: item.body,
+      }
+      const existing = target.get(fingerprint) ?? []
+      existing.push(issue)
+      target.set(fingerprint, existing)
+    }
+  }
+
+  groupInto(openItems, openByFingerprint)
+  groupInto(closedItems, closedByFingerprint)
+
+  return {openByFingerprint, closedByFingerprint, invalidMarkerCount}
+}

--- a/scripts/capture-patterns-synthesis.ts
+++ b/scripts/capture-patterns-synthesis.ts
@@ -8,6 +8,8 @@
 
 import {parse} from 'yaml'
 
+import {isRecord} from './capture-learnings-privacy.ts'
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -83,17 +85,39 @@ const SOURCE_IDS_MARKER_PATTERN = /<!-- pattern-proposal:source-ids=([^\n]+?) --
 const SUPERSEDES_MARKER_PATTERN = /<!-- pattern-proposal:supersedes=([a-f0-9]{64}) -->/u
 
 /**
+ * Characters forbidden in a source ID: comma (the marker's join delimiter), newline
+ * (would break the single-line marker), and any other ASCII control character. A
+ * source ID containing one of these could corrupt the marker or be used to smuggle a
+ * spoofed ID list past `parsePatternProposalSourceIds`.
+ */
+// eslint-disable-next-line no-control-regex -- intentional: rejects raw control chars (incl. \n, \r) in source IDs
+const SOURCE_ID_FORBIDDEN_PATTERN = /[,\u0000-\u001F\u007F]/u
+
+/** True when a source ID is safe to embed in the comma-joined marker. */
+export function isValidPatternProposalSourceId(id: string): boolean {
+  return id.length > 0 && !SOURCE_ID_FORBIDDEN_PATTERN.test(id)
+}
+
+/**
  * Build hidden markers for a pattern-proposal issue body.
  *
  * `sourceIds` is sorted before rendering so the marker (and the fingerprint it
  * accompanies) never depends on input ordering. `supersedes`, when present, is an
  * optional fourth marker pointing at the fingerprint this proposal replaces.
+ *
+ * Fail-fast: throws if any source ID contains a comma, newline, or other control
+ * character that would corrupt the marker or its round-trip parse.
  */
 export function buildPatternProposalMarkers(params: {
   fingerprint: string
   sourceIds: string[]
   supersedes?: string
 }): string {
+  for (const id of params.sourceIds) {
+    if (!isValidPatternProposalSourceId(id)) {
+      throw new Error(`capture-patterns-synthesis: invalid source ID contains a forbidden delimiter character`)
+    }
+  }
   const sortedIds = [...params.sourceIds].sort((a, b) => a.localeCompare(b))
   const lines = [
     `<!-- pattern-proposal:fingerprint=${params.fingerprint} -->`,
@@ -243,10 +267,6 @@ export interface PatternSourceArtifact {
 export interface SourceCollectionResult {
   sources: PatternSourceArtifact[]
   invalidCount: number
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 /**

--- a/scripts/capture-patterns-workflow.test.ts
+++ b/scripts/capture-patterns-workflow.test.ts
@@ -67,9 +67,16 @@ describe('capture-patterns.yaml workflow contract', () => {
     expect(detectJob?.permissions).toEqual({contents: 'read', issues: 'read'})
   })
 
-  it('open job carries only read-only permissions on the job token; writes come from a minted app token', () => {
+  it('open job carries only read-only contents permission on the job token; no issues:read grant is needed since it only reads via the minted app token, and writes come from that same minted token', () => {
     expect(openJob).toBeDefined()
-    expect(openJob?.permissions).toEqual({contents: 'read', issues: 'read'})
+    expect(openJob?.permissions).toEqual({contents: 'read'})
+  })
+
+  it('the open job itself is skipped entirely on dry-run — the job-level `if` requires an explicit live dispatch', () => {
+    const openJobRaw = (parsed.jobs.open as unknown as {if?: string}).if
+    expect(openJobRaw).toBeDefined()
+    expect(String(openJobRaw)).toContain("github.event_name == 'workflow_dispatch'")
+    expect(String(openJobRaw)).toContain("github.event.inputs.dry_run == 'false'")
   })
 
   it('the write-scoped app token is minted only for an explicit live (dry_run=false) manual dispatch', () => {
@@ -165,6 +172,22 @@ describe('capture-patterns.yaml workflow contract', () => {
     for (const pattern of forbiddenPatterns) {
       expect(pattern.test(raw)).toBe(false)
     }
+  })
+
+  it('the detect and open node|tee pipelines run under pipefail so a node failure fails the step', () => {
+    const detectStep = detectJob?.steps.find(step => step.id === 'detect')
+    const openStep = openJob?.steps.find(step => step.id === 'open')
+    expect(String(detectStep?.run ?? '')).toContain('| tee')
+    expect(String((detectStep as WorkflowStep & {shell?: string})?.shell ?? '')).toContain('pipefail')
+    expect(String(openStep?.run ?? '')).toContain('| tee')
+    expect(String((openStep as WorkflowStep & {shell?: string})?.shell ?? '')).toContain('pipefail')
+  })
+
+  it('the digest artifact retains for 1 day, not the default longer window', () => {
+    const uploadStep = detectJob?.steps.find(
+      step => typeof step.name === 'string' && step.name.includes('Upload digest artifact'),
+    ) as (WorkflowStep & {with?: {'retention-days'?: number}}) | undefined
+    expect(uploadStep?.with?.['retention-days']).toBe(1)
   })
 
   it('never echoes digest/body file contents or the write token into logs', () => {

--- a/scripts/capture-patterns-workflow.test.ts
+++ b/scripts/capture-patterns-workflow.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Contract tests for .github/workflows/capture-patterns.yaml: dry-run default,
+ * live-write token boundary, digest/body-file env wiring, and agent prompt
+ * write contract. Style mirrors fro-bot-workflow-wiki-handoff.test.ts.
+ */
+
+import {readFileSync} from 'node:fs'
+import {resolve} from 'node:path'
+import {describe, expect, it} from 'vitest'
+import {parse} from 'yaml'
+
+interface WorkflowStep {
+  name?: string
+  id?: string
+  if?: string
+  run?: string
+  env?: Record<string, unknown>
+  with?: Record<string, unknown>
+}
+
+interface WorkflowJob {
+  steps: WorkflowStep[]
+  permissions?: Record<string, string>
+}
+
+function assertCapturePatternsWorkflow(value: unknown): asserts value is {
+  on: {workflow_dispatch?: {inputs?: Record<string, {default?: string}>}}
+  concurrency?: {group?: string; 'cancel-in-progress'?: boolean}
+  jobs: Record<string, WorkflowJob>
+} {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    !('jobs' in value) ||
+    typeof (value as Record<string, unknown>).jobs !== 'object'
+  ) {
+    throw new TypeError('capture-patterns.yaml does not have expected shape: missing jobs object')
+  }
+}
+
+describe('capture-patterns.yaml workflow contract', () => {
+  const workflowPath = resolve(import.meta.dirname, '../.github/workflows/capture-patterns.yaml')
+  const raw = readFileSync(workflowPath, 'utf8')
+  const parsed: unknown = parse(raw)
+  assertCapturePatternsWorkflow(parsed)
+
+  const detectJob = parsed.jobs.detect
+  const openJob = parsed.jobs.open
+
+  it('has a manual dispatch trigger with dry_run defaulting to true', () => {
+    const dryRunInput = parsed.on.workflow_dispatch?.inputs?.dry_run
+    expect(dryRunInput).toBeDefined()
+    expect(dryRunInput?.default).toBe('true')
+  })
+
+  it('has no schedule trigger — no live scheduled writes in v1', () => {
+    expect(parsed.on).not.toHaveProperty('schedule')
+  })
+
+  it('serializes runs with a dedicated concurrency group and never cancels in-progress runs', () => {
+    expect(parsed.concurrency?.group).toBe('capture-patterns')
+    expect(parsed.concurrency?.['cancel-in-progress']).toBe(false)
+  })
+
+  it('detect job carries only read-only permissions', () => {
+    expect(detectJob).toBeDefined()
+    expect(detectJob?.permissions).toEqual({contents: 'read', issues: 'read'})
+  })
+
+  it('open job carries only read-only permissions on the job token; writes come from a minted app token', () => {
+    expect(openJob).toBeDefined()
+    expect(openJob?.permissions).toEqual({contents: 'read', issues: 'read'})
+  })
+
+  it('the write-scoped app token is minted only for an explicit live (dry_run=false) manual dispatch', () => {
+    const mintStep = openJob?.steps.find(step => step.id === 'app-token')
+    expect(mintStep).toBeDefined()
+    expect(mintStep?.if).toContain("github.event_name == 'workflow_dispatch'")
+    expect(mintStep?.if).toContain("github.event.inputs.dry_run == 'false'")
+  })
+
+  it('the app token is scoped to this repository only', () => {
+    const mintStep = openJob?.steps.find(step => step.id === 'app-token')
+    const withBlock = mintStep?.with
+    expect(String(withBlock?.repositories ?? '')).toContain('github.event.repository.name')
+  })
+
+  it('the open (issue-write) step itself only runs on an explicit live dispatch', () => {
+    const openStep = openJob?.steps.find(step => step.id === 'open')
+    expect(openStep).toBeDefined()
+    expect(openStep?.if).toContain("github.event_name == 'workflow_dispatch'")
+    expect(openStep?.if).toContain("github.event.inputs.dry_run == 'false'")
+  })
+
+  it('the agent drafting step only runs on an explicit live dispatch', () => {
+    const agentStep = openJob?.steps.find(step => step.id === 'agent')
+    expect(agentStep).toBeDefined()
+    expect(agentStep?.if).toContain("github.event_name == 'workflow_dispatch'")
+    expect(agentStep?.if).toContain("github.event.inputs.dry_run == 'false'")
+    expect(agentStep?.if).not.toContain('||')
+  })
+
+  it('the detect step writes the digest to CAPTURE_PATTERNS_DIGEST_PATH under runner.temp', () => {
+    const detectStep = detectJob?.steps.find(step => step.id === 'detect')
+    expect(detectStep).toBeDefined()
+    const digestPath = detectStep?.env?.CAPTURE_PATTERNS_DIGEST_PATH
+    expect(typeof digestPath).toBe('string')
+    expect(String(digestPath)).toContain('runner.temp')
+  })
+
+  it('the agent step and the open step receive the same digest path env var', () => {
+    const agentStep = openJob?.steps.find(step => step.id === 'agent')
+    const openStep = openJob?.steps.find(step => step.id === 'open')
+    expect(agentStep).toBeDefined()
+    expect(openStep).toBeDefined()
+
+    const agentDigestPath = agentStep?.env?.CAPTURE_PATTERNS_DIGEST_PATH
+    const openDigestPath = openStep?.env?.CAPTURE_PATTERNS_DIGEST_PATH
+    expect(typeof agentDigestPath).toBe('string')
+    expect(agentDigestPath).toBe(openDigestPath)
+  })
+
+  it('the open step wires CAPTURE_PATTERNS_BODIES_PATH and CAPTURE_PATTERNS_RESULT_PATH under runner.temp', () => {
+    const openStep = openJob?.steps.find(step => step.id === 'open')
+    const bodiesPath = openStep?.env?.CAPTURE_PATTERNS_BODIES_PATH
+    const resultPath = openStep?.env?.CAPTURE_PATTERNS_RESULT_PATH
+    expect(String(bodiesPath ?? '')).toContain('runner.temp')
+    expect(String(resultPath ?? '')).toContain('runner.temp')
+  })
+
+  it('the detect step uses the read-only workflow token explicitly', () => {
+    const detectStep = detectJob?.steps.find(step => step.id === 'detect')
+    expect(String(detectStep?.env?.GITHUB_TOKEN ?? '')).toContain('github.token')
+  })
+
+  it('the open step uses only the minted app token and does not fall back to the job token', () => {
+    const openStep = openJob?.steps.find(step => step.id === 'open')
+    const token = String(openStep?.env?.GITHUB_TOKEN ?? '')
+    expect(token).toContain('steps.app-token.outputs.token')
+    expect(token).not.toContain('github.token')
+  })
+
+  it('the agent step uses the read-only workflow GITHUB_TOKEN, not the minted write token', () => {
+    const agentStep = openJob?.steps.find(step => step.id === 'agent')
+    const withBlock = agentStep?.with
+    expect(String(withBlock?.['github-token'] ?? '')).toContain('github.token')
+  })
+
+  it('the agent prompt states a temp-file-only write contract and no repo-edit instruction', () => {
+    const agentStep = openJob?.steps.find(step => step.id === 'agent')
+    const prompt = String(agentStep?.env?.TASK_PROMPT ?? '')
+
+    expect(prompt).toContain('capture-patterns-bodies.json')
+    expect(prompt.toLowerCase()).toContain('no code edits')
+    expect(prompt.toLowerCase()).toContain('never create issues yourself')
+    expect(prompt.toLowerCase()).toContain('never write to any path other than')
+  })
+
+  it('the digest → open sequence depends on the detect job completing first', () => {
+    expect((parsed.jobs.open as unknown as {needs?: string}).needs).toBe('detect')
+  })
+
+  it('the workflow file uses plain operator-facing vocabulary, not internal plan taxonomy', () => {
+    const forbiddenPatterns = [/\bUnit \d/u, /\bU\d\b/u, /\bA1\b/u, /\bC4\b/u]
+    for (const pattern of forbiddenPatterns) {
+      expect(pattern.test(raw)).toBe(false)
+    }
+  })
+
+  it('never echoes digest/body file contents or the write token into logs', () => {
+    const suspiciousPatterns = [
+      /echo.*CAPTURE_PATTERNS_DIGEST_PATH/u,
+      /cat.*CAPTURE_PATTERNS_DIGEST_PATH/u,
+      /echo.*CAPTURE_PATTERNS_BODIES_PATH/u,
+      /cat.*CAPTURE_PATTERNS_BODIES_PATH/u,
+      /echo.*steps\.app-token\.outputs\.token/u,
+    ]
+    for (const pattern of suspiciousPatterns) {
+      expect(pattern.test(raw)).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Adds a recurring-pattern proposal loop for Fro Bot's learning corpus.

The new workflow scans accepted solution docs and learning-proposal issues, clusters repeated correction patterns, asks the agent to draft bounded proposal bodies, then lets a deterministic opener validate and post proposal issues when manually armed for a live run.

## What changed

- Added pattern proposal metadata, labels, source parsing, clustering, suppression, and deterministic issue-opening scripts.
- Added `Capture Patterns`, a manual-first workflow that defaults to dry-run and skips live writes unless explicitly requested.
- Reused the shared public-output gate for source titles, issue titles, and proposal bodies.
- Documented the operator label contract for accepting, deferring, rejecting, or superseding pattern proposals.

## Verification

- `pnpm bootstrap && pnpm check-types && pnpm lint && pnpm test`
- `actionlint .github/workflows/capture-patterns.yaml`