### PR TITLE
fix: suppress weak pattern synthesis candidates

### DIFF
--- a/.github/workflows/capture-patterns.yaml
+++ b/.github/workflows/capture-patterns.yaml
@@ -102,6 +102,7 @@ jobs:
               echo "| Invalid sources | $(jq '.invalidSources // 0' "$result") |"
               echo "| Candidates scanned | $(jq '.candidatesScanned // 0' "$result") |"
               echo "| Low-signal skipped | $(jq '.lowSignalSkipped // 0' "$result") |"
+              echo "| Quality-suppressed | $(jq '.qualitySuppressed // 0' "$result") |"
               echo "| Duplicate/open-overlap | $(jq '.duplicateOpenOverlap // 0' "$result") |"
               echo "| Hard-suppressed | $(jq '.hardSuppressed // 0' "$result") |"
               echo "| Soft-suppressed | $(jq '.softSuppressed // 0' "$result") |"

--- a/scripts/capture-patterns-cluster.test.ts
+++ b/scripts/capture-patterns-cluster.test.ts
@@ -138,6 +138,122 @@ describe('planPatternCandidates: correction-substance clustering', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Candidate quality suppression — overbroad clusters and hash-title-only evidence
+// ---------------------------------------------------------------------------
+
+describe('planPatternCandidates: candidate quality suppression', () => {
+  it('edge case: a large cluster with no single shared problem_type is suppressed as overbroad/generic', () => {
+    // 9 sources exceed OVERBROAD_CLUSTER_SIZE_THRESHOLD and share only a module token,
+    // a tag, and one title token per pair (30 points, clears the cluster threshold) —
+    // but each carries a distinct problem_type, so there is no single decision-ready topic.
+    const sources: PatternCandidateSource[] = Array.from({length: 9}, (_, i) =>
+      makeSource({
+        id: `broad-source-${i}`,
+        title: `Best practice guidance number ${i} for workflow hygiene`,
+        signals: {
+          module: 'docs/solutions/best-practices',
+          tags: ['best-practice'],
+          problemType: `best_practice_${i}`,
+          titleTokens: ['best', 'practice', 'guidance', 'workflow', 'hygiene'],
+        },
+      }),
+    )
+
+    const result = plan({sources, existing: emptyExisting()})
+
+    expect(result.candidates).toHaveLength(0)
+    expect(result.counts.qualitySuppressed).toBe(1)
+  })
+
+  it('happy path: a large cluster sharing one specific problem_type is NOT suppressed as overbroad', () => {
+    // Same shape and size as the overbroad case, but every source shares one specific
+    // problem_type — this is a legitimate high-evidence repeated pattern, not generic noise.
+    const sources: PatternCandidateSource[] = Array.from({length: 9}, (_, i) =>
+      makeSource({
+        id: `focused-source-${i}`,
+        title: `Retry idempotent writes on 5xx failures variant ${i}`,
+        signals: {
+          module: 'scripts/retry.ts',
+          tags: ['ci'],
+          problemType: 'best_practice_retry_5xx',
+          titleTokens: ['retry', 'idempotent', 'writes', '5xx', 'failures'],
+        },
+      }),
+    )
+
+    const result = plan({sources, existing: emptyExisting()})
+
+    expect(result.candidates).toHaveLength(1)
+    expect(result.counts.qualitySuppressed).toBe(0)
+  })
+
+  it('edge case: a cluster made mostly of hash-title learning proposals is suppressed as weak signal', () => {
+    // Both sources are learning-proposal issues whose title is still the neutral
+    // `Learning proposal: (<shortSha>)` placeholder — no human-readable correction
+    // substance until codified into a solution doc or retitled.
+    const sources: PatternCandidateSource[] = [
+      makeSource({
+        id: '7012832fabcdef',
+        kind: 'learning-proposal',
+        title: 'Learning proposal: (7012832f)',
+        signals: {
+          module: '',
+          tags: ['pattern-proposal'],
+          problemType: '',
+          titleTokens: ['retry', 'idempotent', 'writes'],
+        },
+      }),
+      makeSource({
+        id: '9a1bc2d3ef456',
+        kind: 'learning-proposal',
+        title: 'Learning proposal: (9a1bc2d3)',
+        signals: {
+          module: '',
+          tags: ['pattern-proposal'],
+          problemType: '',
+          titleTokens: ['retry', 'idempotent', 'writes'],
+        },
+      }),
+    ]
+
+    const result = plan({sources, existing: emptyExisting()})
+
+    expect(result.candidates).toHaveLength(0)
+    expect(result.counts.qualitySuppressed).toBe(1)
+  })
+
+  it('happy path: a cluster with a minority of hash-title learning proposals is NOT suppressed', () => {
+    const sourceB = makeSource({
+      id: 'source-b',
+      title: 'Retry idempotent writes after 5xx failures',
+      signals: {
+        module: 'scripts/foo.ts',
+        tags: ['ci'],
+        problemType: 'best_practice',
+        titleTokens: ['retry', 'idempotent', 'writes', 'after', '5xx', 'failures'],
+      },
+    })
+    const learningSource = makeSource({
+      id: '7012832fabcdef',
+      kind: 'learning-proposal',
+      title: 'Learning proposal: (7012832f)',
+      signals: {
+        module: 'scripts/foo.ts',
+        tags: ['ci'],
+        problemType: 'best_practice',
+        titleTokens: ['retry', 'idempotent', 'writes'],
+      },
+    })
+    const sources = [makeSource(), sourceB, learningSource]
+
+    const result = plan({sources, existing: emptyExisting()})
+
+    expect(result.candidates).toHaveLength(1)
+    expect(result.counts.qualitySuppressed).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Suppression / filter behavior
 // ---------------------------------------------------------------------------
 

--- a/scripts/capture-patterns-cluster.ts
+++ b/scripts/capture-patterns-cluster.ts
@@ -5,8 +5,9 @@
  * artifacts and existing pattern-proposal state, then decides which candidates may be
  * sent to the agent for proposal drafting. No I/O — all data is injected.
  *
- * Filter order (fixed): weak cluster -> open-proposal overlap -> hard suppression ->
- * soft suppression (without upgrade threshold) -> unsafe evidence placeholder -> rank -> cap.
+ * Filter order (fixed): weak cluster -> quality suppression (overbroad / hash-title-only) ->
+ * open-proposal overlap -> hard suppression -> soft suppression (without upgrade threshold) ->
+ * unsafe evidence placeholder -> rank -> cap.
  *
  * Strip-only safe: no parameter properties, enums, or namespaces.
  */
@@ -56,6 +57,22 @@ const HARD_SUPPRESSION_UPGRADE_THRESHOLD = 2
 /** Number of new independent public-safe sources required to lift soft (deferred) suppression. */
 const SOFT_SUPPRESSION_UPGRADE_THRESHOLD = 1
 
+/**
+ * Cluster size (in unique sources) above which a candidate is decision-ready only if
+ * every member shares one specific non-empty `problem_type`. A cluster this large that
+ * lacks a single shared problem type is a broad cross-cutting grouping (e.g. generic
+ * best-practice/workflow docs sharing only module/tag tokens), not a reusable pattern.
+ */
+const OVERBROAD_CLUSTER_SIZE_THRESHOLD = 8
+
+/**
+ * Matches the neutral hash-title format `deriveLearningTitle` assigns to opened
+ * learning proposals (`Learning proposal: (<shortSha>)`). A title in this shape carries
+ * no human-readable correction substance until the proposal is codified into a solution
+ * doc or given a stronger semantic title.
+ */
+const HASH_ONLY_LEARNING_TITLE_PATTERN = /^learning proposal:\s*\([0-9a-f]{6,40}\)$/u
+
 // ---------------------------------------------------------------------------
 // Domain types
 // ---------------------------------------------------------------------------
@@ -95,6 +112,8 @@ export interface PatternPlannerCounts {
   invalidSource: number
   noOp: number
   failed: number
+  /** Overbroad or weak-signal clusters suppressed before ranking (never suppression state). */
+  qualitySuppressed: number
 }
 
 /** Result of `planPatternCandidates`. */
@@ -234,6 +253,34 @@ function buildRawClusters(sources: PatternCandidateSource[]): PatternCandidateSo
 // ---------------------------------------------------------------------------
 // Score bucket + evidence strength ranking
 // ---------------------------------------------------------------------------
+
+/**
+ * Reject candidates whose evidence is broad/generic or whose sources carry no
+ * human-readable correction substance yet, even though clustering merged them.
+ *
+ * Two deterministic rules, either of which disqualifies a candidate:
+ * 1. Overbroad: cluster size exceeds `OVERBROAD_CLUSTER_SIZE_THRESHOLD` and the sources
+ *    do not all share one specific non-empty `problem_type` — a large cluster held
+ *    together only by scattered module/tag/title-token overlap is a generic grouping,
+ *    not a decision-ready recurring pattern.
+ * 2. Hash-title learning proposals: more than half the cluster's sources are
+ *    learning-proposal issues whose title is still the neutral `Learning proposal:
+ *    (<shortSha>)` placeholder — these carry no human-readable signal until codified
+ *    into a solution doc or retitled.
+ */
+function isLowQualityCandidate(sources: PatternCandidateSource[]): boolean {
+  if (sources.length > OVERBROAD_CLUSTER_SIZE_THRESHOLD) {
+    const problemTypes = new Set(sources.map(s => s.signals.problemType).filter(t => t !== ''))
+    if (problemTypes.size !== 1) return true
+  }
+
+  const hashTitleCount = sources.filter(
+    s => s.kind === 'learning-proposal' && HASH_ONLY_LEARNING_TITLE_PATTERN.test(s.title.trim().toLowerCase()),
+  ).length
+  if (hashTitleCount > sources.length / 2) return true
+
+  return false
+}
 
 function scoreBucketFor(sources: PatternCandidateSource[]): PatternCandidateScoreBucket {
   const uniqueSourceCount = new Set(sources.map(s => s.id)).size
@@ -396,8 +443,9 @@ export interface PlanPatternCandidatesInput {
  * Build deterministic cluster candidates from source artifacts and decide which
  * candidates may proceed to the agent drafting step.
  *
- * Filter order (fixed): weak cluster -> open-proposal overlap -> hard suppression ->
- * soft suppression (without upgrade threshold) -> unsafe evidence placeholder -> rank -> cap.
+ * Filter order (fixed): weak cluster -> quality suppression (overbroad / hash-title-only) ->
+ * open-proposal overlap -> hard suppression -> soft suppression (without upgrade threshold) ->
+ * unsafe evidence placeholder -> rank -> cap.
  *
  * Pure function: no I/O, no side effects.
  */
@@ -416,6 +464,7 @@ export function planPatternCandidates(input: PlanPatternCandidatesInput): Patter
     invalidSource: 0,
     noOp: 0,
     failed: 0,
+    qualitySuppressed: 0,
   }
 
   // Accepted proposals immediately retire their source IDs from active clustering.
@@ -439,10 +488,19 @@ export function planPatternCandidates(input: PlanPatternCandidatesInput): Patter
     }
   })
 
+  const afterQualityFilter: PatternCandidate[] = []
+  for (const candidate of builtCandidates) {
+    if (isLowQualityCandidate(candidate.sources)) {
+      counts.qualitySuppressed += 1
+      continue
+    }
+    afterQualityFilter.push(candidate)
+  }
+
   const closedRecords = resolveClosedSuppressionRecords(input.existing)
 
   const afterOpenOverlap: PatternCandidate[] = []
-  for (const candidate of builtCandidates) {
+  for (const candidate of afterQualityFilter) {
     const openMatches = input.existing.openByFingerprint.get(candidate.fingerprint)
     const candidateIds = new Set(candidate.sourceIds)
     let overlapsOpen = openMatches !== undefined && openMatches.length > 0
@@ -546,7 +604,8 @@ export function planPatternCandidates(input: PlanPatternCandidatesInput): Patter
     counts.hardSuppressed === 0 &&
     counts.softSuppressed === 0 &&
     counts.unsafe === 0 &&
-    counts.lowSignal === 0
+    counts.lowSignal === 0 &&
+    counts.qualitySuppressed === 0
   ) {
     counts.noOp = 1
   }
@@ -656,6 +715,7 @@ export interface PatternDetectResult {
   candidatesEmitted: number
   tokenLoadFailure: boolean
   scanFailure: boolean
+  qualitySuppressed: number
 }
 
 /** Result of loading solution-doc files from disk: contents plus unreadable-file count. */
@@ -785,6 +845,7 @@ async function main(): Promise<void> {
     candidatesEmitted: 0,
     tokenLoadFailure: false,
     scanFailure: false,
+    qualitySuppressed: 0,
   }
 
   let digestCandidates: PatternCandidateDigest[] = []
@@ -839,13 +900,15 @@ async function main(): Promise<void> {
       plan.counts.duplicateOpenOverlap +
       plan.counts.hardSuppressed +
       plan.counts.softSuppressed +
-      plan.counts.unsafe
+      plan.counts.unsafe +
+      plan.counts.qualitySuppressed
     result.lowSignalSkipped = plan.counts.lowSignal
     result.duplicateOpenOverlap = plan.counts.duplicateOpenOverlap
     result.hardSuppressed = plan.counts.hardSuppressed
     result.softSuppressed = plan.counts.softSuppressed
     result.unsafe = plan.counts.unsafe
     result.capped = plan.counts.capped
+    result.qualitySuppressed = plan.counts.qualitySuppressed
     result.candidatesEmitted = plan.candidates.length
 
     digestCandidates = plan.candidates.map(candidate =>

--- a/scripts/capture-patterns-workflow.test.ts
+++ b/scripts/capture-patterns-workflow.test.ts
@@ -190,6 +190,11 @@ describe('capture-patterns.yaml workflow contract', () => {
     expect(uploadStep?.with?.['retention-days']).toBe(1)
   })
 
+  it('the detect summary reports candidate quality suppression separately from low-signal skips', () => {
+    expect(raw).toContain('Quality-suppressed')
+    expect(raw).toContain('.qualitySuppressed // 0')
+  })
+
   it('never echoes digest/body file contents or the write token into logs', () => {
     const suspiciousPatterns = [
       /echo.*CAPTURE_PATTERNS_DIGEST_PATH/u,


### PR DESCRIPTION
## Summary

Tightens Capture Patterns signal quality after the first accepted proposal cycle.

The post-acceptance dry-run showed the accepted sources suppress correctly, but two weak candidates still reached the digest: one overbroad 36-source cluster and one 27-source cluster made mostly of hash-title learning proposals. This change suppresses those before agent drafting.

## What changed

- Suppresses overbroad clusters that exceed the focused-pattern threshold without sharing a specific problem type.
- Suppresses clusters where most evidence comes from hash-title learning proposals without useful human-readable substance.
- Reports `qualitySuppressed` separately in detect JSON and the workflow summary.
- Keeps legitimate high-evidence clusters with a shared problem type eligible.

## Verification

- Local detect after #3667: `2` candidates scanned, `2` quality-suppressed, `0` emitted
- `pnpm bootstrap && pnpm check-types && pnpm lint && pnpm test`
- `actionlint .github/workflows/capture-patterns.yaml`