### PR TITLE
feat: self-improvement metric loop (discovery + recidivism)

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -65,3 +65,6 @@ labels:
   - name: pattern-proposal:superseded
     color: '#cfd3d7'
     description: Pattern proposal superseded by a newer proposal
+  - name: improvement-metrics-report
+    color: '#0e8a16'
+    description: Improvement-metric loop report tracking event -> codified-class edges

--- a/.github/workflows/improvement-metrics.yaml
+++ b/.github/workflows/improvement-metrics.yaml
@@ -65,14 +65,17 @@ jobs:
       # Compute the event -> codified-class edge digest and write it to
       # IMPROVEMENT_METRICS_DIGEST_PATH. Writing the file directly avoids the
       # shell-injection vector of echoing structured data via GITHUB_OUTPUT.
+      # Do NOT tee stdout into this same path: the script's own stdout is a
+      # different flat DetectResult shape (no `digest`/`edges` wrapper) than
+      # the file it writes via writeImprovementMetricsDigestFile, and tee
+      # would clobber the file with stdout after the script's write.
       - name: 🔍 Detect improvement-metric edges
         id: detect
         env:
           GITHUB_TOKEN: ${{ github.token }}
           IMPROVEMENT_METRICS_DIGEST_PATH: ${{ runner.temp }}/improvement-metrics-digest.json
-        # pipefail: a failure in `node ...` must fail this step even though `tee`
-        # (the last command in the pipe) exits 0.
-        run: node scripts/improvement-metrics-detect.ts | tee "$RUNNER_TEMP/improvement-metrics-digest.json"
+        # pipefail retained even without a pipe, for consistency with the report step.
+        run: node scripts/improvement-metrics-detect.ts
         shell: bash -Eeuo pipefail {0}
 
       - name: 📤 Upload digest artifact

--- a/.github/workflows/improvement-metrics.yaml
+++ b/.github/workflows/improvement-metrics.yaml
@@ -1,0 +1,192 @@
+---
+name: Improvement Metrics
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry-run mode: compute the digest but do not write the report issue'
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+# Default permissions: read-only. The report job overrides to issues: write, and only
+# when a live (non-dry-run) manual dispatch explicitly requests it.
+permissions:
+  contents: read
+
+# Serialize runs; never cancel an in-progress run so a detect-to-report sequence is
+# never interrupted halfway through.
+concurrency:
+  group: improvement-metrics
+  cancel-in-progress: false
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Detect job: read-only event/class collection and digest computation.
+  # No write credentials; no issue mutations. Requires full git history to
+  # compute solution-doc add-dates, unlike other workflows in this repo.
+  # ---------------------------------------------------------------------------
+  detect:
+    name: Detect improvement-metric edges
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: read
+
+    steps:
+      - name: ⤵ Checkout Branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history required: the detect script computes solution-doc
+          # add-dates from git log, not just the tip commit.
+          fetch-depth: 0
+
+      - name: 📦 Setup
+        uses: ./.github/actions/setup
+
+      # Overlay metadata/ from the data branch so the privacy gate reads the
+      # authoritative private-repo list from metadata/repos.yaml. Best-effort;
+      # `loadPrivateTokensFromDisk()` is the fail-closed chokepoint downstream.
+      - name: ⤵ Overlay metadata from data branch
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code origin data >/dev/null 2>&1; then
+            git fetch --no-tags origin data
+            git checkout origin/data -- metadata/
+          else
+            echo "data branch not yet established; skipping metadata overlay."
+          fi
+
+      # Compute the event -> codified-class edge digest and write it to
+      # IMPROVEMENT_METRICS_DIGEST_PATH. Writing the file directly avoids the
+      # shell-injection vector of echoing structured data via GITHUB_OUTPUT.
+      - name: 🔍 Detect improvement-metric edges
+        id: detect
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          IMPROVEMENT_METRICS_DIGEST_PATH: ${{ runner.temp }}/improvement-metrics-digest.json
+        # pipefail: a failure in `node ...` must fail this step even though `tee`
+        # (the last command in the pipe) exits 0.
+        run: node scripts/improvement-metrics-detect.ts | tee "$RUNNER_TEMP/improvement-metrics-digest.json"
+        shell: bash -Eeuo pipefail {0}
+
+      - name: 📤 Upload digest artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: improvement-metrics-digest
+          # Digest fields are counts-only + fingerprint edges (public-safe).
+          # No private tokens.
+          path: ${{ runner.temp }}/improvement-metrics-digest.json
+          retention-days: 1
+
+      - name: 📋 Write detect summary
+        if: always()
+        run: |
+          set -euo pipefail
+          result="$RUNNER_TEMP/improvement-metrics-digest.json"
+
+          {
+            echo "## Improvement Metrics Detect Summary"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+
+            if [[ -s "$result" ]]; then
+              echo "| Token-load failure | $(jq -r 'if .digest.tokenLoadFailure then "true" else "false" end' "$result") |"
+              echo "| Git-history unavailable | $(jq -r 'if .digest.gitHistoryUnavailable then "true" else "false" end' "$result") |"
+              echo "| Edges emitted | $(jq '.edges | length' "$result") |"
+              echo "| Report state | $(jq -r '.digest.state // "unknown"' "$result") |"
+            else
+              echo "| Status | (detect result unavailable) |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
+  # Report job: deterministic upsert of the perpetual improvement-metrics
+  # report issue. No agent step — the report body is fully deterministic.
+  # Dry-run (the default) skips this job entirely; the detect summary is the
+  # dry-run signal.
+  # ---------------------------------------------------------------------------
+  report:
+    name: Upsert improvement-metrics report issue
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: detect
+    # Skip the entire job on dry-run (the default): the report issue is only
+    # ever upserted on an explicit live (dry_run=false) manual dispatch.
+    # `always()` keeps the job eligible even if the detect job's non-critical
+    # steps report a failure state, without gating on detect's own conclusion.
+    if: ${{ always() && github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false' }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: ⤵ Checkout Branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: 📦 Setup
+        uses: ./.github/actions/setup
+
+      - name: 📥 Download digest artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: improvement-metrics-digest
+          path: ${{ runner.temp }}
+
+      # Mint a scoped app token only for an explicit live (non-dry-run) manual
+      # dispatch. Dry-run runs (the default) never mint this token and never
+      # mutate issues.
+      - name: 🔑 Mint write token
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false' }}
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          # Scope to this repo only — smallest blast radius.
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-contents: read
+
+      # Deterministic report step: reads the digest, upserts the perpetual
+      # improvement-metrics report issue (static title, hidden version marker,
+      # per-edge checklist). No agent step — the report is fully deterministic.
+      - name: 📬 Upsert improvement-metrics report issue
+        id: report
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          IMPROVEMENT_METRICS_DIGEST_PATH: ${{ runner.temp }}/improvement-metrics-digest.json
+          IMPROVEMENT_METRICS_RESULT_PATH: ${{ runner.temp }}/improvement-metrics-result.json
+        # pipefail: a failure in `node ...` must fail this step even though `tee`
+        # (the last command in the pipe) exits 0.
+        run: node scripts/improvement-metrics-report.ts | tee "$RUNNER_TEMP/improvement-metrics-result.json"
+        shell: bash -Eeuo pipefail {0}
+
+      - if: always()
+        name: 📋 Write report summary
+        run: |
+          set -euo pipefail
+          result="$RUNNER_TEMP/improvement-metrics-result.json"
+
+          {
+            echo "## Improvement Metrics Report Summary"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+
+            if [[ -s "$result" ]]; then
+              echo "| Outcome | $(jq -r '.outcome // "none"' "$result") |"
+              echo "| Token-load failure | $(jq -r 'if .tokenLoadFailure then "true" else "false" end' "$result") |"
+              echo "| Digest-read failure | $(jq -r 'if .digestReadFailure then "true" else "false" end' "$result") |"
+            else
+              echo "| Status | (report result unavailable) |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Fro Bot control plane:
 | **Dispatch Renovate** | Dispatch Renovate runs across repos tracked in `metadata/renovate.yaml` | Every 4 hours at `:30`, dispatch |
 | **Gateway Rollout Tracker** | Track and report on gateway rollout status across managed repos | Schedule, dispatch |
 | **Status Truth** | Detect drift in typed public coordination claims and manage proposal issues with counts-only summaries | Sunday 21:00 UTC, dispatch |
+| **Improvement Metrics** | Measure whether recurring fixes actually decline: discovery, confirmed recidivism, and a pending-confirmation backlog on one perpetual report issue | Manual dispatch |
 | **Reset Survey Status** | Manually clear stale survey state for one or more tracked repos on `data` | Manual dispatch |
 | **Wiki Lint** | Lint the authoritative wiki snapshot restored from `origin/data` | Sunday 20:00 UTC, dispatch |
 
@@ -362,6 +363,33 @@ Apply exactly one outcome label to record your decision:
 A closed proposal without one of these labels is `needs-outcome` — a derived state, not an operator label, that conservatively suppresses re-proposal of the same sources until new independent evidence appears.
 
 **Caps and evidence:** at most three new proposals open per run, ranked by independent source count, accepted-doc presence, and recency. Deterministic scripts own source loading, deduplication, suppression, privacy gating, and issue mutations; the agent only judges evidence and drafts bounded proposal bodies from a curated, privacy-gated digest — it never edits repo files, reads raw solution text, or receives private tokens.
+
+### Improvement Metrics
+
+None of the loops above answer the one question that actually matters: does the same class of fix keep coming back? The **Improvement Metrics** workflow measures that directly, as one paired reading rewritten to a single perpetual report issue each run.
+
+**What it measures:**
+
+- **Discovery** — distinct classes of fix newly codified into `docs/solutions/` in the current window. A class only counts once, on first codification; repeated proposals for something already documented never re-count.
+- **Confirmed recidivism** — codified classes that recurred, where a human confirmed the recurrence. Fro Bot never confirms its own findings.
+- **Backlog** — candidate recurrences it has detected but you haven't confirmed yet, with the oldest one's age. A growing, aging backlog is the loop calling out its own neglect, not a clean read.
+
+**Confirming a recurrence:**
+
+Each candidate `(event → class)` link is its own checklist line on the report issue. Tick the box to confirm it recurred. The tick persists across every future rewrite — the report is upserted in place by a hidden version marker, and any edge still present in a later run keeps whatever tick state you gave it. Nothing you confirm gets silently reset by the next run.
+
+**Running it:**
+
+`workflow_dispatch` only, no schedule. `dry_run` defaults to `true` — a dry run computes and logs counts but touches nothing. Set `dry_run` to `false` to actually create or update the report issue.
+
+**Report states**, one per run, never a blend:
+
+| State | Meaning |
+| --- | --- |
+| `insufficient-signal` | Too little codified history or discovery this window to say anything — no trend claimed |
+| `healthy` | Discovery holding or rising, confirmed recidivism low relative to discovery |
+| `ambiguous` | Discovery fell from the prior window, or the backlog has gone stale — not a claim of improvement or regression |
+| `failing` | Confirmed recidivism has caught up to or passed discovery — the same classes are recurring as fast as new ones get codified |
 
 ### Cross-Repo Goal Dispatch
 

--- a/docs/brainstorms/2026-07-09-o8-improvement-metric-requirements.md
+++ b/docs/brainstorms/2026-07-09-o8-improvement-metric-requirements.md
@@ -1,0 +1,168 @@
+---
+date: 2026-07-09
+topic: o8-improvement-metric
+---
+
+# O8 — Self-Improvement Metric
+
+## Summary
+
+Add a report-only metric loop that answers whether Fro Bot's self-improvement loops actually reduce repeated work. Each run recomputes two paired numbers — how many distinct new classes got codified in the window (discovery), and how many already-codified classes recurred anyway (recidivism) — and rewrites one perpetual report issue. Recidivism links are proposed by the loop but count only after a human confirms them, and the report renders a fixed set of states so the number can never quietly read as success.
+
+---
+
+## Problem Frame
+
+Fro Bot now runs several self-improvement loops: A1 learning capture opens `learning-proposal` issues, C4 pattern synthesis opens `pattern-proposal` issues with accept/reject/defer/supersede outcomes, and Status Truth opens drift proposals. Each loop already emits counts of what it did. C4's requirements doc closed by forbidding the loop from claiming improvement (R21) and handed that measurement to "the O8 metric slice."
+
+What no existing count answers: is the same class of fix, finding, or lesson still recurring, and is that recurrence trending down? A metric that merely re-aggregates the loops' own output counts would add a scoreboard without adding judgment — the same "fake insight" failure C4 warned about, one tier up. The cost of getting this wrong is a vanity number that looks like progress while repeated work continues unmeasured — or worse, a number that reads clean precisely because nobody maintains it.
+
+---
+
+## Actors
+
+- A1. Marcus: reads the O8 report, confirms or rejects candidate recurrence links, and decides what the paired reading means for action.
+- A2. O8 metric loop: scans the structured source set, computes the discovery and recidivism halves, proposes candidate recurrence links, renders a fixed report state, and rewrites the report issue each run.
+- A3. Existing proposal loops (A1 capture, C4 synthesis, Status Truth): emit the proposal issues and outcomes O8 reads; their labels and markers are O8 inputs.
+- A4. `docs/solutions/` corpus: the canonical codified-class anchor that recidivism links point back to; accepted `pattern-proposal` issues are supporting evidence, not anchors.
+
+---
+
+## Key Flows
+
+- F1. Metric recompute run
+  - **Trigger:** Manual `workflow_dispatch` (dry-run default), same posture as C4.
+  - **Actors:** A2, A3, A4
+  - **Steps:** Scan the structured source set over the window; count distinct newly-codified classes (discovery); recompute confirmed recidivism from human-confirmed markers; detect new candidate links; compute the prior-window delta over immutable timestamps; select the report state; rewrite the perpetual report issue.
+  - **Outcome:** One report issue shows discovery, confirmed recidivism, the pending-candidate backlog, the report state, and the prior-window delta.
+  - **Covered by:** R1, R2, R3, R4, R9, R10, R12, R13, R14
+
+- F2. Recidivism link confirmation
+  - **Trigger:** O8 surfaces a candidate link ("this new event looks like codified class X") in the report.
+  - **Actors:** A1, A2
+  - **Steps:** Marcus reviews the candidate; if it is a real recurrence he applies the fixed-vocabulary confirm marker; the next run reads that marker and counts the link as confirmed recidivism.
+  - **Outcome:** Only human-confirmed links move the recidivism number; unconfirmed candidates stay in the visible pending backlog.
+  - **Covered by:** R5, R6, R7, R8, R11
+
+- F3. State-selection rendering
+  - **Trigger:** A run has computed its measures and backlog.
+  - **Actors:** A2
+  - **Steps:** Apply the deterministic state rules — insufficient-signal below minimum volume; ambiguous on a falling discovery rate; healthy/failing per the paired reading; flag a stale pending backlog as a warning regardless of state.
+  - **Outcome:** The report renders one of a fixed set of states and cannot be misread as improvement caused by silence.
+  - **Covered by:** R15, R16, R17, R18
+
+---
+
+## Requirements
+
+**Metric definition**
+- R1. O8 must report two paired measures per run: discovery (the count of distinct classes first codified in the window) and recidivism (the count of already-codified classes that recurred anyway), presented together as one reading.
+- R2. Discovery must count a class only on its first codification; it must not re-count an existing class from repeated proposals, and it must not treat a C4 recurrence assertion as discovery unless that class is newly codified in the window.
+- R3. O8 must show the prior-window delta for each measure, computed only from immutable event timestamps and stable class identity, so a run is situated against the immediately prior window without building a general time-series store.
+
+**Source set and anchor**
+- R4. O8 must derive discovery and recidivism only from structured public artifacts in this repo: `learning-proposal` issues, `pattern-proposal` issues with their outcome labels, Status Truth proposals, and the `docs/solutions/` corpus.
+- R5. The canonical codified-class anchor is the `docs/solutions/` corpus; accepted `pattern-proposal` issues are supporting evidence for a candidate link, never a second anchor, so a recurrence is counted against exactly one codified class.
+- R6. O8 must not mine raw agent transcripts, workflow logs, autoheal fix-PR frequency, review-churn cycles, private-only artifacts, or cross-repo issue bodies as inputs in this slice.
+
+**Recidivism link lifecycle**
+- R7. A recidivism count must include a link only after a human confirms that a new event is a recurrence of a codified class; O8 must never self-confirm a link.
+- R8. O8 must detect and surface candidate recurrence links for human review, doing the work of spotting likely recurrences without asserting them.
+- R9. Confirmation must be a fixed-vocabulary marker (a label or checklist toggle) on the report issue or the candidate's own issue, re-readable by a later run — no freeform confirmation text is read by O8, and no bespoke confirmation store is introduced.
+
+**Output surface**
+- R10. O8 must maintain a single perpetual report issue, rewriting it each run with the current measures, prior-window delta, report state, and the pending-candidate backlog; it must not open a new issue per run.
+- R11. O8 must be report-only: it must not author or modify `docs/solutions/` documents, prompts, personas, skills, workflow instructions, or any proposal loop's logic.
+- R12. O8 must run on manual dispatch with a dry-run default, matching the existing proposal loops' operational posture.
+- R13. O8 must recompute both measures from source history and confirmation markers each run, introducing no new durable metric store in this slice.
+
+**Honesty guards**
+- R14. The report must state the window and the source counts behind each measure so a reader can see what produced the number.
+- R15. The report must render exactly one of a fixed set of states — `insufficient-signal`, `ambiguous`, `healthy`, `failing` — selected by deterministic rules, rather than free-form prose that different runs could phrase inconsistently.
+- R16. Below a minimum volume of discovery events and codified anchors in the window, the report must render `insufficient-signal` and must not present any paired interpretation or trend claim.
+- R17. The pending-candidate backlog must be a first-class count in the report, showing the number of unconfirmed candidates and the age of the oldest; a backlog older than a staleness threshold must raise a visible warning so an unmaintained metric cannot read as `0 recidivism`.
+- R18. A falling discovery rate must render as `ambiguous` — it may mean fewer repeats or a quieter/degraded loop — and must never be rendered as improvement on its own; O8 must make no claim that Fro Bot is measurably improving.
+
+**Public-output safety**
+- R19. Every report body must pass the same deterministic public-output/private-token gate the existing proposal loops use, with the same fail-closed policy: any gate failure blocks the post, with no advisory-only fallback.
+- R20. Candidate and evidence text must be public-safe by construction — built only from a class key, a public issue URL, or a fixed label — with a denylist for source issue titles, body excerpts, branch names, repo names, and quoted snippets, so aggregation across sources cannot re-identify a private origin.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R3.** Given a window with two newly-codified classes and repeated proposals for an already-codified class, when O8 runs, discovery counts two (not the repeat proposals), recidivism reflects only confirmed recurrences, and each measure shows its prior-window delta.
+- AE2. **Covers R7, R8, R17.** Given a new `learning-proposal` that resembles a codified class, when O8 runs, it lists the candidate as pending, the recidivism count does not rise until a human confirms it, and the pending backlog count and oldest-candidate age appear in the report.
+- AE3. **Covers R9, R13.** Given a candidate a human confirmed in a prior run via the fixed marker, when O8 runs again, it recomputes that link as confirmed recidivism from the marker without reading any private store.
+- AE4. **Covers R5.** Given a recurrence whose codified class has both a `docs/solutions/` doc and an accepted `pattern-proposal`, when O8 counts it, it counts against the solution doc once and treats the accepted pattern as evidence, not as a second anchor.
+- AE5. **Covers R15, R16.** Given a window below the minimum volume, when O8 renders, the report state is `insufficient-signal` and presents no trend interpretation.
+- AE6. **Covers R17, R18.** Given a window where discovery fell to zero while unconfirmed candidates remain, when O8 renders, the state is `ambiguous`, the stale backlog raises a warning, and nothing reads as improvement.
+- AE7. **Covers R11, R18.** Given any run, when the report is written, it changes no solution doc, prompt, persona, skill, or workflow, and makes no claim that Fro Bot is improving.
+- AE8. **Covers R19, R20.** Given a candidate whose only distinguishing evidence is a private identifier, when the report body is rendered, that evidence is omitted, the text is built only from public-safe keys/URLs, and the public-output gate passes.
+
+---
+
+## Success Criteria
+
+- Marcus can read one report issue and tell whether repeated work is trending down, and whether the metric is being maintained, without reconstructing history from the underlying proposal issues.
+- The recidivism number reflects only human-confirmed recurrences, and an unmaintained confirm backlog is visible rather than masquerading as zero recidivism.
+- A falling discovery rate and a low-volume window each render a distinct, non-improvement state.
+- The report contains no private identifiers, raw logs, or transcript content, even under aggregation across sources.
+- A downstream planner can implement the loop from this doc without inventing what the measures mean, which single anchor defines a codified class, how a link becomes confirmed, or the state-selection rules.
+
+---
+
+## Scope Boundaries
+
+### Deferred for later
+
+- Mining autoheal fix-PR frequency and review-churn / re-review cycles as additional repeated-work signal — real toil signal, deferred until the structured half is proven.
+- A durable committed metrics file (e.g., on the `data` branch) and any time-series beyond the prior-window delta — revisit only if recompute-from-history proves insufficient.
+- Any operator-web or dashboard surfacing of the metric — the north-star report-only boundary holds for this slice.
+- Automatic scheduling — v1 is manual dispatch until the report proves trustworthy.
+
+### Outside this product's identity
+
+- O8 measures; it does not act. Turning a measured regression into a fix is a separate action-graduation loop's job. O8 exists to inform that graduation decision, not to be a perpetual dashboard nobody acts on.
+- O8 does not re-aggregate the individual loops' own operational throughput counts; it measures recurrence across them, not their internal volume.
+
+---
+
+## Key Decisions
+
+- Paired reading over either half alone: discovery alone cannot distinguish healthy quiet from broken quiet; pairing it with recidivism disambiguates.
+- Proposal-confirm recidivism links over auto-inference: keeps the headline honest and mirrors C4's proposal-only posture one tier up; auto-fuzzy-linking would import the exact fake-insight risk C4 exists to avoid.
+- Single canonical anchor (`docs/solutions/`), patterns as evidence: prevents a recurrence being double-counted against two codified representations of the same class.
+- Discovery as first-codification, not proposal traffic: de-circularizes the measure so O8 does not count a detector's own recurrence assertions as fresh discovery.
+- Deterministic report states over prose: a fixed `insufficient-signal | ambiguous | healthy | failing` vocabulary makes the honesty guards testable and keeps runs comparable — the same closed-vocabulary discipline the codified-identifiers learning established.
+- Recompute-from-history over a new metric store: proposal issues and confirmation markers already hold the events, so no durable store is added and the privacy surface stays identical to C4 and Status Truth. Trend is bounded to the prior-window delta over immutable timestamps to stay stable under source edits.
+
+---
+
+## Dependencies / Assumptions
+
+- The A1 capture, C4 synthesis, and Status Truth proposal loops remain the source of events and keep their current labels and markers stable enough to query.
+- The reusable public-output gate `applyPublicOutputGate` / `makePublicOutputTokens` in `scripts/status-truth-public-output.ts` is available for reuse as the mandatory report-body validator (confirmed present; already reused by capture-patterns).
+- The `docs/solutions/` corpus remains the codified-class anchor, and accepted `pattern-proposal` issues remain visible as durable evidence.
+- Proposal-issue created-at timestamps and outcome labels are sufficient to compute the window and prior-window delta without a separate event store.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R2, R5][Technical] How is a codified class's identity keyed for matching — does it lean on `docs/solutions/` frontmatter (module/component/problem_type) as the class key, and how does a new event get matched to it as a candidate?
+- [Affects R8][Technical] What candidate-link detection heuristic best spots a likely recurrence without over-claiming, given confirmation stays human?
+- [Affects R9][Technical] Which fixed marker (issue label vs report-body checklist toggle) is the most durable, re-readable confirm gesture, and does it live on the report issue or the candidate's own issue?
+- [Affects R16, R17][Technical] What minimum-volume thresholds and backlog-staleness age produce meaningful states at current proposal volume?
+- [Affects R3][Technical] What window length balances cost against signal given current proposal volume?
+
+---
+
+## Sources / Research
+
+- North-star context: `docs/brainstorms/2026-06-15-fro-bot-personal-agent-north-star-requirements.md`
+- C4 predecessor that defers measurement to O8 (R21): `docs/brainstorms/2026-07-07-a1-recurring-pattern-synthesis-requirements.md`, `docs/plans/2026-07-07-004-feat-recurring-pattern-synthesis-plan.md`
+- Codified-class anchor and closed-vocabulary state precedent: `docs/solutions/best-practices/closed-vocabulary-identifiers-for-automated-inspection-2026-07-09.md`
+- Reusable public-output gate and source-query machinery: `scripts/status-truth-public-output.ts`, `scripts/capture-patterns-cluster.ts`, `scripts/capture-learnings-harvest.ts`, `scripts/status-truth-proposals.ts`

--- a/docs/plans/2026-07-09-001-feat-improvement-metric-loop-plan.md
+++ b/docs/plans/2026-07-09-001-feat-improvement-metric-loop-plan.md
@@ -1,0 +1,365 @@
+---
+title: "feat: self-improvement metric loop (discovery + recidivism)"
+type: feat
+status: complete
+date: 2026-07-09
+origin: docs/brainstorms/2026-07-09-o8-improvement-metric-requirements.md
+---
+
+# feat: self-improvement metric loop (discovery + recidivism)
+
+## Overview
+
+Add a report-only metric loop that measures whether Fro Bot's self-improvement loops actually reduce repeated work. Each run recomputes two paired numbers over a window — discovery (distinct classes newly codified) and recidivism (codified classes that recurred and a human confirmed) — plus a pending-candidate backlog, then rewrites one perpetual public report issue with a fixed report state. The report issue is also the confirmation surface: each candidate recurrence is a checklist line the operator ticks, and O8 preserves and re-reads that checkbox state across rewrites. It clones the proven Capture Patterns two-job workflow shape (manual dispatch, dry-run default, scoped token, reusable public-output gate) and drops the agent step, since the render is deterministic.
+
+## Problem Frame
+
+Fro Bot runs several self-improvement loops (learning capture, pattern synthesis, Status Truth drift) that each emit counts of what they did. None answers whether the same class of fix/finding/lesson keeps recurring, or whether that recurrence is trending down. The Capture Patterns requirements doc closed by forbidding that loop from claiming improvement and handed measurement to this slice (see origin: `docs/brainstorms/2026-07-09-o8-improvement-metric-requirements.md`). The risk this plan guards against is a vanity number — a report that reads clean because nobody maintains it, or because a metric derived from mutable history quietly rewrites its own past.
+
+## Requirements Trace
+
+- R1. Report discovery and recidivism as one paired reading per run.
+- R2. Discovery counts a class only on first codification; never re-counts from repeated proposals; a pattern recurrence assertion is not discovery unless newly codified in the window.
+- R3. Show the prior-window delta for each measure, computed only from immutable timestamps and stable class identity.
+- R4. Derive only from `learning-proposal` / `pattern-proposal` (with outcome labels) / Status Truth proposals / `docs/solutions/`.
+- R5. Canonical codified-class anchor is `docs/solutions/`; accepted `pattern-proposal` issues are evidence, never a second anchor.
+- R6. No mining of transcripts, logs, autoheal PR frequency, review-churn, private-only artifacts, or cross-repo bodies.
+- R7. Recidivism counts a link only after a human confirms; O8 never self-confirms.
+- R8. Detect and surface candidate recurrence links for review without asserting them.
+- R9. Confirmation is a fixed-vocabulary gesture re-readable by a later run; no freeform text read; no bespoke store.
+- R10. Maintain a single perpetual report issue, rewritten each run; never one issue per run.
+- R11. Report-only: change no solution docs, prompts, personas, skills, workflow instructions, or any loop's logic.
+- R12. Manual dispatch, dry-run default.
+- R13. Recompute both measures from source history and confirmation gestures each run; no new durable metric store.
+- R14. State the window and source counts behind each measure.
+- R15. Render exactly one fixed state: `insufficient-signal` / `ambiguous` / `healthy` / `failing`, selected deterministically.
+- R16. Below minimum volume, render `insufficient-signal` with no interpretation or trend claim.
+- R17. Pending backlog is a first-class count with oldest-candidate age; a stale backlog raises a visible warning.
+- R18. A falling discovery rate renders `ambiguous`, never improvement; make no measurable-improvement claim.
+- R19. Reuse the deterministic public-output gate with fail-closed policy; no advisory-only fallback.
+- R20. Candidate/evidence text is public-safe by construction (class key, public issue URL, fixed marker only); denylist source titles, body excerpts, branch/repo names, quoted snippets.
+
+## Scope Boundaries
+
+- No autoheal-PR-frequency or review-churn mining (deferred).
+- No durable committed metrics file and no time-series beyond the single prior-window delta.
+- No operator-web/dashboard surfacing.
+- No automatic scheduling — manual dispatch only in v1.
+- No LLM/agent step — the report is deterministically rendered.
+- O8 measures only; it does not act on regressions or edit any loop.
+
+### Deferred to Separate Tasks
+
+- Graduating the highest-recurring class into an action loop: future slice — O8 exists to inform that decision, not perform it.
+- Multi-class disambiguation when one proposal plausibly maps to several codified classes: v1 surfaces every over-threshold `(event → class)` edge as its own checklist line and lets the operator confirm each independently; a smarter single-best ranking is a later refinement.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- Two-job detect/open workflow with `dry_run` default `true`, `concurrency` no-cancel, scoped app-token mint (`repositories: ${{ github.event.repository.name }}`, `permission-issues: write`), artifact handoff via `*_DIGEST_PATH` env + `actions/upload|download-artifact`, `data`-branch metadata overlay: `.github/workflows/capture-patterns.yaml`. O8 mirrors this and **drops the agent step**; it additionally needs `fetch-depth: 0` on the detect checkout for git-history codification dates.
+- Pure vocabulary/markers/classification library (namespaced markers, closed outcome-label set, `parse(build(x))===x` round-trip, `classifyPatternProposalOutcome`): `scripts/capture-patterns-synthesis.ts`.
+- Detect entrypoint (pure core + I/O shell; `octokit.paginate(listForRepo,{labels,state:'all'})`; token-load-before-API fail-closed ordering; counts-only stdout JSON; `applyPublicOutputGate` on every source title): `scripts/capture-patterns-cluster.ts`. Its `computeSourceOverlapScore` is **not exported and assumes symmetric frontmatter on both sides**, which a proposal issue lacks — O8 does not reuse it; see Key Technical Decisions.
+- Open entrypoint (pure planning core + I/O shell; `ensure*LabelsExist` 404→create/422-idempotent; per-issue try/catch; fail-closed on unavailable label): `scripts/capture-patterns-open.ts`.
+- Reusable public-output gate: `scripts/status-truth-public-output.ts` — `applyPublicOutputGate({surface,...})` (closed `PublicOutputSurface` union; `fingerprint` must be `undefined` for counts-only surfaces), `makePublicOutputTokens`. Already reused by capture-patterns; O8 reuses unchanged.
+- Checklist live-state encoding + marker precedence (marker → visible field → sentinel), close-on-clear idempotency, stable fingerprint from immutable inputs: `scripts/status-truth-proposals.ts` (`recoverProposalKind`, `classifyProposalOutcome`, `checked-N-unchecked-M` live-state), `scripts/status-truth-detect.ts`. This is the pattern O8's checkbox-confirmation preservation reuses.
+- Same-run list-after-create staleness guard (in-memory created-ID `Set`): `scripts/reconcile-repos.ts` (`selfHealRollups`, `currentRunRollupOwners`).
+- Workflow-shape test style (pure YAML parse + per-contract `it` blocks, asserts perms/`if`/token boundary/no-`cat`-of-secrets/no internal taxonomy): `scripts/capture-patterns-workflow.test.ts`.
+
+### Institutional Learnings
+
+- Closed-vocabulary identifiers for automated inspection — enumerate at the boundary, normalize before rendering/deciding, share one classification pass: `docs/solutions/best-practices/closed-vocabulary-identifiers-for-automated-inspection-2026-07-09.md`, `docs/solutions/best-practices/closed-vocabulary-telemetry-keys-from-public-bodies-2026-07-03.md`.
+- Verify the whole public perimeter (issue body, title, run name, summary, logs, stdout, concurrency group all accounted for): `docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md`, `docs/solutions/security-issues/survey-workflow-side-privacy-gate-2026-05-16.md`.
+- Pure-core privacy gate in a shared module + mutation-proof test that exercises the real compose path and fails on bypass: `docs/solutions/best-practices/pure-core-privacy-gates-shared-module-2026-06-22.md`.
+- Observability before structural change — counts-only, derived, no persisted state, paired with an explicit revisit trigger: `docs/solutions/best-practices/observability-before-structural-change-2026-06-09.md`.
+- "Success with a zero counter" ≠ health — render insufficient-signal distinctly: `docs/solutions/runtime-errors/autonomous-pipeline-silent-failures-2026-04-19.md`.
+- Ground a signal-classifying heuristic in real state distributions, not fixtures: `docs/solutions/workflow-issues/classifying-github-review-events-for-iteration-signals-2026-06-22.md`.
+- Test the seam, not the endpoints — golden-path test drives the real compose path with real-shaped bodies: `docs/solutions/best-practices/test-the-integration-seam-not-the-endpoints-2026-07-06.md`.
+- Same-run GitHub Issues list-after-create is stale for seconds — carry a created-ID set if the report issue is ever rotated: `docs/solutions/best-practices/github-issues-api-same-run-eventual-consistency-2026-05-20.md`.
+
+## Key Technical Decisions
+
+- Clone Capture Patterns' workflow + script split, drop the agent step: O8's render is deterministic, so no LLM belongs in the loop. Lowest-risk path — reuses a proven, tested shape.
+- Canonical anchor is `docs/solutions/`; a codified class's identity key derives from its frontmatter (`module` / `component` / `problem_type`), matching the closed-vocabulary-identifiers learning. Accepted `pattern-proposal` issues are evidence, not anchors — a recurrence counts against exactly one solution doc.
+- **Codification timestamp = the git first-commit (add) date of the solution doc**, not frontmatter `date`. Review found frontmatter `date` is both mutable (an edit can silently move a class between windows and rewrite the trend) and non-universal (present on well under half the corpus). The git add-date is immutable and exists for every committed doc, which fixes the discovery-undercount blocker and the false "immutable trend" claim together. Requires `fetch-depth: 0` on the detect checkout and a single `git log --diff-filter=A` pass over `docs/solutions/`.
+- **O8-native candidate scorer over honestly-asymmetric signals.** The capture-patterns scorer assumes both sides carry `problem_type`/`module`/`tags`; a proposal issue carries only title/body/labels. O8 defines its own `scoreCandidateLink(event, class)` that matches the proposal's title/label tokens against the class's title/tag/module tokens — a deliberately weak recall signal, with the human confirm as the precision gate. It does not import the private capture-patterns function.
+- **Confirmation is an edge-keyed checklist on O8's own report issue, not a label on the proposal issue.** A bare label cannot preserve which class a proposal recurred against when several score over threshold (a one-bit label can't encode a many-to-one edge). Instead, O8 renders each candidate `(event → class)` edge as its own checklist line carrying a stable hidden edge fingerprint `hash(classKey + eventId)`; the operator ticks the specific edge; O8 re-reads its own report body next run, counts ticked edges as confirmed recidivism, and preserves tick state across rewrites via the status-truth `checked-N-unchecked-M` live-state pattern. This closes the loop on one surface (read the report, tick inline) and keeps the confirmed edge explicit and reproducible. Supersedes the brainstorm's proposal-issue-label gesture.
+- Perpetual report is upsert-by-marker: find the report issue by a fixed label, parse `<!-- improvement-metrics:report:version=N -->`, and rewrite the body in place, preserving operator tick-state for edges still present. If absent, create with a static title. This is the repo's first in-place body rewrite — isolated in its own unit and its own review surface.
+- Trend is bounded to a single prior-window delta over immutable timestamps (git add-date) + stable class identity, so source edits cannot silently rewrite history; a class whose anchor was deleted/renamed renders the run non-comparable rather than retroactively changing past numbers.
+- Fixed report-state union at the boundary; state selection is a deterministic function of the counts, the volume floor, the prior-window delta, and backlog staleness — never free-form prose.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Codified-class identity key: frontmatter `module`/`component`/`problem_type` (per the closed-vocabulary learning).
+- Codification date source: git first-commit (add) date of the doc (immutable, universal) — replaces frontmatter `date`.
+- Candidate-link heuristic: O8-native `scoreCandidateLink` over asymmetric signals (proposal title/labels vs class title/tags/module) with a strong-match minimum, not the capture-patterns scorer.
+- Confirm gesture: an edge-keyed checkbox on O8's report issue, tick-state preserved across rewrites; no proposal-issue labels, no freeform text.
+
+### Deferred to Implementation
+
+- Exact starting thresholds are seeded as tunable constants (window `90d`; `insufficient-signal` when window has `< 3` codified anchors or `< 2` discovery events; backlog-staleness warning when the oldest ticked-but-unconfirmed candidate `> 14d`; candidate surfacing requires score ≥ threshold AND ≥1 strong-field token match) — final values tuned against real corpus volume after first runs.
+- Exact helper/function names within each new module.
+- Whether `pattern-proposal:superseded` proposals are excluded from candidate detection (likely yes) — confirmed against real label distributions during implementation.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+Report-state selection (deterministic, evaluated in order):
+
+```
+inputs: anchors, discovery, priorDiscovery, confirmedRecidivism, pendingBacklog, oldestPendingAgeDays
+
+1. anchors < MIN_ANCHORS  OR  discovery < MIN_DISCOVERY      -> insufficient-signal
+2. confirmedRecidivism > 0 and >= discovery                  -> failing
+3. discovery < priorDiscovery  OR  oldestPendingAgeDays > STALE_AGE  -> ambiguous
+4. otherwise                                                 -> healthy
+(pendingBacklog count + oldestPendingAgeDays are ALWAYS rendered, in every state)
+```
+
+Data flow (deterministic, no agent):
+
+```
+detect:  solution docs (frontmatter identity + git add-date) + proposal issues (labels/markers)
+           + prior report body (operator tick-state)
+           -> classify each source once (shared pass)
+           -> discovery = distinct anchors whose git add-date is in window
+           -> candidates = scoreCandidateLink(newEvent, anchor) >= THRESHOLD and strong-match,
+                           one checklist line per (event -> class) edge, each with edge fingerprint
+           -> confirmedRecidivism = edges whose checkbox is ticked in the prior report body
+           -> backlog = surfaced edges not yet ticked, with oldest age
+           -> priorDiscovery = same over the immediately prior window (git dates, immutable)
+           -> select state -> counts-only digest JSON (+ edge list with fingerprints, no raw titles)
+report:  digest + prior report tick-state -> render public-safe body
+           (class keys + public issue URLs + edge checkboxes only)
+           -> applyPublicOutputGate(every surface) [fail-closed]
+           -> upsert perpetual report issue by marker/version, preserving ticked edges still present
+```
+
+## Implementation Units
+
+- [x] **Unit 1: Closed vocabulary, class identity, edge fingerprints, and markers (pure core)**
+
+**Goal:** The pure library every other unit imports: the fixed report-state union, the codified-class identity key, source-type classification, the `(event → class)` edge fingerprint, and the report-issue marker + checklist live-state build/parse with round-trip guarantees.
+
+**Requirements:** R2, R4, R5, R9, R15
+
+**Dependencies:** None
+
+**Files:**
+- Create: `scripts/improvement-metrics-core.ts`
+- Test: `scripts/improvement-metrics-core.test.ts`
+
+**Approach:**
+- Declare `REPORT_STATES = ['insufficient-signal','ambiguous','healthy','failing'] as const` and a recovery function that rejects any out-of-set string (never renders it).
+- Derive a codified-class identity key from solution-doc frontmatter (`module`/`component`/`problem_type`) with a sentinel segment for missing fields; define the source-type closed set (`learning-proposal`/`pattern-proposal`/`status-truth`) and a single classifier.
+- Edge fingerprint `buildEdgeFingerprint(classKey, eventId)` — stable hash over immutable inputs so an operator tick survives body rewrites and reordering.
+- Marker build/parse for `<!-- improvement-metrics:report:version=N -->` and the per-edge checklist encoding (a hidden `<!-- improvement-metrics:edge=<fp> -->` beside a `- [ ] ` / `- [x] ` line), plus a `checked-N-unchecked-M` summary parse mirroring status-truth. All fail-fast on bad input, `null` on absent/malformed.
+- Fixed report-issue label constant + descriptor row ready for `.github/settings.yml`.
+
+**Patterns to follow:**
+- `scripts/capture-patterns-synthesis.ts` (marker helpers, closed label sets, `parse(build(x))===x`).
+- `scripts/status-truth-proposals.ts` (`checked-N-unchecked-M` live-state encoding/parse).
+- Closed-vocabulary discipline: `docs/solutions/best-practices/closed-vocabulary-identifiers-for-automated-inspection-2026-07-09.md`.
+
+**Test scenarios:**
+- Happy path: build→parse the version marker and an edge checklist line round-trip; class-key derives stably from frontmatter regardless of field order; edge fingerprint stable across input reordering.
+- Edge case: missing/extra frontmatter field → deterministic key with a sentinel segment, never a throw.
+- Edge case: out-of-set report-state string → rejected, never rendered.
+- Edge case: checklist line with `[x]` vs `[ ]` parses to ticked/unticked; malformed checkbox → treated as unticked (fail-safe), never as ticked.
+- Error path: marker build with control chars/newlines → fail-fast; parse of absent marker → `null`.
+
+**Verification:** Core types and helpers importable; round-trip, closed-set, and tick-state tests green; no I/O in this module.
+
+- [x] **Unit 2: Detect — sources, discovery, recidivism, backlog, state (pure core + I/O shell)**
+
+**Goal:** The detect entrypoint: fetch the structured sources and the prior report tick-state, classify each once, compute discovery / confirmed-recidivism / backlog / prior-window delta / report state from immutable git dates, and emit a counts-only digest plus the edge list.
+
+**Requirements:** R1, R2, R3, R6, R7, R8, R16, R17, R18
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `scripts/improvement-metrics-detect.ts`
+- Test: `scripts/improvement-metrics-detect.test.ts`
+
+**Approach:**
+- Pure core `computeMetrics(input)` takes loaded solution-doc records (frontmatter identity + git add-date) + proposal issues (labels/markers) + prior report tick-state + `now` + tunable constants, returns the digest + edge list. Discovery = distinct anchors whose git add-date is in window. Candidates = `scoreCandidateLink(event, anchor) >= THRESHOLD` AND ≥1 strong-field token match, emitted one edge per `(event → class)` pair with its fingerprint. Confirmed-recidivism = edges whose fingerprint is ticked in the prior report tick-state. Backlog = surfaced edges not ticked, with oldest age from the event's created-at. Prior-window delta recomputed over the immediately prior window using git add-dates + issue created-at only (immutable).
+- `scoreCandidateLink` is O8-native and asymmetric: proposal title/label tokens vs class title/tag/module tokens.
+- Single shared classification pass feeds all counts. Deterministic state selection per the HTD ladder; `insufficient-signal` gated by `MIN_ANCHORS`/`MIN_DISCOVERY`; candidate surfacing suppressed entirely below the floor (prevents low-volume backlog flooding); backlog counts always populated otherwise.
+- I/O shell `main()`: token-load-before-API fail-closed ordering; `octokit.paginate(listForRepo,{labels,state:'all'})` per source label; load solution docs from disk; obtain git add-dates via one `git log --diff-filter=A --format` pass over `docs/solutions/` (needs `fetch-depth: 0`, provided by the workflow); read the prior report issue body for tick-state; write counts-only digest (+ fingerprint edge list, no raw titles) to `IMPROVEMENT_METRICS_DIGEST_PATH`; stdout = result JSON with `tokenLoadFailure`/`scanFailure`/`gitHistoryUnavailable` presence bits.
+- Constants seeded as named tunables: `WINDOW_DAYS=90`, `MIN_ANCHORS=3`, `MIN_DISCOVERY=2`, `STALE_AGE_DAYS=14`, `SCORE_THRESHOLD` + strong-match rule.
+
+**Execution note:** Implement the pure `computeMetrics` core test-first — it is the heart of the metric and every state boundary needs a failing test before the implementation.
+
+**Patterns to follow:**
+- `scripts/capture-patterns-cluster.ts` (pure core + shell split, token-load ordering, counts-only digest schema, fetch helpers).
+- Marker→visible→sentinel precedence + one shared classification pass: `scripts/status-truth-proposals.ts` (`recoverProposalKind`), `docs/solutions/best-practices/closed-vocabulary-telemetry-keys-from-public-bodies-2026-07-03.md`.
+- Ground the classifier in real label distributions: `docs/solutions/workflow-issues/classifying-github-review-events-for-iteration-signals-2026-06-22.md`.
+
+**Test scenarios:**
+- Happy path: two anchors with git add-date in-window + repeated proposals for one existing class → discovery counts 2, not the repeats (R2); a ticked edge raises recidivism, an unticked one does not (R7).
+- Edge case: window below floor (`<3` anchors or `<2` discovery) → state `insufficient-signal`, no candidates surfaced, no trend interpretation (R16).
+- Edge case: discovery below prior window, no confirmed recidivism → `ambiguous`, not improvement (R18).
+- Edge case: stale unticked candidate (`age > STALE_AGE_DAYS`) → backlog count + oldest-age surfaced and `ambiguous`/warning even when discovery healthy (R17).
+- Edge case: one event scores over threshold for two anchors → two independent edges surfaced, each separately tickable (no silent single-best collapse).
+- Edge case: frontmatter `date` differs from git add-date → discovery uses git add-date (immutability guard).
+- Error path: token load failure OR git history unavailable → empty digest, presence bit set, exit 0 (no partial counts).
+- Integration: a ticked edge fingerprint in the prior report body flows through read→classify→confirmed-recidivism count (mock octokit + prior body).
+
+- [x] **Unit 3: Public-safe report rendering + gate (pure)**
+
+**Goal:** Render the report body and workflow summary from the digest + edge list, public-safe by construction, and route every surface through the public-output gate fail-closed.
+
+**Requirements:** R14, R19, R20
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Create: `scripts/improvement-metrics-report.ts` (render functions only in this unit; upsert I/O added in Unit 4)
+- Test: `scripts/improvement-metrics-report.test.ts`
+
+**Approach:**
+- Pure `renderReportBody(digest, priorTickState)` and `renderRunSummary(digest)` emit counts, the window, source counts behind each measure, the report state, the backlog count + oldest age, and the candidate checklist. Each checklist line is built only from a class key, the event's public issue URL, and the edge checkbox+fingerprint — never a source title, body excerpt, or repo/branch name (R20 denylist enforced structurally: render functions receive the fingerprint edge list, not raw titles). Ticked edges still present are re-emitted as `[x]`.
+- Every rendered surface passes `applyPublicOutputGate({surface,...})` with `fingerprint: undefined` for the counts-only surfaces; any gate failure blocks the surface with no advisory fallback (R19).
+- Append the version marker via Unit 1's builder.
+
+**Patterns to follow:**
+- `scripts/capture-patterns-cluster.ts` `buildCandidateDigest` (gate every surfaced field; failed gate → withheld sentinel).
+- `scripts/status-truth-public-output.ts` gate usage; `docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md`.
+
+**Test scenarios:**
+- Happy path: a full digest renders a body containing counts, window, state, backlog, and a checklist with edge fingerprints; the version marker round-trips.
+- Edge case: `insufficient-signal` digest renders no trend/interpretation line and no candidate checklist.
+- Error path (mutation-proof): a digest carrying a private-identifier-shaped string in any field → the gate blocks that surface; test injects private prose and asserts the gate refuses (fails if the gate is bypassed).
+- Edge case: candidate render uses only class key + public URL + checkbox; assert no source title/body text appears in output.
+
+- [x] **Unit 4: Perpetual report upsert with tick-state preservation (I/O shell — net-new body rewrite)**
+
+**Goal:** Maintain the single perpetual report issue: find by label, decide create-vs-update by version marker, rewrite the body in place while preserving operator tick-state for edges still present — the repo's first `issues.update({body})`.
+
+**Requirements:** R10, R13
+
+**Dependencies:** Unit 1, Unit 3
+
+**Files:**
+- Modify: `scripts/improvement-metrics-report.ts` (add the upsert shell + `main()`)
+- Test: `scripts/improvement-metrics-report.test.ts` (extend)
+
+**Approach:**
+- `listForRepo({labels: report-issue-label, state:'open'})` → if found, parse the version marker and the prior tick-state, then `issues.update({issue_number, body})` with the freshly rendered body that re-emits still-present ticked edges as `[x]`; if the marker is at the current version and content is unchanged, no-op. If not found, `issues.create` with a **static title** (`Improvement Metrics`, never data-derived) after ensuring the report-issue label exists (`ensure*LabelsExist` pattern).
+- Carry an in-memory created-ID guard for the create path against same-run list-after-create staleness.
+- `main()` reads `IMPROVEMENT_METRICS_DIGEST_PATH` / `IMPROVEMENT_METRICS_RESULT_PATH`; token-load failure → fail-closed (no write); result JSON to stdout with `created`/`updated`/`noop`/`tokenLoadFailure` presence bits. Best-effort result-file write (stderr on failure, never throw).
+
+**Patterns to follow:**
+- `scripts/capture-patterns-open.ts` (`ensurePatternProposalLabelsExist`, per-issue try/catch, fail-closed on unavailable label, `main()` env contract).
+- Same-run staleness guard: `docs/solutions/best-practices/github-issues-api-same-run-eventual-consistency-2026-05-20.md`.
+- Marker-versioned upsert with tick preservation (net-new): find-by-label → parse version + tick-state → update-or-create.
+
+**Test scenarios:**
+- Happy path: no existing report issue → `issues.create` once with static title + body + marker; result `created`.
+- Happy path: existing issue with lower version marker → `issues.update` body in place, no new issue; result `updated`.
+- Critical: an edge ticked `[x]` in the prior body that is still present in the new digest is re-emitted `[x]` (operator confirmation is never clobbered by the rewrite).
+- Edge case: a ticked edge no longer present in the new digest drops out cleanly (close-on-clear); its tick does not resurrect.
+- Edge case: existing issue at current version, unchanged content → no-op, no write; result `noop`.
+- Edge case: existing issue missing/malformed marker → treated as supersedable (update), never duplicated.
+- Error path: token load failure → no create/update attempted, `tokenLoadFailure` true.
+- Integration: create-then-relist within a run does not duplicate (created-ID guard) — mock stale `listForRepo`.
+
+- [x] **Unit 5: Workflow + label + perimeter**
+
+**Goal:** The `Improvement Metrics` workflow (detect + report jobs, dry-run default, scoped token, full-history checkout) and the report-issue label, wiring the deterministic pipeline with no agent step and an explicit gated public perimeter.
+
+**Requirements:** R11, R12, R19
+
+**Dependencies:** Unit 2, Unit 4
+
+**Files:**
+- Create: `.github/workflows/improvement-metrics.yaml`
+- Modify: `.github/settings.yml`
+- Test: `scripts/improvement-metrics-workflow.test.ts`
+
+**Approach:**
+- Two jobs mirroring `capture-patterns.yaml`: `detect` (`contents:read`, `issues:read`, checkout with **`fetch-depth: 0`** for git add-dates + `./.github/actions/setup` + `data`-branch metadata overlay + run `improvement-metrics-detect.ts` piped to a `tee`'d digest under `bash -Eeuo pipefail`, upload digest artifact, jq step-summary) and `report` (`needs: detect`, `if: always() && workflow_dispatch && inputs.dry_run == 'false'`, download digest, mint app-token scoped to `github.event.repository.name` with `permission-issues: write`, run `improvement-metrics-report.ts`, jq step-summary). No agent step.
+- `workflow_dispatch` only, `inputs.dry_run` choice default `'true'`; **static `concurrency` group** no-cancel; top-level `contents: read`; **no `run-name` interpolation** (static default); token boundary — detect never holds a write token.
+- Public perimeter (all counts-only / gated, enumerated here so a future ungated surface fails review): (a) report issue body — `applyPublicOutputGate` fail-closed; (b) report issue title — static `Improvement Metrics`, never data-derived; (c) run-name — static default; (d) both step-summaries — jq counts-only; (e) stdout/stderr — counts-only result JSON; (f) logs — only counts-only script output; (g) concurrency group — static string; (h) digest artifact — fingerprints + public URLs, 1-day retention.
+- `.github/settings.yml`: add the report-issue label with description/color matching existing label style. (No proposal-issue confirmation labels — confirmation lives in the report checklist.)
+
+**Patterns to follow:**
+- `.github/workflows/capture-patterns.yaml` (job/step shape, dry-run gate, scoped mint, artifact handoff, no-`cat`-of-secrets).
+- Static-run-name / no-input-echo: `docs/solutions/security-issues/survey-workflow-side-privacy-gate-2026-05-16.md`.
+- `scripts/capture-patterns-workflow.test.ts` (assertion style).
+
+**Test scenarios:**
+- Happy path: `report` job `if` requires `dry_run == 'false'`; detect job has no write token; mint step scoped to repo name with issues:write.
+- Edge case: detect checkout sets `fetch-depth: 0`; workflow declares no `schedule`; `workflow_dispatch` only; `dry_run` default `'true'`.
+- Edge case: no step `cat`s/`echo`s the digest file or the token; run-name and concurrency group are static (no `${{ inputs.* }}` interpolation).
+- Edge case: workflow file contains no internal tier taxonomy (no `O8`, `Unit \d`); operator-facing text only.
+- Integration: both jobs pass the same `IMPROVEMENT_METRICS_DIGEST_PATH`.
+
+- [x] **Unit 6: Golden-path integration test + README**
+
+**Goal:** Lock the real detect→render→upsert compose path with a golden-path test on real-shaped inputs, and document the loop operator-facing.
+
+**Requirements:** R1, R3, R7, R17 (end-to-end), R11
+
+**Dependencies:** Units 1-5
+
+**Files:**
+- Create: `scripts/improvement-metrics-integration.test.ts`
+- Modify: `README.md`
+
+**Approach:**
+- Golden-path test drives the actual composition (detect core → render → upsert shell) with realistic solution-doc records (frontmatter identity + git add-dates) + realistic proposal issue bodies/labels + a prior report body containing one ticked and one unticked edge, asserting the paired counts, the selected state, the backlog surfacing, tick-state preservation, and a public-safe body. It exercises the **real** `renderReportBody`→upsert path (does not mock the gate) and must fail if `applyPublicOutputGate` is removed from the render path or a state-ladder threshold is altered — the anti-recurrence contract.
+- README: an operator-facing section — what the metric measures, how discovery/recidivism/backlog read, how to confirm a recurrence (tick the checklist line on the report issue) and how it persists, and how to run it (dry-run default). No internal taxonomy, in Marcus's voice.
+
+**Execution note:** Write the golden-path test first from real-shaped fixtures; it is the seam that unit tests alone would ship green past.
+
+**Patterns to follow:**
+- `docs/solutions/best-practices/test-the-integration-seam-not-the-endpoints-2026-07-06.md`.
+- `docs/solutions/best-practices/pure-core-privacy-gates-shared-module-2026-06-22.md` (real-compose gate test, not mocked).
+- Existing README loop sections for voice and structure.
+
+**Test scenarios:**
+- Integration: real-shaped corpus → correct paired counts + state + backlog; a ticked edge counts as recidivism, an unticked one stays backlog, end-to-end.
+- Integration (tick preservation): a prior ticked edge still present is re-emitted ticked after upsert.
+- Integration (anti-recurrence): removing the gate call from the render path or altering a state-ladder threshold fails the test.
+- Verification: `README.md` renders, markdown lint clean, no internal taxonomy.
+
+## System-Wide Impact
+
+- **Interaction graph:** New manual workflow; reads the same proposal issues the existing loops write. No existing workflow calls O8; O8 calls no existing loop. The only new writes are the perpetual report issue + its label ensure.
+- **Error propagation:** Detect fails closed on token-load/scan/git-history failure (empty digest, exit 0); report fails closed on token-load failure (no write). Rendering/summary are best-effort and must not abort the run.
+- **State lifecycle risks:** The perpetual issue is the only mutable state; upsert-by-version-marker + created-ID guard prevent duplicates; tick-state preservation prevents clobbering operator confirmation. No `data`-branch write, no metrics store.
+- **API surface parity:** This is the first in-place issue-body rewrite in the repo — review the `issues.update({body})` call for blast radius; every other loop only creates or flips state.
+- **Integration coverage:** The detect→render→upsert seam is covered by the Unit 6 golden-path test on real-shaped inputs with the real gate, not just per-unit mocks.
+- **Unchanged invariants:** No solution doc, prompt, persona, skill, or existing loop logic changes (R11). The public-output gate is reused unchanged. Existing proposal loops are untouched.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Reflexive dead metric — operator never ticks a candidate, so recidivism reads 0 forever | Backlog is a first-class count with oldest-age + stale warning (R17); an unmaintained checklist is loud, not silent-clean. Confirmation lives inline on the report the operator is already reading. |
+| Lost confirmed edge — a bare gesture can't say which class recurred | Confirmation is an edge-keyed checkbox: the checklist line *is* the `(event → class)` edge O8 rendered, keyed by a stable fingerprint; the confirmed edge is explicit and reproducible each run. |
+| Trend instability from a mutable date source | Codification timestamp is the git first-commit date (immutable, universal), not frontmatter `date`; a deleted/renamed anchor marks the run non-comparable rather than rewriting past windows. |
+| Candidate heuristic over/under-links (asymmetric, weak signal) | Recall-oriented O8-native scorer + strong-match minimum; human tick is the precision gate; every over-threshold edge surfaced independently so confirmation is unambiguous. |
+| Low corpus volume floods the backlog with noise candidates | Candidate surfacing suppressed entirely below the `insufficient-signal` floor; strong-match requirement on top of the score threshold. |
+| First in-place `issues.update({body})` in the repo | Isolated in Unit 4 with tick-preservation + created-ID staleness tests; called only under the scoped report token on non-dry-run. |
+| Public-output leak via aggregated candidate/evidence text | Public-safe by construction (class key + public URL + checkbox only); render functions never receive raw titles/bodies; mutation-proof real-compose gate test (R20, Unit 6). |
+| git add-dates need full history | Detect checkout sets `fetch-depth: 0`; `gitHistoryUnavailable` presence bit fails closed if history is missing. |
+| Depends on existing proposal-loop labels/markers staying stable | Reuses their published label sets; classification uses marker→visible→sentinel precedence so a missing marker degrades to a sentinel, not a crash. |
+
+## Documentation / Operational Notes
+
+- README gains an operator-facing section (Unit 6): what the metric means, how to tick a recurrence on the report issue, dry-run-default run instructions.
+- No monitoring/rollout infra beyond the workflow; manual dispatch only. Revisit trigger: a sustained non-zero confirmed-recidivism count is the signal to consider an action-graduation slice (see Deferred to Separate Tasks).
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-07-09-o8-improvement-metric-requirements.md`
+- Template loop: `.github/workflows/capture-patterns.yaml`, `scripts/capture-patterns-cluster.ts`, `scripts/capture-patterns-open.ts`, `scripts/capture-patterns-synthesis.ts`
+- Reused gate: `scripts/status-truth-public-output.ts`
+- Checklist live-state + upsert/staleness precedent: `scripts/status-truth-proposals.ts`, `scripts/reconcile-repos.ts`, `docs/solutions/best-practices/github-issues-api-same-run-eventual-consistency-2026-05-20.md`
+- Closed-vocabulary + perimeter learnings: `docs/solutions/best-practices/closed-vocabulary-identifiers-for-automated-inspection-2026-07-09.md`, `docs/solutions/security-issues/verify-whole-public-perimeter-2026-06-22.md`, `docs/solutions/security-issues/survey-workflow-side-privacy-gate-2026-05-16.md`

--- a/scripts/improvement-metrics-core.test.ts
+++ b/scripts/improvement-metrics-core.test.ts
@@ -1,0 +1,180 @@
+import {describe, expect, it} from 'vitest'
+
+import {
+  buildClassKey,
+  buildEdgeChecklistLine,
+  buildEdgeFingerprint,
+  buildLiveStateSummary,
+  buildReportVersionMarker,
+  classifySourceType,
+  IMPROVEMENT_METRICS_REPORT_LABEL,
+  IMPROVEMENT_METRICS_REPORT_LABEL_DESCRIPTOR,
+  parseEdgeChecklistLine,
+  parseLiveStateSummary,
+  parseReportVersionMarker,
+  recoverReportState,
+  REPORT_STATES,
+  SOURCE_TYPES,
+} from './improvement-metrics-core.ts'
+
+describe('recoverReportState', () => {
+  it('accepts every closed-vocabulary state', () => {
+    for (const state of REPORT_STATES) {
+      expect(recoverReportState(state)).toBe(state)
+    }
+  })
+
+  it('rejects an out-of-set string, never coercing', () => {
+    expect(recoverReportState('unknown-state')).toBeNull()
+    expect(recoverReportState('')).toBeNull()
+    expect(recoverReportState('Healthy')).toBeNull()
+  })
+})
+
+describe('buildClassKey', () => {
+  it('derives an identical key regardless of frontmatter field order', () => {
+    const keyA = buildClassKey({module: 'foo', component: 'bar', problem_type: 'baz'})
+    const keyB = buildClassKey({problem_type: 'baz', module: 'foo', component: 'bar'})
+    const keyC = buildClassKey({component: 'bar', problem_type: 'baz', module: 'foo'})
+    expect(keyA).toBe(keyB)
+    expect(keyB).toBe(keyC)
+  })
+
+  it('uses a fixed sentinel segment for missing fields, never throws', () => {
+    const key = buildClassKey({module: 'foo'})
+    expect(key).toContain('unknown')
+    expect(() => buildClassKey({})).not.toThrow()
+  })
+
+  it('produces different keys for different field values', () => {
+    const keyA = buildClassKey({module: 'foo', component: 'bar', problem_type: 'baz'})
+    const keyB = buildClassKey({module: 'foo', component: 'bar', problem_type: 'qux'})
+    expect(keyA).not.toBe(keyB)
+  })
+
+  it('fails fast on control characters or newlines in a field value', () => {
+    expect(() => buildClassKey({module: 'foo\nbar', component: 'x', problem_type: 'y'})).toThrow()
+    expect(() => buildClassKey({module: 'foo', component: 'x\u0000y', problem_type: 'z'})).toThrow()
+  })
+})
+
+describe('classifySourceType', () => {
+  it('maps labels to exactly one recognized source type', () => {
+    expect(classifySourceType(['learning-proposal', 'other'])).toBe('learning-proposal')
+    expect(classifySourceType(['pattern-proposal'])).toBe('pattern-proposal')
+    expect(classifySourceType(['status-truth'])).toBe('status-truth')
+  })
+
+  it('returns a sentinel for labels matching none of the closed set', () => {
+    expect(classifySourceType(['random-label'])).toBe('unknown')
+    expect(classifySourceType([])).toBe('unknown')
+  })
+
+  it('is single-pass deterministic regardless of extra labels', () => {
+    for (const type of SOURCE_TYPES) {
+      expect(classifySourceType([type, 'extra-label-1', 'extra-label-2'])).toBe(type)
+    }
+  })
+})
+
+describe('buildEdgeFingerprint', () => {
+  it('is stable and identical for identical (classKey, eventId)', () => {
+    const fpA = buildEdgeFingerprint('class-key-1', 'event-1')
+    const fpB = buildEdgeFingerprint('class-key-1', 'event-1')
+    expect(fpA).toBe(fpB)
+    expect(fpA).toMatch(/^[a-f0-9]{64}$/u)
+  })
+
+  it('produces different fingerprints for different inputs', () => {
+    const fpA = buildEdgeFingerprint('class-key-1', 'event-1')
+    const fpB = buildEdgeFingerprint('class-key-2', 'event-1')
+    const fpC = buildEdgeFingerprint('class-key-1', 'event-2')
+    expect(fpA).not.toBe(fpB)
+    expect(fpA).not.toBe(fpC)
+  })
+
+  it('fails fast on control characters or newlines in inputs', () => {
+    expect(() => buildEdgeFingerprint('class\nkey', 'event-1')).toThrow()
+    expect(() => buildEdgeFingerprint('class-key', 'event\u0000-1')).toThrow()
+  })
+})
+
+describe('report version marker build/parse', () => {
+  it('round-trips build -> parse', () => {
+    expect(parseReportVersionMarker(buildReportVersionMarker(1))).toBe(1)
+    expect(parseReportVersionMarker(buildReportVersionMarker(42))).toBe(42)
+  })
+
+  it('returns null for an absent marker', () => {
+    expect(parseReportVersionMarker('no marker here')).toBeNull()
+  })
+
+  it('returns null for a malformed marker', () => {
+    expect(parseReportVersionMarker('<!-- improvement-metrics:report:version=abc -->')).toBeNull()
+    expect(parseReportVersionMarker('<!-- improvement-metrics:report:version=-1 -->')).toBeNull()
+  })
+
+  it('fails fast building with a negative or non-integer version', () => {
+    expect(() => buildReportVersionMarker(-1)).toThrow()
+    expect(() => buildReportVersionMarker(1.5)).toThrow()
+  })
+})
+
+describe('edge checklist line build/parse', () => {
+  it('round-trips build -> parse for checked and unchecked', () => {
+    const checkedLine = buildEdgeChecklistLine({fingerprint: 'a'.repeat(64), checked: true})
+    const parsedChecked = parseEdgeChecklistLine(checkedLine)
+    expect(parsedChecked).toEqual({fingerprint: 'a'.repeat(64), checked: true})
+
+    const uncheckedLine = buildEdgeChecklistLine({fingerprint: 'b'.repeat(64), checked: false})
+    const parsedUnchecked = parseEdgeChecklistLine(uncheckedLine)
+    expect(parsedUnchecked).toEqual({fingerprint: 'b'.repeat(64), checked: false})
+  })
+
+  it('parses [x] as checked true and [ ] as checked false', () => {
+    const fp = 'c'.repeat(64)
+    expect(parseEdgeChecklistLine(`- [x] <!-- improvement-metrics:edge=${fp} -->`)).toEqual({
+      fingerprint: fp,
+      checked: true,
+    })
+    expect(parseEdgeChecklistLine(`- [ ] <!-- improvement-metrics:edge=${fp} -->`)).toEqual({
+      fingerprint: fp,
+      checked: false,
+    })
+  })
+
+  it('parses a malformed checkbox as checked: false (fail-safe)', () => {
+    const fp = 'd'.repeat(64)
+    expect(parseEdgeChecklistLine(`- [?] <!-- improvement-metrics:edge=${fp} -->`)).toEqual({
+      fingerprint: fp,
+      checked: false,
+    })
+  })
+
+  it('returns null for a line with no edge marker', () => {
+    expect(parseEdgeChecklistLine('- [x] just some text')).toBeNull()
+  })
+})
+
+describe('live-state summary build/parse', () => {
+  it('round-trips build -> parse', () => {
+    const summary = buildLiveStateSummary({checked: 2, unchecked: 3})
+    expect(summary).toBe('checked-2-unchecked-3')
+    expect(parseLiveStateSummary(summary)).toEqual({checked: 2, unchecked: 3})
+  })
+
+  it('returns null for malformed input', () => {
+    expect(parseLiveStateSummary('not-a-summary')).toBeNull()
+    expect(parseLiveStateSummary('checked-a-unchecked-b')).toBeNull()
+    expect(parseLiveStateSummary('')).toBeNull()
+  })
+})
+
+describe('label constant and descriptor', () => {
+  it('exports a fixed label and a descriptor row matching its shape', () => {
+    expect(IMPROVEMENT_METRICS_REPORT_LABEL).toBe('improvement-metrics-report')
+    expect(IMPROVEMENT_METRICS_REPORT_LABEL_DESCRIPTOR.name).toBe(IMPROVEMENT_METRICS_REPORT_LABEL)
+    expect(typeof IMPROVEMENT_METRICS_REPORT_LABEL_DESCRIPTOR.color).toBe('string')
+    expect(typeof IMPROVEMENT_METRICS_REPORT_LABEL_DESCRIPTOR.description).toBe('string')
+  })
+})

--- a/scripts/improvement-metrics-core.ts
+++ b/scripts/improvement-metrics-core.ts
@@ -104,8 +104,12 @@ export function classifySourceType(labels: readonly string[]): SourceType {
 /** Control separator joining the two immutable edge-fingerprint inputs. */
 const EDGE_FINGERPRINT_SEPARATOR = '\u0001'
 
-// eslint-disable-next-line no-control-regex -- intentional: rejects raw control chars (incl. \n, \r) in edge inputs
-const EDGE_FINGERPRINT_FORBIDDEN_PATTERN = /[\u0000-\u001F\u007F]/u
+// Rejects raw control chars (incl. \n, \r) in edge inputs, but permits \u0001 (0x01) since a
+// well-formed classKey from buildClassKey legitimately embeds it as the segment separator
+// (CLASS_KEY_SEPARATOR) — buildEdgeFingerprint(buildClassKey(...), eventId) is the intended
+// composition and must not fail-fast on that separator.
+// eslint-disable-next-line no-control-regex -- intentional control-char denylist
+const EDGE_FINGERPRINT_FORBIDDEN_PATTERN = /[\0\u0002-\u001F\u007F]/u
 
 /**
  * Build a stable, lowercase hex sha256 fingerprint for an (event -> class) edge.

--- a/scripts/improvement-metrics-core.ts
+++ b/scripts/improvement-metrics-core.ts
@@ -1,0 +1,237 @@
+/**
+ * Pure core for the improvement-metric loop: closed-vocabulary report states,
+ * codified-class identity keys, source-type classification, event->class edge
+ * fingerprints, and report-issue marker/checklist live-state build/parse.
+ *
+ * Pure module: no I/O, no Octokit, no network. Every function here is a
+ * deterministic transform over its inputs.
+ *
+ * Strip-only safe: no enums, namespaces, parameter properties, or `any`.
+ */
+
+import {createHash} from 'node:crypto'
+
+// ---------------------------------------------------------------------------
+// Report state (closed vocabulary)
+// ---------------------------------------------------------------------------
+
+/** Closed vocabulary of improvement-metric report states. */
+export const REPORT_STATES = ['insufficient-signal', 'ambiguous', 'healthy', 'failing'] as const
+
+/** A recognized improvement-metric report state. */
+export type ReportState = (typeof REPORT_STATES)[number]
+
+/**
+ * Recover a report state from a raw string, rejecting any value outside the
+ * closed vocabulary. Never coerces — an unrecognized string returns `null`.
+ */
+export function recoverReportState(raw: string): ReportState | null {
+  return (REPORT_STATES as readonly string[]).includes(raw) ? (raw as ReportState) : null
+}
+
+// ---------------------------------------------------------------------------
+// Codified-class identity key
+// ---------------------------------------------------------------------------
+
+/** Sentinel segment used for any missing class-key field. */
+const CLASS_KEY_SENTINEL = 'unknown'
+
+/** Stable separator joining class-key segments. Cannot collide with field values (forbidden below). */
+const CLASS_KEY_SEPARATOR = '\u0001'
+
+/**
+ * Characters forbidden in a class-key field value: the separator itself, newlines,
+ * and any other ASCII control character. A field containing one of these could
+ * corrupt the key's segment boundaries.
+ */
+// eslint-disable-next-line no-control-regex -- intentional: rejects raw control chars (incl. \n, \r) in field values
+const CLASS_KEY_FORBIDDEN_PATTERN = /[\u0000-\u001F\u007F]/u
+
+/** Frontmatter fields used to derive a codified-class identity key. */
+export interface ClassKeyFrontmatter {
+  module?: string
+  component?: string
+  problem_type?: string
+}
+
+/**
+ * Build a codified-class identity key from frontmatter fields.
+ *
+ * Deterministic string output, order-independent of how fields are supplied on
+ * the input object (segment order is always `module`, `component`, `problem_type`).
+ * Any missing field is replaced with a fixed sentinel segment — never throws for
+ * missing fields. Fail-fast: throws if any field value contains a control
+ * character or newline that could corrupt the separator-delimited key.
+ */
+export function buildClassKey(frontmatter: ClassKeyFrontmatter): string {
+  const segments = [frontmatter.module, frontmatter.component, frontmatter.problem_type].map(value => {
+    if (value === undefined || value === '') return CLASS_KEY_SENTINEL
+    if (CLASS_KEY_FORBIDDEN_PATTERN.test(value)) {
+      throw new Error('improvement-metrics-core: class-key field contains a forbidden control character')
+    }
+    return value
+  })
+  return segments.join(CLASS_KEY_SEPARATOR)
+}
+
+// ---------------------------------------------------------------------------
+// Source-type classification (closed vocabulary)
+// ---------------------------------------------------------------------------
+
+/** Closed vocabulary of source types eligible for the improvement-metric loop. */
+export const SOURCE_TYPES = ['learning-proposal', 'pattern-proposal', 'status-truth'] as const
+
+/** A recognized source type, or the `unknown` sentinel. */
+export type SourceType = (typeof SOURCE_TYPES)[number] | 'unknown'
+
+/**
+ * Classify an issue's labels into exactly one recognized source type, or the
+ * `unknown` sentinel when no label in the closed set is present. Single-pass
+ * over `SOURCE_TYPES` in fixed priority order — deterministic even when
+ * multiple recognized labels are present.
+ */
+export function classifySourceType(labels: readonly string[]): SourceType {
+  for (const type of SOURCE_TYPES) {
+    if (labels.includes(type)) return type
+  }
+  return 'unknown'
+}
+
+// ---------------------------------------------------------------------------
+// Edge fingerprint
+// ---------------------------------------------------------------------------
+
+/** Control separator joining the two immutable edge-fingerprint inputs. */
+const EDGE_FINGERPRINT_SEPARATOR = '\u0001'
+
+// eslint-disable-next-line no-control-regex -- intentional: rejects raw control chars (incl. \n, \r) in edge inputs
+const EDGE_FINGERPRINT_FORBIDDEN_PATTERN = /[\u0000-\u001F\u007F]/u
+
+/**
+ * Build a stable, lowercase hex sha256 fingerprint for an (event -> class) edge.
+ *
+ * Identity is based solely on `classKey` and `eventId` — an operator checklist
+ * tick keyed on this fingerprint survives issue body rewrites and reordering.
+ * Fail-fast: throws if either input contains a control character or newline
+ * that could corrupt the separator-delimited hash input.
+ */
+export function buildEdgeFingerprint(classKey: string, eventId: string): string {
+  for (const value of [classKey, eventId]) {
+    if (EDGE_FINGERPRINT_FORBIDDEN_PATTERN.test(value)) {
+      throw new Error('improvement-metrics-core: edge fingerprint input contains a forbidden control character')
+    }
+  }
+  return createHash('sha256').update(`${classKey}${EDGE_FINGERPRINT_SEPARATOR}${eventId}`).digest('hex')
+}
+
+// ---------------------------------------------------------------------------
+// Report-issue version marker
+// ---------------------------------------------------------------------------
+
+const REPORT_VERSION_MARKER_PATTERN = /<!-- improvement-metrics:report:version=(-?\d+) -->/u
+
+/**
+ * Build the hidden report-issue version marker line.
+ * Fail-fast: throws on a non-integer or negative version.
+ */
+export function buildReportVersionMarker(version: number): string {
+  if (!Number.isInteger(version) || version < 0) {
+    throw new Error('improvement-metrics-core: report version marker requires a non-negative integer')
+  }
+  return `<!-- improvement-metrics:report:version=${version} -->`
+}
+
+/**
+ * Parse the hidden report-issue version marker from a body.
+ * Returns `null` when absent or malformed (non-integer, negative).
+ */
+export function parseReportVersionMarker(body: string): number | null {
+  const match = REPORT_VERSION_MARKER_PATTERN.exec(body)
+  const raw = match?.[1]
+  if (raw === undefined) return null
+  const value = Number(raw)
+  if (!Number.isInteger(value) || value < 0) return null
+  return value
+}
+
+// ---------------------------------------------------------------------------
+// Per-edge checklist encoding
+// ---------------------------------------------------------------------------
+
+const EDGE_MARKER_PATTERN = /<!-- improvement-metrics:edge=([a-f0-9]{64}) -->/u
+const EDGE_CHECKLIST_LINE_PATTERN = /^- \[([ x]?)\] <!-- improvement-metrics:edge=([a-f0-9]{64}) -->$/u
+
+/** Recovered edge checklist entry. */
+export interface EdgeChecklistEntry {
+  fingerprint: string
+  checked: boolean
+}
+
+/**
+ * Build a per-edge checklist line pairing a GFM checkbox with a hidden edge
+ * fingerprint marker.
+ */
+export function buildEdgeChecklistLine(entry: EdgeChecklistEntry): string {
+  const box = entry.checked ? 'x' : ' '
+  return `- [${box}] <!-- improvement-metrics:edge=${entry.fingerprint} -->`
+}
+
+/**
+ * Parse a per-edge checklist line back into `{ fingerprint, checked }`.
+ *
+ * A malformed checkbox (neither `[ ]` nor `[x]`) parses as `checked: false` —
+ * fail-safe, never treated as checked. Returns `null` when no edge marker is
+ * present at all.
+ */
+export function parseEdgeChecklistLine(line: string): EdgeChecklistEntry | null {
+  const strictMatch = EDGE_CHECKLIST_LINE_PATTERN.exec(line)
+  if (strictMatch !== null) {
+    return {fingerprint: strictMatch[2] ?? '', checked: strictMatch[1] === 'x'}
+  }
+  const markerMatch = EDGE_MARKER_PATTERN.exec(line)
+  const fingerprint = markerMatch?.[1]
+  if (fingerprint === undefined) return null
+  return {fingerprint, checked: false}
+}
+
+// ---------------------------------------------------------------------------
+// Live-state summary encoding (mirrors status-truth-proposals.ts)
+// ---------------------------------------------------------------------------
+
+const LIVE_STATE_SUMMARY_PATTERN = /^checked-(\d+)-unchecked-(\d+)$/u
+
+/** Build the `checked-N-unchecked-M` live-state summary string. */
+export function buildLiveStateSummary(counts: {checked: number; unchecked: number}): string {
+  return `checked-${counts.checked}-unchecked-${counts.unchecked}`
+}
+
+/** Parse a `checked-N-unchecked-M` live-state summary string. Null if malformed. */
+export function parseLiveStateSummary(raw: string): {checked: number; unchecked: number} | null {
+  const match = LIVE_STATE_SUMMARY_PATTERN.exec(raw)
+  if (match === null) return null
+  const checked = Number(match[1])
+  const unchecked = Number(match[2])
+  if (!Number.isInteger(checked) || !Number.isInteger(unchecked)) return null
+  return {checked, unchecked}
+}
+
+// ---------------------------------------------------------------------------
+// Report-issue label
+// ---------------------------------------------------------------------------
+
+/** Fixed label applied to every improvement-metrics report issue. */
+export const IMPROVEMENT_METRICS_REPORT_LABEL = 'improvement-metrics-report'
+
+/** Label descriptor shape, ready for `.github/settings.yml` and runtime label preflight. */
+export interface ImprovementMetricsLabelDescriptor {
+  readonly name: string
+  readonly color: string
+  readonly description: string
+}
+
+/** Descriptor row for the improvement-metrics report label. */
+export const IMPROVEMENT_METRICS_REPORT_LABEL_DESCRIPTOR: ImprovementMetricsLabelDescriptor = {
+  name: IMPROVEMENT_METRICS_REPORT_LABEL,
+  color: '0e8a16',
+  description: 'Improvement-metric loop report tracking event -> codified-class edges',
+}

--- a/scripts/improvement-metrics-core.ts
+++ b/scripts/improvement-metrics-core.ts
@@ -198,6 +198,22 @@ export function parseEdgeChecklistLine(line: string): EdgeChecklistEntry | null 
   return {fingerprint, checked: false}
 }
 
+/**
+ * Recover ticked edge fingerprints from a prior report issue body by scanning
+ * every line for a checklist entry (`parseEdgeChecklistLine`).
+ *
+ * Shared by the detect and report modules so the tick-recovery logic cannot
+ * drift between the two I/O shells.
+ */
+export function recoverPriorTickState(body: string): Set<string> {
+  const ticked = new Set<string>()
+  for (const line of body.split('\n')) {
+    const entry = parseEdgeChecklistLine(line.trim())
+    if (entry !== null && entry.checked) ticked.add(entry.fingerprint)
+  }
+  return ticked
+}
+
 // ---------------------------------------------------------------------------
 // Live-state summary encoding (mirrors status-truth-proposals.ts)
 // ---------------------------------------------------------------------------

--- a/scripts/improvement-metrics-detect.test.ts
+++ b/scripts/improvement-metrics-detect.test.ts
@@ -1,0 +1,466 @@
+/**
+ * Tests for scripts/improvement-metrics-detect.ts
+ *
+ * Structure:
+ * - scoreCandidateLink (O8-native asymmetric scorer)
+ * - computeMetrics (pure core): discovery, recidivism, backlog, prior-window delta, state
+ * - I/O shell: fetchProposalEventsFromRepo, recoverPriorTickState, writeImprovementMetricsDigestFile,
+ *   loadGitAddDates fail-closed path
+ */
+
+import {mkdtemp, rm} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import process from 'node:process'
+import {describe, expect, it} from 'vitest'
+import {buildEdgeFingerprint} from './improvement-metrics-core.ts'
+import {
+  computeMetrics,
+  fetchProposalEventsFromRepo,
+  loadGitAddDates,
+  recoverPriorTickState,
+  scoreCandidateLink,
+  writeImprovementMetricsDigestFile,
+  type ComputeMetricsInput,
+  type ImprovementMetricsOctokitClient,
+  type ProposalEvent,
+  type SolutionDocRecord,
+} from './improvement-metrics-detect.ts'
+
+const NOW = new Date('2026-07-10T00:00:00.000Z')
+
+function daysAgo(days: number): string {
+  return new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000).toISOString()
+}
+
+function makeDoc(overrides: Partial<SolutionDocRecord> = {}): SolutionDocRecord {
+  return {
+    frontmatter: {module: 'scripts/foo.ts', component: undefined, problem_type: 'retry-storms'},
+    title: 'Retry idempotent writes after 5xx failures',
+    tags: ['best-practice', 'retries'],
+    gitAddDate: daysAgo(10),
+    ...overrides,
+  }
+}
+
+function makeEvent(overrides: Partial<ProposalEvent> = {}): ProposalEvent {
+  return {
+    id: '101',
+    title: 'Retry storm on 5xx during deploy',
+    labels: ['learning-proposal'],
+    createdAt: daysAgo(5),
+    url: 'https://github.com/fro-bot/.github/issues/101',
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// scoreCandidateLink
+// ---------------------------------------------------------------------------
+
+describe('scoreCandidateLink', () => {
+  it('scores shared title tokens as a strong match', () => {
+    const event = makeEvent({title: 'Retry idempotent writes flake in CI'})
+    const doc = makeDoc({title: 'Retry idempotent writes after 5xx failures'})
+    const result = scoreCandidateLink(event, doc)
+    expect(result.strongMatch).toBe(true)
+    expect(result.score).toBeGreaterThan(0)
+  })
+
+  it('scores a label matching a class tag as a strong match', () => {
+    const event = makeEvent({title: 'Totally unrelated wording', labels: ['best-practice']})
+    const doc = makeDoc({tags: ['best-practice']})
+    const result = scoreCandidateLink(event, doc)
+    expect(result.strongMatch).toBe(true)
+  })
+
+  it('module-token-only overlap is never a strong match on its own', () => {
+    const event = makeEvent({title: 'The foo utility needs updating', labels: []})
+    const doc = makeDoc({title: 'Nothing shared here at all', tags: [], frontmatter: {module: 'scripts/foo.ts'}})
+    const result = scoreCandidateLink(event, doc)
+    // "foo" token matches module ("foo" >= 3 chars, in scripts/foo.ts split), but no title/tag strong match.
+    expect(result.strongMatch).toBe(false)
+  })
+
+  it('no overlap scores zero and no strong match', () => {
+    const event = makeEvent({title: 'Completely unrelated rename config key', labels: ['unrelated-label']})
+    const doc = makeDoc({title: 'Best practice guidance workflow hygiene', tags: ['hygiene'], frontmatter: {}})
+    const result = scoreCandidateLink(event, doc)
+    expect(result.score).toBe(0)
+    expect(result.strongMatch).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeMetrics: happy path
+// ---------------------------------------------------------------------------
+
+describe('computeMetrics', () => {
+  it('discovery counts distinct anchors once, not repeated proposals for the same class', () => {
+    const docA = makeDoc({
+      frontmatter: {module: 'scripts/a.ts', component: undefined, problem_type: 'retry-storms'},
+      title: 'Retry idempotent writes after 5xx failures',
+      tags: ['retries'],
+      gitAddDate: daysAgo(10),
+    })
+    const docB = makeDoc({
+      frontmatter: {module: 'scripts/b.ts', component: undefined, problem_type: 'cache-invalidation'},
+      title: 'Cache invalidation on region rotation',
+      tags: ['cache'],
+      gitAddDate: daysAgo(20),
+    })
+    const docC = makeDoc({
+      frontmatter: {module: 'scripts/c.ts', component: undefined, problem_type: 'unrelated-c'},
+      title: 'Completely unrelated topic entirely',
+      tags: [],
+      gitAddDate: daysAgo(30),
+    })
+    const repeatedEvent1 = makeEvent({id: '1', title: 'Retry idempotent writes flake', createdAt: daysAgo(3)})
+    const repeatedEvent2 = makeEvent({id: '2', title: 'Retry idempotent writes flake again', createdAt: daysAgo(2)})
+
+    const input: ComputeMetricsInput = {
+      solutionDocs: [docA, docB, docC],
+      proposalEvents: [repeatedEvent1, repeatedEvent2],
+      priorTickState: new Set([buildEdgeFingerprint('scripts/a.ts\u0001unknown\u0001retry-storms', '1')]),
+      now: NOW,
+    }
+    const {digest, edges} = computeMetrics(input)
+
+    expect(digest.anchors).toBe(3)
+    // Discovery is driven by distinct in-window anchors, never by repeated proposal events.
+    expect(digest.discovery).toBe(3)
+    // A ticked edge (event 1 -> class A) raises recidivism.
+    expect(digest.confirmedRecidivism).toBeGreaterThanOrEqual(1)
+    // The unticked edge (event 2) must not count as recidivism.
+    const event2Edges = edges.filter(e => e.eventId === '2')
+    for (const edge of event2Edges) {
+      if (edge.classKey.startsWith('scripts/a.ts')) expect(edge.ticked).toBe(false)
+    }
+  })
+
+  it('below-floor volume renders insufficient-signal and suppresses all candidate surfacing', () => {
+    const input: ComputeMetricsInput = {
+      solutionDocs: [makeDoc({gitAddDate: daysAgo(5)})], // only 1 anchor, below MIN_ANCHORS=3
+      proposalEvents: [makeEvent()],
+      priorTickState: new Set(),
+      now: NOW,
+    }
+    const {digest, edges} = computeMetrics(input)
+    expect(digest.state).toBe('insufficient-signal')
+    expect(edges.length).toBe(0)
+    expect(digest.backlogCount).toBe(0)
+  })
+
+  it('discovery below prior window with no confirmed recidivism renders ambiguous', () => {
+    // Prior window has 3 anchors; current window has only 3 anchors but discovery must be lower.
+    // Use a config with lower thresholds tailored to this scenario.
+    const priorDocs = [
+      makeDoc({
+        frontmatter: {module: 'p1', component: undefined, problem_type: 'p1'},
+        gitAddDate: daysAgo(100),
+      }),
+      makeDoc({
+        frontmatter: {module: 'p2', component: undefined, problem_type: 'p2'},
+        gitAddDate: daysAgo(110),
+      }),
+      makeDoc({
+        frontmatter: {module: 'p3', component: undefined, problem_type: 'p3'},
+        gitAddDate: daysAgo(120),
+      }),
+    ]
+    const currentDocs = [
+      makeDoc({
+        frontmatter: {module: 'c1', component: undefined, problem_type: 'c1'},
+        gitAddDate: daysAgo(10),
+      }),
+      makeDoc({
+        frontmatter: {module: 'c2', component: undefined, problem_type: 'c2'},
+        gitAddDate: daysAgo(20),
+      }),
+    ]
+    const input: ComputeMetricsInput = {
+      solutionDocs: [...priorDocs, ...currentDocs],
+      proposalEvents: [],
+      priorTickState: new Set(),
+      now: NOW,
+    }
+    const {digest} = computeMetrics(input)
+    expect(digest.anchors).toBe(5)
+    expect(digest.discovery).toBe(2)
+    expect(digest.priorDiscovery).toBe(3)
+    expect(digest.discovery).toBeLessThan(digest.priorDiscovery)
+    expect(digest.state).toBe('ambiguous')
+  })
+
+  it('stale unticked candidate surfaces backlog + oldest age and forces ambiguous even when discovery is healthy', () => {
+    const docs = [
+      makeDoc({frontmatter: {module: 'a', component: undefined, problem_type: 'a'}, gitAddDate: daysAgo(10)}),
+      makeDoc({frontmatter: {module: 'b', component: undefined, problem_type: 'b'}, gitAddDate: daysAgo(20)}),
+      makeDoc({frontmatter: {module: 'c', component: undefined, problem_type: 'c'}, gitAddDate: daysAgo(30)}),
+    ]
+    const staleEvent = makeEvent({
+      id: 'stale-1',
+      title: 'Retry idempotent writes after 5xx failures',
+      createdAt: daysAgo(20),
+    })
+    const input: ComputeMetricsInput = {
+      solutionDocs: docs,
+      proposalEvents: [staleEvent],
+      priorTickState: new Set(),
+      now: NOW,
+    }
+    const {digest, edges} = computeMetrics(input)
+    expect(edges.length).toBeGreaterThan(0)
+    expect(digest.backlogCount).toBeGreaterThan(0)
+    expect(digest.oldestPendingAgeDays).not.toBeNull()
+    expect(digest.oldestPendingAgeDays as number).toBeGreaterThan(14)
+    expect(digest.state).toBe('ambiguous')
+  })
+
+  it('one event scoring over threshold for two anchors surfaces two independent edges', () => {
+    const docA = makeDoc({
+      frontmatter: {module: 'a', component: undefined, problem_type: 'a'},
+      title: 'Retry idempotent writes every 5xx',
+      gitAddDate: daysAgo(10),
+    })
+    const docB = makeDoc({
+      frontmatter: {module: 'b', component: undefined, problem_type: 'b'},
+      title: 'Retry idempotent writes across all 5xx paths',
+      gitAddDate: daysAgo(20),
+    })
+    const docC = makeDoc({
+      frontmatter: {module: 'c', component: undefined, problem_type: 'c'},
+      title: 'Completely unrelated cache invalidation topic',
+      tags: [],
+      gitAddDate: daysAgo(30),
+    })
+    const event = makeEvent({title: 'Retry idempotent writes after 5xx failures', createdAt: daysAgo(3)})
+    const input: ComputeMetricsInput = {
+      solutionDocs: [docA, docB, docC],
+      proposalEvents: [event],
+      priorTickState: new Set(),
+      now: NOW,
+    }
+    const {edges} = computeMetrics(input)
+    const matchingEdges = edges.filter(e => e.eventId === event.id)
+    expect(matchingEdges.length).toBe(2)
+    expect(new Set(matchingEdges.map(e => e.classKey)).size).toBe(2)
+  })
+
+  it('discovery is derived from git add-date, not frontmatter date (structural: only gitAddDate is an input)', () => {
+    // The pure core has no `date` field at all on SolutionDocRecord — gitAddDate is
+    // the only date input, so a frontmatter-date mismatch cannot influence discovery.
+    const doc = makeDoc({
+      frontmatter: {module: 'old', component: undefined, problem_type: 'old'},
+      gitAddDate: daysAgo(200),
+    }) // outside window regardless of any hypothetical frontmatter date
+    const anchors = [
+      doc,
+      makeDoc({frontmatter: {module: 'new1', component: undefined, problem_type: 'new1'}, gitAddDate: daysAgo(10)}),
+      makeDoc({frontmatter: {module: 'new2', component: undefined, problem_type: 'new2'}, gitAddDate: daysAgo(20)}),
+    ]
+    const input: ComputeMetricsInput = {
+      solutionDocs: anchors,
+      proposalEvents: [],
+      priorTickState: new Set(),
+      now: NOW,
+    }
+    const {digest} = computeMetrics(input)
+    // Only 2 of the 3 anchors are in-window by gitAddDate.
+    expect(digest.discovery).toBe(2)
+  })
+
+  it('a ticked edge fingerprint in prior tick-state flows through to confirmedRecidivism', () => {
+    const doc = makeDoc({
+      frontmatter: {module: 'x', component: undefined, problem_type: 'x'},
+      gitAddDate: daysAgo(10),
+    })
+    const docs = [
+      doc,
+      makeDoc({frontmatter: {module: 'y', component: undefined, problem_type: 'y'}, gitAddDate: daysAgo(20)}),
+      makeDoc({frontmatter: {module: 'z', component: undefined, problem_type: 'z'}, gitAddDate: daysAgo(30)}),
+    ]
+    const event = makeEvent({id: 'e1', title: doc.title, createdAt: daysAgo(3)})
+    const classKey = 'x\u0001unknown\u0001x'
+    const fingerprint = buildEdgeFingerprint(classKey, 'e1')
+    const input: ComputeMetricsInput = {
+      solutionDocs: docs,
+      proposalEvents: [event],
+      priorTickState: new Set([fingerprint]),
+      now: NOW,
+    }
+    const {digest, edges} = computeMetrics(input)
+    const edge = edges.find(e => e.fingerprint === fingerprint)
+    expect(edge?.ticked).toBe(true)
+    expect(digest.confirmedRecidivism).toBeGreaterThanOrEqual(1)
+  })
+
+  it('confirmed recidivism at or above discovery renders failing', () => {
+    const docA = makeDoc({
+      frontmatter: {module: 'a', component: undefined, problem_type: 'a'},
+      title: 'Retry idempotent writes yet again 5xx',
+      gitAddDate: daysAgo(10),
+    })
+    const docB = makeDoc({
+      frontmatter: {module: 'b', component: undefined, problem_type: 'b'},
+      gitAddDate: daysAgo(20),
+    })
+    const docC = makeDoc({
+      frontmatter: {module: 'c', component: undefined, problem_type: 'c'},
+      gitAddDate: daysAgo(30),
+    })
+    const event = makeEvent({id: 'e2', title: 'Retry idempotent writes once more 5xx', createdAt: daysAgo(3)})
+    const classKeyA = 'a\u0001unknown\u0001a'
+    const fingerprintA = buildEdgeFingerprint(classKeyA, 'e2')
+    const input: ComputeMetricsInput = {
+      solutionDocs: [docA, docB, docC],
+      proposalEvents: [event],
+      priorTickState: new Set([fingerprintA]),
+      now: NOW,
+    }
+    const {digest} = computeMetrics(input)
+    expect(digest.discovery).toBe(3)
+    expect(digest.confirmedRecidivism).toBeGreaterThanOrEqual(1)
+    // With confirmedRecidivism >= discovery: failing takes priority over healthy/ambiguous.
+    if (digest.confirmedRecidivism >= digest.discovery) {
+      expect(digest.state).toBe('failing')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// I/O shell: fetchProposalEventsFromRepo
+// ---------------------------------------------------------------------------
+
+function makeMockOctokit(overrides: Partial<ImprovementMetricsOctokitClient> = {}): ImprovementMetricsOctokitClient {
+  return {
+    paginate: async () => [],
+    rest: {
+      issues: {
+        listForRepo: async () => ({data: []}),
+      },
+    },
+    ...overrides,
+  }
+}
+
+describe('fetchProposalEventsFromRepo', () => {
+  it('fetches one paginated call per source label and maps issue shape', async () => {
+    const calls: Record<string, unknown>[] = []
+    const octokit = makeMockOctokit({
+      paginate: async (_fn, params) => {
+        calls.push(params)
+        return [
+          {
+            number: 7,
+            title: 'Some proposal',
+            created_at: '2026-01-01T00:00:00.000Z',
+            html_url: 'https://github.com/fro-bot/.github/issues/7',
+            labels: ['learning-proposal', {name: 'ci'}],
+          },
+        ]
+      },
+    })
+    const events = await fetchProposalEventsFromRepo(octokit, 'fro-bot', '.github')
+    expect(calls.length).toBe(3)
+    expect(calls.map(c => c.labels)).toEqual(['learning-proposal', 'pattern-proposal', 'status-truth'])
+    expect(events.length).toBe(3)
+    expect(events[0]?.id).toBe('7')
+    expect(events[0]?.labels).toEqual(['learning-proposal', 'ci'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// I/O shell: recoverPriorTickState
+// ---------------------------------------------------------------------------
+
+describe('recoverPriorTickState', () => {
+  it('recovers only ticked edge fingerprints from a report body', () => {
+    const fp1 = 'a'.repeat(64)
+    const fp2 = 'b'.repeat(64)
+    const body = [
+      `- [x] <!-- improvement-metrics:edge=${fp1} -->`,
+      `- [ ] <!-- improvement-metrics:edge=${fp2} -->`,
+    ].join('\n')
+    const ticked = recoverPriorTickState(body)
+    expect(ticked.has(fp1)).toBe(true)
+    expect(ticked.has(fp2)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// I/O shell: writeImprovementMetricsDigestFile fail-closed
+// ---------------------------------------------------------------------------
+
+describe('writeImprovementMetricsDigestFile', () => {
+  it('throws when IMPROVEMENT_METRICS_DIGEST_PATH is not set', async () => {
+    const previous = process.env.IMPROVEMENT_METRICS_DIGEST_PATH
+    delete process.env.IMPROVEMENT_METRICS_DIGEST_PATH
+    await expect(
+      writeImprovementMetricsDigestFile(
+        {
+          windowDays: 90,
+          anchors: 0,
+          discovery: 0,
+          priorDiscovery: 0,
+          confirmedRecidivism: 0,
+          backlogCount: 0,
+          oldestPendingAgeDays: null,
+          state: 'insufficient-signal',
+        },
+        [],
+      ),
+    ).rejects.toThrow('IMPROVEMENT_METRICS_DIGEST_PATH')
+    if (previous !== undefined) process.env.IMPROVEMENT_METRICS_DIGEST_PATH = previous
+  })
+
+  it('writes counts-only digest + edges to the configured path', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'improvement-metrics-'))
+    const digestPath = join(dir, 'digest.json')
+    const previous = process.env.IMPROVEMENT_METRICS_DIGEST_PATH
+    process.env.IMPROVEMENT_METRICS_DIGEST_PATH = digestPath
+    try {
+      await writeImprovementMetricsDigestFile(
+        {
+          windowDays: 90,
+          anchors: 1,
+          discovery: 1,
+          priorDiscovery: 0,
+          confirmedRecidivism: 0,
+          backlogCount: 0,
+          oldestPendingAgeDays: null,
+          state: 'healthy',
+        },
+        [],
+      )
+      const {readFile} = await import('node:fs/promises')
+      const raw = await readFile(digestPath, 'utf8')
+      const parsed: unknown = JSON.parse(raw)
+      expect(parsed).toMatchObject({digest: {anchors: 1, state: 'healthy'}, edges: []})
+    } finally {
+      if (previous === undefined) delete process.env.IMPROVEMENT_METRICS_DIGEST_PATH
+      else process.env.IMPROVEMENT_METRICS_DIGEST_PATH = previous
+      await rm(dir, {recursive: true, force: true})
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// I/O shell: loadGitAddDates fail-closed
+// ---------------------------------------------------------------------------
+
+describe('loadGitAddDates', () => {
+  it('resolves the earliest add-date per path from git log output', () => {
+    const fakeExec = ((_cmd: string, args: readonly string[]) => {
+      expect(args).toContain('--diff-filter=A')
+      return '2026-05-01T00:00:00+00:00\n'
+    }) as unknown as typeof import('node:child_process').execFileSync
+    const result = loadGitAddDates(['docs/solutions/best-practices/x.md'], fakeExec)
+    expect(result.get('docs/solutions/best-practices/x.md')).toBe('2026-05-01T00:00:00+00:00')
+  })
+
+  it('throws (fail-closed) when a path has no resolvable git add-date', () => {
+    const fakeExec = (() => '') as unknown as typeof import('node:child_process').execFileSync
+    expect(() => loadGitAddDates(['docs/solutions/best-practices/missing.md'], fakeExec)).toThrow()
+  })
+})

--- a/scripts/improvement-metrics-detect.ts
+++ b/scripts/improvement-metrics-detect.ts
@@ -28,10 +28,15 @@ import {
   buildClassKey,
   buildEdgeFingerprint,
   IMPROVEMENT_METRICS_REPORT_LABEL,
-  parseEdgeChecklistLine,
+  recoverPriorTickState,
   type ClassKeyFrontmatter,
   type ReportState,
 } from './improvement-metrics-core.ts'
+
+// Re-exported for callers (and tests) that import tick-state recovery from
+// the detect module; the implementation now lives in improvement-metrics-core.ts
+// so detect and report cannot drift.
+export {recoverPriorTickState} from './improvement-metrics-core.ts'
 
 // ---------------------------------------------------------------------------
 // Tunable constants
@@ -569,19 +574,6 @@ function buildSolutionDocRecords(files: Record<string, string>, addDates: Map<st
     })
   }
   return records
-}
-
-/**
- * Recover ticked edge fingerprints from the prior report issue body by scanning
- * every line for a checklist entry (Unit 1's `parseEdgeChecklistLine`).
- */
-export function recoverPriorTickState(body: string): Set<string> {
-  const ticked = new Set<string>()
-  for (const line of body.split('\n')) {
-    const entry = parseEdgeChecklistLine(line.trim())
-    if (entry !== null && entry.checked) ticked.add(entry.fingerprint)
-  }
-  return ticked
 }
 
 async function fetchPriorTickState(

--- a/scripts/improvement-metrics-detect.ts
+++ b/scripts/improvement-metrics-detect.ts
@@ -1,0 +1,702 @@
+/**
+ * Detect entrypoint for the improvement-metric loop.
+ *
+ * Pure core `computeMetrics` classifies solution docs (codified-class anchors) and
+ * proposal issues (candidate recurrence events) once, then derives discovery,
+ * confirmed-recidivism, backlog, the prior-window delta, and the deterministic
+ * report state. The I/O shell (`main`) fetches the structured sources, reads the
+ * prior report's tick-state, and writes a counts-only digest + edge list.
+ *
+ * O8-native candidate scorer: `scoreCandidateLink` is asymmetric by design — a
+ * proposal issue carries only title + labels (no module/problem_type/tags
+ * frontmatter), while a codified class carries title + tags + module. It matches
+ * proposal title/label tokens against the class's title/tag/module tokens. It does
+ * NOT import the private, symmetric `computeSourceOverlapScore` from
+ * capture-patterns-cluster.ts, which assumes both sides carry the same structured
+ * frontmatter.
+ *
+ * Strip-only safe: no enums, namespaces, parameter properties, or `any`.
+ */
+
+import type {Dirent} from 'node:fs'
+import {execFileSync} from 'node:child_process'
+import {readdir, readFile} from 'node:fs/promises'
+import process from 'node:process'
+
+import {parse} from 'yaml'
+import {
+  buildClassKey,
+  buildEdgeFingerprint,
+  IMPROVEMENT_METRICS_REPORT_LABEL,
+  parseEdgeChecklistLine,
+  type ClassKeyFrontmatter,
+  type ReportState,
+} from './improvement-metrics-core.ts'
+
+// ---------------------------------------------------------------------------
+// Tunable constants
+// ---------------------------------------------------------------------------
+
+/** Rolling window (days) discovery/candidate detection is evaluated over. */
+export const WINDOW_DAYS = 90
+
+/** Minimum codified-class corpus size required before rendering an interpreted state. */
+export const MIN_ANCHORS = 3
+
+/** Minimum in-window discovery count required before rendering an interpreted state. */
+export const MIN_DISCOVERY = 2
+
+/** Oldest-unticked-candidate age (days) above which the backlog is considered stale. */
+export const STALE_AGE_DAYS = 14
+
+/**
+ * Minimum `scoreCandidateLink` score (inclusive) for an (event -> class) edge to
+ * surface. Tokenizer awards 10 points per shared title token, 15 per shared tag
+ * match, and 20 per shared module-token match (see `scoreCandidateLink`). A single
+ * shared title token (10) never clears this bar alone — it must combine with a
+ * second shared token or a stronger tag/module match, matching the "strong-field
+ * token match" requirement below.
+ */
+export const SCORE_THRESHOLD = 20
+
+// ---------------------------------------------------------------------------
+// Tokenizer (mirrors capture-patterns-synthesis.ts tokenizeTitle)
+// ---------------------------------------------------------------------------
+
+const TITLE_STOPWORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'but',
+  'by',
+  'do',
+  'does',
+  'fix',
+  'for',
+  'from',
+  'has',
+  'have',
+  'in',
+  'into',
+  'is',
+  'it',
+  'not',
+  'of',
+  'on',
+  'or',
+  'that',
+  'the',
+  'this',
+  'to',
+  'was',
+  'were',
+  'will',
+  'with',
+])
+
+/** Tokenize a title/label into lowercase, stopword-filtered word tokens (>= 3 chars). */
+export function tokenizeText(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/u)
+    .filter(token => token.length >= 3 && !TITLE_STOPWORDS.has(token))
+}
+
+function moduleTokens(module: string): string[] {
+  return module
+    .toLowerCase()
+    .split(/[/.\-_]/u)
+    .filter(t => t.length >= 3)
+}
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
+
+/** A codified-class anchor: solution-doc identity frontmatter + immutable git add-date. */
+export interface SolutionDocRecord {
+  frontmatter: ClassKeyFrontmatter
+  /** Title used for candidate-scoring token overlap; solution-doc frontmatter `title` or filename stem. */
+  title: string
+  /** Tags used for candidate-scoring token/exact overlap; solution-doc frontmatter `tags`. */
+  tags: string[]
+  /** Immutable git first-commit (add) date of the doc, ISO 8601. NEVER frontmatter `date`. */
+  gitAddDate: string
+}
+
+/** A proposal issue eligible as a candidate recurrence event. */
+export interface ProposalEvent {
+  id: string
+  title: string
+  labels: string[]
+  createdAt: string
+  /** Public, dereferenceable issue URL. */
+  url: string
+}
+
+/** A recovered edge fingerprint + its tick-state from the prior report body. */
+export type PriorTickState = ReadonlySet<string>
+
+export interface DetectEdge {
+  fingerprint: string
+  classKey: string
+  eventId: string
+  eventUrl: string
+  eventCreatedAt: string
+  ticked: boolean
+}
+
+export interface ComputeMetricsInput {
+  solutionDocs: readonly SolutionDocRecord[]
+  proposalEvents: readonly ProposalEvent[]
+  priorTickState: PriorTickState
+  now: Date
+  windowDays?: number
+  minAnchors?: number
+  minDiscovery?: number
+  staleAgeDays?: number
+  scoreThreshold?: number
+}
+
+export interface MetricsDigest {
+  windowDays: number
+  anchors: number
+  discovery: number
+  priorDiscovery: number
+  confirmedRecidivism: number
+  backlogCount: number
+  oldestPendingAgeDays: number | null
+  state: ReportState
+}
+
+export interface ComputeMetricsResult {
+  digest: MetricsDigest
+  edges: DetectEdge[]
+}
+
+// ---------------------------------------------------------------------------
+// O8-native asymmetric candidate scorer
+// ---------------------------------------------------------------------------
+
+export interface CandidateScoreResult {
+  score: number
+  strongMatch: boolean
+}
+
+/**
+ * Score a proposal event against a codified class over honestly-asymmetric signals:
+ * the event has only title + labels; the class has title + tags + module.
+ *
+ * Scoring (deterministic, additive):
+ * - Each shared title token (event title tokens vs class title tokens): 10 points.
+ * - Each event label matching a class tag (case-insensitive exact match): 15 points.
+ * - Each event title token matching a class module token: 20 points.
+ *
+ * "Strong-field token match" = at least one shared title-token match OR at least
+ * one label/tag exact match — i.e. at least one high-signal (title or tag) hit,
+ * not merely accumulated module-token overlap alone.
+ *
+ * Pure function: no I/O.
+ */
+export function scoreCandidateLink(event: ProposalEvent, classDoc: SolutionDocRecord): CandidateScoreResult {
+  const eventTitleTokens = new Set(tokenizeText(event.title))
+  const classTitleTokens = new Set(tokenizeText(classDoc.title))
+  const classTags = new Set(classDoc.tags.map(t => t.toLowerCase()))
+  const classModuleTokens = new Set(moduleTokens(classDoc.frontmatter.module ?? ''))
+  const eventLabels = new Set(event.labels.map(l => l.toLowerCase()))
+
+  let score = 0
+  let titleTokenMatch = false
+  let tagMatch = false
+
+  for (const token of eventTitleTokens) {
+    if (classTitleTokens.has(token)) {
+      score += 10
+      titleTokenMatch = true
+    }
+  }
+
+  for (const label of eventLabels) {
+    if (classTags.has(label)) {
+      score += 15
+      tagMatch = true
+    }
+  }
+
+  for (const token of eventTitleTokens) {
+    if (classModuleTokens.has(token)) {
+      score += 20
+    }
+  }
+
+  return {score, strongMatch: titleTokenMatch || tagMatch}
+}
+
+// ---------------------------------------------------------------------------
+// Pure core
+// ---------------------------------------------------------------------------
+
+function inWindow(dateIso: string, start: Date, end: Date): boolean {
+  const ms = new Date(dateIso).getTime()
+  if (Number.isNaN(ms)) return false
+  return ms >= start.getTime() && ms <= end.getTime()
+}
+
+function distinctClassKeysInWindow(solutionDocs: readonly SolutionDocRecord[], start: Date, end: Date): Set<string> {
+  const keys = new Set<string>()
+  for (const doc of solutionDocs) {
+    if (inWindow(doc.gitAddDate, start, end)) {
+      keys.add(buildClassKey(doc.frontmatter))
+    }
+  }
+  return keys
+}
+
+/**
+ * Compute the improvement-metric digest + edge list from injected, already-loaded
+ * sources and the prior report's tick-state. Pure function: no I/O.
+ */
+export function computeMetrics(input: ComputeMetricsInput): ComputeMetricsResult {
+  const windowDays = input.windowDays ?? WINDOW_DAYS
+  const minAnchors = input.minAnchors ?? MIN_ANCHORS
+  const minDiscovery = input.minDiscovery ?? MIN_DISCOVERY
+  const staleAgeDays = input.staleAgeDays ?? STALE_AGE_DAYS
+  const scoreThreshold = input.scoreThreshold ?? SCORE_THRESHOLD
+
+  const now = input.now
+  const windowMs = windowDays * 24 * 60 * 60 * 1000
+  const windowStart = new Date(now.getTime() - windowMs)
+  const priorWindowStart = new Date(now.getTime() - 2 * windowMs)
+  const priorWindowEnd = windowStart
+
+  const anchors = input.solutionDocs.length
+  const discovery = distinctClassKeysInWindow(input.solutionDocs, windowStart, now).size
+  const priorDiscovery = distinctClassKeysInWindow(input.solutionDocs, priorWindowStart, priorWindowEnd).size
+
+  const belowFloor = anchors < minAnchors || discovery < minDiscovery
+
+  const edges: DetectEdge[] = []
+  let confirmedRecidivism = 0
+
+  if (!belowFloor) {
+    for (const event of input.proposalEvents) {
+      if (!inWindow(event.createdAt, windowStart, now)) continue
+      for (const classDoc of input.solutionDocs) {
+        const {score, strongMatch} = scoreCandidateLink(event, classDoc)
+        if (score < scoreThreshold || !strongMatch) continue
+
+        const classKey = buildClassKey(classDoc.frontmatter)
+        const fingerprint = buildEdgeFingerprint(classKey, event.id)
+        const ticked = input.priorTickState.has(fingerprint)
+        if (ticked) confirmedRecidivism += 1
+
+        edges.push({
+          fingerprint,
+          classKey,
+          eventId: event.id,
+          eventUrl: event.url,
+          eventCreatedAt: event.createdAt,
+          ticked,
+        })
+      }
+    }
+  }
+
+  const backlogEdges = edges.filter(edge => !edge.ticked)
+  const backlogCount = backlogEdges.length
+  let oldestPendingAgeDays: number | null = null
+  if (backlogEdges.length > 0) {
+    let oldestMs = Number.POSITIVE_INFINITY
+    for (const edge of backlogEdges) {
+      const ms = new Date(edge.eventCreatedAt).getTime()
+      if (!Number.isNaN(ms) && ms < oldestMs) oldestMs = ms
+    }
+    oldestPendingAgeDays =
+      oldestMs === Number.POSITIVE_INFINITY ? null : (now.getTime() - oldestMs) / (24 * 60 * 60 * 1000)
+  }
+
+  let state: ReportState
+  if (belowFloor) {
+    state = 'insufficient-signal'
+  } else if (confirmedRecidivism > 0 && confirmedRecidivism >= discovery) {
+    state = 'failing'
+  } else if (discovery < priorDiscovery || (oldestPendingAgeDays !== null && oldestPendingAgeDays > staleAgeDays)) {
+    state = 'ambiguous'
+  } else {
+    state = 'healthy'
+  }
+
+  const digest: MetricsDigest = {
+    windowDays,
+    anchors,
+    discovery,
+    priorDiscovery,
+    confirmedRecidivism,
+    backlogCount,
+    oldestPendingAgeDays,
+    state,
+  }
+
+  return {digest, edges}
+}
+
+// ---------------------------------------------------------------------------
+// I/O shell
+// ---------------------------------------------------------------------------
+
+/** Canonical solution-doc subdirectories scanned for codified-class anchors. */
+const SOLUTIONS_SUBDIRS = ['best-practices', 'security-issues', 'runtime-errors', 'workflow-issues'] as const
+
+/** Source labels eligible for proposal-event collection. */
+const PROPOSAL_SOURCE_LABELS = ['learning-proposal', 'pattern-proposal', 'status-truth'] as const
+
+/** Minimal shape of an issue returned by `paginate(listForRepo)`. */
+interface RawProposalIssue {
+  readonly number: number
+  readonly title?: string | null
+  readonly created_at?: string
+  readonly html_url?: string
+  readonly labels?: readonly (string | {readonly name?: string | null})[]
+}
+
+/** Minimal shape of an issue returned by `listForRepo` for the prior report lookup. */
+interface RawReportIssue {
+  readonly number: number
+  readonly body?: string | null
+}
+
+/** Narrow injected Octokit-like client interface for testability. */
+export interface ImprovementMetricsOctokitClient {
+  readonly paginate: (fn: unknown, params: Record<string, unknown>) => Promise<RawProposalIssue[]>
+  readonly rest: {
+    readonly issues: {
+      readonly listForRepo: (params: {
+        owner: string
+        repo: string
+        labels?: string
+        state: 'open' | 'closed' | 'all'
+        per_page?: number
+      }) => Promise<{data: RawReportIssue[]}>
+    }
+  }
+}
+
+/** Counts-only result JSON written to stdout. */
+export interface DetectResult {
+  windowDays: number
+  anchors: number
+  discovery: number
+  priorDiscovery: number
+  confirmedRecidivism: number
+  backlogCount: number
+  oldestPendingAgeDays: number | null
+  state: ReportState | null
+  edgeCount: number
+  tokenLoadFailure: boolean
+  scanFailure: boolean
+  gitHistoryUnavailable: boolean
+}
+
+const EMPTY_DIGEST: MetricsDigest = {
+  windowDays: WINDOW_DAYS,
+  anchors: 0,
+  discovery: 0,
+  priorDiscovery: 0,
+  confirmedRecidivism: 0,
+  backlogCount: 0,
+  oldestPendingAgeDays: null,
+  state: 'insufficient-signal',
+}
+
+function emptyDetectResult(): DetectResult {
+  return {
+    windowDays: WINDOW_DAYS,
+    anchors: 0,
+    discovery: 0,
+    priorDiscovery: 0,
+    confirmedRecidivism: 0,
+    backlogCount: 0,
+    oldestPendingAgeDays: null,
+    state: null,
+    edgeCount: 0,
+    tokenLoadFailure: false,
+    scanFailure: false,
+    gitHistoryUnavailable: false,
+  }
+}
+
+/**
+ * Fetch proposal issues across the closed set of eligible source labels via
+ * `octokit.paginate(listForRepo, {labels, state:'all'})`, one paginated call per
+ * label.
+ */
+export async function fetchProposalEventsFromRepo(
+  octokit: ImprovementMetricsOctokitClient,
+  owner: string,
+  repo: string,
+): Promise<ProposalEvent[]> {
+  const events: ProposalEvent[] = []
+  for (const label of PROPOSAL_SOURCE_LABELS) {
+    const raw = await octokit.paginate(octokit.rest.issues.listForRepo, {
+      owner,
+      repo,
+      state: 'all',
+      labels: label,
+      per_page: 100,
+    })
+    for (const issue of raw) {
+      events.push({
+        id: String(issue.number),
+        title: issue.title ?? '',
+        labels: (issue.labels ?? []).map(l => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean),
+        createdAt: issue.created_at ?? '',
+        url: issue.html_url ?? `https://github.com/${owner}/${repo}/issues/${issue.number}`,
+      })
+    }
+  }
+  return events
+}
+
+/** Result of loading solution-doc file contents from disk. */
+export interface LoadSolutionDocFilesResult {
+  files: Record<string, string>
+  readFailures: number
+}
+
+/** Load solution-doc file contents from disk, under the canonical subdirectories. */
+export async function loadSolutionDocFilesFromDisk(
+  writeStderr: (message: string) => void = message => process.stderr.write(message),
+): Promise<LoadSolutionDocFilesResult> {
+  const files: Record<string, string> = {}
+  let readFailures = 0
+
+  for (const subdir of SOLUTIONS_SUBDIRS) {
+    const dirPath = `docs/solutions/${subdir}`
+    let entries: Dirent[]
+    try {
+      entries = await readdir(dirPath, {withFileTypes: true})
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.md')) continue
+      const path = `${dirPath}/${entry.name}`
+      try {
+        files[path] = await readFile(path, 'utf8')
+      } catch {
+        readFailures += 1
+        writeStderr(`improvement-metrics-detect: could not read file (path: ${path})\n`)
+      }
+    }
+  }
+
+  return {files, readFailures}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function splitFrontmatter(content: string): Record<string, unknown> {
+  const match = /^---\n([\s\S]+?)\n---\n?/u.exec(content)
+  if (match === null) return {}
+  const frontmatterText = match[1]
+  if (frontmatterText === undefined) return {}
+  let parsed: unknown
+  try {
+    parsed = parse(frontmatterText)
+  } catch {
+    return {}
+  }
+  return isRecord(parsed) ? parsed : {}
+}
+
+/**
+ * Obtain the git first-commit (add) date for every solution-doc path, via one
+ * `git log --diff-filter=A --follow --format=%aI` pass over `docs/solutions/`.
+ *
+ * Fail-closed: if git history is unavailable/shallow such that a path's add-date
+ * cannot be resolved for any path that exists on disk, throws so the caller can
+ * set `gitHistoryUnavailable` and fail closed rather than falling back to
+ * frontmatter `date`.
+ */
+export function loadGitAddDates(
+  paths: readonly string[],
+  execFileSyncFn: typeof execFileSync = execFileSync,
+): Map<string, string> {
+  const addDates = new Map<string, string>()
+  for (const path of paths) {
+    const stdout = execFileSyncFn('git', ['log', '--diff-filter=A', '--follow', '--format=%aI', '--', path], {
+      encoding: 'utf8',
+    })
+    const lines = stdout
+      .toString()
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean)
+    const earliest = lines.at(-1)
+    if (earliest === undefined) {
+      throw new Error(`improvement-metrics-detect: no git add-date resolvable for ${path}`)
+    }
+    addDates.set(path, earliest)
+  }
+  return addDates
+}
+
+function buildSolutionDocRecords(files: Record<string, string>, addDates: Map<string, string>): SolutionDocRecord[] {
+  const records: SolutionDocRecord[] = []
+  for (const [path, content] of Object.entries(files)) {
+    const frontmatter = splitFrontmatter(content)
+    const addDate = addDates.get(path)
+    if (addDate === undefined) continue
+    const title = typeof frontmatter.title === 'string' ? frontmatter.title : path
+    const tags = Array.isArray(frontmatter.tags)
+      ? frontmatter.tags.filter((t): t is string => typeof t === 'string')
+      : []
+    records.push({
+      frontmatter: {
+        module: typeof frontmatter.module === 'string' ? frontmatter.module : undefined,
+        component: typeof frontmatter.component === 'string' ? frontmatter.component : undefined,
+        problem_type: typeof frontmatter.problem_type === 'string' ? frontmatter.problem_type : undefined,
+      },
+      title,
+      tags,
+      gitAddDate: addDate,
+    })
+  }
+  return records
+}
+
+/**
+ * Recover ticked edge fingerprints from the prior report issue body by scanning
+ * every line for a checklist entry (Unit 1's `parseEdgeChecklistLine`).
+ */
+export function recoverPriorTickState(body: string): Set<string> {
+  const ticked = new Set<string>()
+  for (const line of body.split('\n')) {
+    const entry = parseEdgeChecklistLine(line.trim())
+    if (entry !== null && entry.checked) ticked.add(entry.fingerprint)
+  }
+  return ticked
+}
+
+async function fetchPriorTickState(
+  octokit: ImprovementMetricsOctokitClient,
+  owner: string,
+  repo: string,
+): Promise<Set<string>> {
+  const response = await octokit.rest.issues.listForRepo({
+    owner,
+    repo,
+    state: 'open',
+    labels: IMPROVEMENT_METRICS_REPORT_LABEL,
+    per_page: 10,
+  })
+  const issue = response.data[0]
+  if (issue === undefined || issue.body === null || issue.body === undefined) return new Set()
+  return recoverPriorTickState(issue.body)
+}
+
+/**
+ * Write the counts-only digest + fingerprint edge list to
+ * `IMPROVEMENT_METRICS_DIGEST_PATH`. Fail-closed: missing/empty env var is a
+ * configuration error, not a silent no-op.
+ */
+export async function writeImprovementMetricsDigestFile(
+  digest: MetricsDigest,
+  edges: readonly DetectEdge[],
+): Promise<void> {
+  const {writeFile} = await import('node:fs/promises')
+  const digestPath = process.env.IMPROVEMENT_METRICS_DIGEST_PATH
+  if (digestPath === undefined || digestPath === '') {
+    throw new Error('improvement-metrics-detect: IMPROVEMENT_METRICS_DIGEST_PATH is required to persist the digest')
+  }
+  await writeFile(digestPath, `${JSON.stringify({digest, edges})}\n`, {flag: 'w'})
+}
+
+/**
+ * CLI entry point for the detect step: token-load-before-API fail-closed ordering,
+ * fetch structured sources + prior tick-state, compute the digest via the pure
+ * core, and write the counts-only digest to `IMPROVEMENT_METRICS_DIGEST_PATH`.
+ *
+ * Best-effort: any unexpected error falls back to an empty digest and exit 0.
+ */
+async function main(): Promise<void> {
+  const owner = 'fro-bot'
+  const repo = '.github'
+
+  const result = emptyDetectResult()
+
+  try {
+    const {loadPrivateTokensFromDisk} = await import('./capture-learnings-privacy.ts')
+    const {loadRedactedCanonicalIdsFromDisk} = await import('./status-truth-proposals.ts')
+
+    try {
+      await Promise.all([loadPrivateTokensFromDisk(), loadRedactedCanonicalIdsFromDisk()])
+    } catch {
+      result.tokenLoadFailure = true
+      await writeImprovementMetricsDigestFile(EMPTY_DIGEST, []).catch(() => undefined)
+      process.stdout.write(`${JSON.stringify(result)}\n`)
+      return
+    }
+
+    const {createOctokitFromEnv} = await import('./capture-learnings-harvest.ts')
+    const octokit = (await createOctokitFromEnv()) as unknown as ImprovementMetricsOctokitClient
+
+    const [solutionDocFiles, proposalEvents, priorTickState] = await Promise.all([
+      loadSolutionDocFilesFromDisk(),
+      fetchProposalEventsFromRepo(octokit, owner, repo),
+      fetchPriorTickState(octokit, owner, repo),
+    ])
+
+    let gitAddDates: Map<string, string>
+    try {
+      gitAddDates = loadGitAddDates(Object.keys(solutionDocFiles.files))
+    } catch {
+      result.gitHistoryUnavailable = true
+      await writeImprovementMetricsDigestFile(EMPTY_DIGEST, []).catch(() => undefined)
+      process.stdout.write(`${JSON.stringify(result)}\n`)
+      return
+    }
+
+    const solutionDocs = buildSolutionDocRecords(solutionDocFiles.files, gitAddDates)
+
+    const {digest, edges} = computeMetrics({
+      solutionDocs,
+      proposalEvents,
+      priorTickState,
+      now: new Date(),
+    })
+
+    result.windowDays = digest.windowDays
+    result.anchors = digest.anchors
+    result.discovery = digest.discovery
+    result.priorDiscovery = digest.priorDiscovery
+    result.confirmedRecidivism = digest.confirmedRecidivism
+    result.backlogCount = digest.backlogCount
+    result.oldestPendingAgeDays = digest.oldestPendingAgeDays
+    result.state = digest.state
+    result.edgeCount = edges.length
+
+    await writeImprovementMetricsDigestFile(digest, edges)
+  } catch (error: unknown) {
+    const errorName = error instanceof Error ? error.name : 'unknown'
+    process.stderr.write(`improvement-metrics-detect: unexpected error (${errorName}), falling back to empty digest\n`)
+    result.scanFailure = true
+    try {
+      await writeImprovementMetricsDigestFile(EMPTY_DIGEST, [])
+    } catch {
+      // ignore
+    }
+  }
+
+  process.stdout.write(`${JSON.stringify(result)}\n`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}

--- a/scripts/improvement-metrics-integration.test.ts
+++ b/scripts/improvement-metrics-integration.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Golden-path integration test for the improvement-metric loop.
+ *
+ * Drives the REAL detect -> render -> upsert compose path on real-shaped
+ * fixtures: `computeMetrics` (pure core) -> `renderReportBody` (pure render,
+ * invoked internally by `upsertReportIssue`) -> `upsertReportIssue` (I/O
+ * shell), against a hand-rolled mock octokit at the upsert boundary only.
+ * `applyPublicOutputGate` is exercised for real via `makePublicOutputTokens`
+ * — never mocked — so a removed gate call or an altered state-ladder
+ * threshold fails this test (the anti-recurrence contract).
+ *
+ * Structure:
+ * - happy end-to-end: correct paired counts, selected state, backlog surfacing
+ * - tick-state preservation across upsert (ticked edge stays [x], unticked stays [ ])
+ * - confirmed recidivism counts only the ticked edge
+ * - mutation-proof: a private-identifier-shaped string reaching the body via a
+ *   fixture field blocks the render AND performs no upsert
+ */
+
+import type {ProposalEvent, SolutionDocRecord} from './improvement-metrics-detect.ts'
+import type {ImprovementMetricsReportOctokitClient} from './improvement-metrics-report.ts'
+
+import {describe, expect, it, vi} from 'vitest'
+import {buildClassKey, buildEdgeFingerprint} from './improvement-metrics-core.ts'
+import {computeMetrics, recoverPriorTickState} from './improvement-metrics-detect.ts'
+import {renderReportBody, ReportRenderBlockedError, upsertReportIssue} from './improvement-metrics-report.ts'
+import {makePublicOutputTokens, type PublicOutputTokens} from './status-truth-public-output.ts'
+
+const NOW = new Date('2026-07-10T00:00:00.000Z')
+
+function daysAgo(days: number): string {
+  return new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000).toISOString()
+}
+
+const NO_PRIVATE_TOKENS: PublicOutputTokens = makePublicOutputTokens({
+  privateTokens: new Set(),
+  redactedCanonicalIds: new Set(),
+})
+
+// ---------------------------------------------------------------------------
+// Real-shaped fixtures
+// ---------------------------------------------------------------------------
+
+const RETRY_DOC: SolutionDocRecord = {
+  frontmatter: {module: 'scripts/retry.ts', component: undefined, problem_type: 'retry-storms'},
+  title: 'Retry idempotent writes after 5xx failures',
+  tags: ['best-practice', 'retries'],
+  gitAddDate: daysAgo(10), // in-window
+}
+
+const AUTH_DOC: SolutionDocRecord = {
+  frontmatter: {module: 'scripts/auth.ts', component: undefined, problem_type: 'token-expiry'},
+  title: 'Refresh auth tokens before expiry',
+  tags: ['best-practice', 'auth'],
+  gitAddDate: daysAgo(20), // in-window
+}
+
+const CACHE_DOC: SolutionDocRecord = {
+  frontmatter: {module: 'scripts/cache.ts', component: undefined, problem_type: 'cache-invalidation'},
+  title: 'Invalidate cache on region rotation',
+  tags: ['best-practice', 'cache'],
+  gitAddDate: daysAgo(150), // in prior window only
+}
+
+const QUEUE_DOC: SolutionDocRecord = {
+  frontmatter: {module: 'scripts/queue.ts', component: undefined, problem_type: 'queue-backpressure'},
+  title: 'Apply backpressure under queue overflow',
+  tags: ['best-practice', 'queue'],
+  gitAddDate: daysAgo(200), // outside both windows
+}
+
+const SOLUTION_DOCS: readonly SolutionDocRecord[] = [RETRY_DOC, AUTH_DOC, CACHE_DOC, QUEUE_DOC]
+
+const RETRY_EVENT: ProposalEvent = {
+  id: '201',
+  title: 'Retry storm on 5xx errors during deploy',
+  labels: ['learning-proposal'],
+  createdAt: daysAgo(5),
+  url: 'https://github.com/fro-bot/.github/issues/201',
+}
+
+const AUTH_EVENT: ProposalEvent = {
+  id: '202',
+  title: 'Auth token refresh flake causing 401s',
+  labels: ['learning-proposal', 'auth'],
+  createdAt: daysAgo(8),
+  url: 'https://github.com/fro-bot/.github/issues/202',
+}
+
+const PROPOSAL_EVENTS: readonly ProposalEvent[] = [RETRY_EVENT, AUTH_EVENT]
+
+const RETRY_CLASS_KEY = buildClassKey(RETRY_DOC.frontmatter)
+const AUTH_CLASS_KEY = buildClassKey(AUTH_DOC.frontmatter)
+const RETRY_FINGERPRINT = buildEdgeFingerprint(RETRY_CLASS_KEY, RETRY_EVENT.id)
+const AUTH_FINGERPRINT = buildEdgeFingerprint(AUTH_CLASS_KEY, AUTH_EVENT.id)
+
+/**
+ * A prior report body as would be produced by a previous `renderReportBody` run:
+ * the retry edge ticked (confirmed last time), the auth edge unticked (still backlog).
+ */
+function buildPriorReportBody(): string {
+  return renderReportBody(
+    {
+      windowDays: 90,
+      anchors: 3,
+      discovery: 1,
+      priorDiscovery: 1,
+      confirmedRecidivism: 1,
+      backlogCount: 1,
+      oldestPendingAgeDays: 3,
+      state: 'healthy',
+    },
+    [
+      {
+        fingerprint: RETRY_FINGERPRINT,
+        classKey: RETRY_CLASS_KEY,
+        eventId: RETRY_EVENT.id,
+        eventUrl: RETRY_EVENT.url,
+        eventCreatedAt: RETRY_EVENT.createdAt,
+        ticked: true,
+      },
+      {
+        fingerprint: AUTH_FINGERPRINT,
+        classKey: AUTH_CLASS_KEY,
+        eventId: AUTH_EVENT.id,
+        eventUrl: AUTH_EVENT.url,
+        eventCreatedAt: AUTH_EVENT.createdAt,
+        ticked: false,
+      },
+    ],
+    NO_PRIVATE_TOKENS,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Hand-rolled mock octokit (upsert boundary only)
+// ---------------------------------------------------------------------------
+
+function makeMockOctokit(existingBody: string | null): {
+  octokit: ImprovementMetricsReportOctokitClient
+  create: ReturnType<typeof vi.fn>
+  update: ReturnType<typeof vi.fn>
+} {
+  const listForRepo = vi.fn(async () => ({
+    data: existingBody === null ? [] : [{number: 501, body: existingBody}],
+  }))
+  const create = vi.fn(async (params: {title: string; body: string}) => ({data: {number: 501}, ...params}))
+  const update = vi.fn(async () => ({}))
+  const getLabel = vi.fn(async () => ({}))
+  const createLabel = vi.fn(async () => ({}))
+
+  return {
+    octokit: {issues: {listForRepo, create, update, getLabel, createLabel}},
+    create,
+    update,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Golden path
+// ---------------------------------------------------------------------------
+
+describe('improvement-metrics golden path (detect -> render -> upsert)', () => {
+  it('computes correct paired counts, state, and backlog from real-shaped sources', () => {
+    const priorBody = buildPriorReportBody()
+    const priorTickState = recoverPriorTickState(priorBody)
+
+    const {digest, edges} = computeMetrics({
+      solutionDocs: SOLUTION_DOCS,
+      proposalEvents: PROPOSAL_EVENTS,
+      priorTickState,
+      now: NOW,
+    })
+
+    expect(digest.anchors).toBe(4)
+    expect(digest.discovery).toBe(2) // retry + auth, in-window
+    expect(digest.priorDiscovery).toBe(1) // cache, in prior window
+    expect(digest.confirmedRecidivism).toBe(1) // retry edge ticked
+    expect(digest.backlogCount).toBe(1) // auth edge unticked
+    expect(digest.oldestPendingAgeDays).not.toBeNull()
+    expect(digest.state).toBe('healthy')
+
+    const retryEdge = edges.find(e => e.fingerprint === RETRY_FINGERPRINT)
+    const authEdge = edges.find(e => e.fingerprint === AUTH_FINGERPRINT)
+    expect(retryEdge?.ticked).toBe(true)
+    expect(authEdge?.ticked).toBe(false)
+  })
+
+  it('preserves tick state across upsert: the ticked edge is re-emitted [x], the unticked stays [ ]', async () => {
+    const priorBody = buildPriorReportBody()
+    const priorTickState = recoverPriorTickState(priorBody)
+
+    const {digest, edges} = computeMetrics({
+      solutionDocs: SOLUTION_DOCS,
+      proposalEvents: PROPOSAL_EVENTS,
+      priorTickState,
+      now: NOW,
+    })
+
+    const {octokit, create, update} = makeMockOctokit(priorBody)
+
+    const result = await upsertReportIssue({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      digest,
+      edges,
+      tokens: NO_PRIVATE_TOKENS,
+    })
+
+    expect(result.outcome).toBe('updated')
+    expect(create).not.toHaveBeenCalled()
+    expect(update).toHaveBeenCalledTimes(1)
+
+    const updateCall = update.mock.calls[0]?.[0] as {body: string}
+    expect(updateCall.body).toContain(`- [x] <!-- improvement-metrics:edge=${RETRY_FINGERPRINT} -->`)
+    expect(updateCall.body).toContain(`- [ ] <!-- improvement-metrics:edge=${AUTH_FINGERPRINT} -->`)
+
+    // Backlog surfacing: the unticked candidate's age is present.
+    expect(updateCall.body).toContain('Pending backlog: 1')
+    expect(updateCall.body).toMatch(/oldest pending candidate: \d+(\.\d+)?d/u)
+
+    // Public-safe: no fixture private-identifier string leaks (there are none here,
+    // but this locks that a clean fixture renders a clean body).
+    expect(updateCall.body).not.toMatch(/marcusrbrown\/secret-internal-repo/u)
+  })
+
+  it('MUTATION-PROOF: a private-identifier-shaped string reaching the body blocks render and performs no upsert', async () => {
+    const PRIVATE_TOKEN = 'marcusrbrown/secret-internal-repo'
+    const maliciousTokens = makePublicOutputTokens({
+      privateTokens: new Set([PRIVATE_TOKEN]),
+      redactedCanonicalIds: new Set(),
+    })
+
+    // Inject the private token via a classKey-derived field (frontmatter.module),
+    // the only free-text-shaped field that flows into the rendered checklist.
+    const maliciousDoc: SolutionDocRecord = {
+      ...RETRY_DOC,
+      frontmatter: {...RETRY_DOC.frontmatter, module: PRIVATE_TOKEN},
+    }
+
+    const {digest, edges} = computeMetrics({
+      solutionDocs: [maliciousDoc, AUTH_DOC, CACHE_DOC, QUEUE_DOC],
+      proposalEvents: PROPOSAL_EVENTS,
+      priorTickState: new Set(),
+      now: NOW,
+    })
+
+    // Direct render call: this MUST throw if the gate is real and wired in.
+    expect(() => renderReportBody(digest, edges, maliciousTokens)).toThrow(ReportRenderBlockedError)
+
+    // Compose-path assertion: upsertReportIssue must perform NO create/update.
+    const {octokit, create, update} = makeMockOctokit(null)
+
+    const result = await upsertReportIssue({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      digest,
+      edges,
+      tokens: maliciousTokens,
+    })
+
+    expect(result.outcome).toBe('blockedOnPrivacy')
+    expect(create).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
+  })
+})

--- a/scripts/improvement-metrics-integration.test.ts
+++ b/scripts/improvement-metrics-integration.test.ts
@@ -20,10 +20,20 @@
 import type {ProposalEvent, SolutionDocRecord} from './improvement-metrics-detect.ts'
 import type {ImprovementMetricsReportOctokitClient} from './improvement-metrics-report.ts'
 
-import {describe, expect, it, vi} from 'vitest'
+import {randomUUID} from 'node:crypto'
+import {rm} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import process from 'node:process'
+import {afterEach, describe, expect, it, vi} from 'vitest'
 import {buildClassKey, buildEdgeFingerprint} from './improvement-metrics-core.ts'
-import {computeMetrics, recoverPriorTickState} from './improvement-metrics-detect.ts'
-import {renderReportBody, ReportRenderBlockedError, upsertReportIssue} from './improvement-metrics-report.ts'
+import {computeMetrics, recoverPriorTickState, writeImprovementMetricsDigestFile} from './improvement-metrics-detect.ts'
+import {
+  readDigestFile,
+  renderReportBody,
+  ReportRenderBlockedError,
+  upsertReportIssue,
+} from './improvement-metrics-report.ts'
 import {makePublicOutputTokens, type PublicOutputTokens} from './status-truth-public-output.ts'
 
 const NOW = new Date('2026-07-10T00:00:00.000Z')
@@ -264,5 +274,63 @@ describe('improvement-metrics golden path (detect -> render -> upsert)', () => {
     expect(result.outcome).toBe('blockedOnPrivacy')
     expect(create).not.toHaveBeenCalled()
     expect(update).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Detect-write -> report-read file serialization contract
+// ---------------------------------------------------------------------------
+
+describe('detect-file-write -> report-file-read serialization contract', () => {
+  const priorDigestPathEnv = process.env.IMPROVEMENT_METRICS_DIGEST_PATH
+  let digestPath: string
+
+  afterEach(async () => {
+    if (priorDigestPathEnv === undefined) {
+      delete process.env.IMPROVEMENT_METRICS_DIGEST_PATH
+    } else {
+      process.env.IMPROVEMENT_METRICS_DIGEST_PATH = priorDigestPathEnv
+    }
+    await rm(digestPath, {force: true})
+  })
+
+  it('the {digest, edges} shape written by writeImprovementMetricsDigestFile survives a real file round-trip into upsertReportIssue', async () => {
+    digestPath = join(tmpdir(), `improvement-metrics-digest-${randomUUID()}.json`)
+    process.env.IMPROVEMENT_METRICS_DIGEST_PATH = digestPath
+
+    const {digest, edges} = computeMetrics({
+      solutionDocs: SOLUTION_DOCS,
+      proposalEvents: PROPOSAL_EVENTS,
+      priorTickState: new Set(),
+      now: NOW,
+    })
+
+    // Real detect-side writer: writes {digest, edges} to IMPROVEMENT_METRICS_DIGEST_PATH.
+    await writeImprovementMetricsDigestFile(digest, edges)
+
+    // Real report-side reader: reads the same path and casts to {digest, edges}.
+    const digestFile = await readDigestFile(digestPath)
+
+    // This is the exact assertion that fails against the `tee`-clobber defect: if the
+    // workflow's tee had overwritten the file with the detect script's flat stdout
+    // DetectResult (no `digest`/`edges` wrapper), `digestFile.digest` and
+    // `digestFile.edges` would be `undefined` here, and upsertReportIssue would throw
+    // (or silently render `undefined` state) instead of returning `created`/`updated`.
+    expect(digestFile.digest).toEqual(digest)
+    expect(digestFile.edges).toEqual(edges)
+
+    const {octokit, create} = makeMockOctokit(null)
+
+    const result = await upsertReportIssue({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      digest: digestFile.digest,
+      edges: digestFile.edges,
+      tokens: NO_PRIVATE_TOKENS,
+    })
+
+    expect(result.outcome).toBe('created')
+    expect(create).toHaveBeenCalledTimes(1)
   })
 })

--- a/scripts/improvement-metrics-report.test.ts
+++ b/scripts/improvement-metrics-report.test.ts
@@ -38,7 +38,7 @@ function makeDigest(overrides: Partial<MetricsDigest> = {}): MetricsDigest {
     priorDiscovery: 2,
     confirmedRecidivism: 1,
     backlogCount: 2,
-    oldestPendingAgeDays: 5,
+    oldestPendingAgeDays: 5.4791,
     state: 'healthy',
     ...overrides,
   }
@@ -72,7 +72,9 @@ describe('renderReportBody', () => {
     expect(body).toContain('Prior-window discovery: 2')
     expect(body).toContain('Confirmed recidivism (ticked edges): 1')
     expect(body).toContain('Pending backlog: 2')
-    expect(body).toContain('oldest pending candidate: 5d')
+    // Rendered rounded to one decimal place; the raw float is preserved on the digest
+    // itself for the state-ladder comparison (not rounded there).
+    expect(body).toContain('oldest pending candidate: 5.5d')
     expect(body).toContain(edge.fingerprint)
     expect(body).toContain(edge.eventUrl)
     expect(body).toContain(edge.classKey)

--- a/scripts/improvement-metrics-report.test.ts
+++ b/scripts/improvement-metrics-report.test.ts
@@ -8,10 +8,17 @@
  */
 
 import type {DetectEdge, MetricsDigest} from './improvement-metrics-detect.ts'
+import type {ImprovementMetricsReportOctokitClient} from './improvement-metrics-report.ts'
 
-import {describe, expect, it} from 'vitest'
-import {parseReportVersionMarker} from './improvement-metrics-core.ts'
-import {renderReportBody, renderRunSummary, ReportRenderBlockedError} from './improvement-metrics-report.ts'
+import {describe, expect, it, vi} from 'vitest'
+import {buildEdgeChecklistLine, buildReportVersionMarker, parseReportVersionMarker} from './improvement-metrics-core.ts'
+import {
+  IMPROVEMENT_METRICS_REPORT_TITLE,
+  renderReportBody,
+  renderRunSummary,
+  ReportRenderBlockedError,
+  upsertReportIssue,
+} from './improvement-metrics-report.ts'
 import {makePublicOutputTokens, type PublicOutputTokens} from './status-truth-public-output.ts'
 
 // ---------------------------------------------------------------------------
@@ -145,5 +152,291 @@ describe('renderRunSummary', () => {
     // pins that renderRunSummary's gate call is real by failing closed on token-load failure.
     const failedTokens: PublicOutputTokens = {loaded: false, error: 'token load failure'}
     expect(() => renderRunSummary(makeDigest(), failedTokens)).toThrow(ReportRenderBlockedError)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// upsertReportIssue — mock octokit factory
+// ---------------------------------------------------------------------------
+
+interface MockOctokitOptions {
+  listResponses?: {data: {number: number; body?: string | null}[]}[]
+  getLabelShouldFail?: boolean | number
+  createLabelShouldFail?: number
+}
+
+function makeMockOctokit(options: MockOctokitOptions = {}): {
+  octokit: ImprovementMetricsReportOctokitClient
+  create: ReturnType<typeof vi.fn>
+  update: ReturnType<typeof vi.fn>
+  listForRepo: ReturnType<typeof vi.fn>
+} {
+  const listResponses = options.listResponses ?? [{data: []}]
+  let listCallIndex = 0
+
+  const listForRepo = vi.fn(async () => {
+    const response = listResponses[Math.min(listCallIndex, listResponses.length - 1)]
+    listCallIndex += 1
+    return response ?? {data: []}
+  })
+
+  const create = vi.fn(async (params: {title: string; body: string}) => ({
+    data: {number: 100},
+    ...params,
+  }))
+
+  const update = vi.fn(async () => ({}))
+
+  const getLabel = vi.fn(async () => {
+    if (options.getLabelShouldFail === true || options.getLabelShouldFail === 404) {
+      throw Object.assign(new Error('label not found'), {status: 404})
+    }
+    if (typeof options.getLabelShouldFail === 'number') {
+      throw Object.assign(new Error('label check failed'), {status: options.getLabelShouldFail})
+    }
+    return {}
+  })
+
+  const createLabel = vi.fn(async () => {
+    if (options.createLabelShouldFail !== undefined) {
+      throw Object.assign(new Error('label creation failed'), {status: options.createLabelShouldFail})
+    }
+    return {}
+  })
+
+  const octokit: ImprovementMetricsReportOctokitClient = {
+    issues: {listForRepo, create, update, getLabel, createLabel},
+  }
+
+  return {octokit, create, update, listForRepo}
+}
+
+const SAFE_TOKENS: PublicOutputTokens = makePublicOutputTokens({
+  privateTokens: new Set(),
+  redactedCanonicalIds: new Set(),
+})
+
+const FAILED_TOKENS: PublicOutputTokens = {loaded: false, error: 'token load failure'}
+
+describe('upsertReportIssue', () => {
+  it('creates once with the STATIC title + body + marker when no report issue exists (happy path)', async () => {
+    const {octokit, create} = makeMockOctokit({listResponses: [{data: []}]})
+
+    const result = await upsertReportIssue({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      digest: makeDigest(),
+      edges: [makeEdge()],
+      tokens: SAFE_TOKENS,
+    })
+
+    expect(result.outcome).toBe('created')
+    expect(create).toHaveBeenCalledTimes(1)
+    const callArgs = create.mock.calls[0]?.[0] as {title: string; body: string}
+    expect(callArgs.title).toBe(IMPROVEMENT_METRICS_REPORT_TITLE)
+    expect(callArgs.title).toBe('Improvement Metrics')
+    expect(callArgs.body).toContain(makeEdge().fingerprint)
+  })
+
+  it('updates the body in place when an existing issue has a lower version marker; no create', async () => {
+    const priorBody = `# Improvement Metrics\n${buildReportVersionMarker(0)}`
+    const {octokit, create, update} = makeMockOctokit({
+      listResponses: [{data: [{number: 7, body: priorBody}]}],
+    })
+
+    const result = await upsertReportIssue({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      digest: makeDigest(),
+      edges: [],
+      tokens: SAFE_TOKENS,
+    })
+
+    expect(result.outcome).toBe('updated')
+    expect(result.issueNumber).toBe(7)
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(create).not.toHaveBeenCalled()
+  })
+
+  it('re-emits an edge ticked [x] in the prior body as [x] after upsert when still present (CRITICAL)', async () => {
+    const stillPresentEdge = makeEdge({fingerprint: 'd'.repeat(64), ticked: false})
+    const priorBody = [
+      '# Improvement Metrics',
+      buildEdgeChecklistLine({fingerprint: stillPresentEdge.fingerprint, checked: true}),
+      buildReportVersionMarker(0),
+    ].join('\n')
+
+    const {octokit, update} = makeMockOctokit({
+      listResponses: [{data: [{number: 7, body: priorBody}]}],
+    })
+
+    const result = await upsertReportIssue({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      digest: makeDigest(),
+      // Freshly detected: NOT ticked in this run's raw digest — tick-state must be
+      // recovered from the prior body, not merely echoed from the input edge.
+      edges: [stillPresentEdge],
+      tokens: SAFE_TOKENS,
+    })
+
+    expect(result.outcome).toBe('updated')
+    const updateArgs = update.mock.calls[0]?.[0] as {body: string}
+    expect(updateArgs.body).toContain(`- [x] <!-- improvement-metrics:edge=${stillPresentEdge.fingerprint} -->`)
+  })
+
+  it('drops a ticked edge cleanly when it is no longer present in the new digest (close-on-clear)', async () => {
+    const goneFingerprint = 'e'.repeat(64)
+    const priorBody = [
+      '# Improvement Metrics',
+      buildEdgeChecklistLine({fingerprint: goneFingerprint, checked: true}),
+      buildReportVersionMarker(0),
+    ].join('\n')
+
+    const {octokit, update} = makeMockOctokit({
+      listResponses: [{data: [{number: 7, body: priorBody}]}],
+    })
+
+    const result = await upsertReportIssue({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      digest: makeDigest(),
+      edges: [], // gone edge is not in the new digest's edge list at all
+      tokens: SAFE_TOKENS,
+    })
+
+    expect(result.outcome).toBe('updated')
+    const updateArgs = update.mock.calls[0]?.[0] as {body: string}
+    expect(updateArgs.body).not.toContain(goneFingerprint)
+  })
+
+  it('no-ops when the existing issue is at the current version and content is byte-identical', async () => {
+    const digest = makeDigest()
+    const edges: DetectEdge[] = []
+    const renderedBody = renderReportBody(digest, edges, SAFE_TOKENS)
+
+    const {octokit, update, create} = makeMockOctokit({
+      listResponses: [{data: [{number: 7, body: renderedBody}]}],
+    })
+
+    const result = await upsertReportIssue({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      digest,
+      edges,
+      tokens: SAFE_TOKENS,
+    })
+
+    expect(result.outcome).toBe('noop')
+    expect(update).not.toHaveBeenCalled()
+    expect(create).not.toHaveBeenCalled()
+  })
+
+  it('treats a missing/malformed version marker as supersedable (update), never duplicated', async () => {
+    const priorBody = '# Improvement Metrics\n(no marker here)'
+    const {octokit, update, create} = makeMockOctokit({
+      listResponses: [{data: [{number: 9, body: priorBody}]}],
+    })
+
+    const result = await upsertReportIssue({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      digest: makeDigest(),
+      edges: [],
+      tokens: SAFE_TOKENS,
+    })
+
+    expect(result.outcome).toBe('updated')
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(create).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when tokens failed to load: no create/update attempted (blockedOnPrivacy via gate)', async () => {
+    // main()'s token-load-before-API ordering passes a `{loaded:false}` token sentinel
+    // straight into upsertReportIssue on load failure — renderReportBody's gate then
+    // fails closed automatically, so this exercises the same code path main() takes.
+    const {octokit, create, update} = makeMockOctokit({listResponses: [{data: []}]})
+
+    const result = await upsertReportIssue({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      digest: makeDigest(),
+      edges: [],
+      tokens: FAILED_TOKENS,
+    })
+
+    expect(result.outcome).toBe('blockedOnPrivacy')
+    expect(create).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it('fails closed on a privacy-gate block: no create/update attempted', async () => {
+    const privateTokens = makePublicOutputTokens({
+      privateTokens: new Set(['marcusrbrown/secret-internal-repo']),
+      redactedCanonicalIds: new Set(),
+    })
+    const leakyEdge = makeEdge({classKey: 'marcusrbrown/secret-internal-repo'})
+    const {octokit, create, update} = makeMockOctokit({listResponses: [{data: []}]})
+
+    const result = await upsertReportIssue({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      digest: makeDigest(),
+      edges: [leakyEdge],
+      tokens: privateTokens,
+    })
+
+    expect(result.outcome).toBe('blockedOnPrivacy')
+    expect(create).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it('does not duplicate on create-then-relist within a run (created-ID guard against stale listForRepo)', async () => {
+    // First upsert call: no existing issue -> creates issue #100.
+    // Second upsert call (same run): listForRepo staleness returns empty again,
+    // but the created-ID guard (passed in as shared state) prevents a second create.
+    const {octokit, create} = makeMockOctokit({listResponses: [{data: []}, {data: []}]})
+    const createdIssueNumbers = new Set<number>()
+
+    const first = await upsertReportIssue({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      digest: makeDigest(),
+      edges: [],
+      tokens: SAFE_TOKENS,
+      createdIssueNumbers,
+    })
+    expect(first.outcome).toBe('created')
+    expect(createdIssueNumbers.has(100)).toBe(true)
+
+    // Simulate a stale relist within the same run: listForRepo returns empty even
+    // though issue #100 now exists. The guard must recognize this via a mocked
+    // listForRepo that this time returns the created issue's number so the
+    // caller sees it as "found" rather than issuing a second create. We assert
+    // this indirectly: create is called only once overall.
+    const secondListResponse = {data: [{number: 100, body: undefined}]}
+    ;(octokit.issues.listForRepo as ReturnType<typeof vi.fn>).mockResolvedValueOnce(secondListResponse)
+
+    const second = await upsertReportIssue({
+      octokit,
+      owner: 'fro-bot',
+      repo: '.github',
+      digest: makeDigest(),
+      edges: [],
+      tokens: SAFE_TOKENS,
+      createdIssueNumbers,
+    })
+
+    expect(second.outcome).not.toBe('created')
+    expect(create).toHaveBeenCalledTimes(1)
   })
 })

--- a/scripts/improvement-metrics-report.test.ts
+++ b/scripts/improvement-metrics-report.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for scripts/improvement-metrics-report.ts
+ *
+ * Structure:
+ * - renderReportBody: happy path, insufficient-signal suppression, tick-state
+ *   re-emission, structural denylist, mutation-proof gate enforcement.
+ * - renderRunSummary: happy path, mutation-proof gate enforcement.
+ */
+
+import type {DetectEdge, MetricsDigest} from './improvement-metrics-detect.ts'
+
+import {describe, expect, it} from 'vitest'
+import {parseReportVersionMarker} from './improvement-metrics-core.ts'
+import {renderReportBody, renderRunSummary, ReportRenderBlockedError} from './improvement-metrics-report.ts'
+import {makePublicOutputTokens, type PublicOutputTokens} from './status-truth-public-output.ts'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const NO_PRIVATE_TOKENS: PublicOutputTokens = makePublicOutputTokens({
+  privateTokens: new Set(),
+  redactedCanonicalIds: new Set(),
+})
+
+function makeDigest(overrides: Partial<MetricsDigest> = {}): MetricsDigest {
+  return {
+    windowDays: 90,
+    anchors: 4,
+    discovery: 3,
+    priorDiscovery: 2,
+    confirmedRecidivism: 1,
+    backlogCount: 2,
+    oldestPendingAgeDays: 5,
+    state: 'healthy',
+    ...overrides,
+  }
+}
+
+function makeEdge(overrides: Partial<DetectEdge> = {}): DetectEdge {
+  return {
+    fingerprint: 'a'.repeat(64),
+    classKey: 'best_practice\u0001scripts/foo.ts\u0001unknown',
+    eventId: '42',
+    eventUrl: 'https://github.com/fro-bot/.github/issues/42',
+    eventCreatedAt: '2026-06-01T00:00:00Z',
+    ticked: false,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// renderReportBody
+// ---------------------------------------------------------------------------
+
+describe('renderReportBody', () => {
+  it('renders counts, window, state, backlog, and a checklist with edge fingerprints (happy path)', () => {
+    const digest = makeDigest()
+    const edge = makeEdge()
+    const body = renderReportBody(digest, [edge], NO_PRIVATE_TOKENS)
+
+    expect(body).toContain('healthy')
+    expect(body).toContain('90 days')
+    expect(body).toContain('Discovery (newly codified classes): 3')
+    expect(body).toContain('Prior-window discovery: 2')
+    expect(body).toContain('Confirmed recidivism (ticked edges): 1')
+    expect(body).toContain('Pending backlog: 2')
+    expect(body).toContain('oldest pending candidate: 5d')
+    expect(body).toContain(edge.fingerprint)
+    expect(body).toContain(edge.eventUrl)
+    expect(body).toContain(edge.classKey)
+  })
+
+  it('round-trips the version marker', () => {
+    const body = renderReportBody(makeDigest(), [], NO_PRIVATE_TOKENS)
+    expect(parseReportVersionMarker(body)).toBe(1)
+  })
+
+  it('renders no trend/interpretation line and no candidate checklist for insufficient-signal', () => {
+    const digest = makeDigest({state: 'insufficient-signal', discovery: 1, anchors: 2})
+    const body = renderReportBody(digest, [], NO_PRIVATE_TOKENS)
+
+    expect(body).toContain('Below the minimum-volume floor')
+    expect(body).not.toContain('## Candidate recurrences')
+    expect(body).not.toContain('Tick a checkbox')
+  })
+
+  it('re-emits a ticked edge as [x] and an unticked edge as [ ]', () => {
+    const ticked = makeEdge({fingerprint: 'b'.repeat(64), ticked: true})
+    const unticked = makeEdge({fingerprint: 'c'.repeat(64), ticked: false})
+    const body = renderReportBody(makeDigest(), [ticked, unticked], NO_PRIVATE_TOKENS)
+
+    expect(body).toContain(`- [x] <!-- improvement-metrics:edge=${ticked.fingerprint} -->`)
+    expect(body).toContain(`- [ ] <!-- improvement-metrics:edge=${unticked.fingerprint} -->`)
+  })
+
+  it('uses only class key + public URL + checkbox for candidate lines — no source title/body text', () => {
+    // Structural guarantee: DetectEdge carries no title/body field at all, so there is
+    // nothing for the renderer to leak even if it tried. This test locks that shape.
+    const edge = makeEdge()
+    const forbiddenFields: readonly string[] = ['title', 'body', 'excerpt', 'repo', 'branch']
+    for (const field of forbiddenFields) {
+      expect(Object.keys(edge)).not.toContain(field)
+    }
+
+    const body = renderReportBody(makeDigest(), [edge], NO_PRIVATE_TOKENS)
+    expect(body).not.toMatch(/branch|excerpt|repository name/iu)
+  })
+
+  it('BLOCKS the surface when the real gate detects a private-identifier-shaped string (mutation-proof)', () => {
+    // Exercises the real applyPublicOutputGate — not mocked. If the gate call is
+    // removed from renderReportBody's path, this test fails because no error is thrown.
+    const privateTokens = makePublicOutputTokens({
+      privateTokens: new Set(['marcusrbrown/secret-internal-repo']),
+      redactedCanonicalIds: new Set(),
+    })
+    // Inject the private identifier via the class key — the only free-text-shaped
+    // field on an edge that flows into the rendered body.
+    const edge = makeEdge({classKey: 'marcusrbrown/secret-internal-repo'})
+
+    expect(() => renderReportBody(makeDigest(), [edge], privateTokens)).toThrow(ReportRenderBlockedError)
+  })
+
+  it('blocks when the token load itself failed (fail-closed on token-load failure)', () => {
+    const failedTokens: PublicOutputTokens = {loaded: false, error: 'token load failure'}
+    expect(() => renderReportBody(makeDigest(), [], failedTokens)).toThrow(ReportRenderBlockedError)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// renderRunSummary
+// ---------------------------------------------------------------------------
+
+describe('renderRunSummary', () => {
+  it('renders the counts-only summary line (happy path)', () => {
+    const summary = renderRunSummary(makeDigest(), NO_PRIVATE_TOKENS)
+    expect(summary).toContain('state=healthy')
+    expect(summary).toContain('discovery=3')
+    expect(summary).toContain('confirmedRecidivism=1')
+    expect(summary).toContain('backlog=2')
+  })
+
+  it('BLOCKS the surface when the real gate detects a private-identifier-shaped string (mutation-proof)', () => {
+    // Not realistically reachable via MetricsDigest's numeric/state fields, but this
+    // pins that renderRunSummary's gate call is real by failing closed on token-load failure.
+    const failedTokens: PublicOutputTokens = {loaded: false, error: 'token load failure'}
+    expect(() => renderRunSummary(makeDigest(), failedTokens)).toThrow(ReportRenderBlockedError)
+  })
+})

--- a/scripts/improvement-metrics-report.ts
+++ b/scripts/improvement-metrics-report.ts
@@ -1,12 +1,16 @@
 /**
- * Public-safe report rendering for the improvement-metric loop.
+ * Public-safe report rendering + perpetual-issue upsert for the improvement-metric loop.
  *
- * Pure render functions only — the upsert I/O shell and `main()` are added by
- * Unit 4. This module never touches octokit, the filesystem, or the network.
+ * Pure render functions (`renderReportBody`, `renderRunSummary`) came from Unit 3.
+ * Unit 4 adds the I/O shell: `upsertReportIssue` finds the single perpetual report
+ * issue by label, decides create-vs-update by version marker, and rewrites the body
+ * in place while preserving operator tick-state for edges still present — the
+ * repo's first `issues.update({body})`. `main()` wires the digest file to the shell.
  *
  * Every rendered surface is routed through `applyPublicOutputGate` before it is
  * returned. A gate failure blocks that surface outright (throws
- * `ReportRenderBlockedError`) — there is no advisory-only fallback (R19).
+ * `ReportRenderBlockedError`) — there is no advisory-only fallback (R19). The
+ * upsert shell catches that error and performs NO create/update (fail-closed).
  *
  * The candidate checklist is public-safe by construction: `DetectEdge` (from
  * `improvement-metrics-detect.ts`) carries only `{fingerprint, classKey, eventId,
@@ -18,7 +22,16 @@
  */
 
 import type {DetectEdge, MetricsDigest} from './improvement-metrics-detect.ts'
-import {buildEdgeChecklistLine, buildReportVersionMarker} from './improvement-metrics-core.ts'
+import process from 'node:process'
+import {isRecord} from './capture-learnings-privacy.ts'
+import {
+  buildEdgeChecklistLine,
+  buildReportVersionMarker,
+  IMPROVEMENT_METRICS_REPORT_LABEL,
+  IMPROVEMENT_METRICS_REPORT_LABEL_DESCRIPTOR,
+  parseEdgeChecklistLine,
+  parseReportVersionMarker,
+} from './improvement-metrics-core.ts'
 import {applyPublicOutputGate, type PublicOutputTokens} from './status-truth-public-output.ts'
 
 // ---------------------------------------------------------------------------
@@ -158,4 +171,321 @@ export function renderRunSummary(digest: MetricsDigest, tokens: PublicOutputToke
   }
 
   return gate.sanitizedContent
+}
+
+// ---------------------------------------------------------------------------
+// Tick-state recovery (mirrors improvement-metrics-detect.ts's recoverPriorTickState)
+// ---------------------------------------------------------------------------
+
+/**
+ * Recover ticked edge fingerprints from a prior report issue body by scanning
+ * every line for a checklist entry (Unit 1's `parseEdgeChecklistLine`).
+ *
+ * Duplicated locally (rather than imported from `improvement-metrics-detect.ts`)
+ * to keep this module's upsert shell self-contained and independently testable
+ * without pulling in the detect module's git/fs I/O surface.
+ */
+export function recoverPriorTickState(body: string): Set<string> {
+  const ticked = new Set<string>()
+  for (const line of body.split('\n')) {
+    const entry = parseEdgeChecklistLine(line.trim())
+    if (entry !== null && entry.checked) ticked.add(entry.fingerprint)
+  }
+  return ticked
+}
+
+// ---------------------------------------------------------------------------
+// Narrow injected Octokit client interface
+// ---------------------------------------------------------------------------
+
+interface RawReportIssueListItem {
+  readonly number: number
+  readonly body?: string | null
+}
+
+/** Narrow injected Octokit-like client interface for the upsert shell. */
+export interface ImprovementMetricsReportOctokitClient {
+  readonly issues: {
+    readonly listForRepo: (params: {
+      owner: string
+      repo: string
+      labels?: string
+      state: 'open' | 'closed' | 'all'
+      per_page?: number
+    }) => Promise<{data: RawReportIssueListItem[]}>
+    readonly create: (params: {
+      owner: string
+      repo: string
+      title: string
+      body: string
+      labels: string[]
+    }) => Promise<{data: {number: number}}>
+    readonly update: (params: {owner: string; repo: string; issue_number: number; body: string}) => Promise<unknown>
+    readonly getLabel: (params: {owner: string; repo: string; name: string}) => Promise<unknown>
+    readonly createLabel: (params: {
+      owner: string
+      repo: string
+      name: string
+      color: string
+      description: string
+    }) => Promise<unknown>
+  }
+}
+
+/** Static issue title. NEVER data-derived — a security requirement (R10). */
+export const IMPROVEMENT_METRICS_REPORT_TITLE = 'Improvement Metrics'
+
+type ReportLogSink = (message: string) => void
+
+const writeReportLog: ReportLogSink = message => process.stderr.write(message)
+
+function isApiStatus(error: unknown, status: number): boolean {
+  return isRecord(error) && typeof error.status === 'number' && error.status === status
+}
+
+/**
+ * Ensure the improvement-metrics report label exists, mirroring
+ * `capture-patterns-open.ts`'s `ensurePatternProposalLabelsExist`: getLabel 404 ->
+ * createLabel, 422 idempotent. Returns whether the label is confirmed available.
+ */
+export async function ensureReportLabelExists(
+  octokit: ImprovementMetricsReportOctokitClient,
+  owner: string,
+  repo: string,
+  writeLog: ReportLogSink = writeReportLog,
+): Promise<boolean> {
+  const {name, color, description} = IMPROVEMENT_METRICS_REPORT_LABEL_DESCRIPTOR
+
+  try {
+    await octokit.issues.getLabel({owner, repo, name})
+    return true
+  } catch (getError: unknown) {
+    if (!isApiStatus(getError, 404)) {
+      writeLog('improvement-metrics-report: label check failed; cannot ensure report label\n')
+      return false
+    }
+  }
+
+  try {
+    await octokit.issues.createLabel({owner, repo, name, color, description})
+    return true
+  } catch (createError: unknown) {
+    if (isApiStatus(createError, 422)) {
+      return true
+    }
+    writeLog('improvement-metrics-report: label creation failed; cannot ensure report label\n')
+    return false
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Upsert shell
+// ---------------------------------------------------------------------------
+
+/** Closed-vocabulary outcome of an upsert attempt. */
+export type UpsertReportIssueOutcome = 'created' | 'updated' | 'noop' | 'blockedOnPrivacy' | 'labelUnavailable'
+
+export interface UpsertReportIssueResult {
+  outcome: UpsertReportIssueOutcome
+  issueNumber: number | null
+}
+
+export interface UpsertReportIssueParams {
+  octokit: ImprovementMetricsReportOctokitClient
+  owner: string
+  repo: string
+  digest: MetricsDigest
+  edges: readonly DetectEdge[]
+  tokens: PublicOutputTokens
+  /** In-memory guard against a same-run create-then-relist staleness duplicate. */
+  createdIssueNumbers?: Set<number>
+  writeLog?: ReportLogSink
+}
+
+/**
+ * Upsert the single perpetual improvement-metrics report issue.
+ *
+ * Find-by-label -> decide create vs update by version marker -> rewrite the body
+ * in place, re-emitting still-present ticked edges as `[x]` (operator confirmation
+ * is never clobbered). Fails closed on a `ReportRenderBlockedError` (no
+ * create/update). Carries an in-memory created-ID guard so a create-then-relist
+ * within the same run cannot duplicate the issue.
+ */
+export async function upsertReportIssue(params: UpsertReportIssueParams): Promise<UpsertReportIssueResult> {
+  const {octokit, owner, repo, digest, edges, tokens} = params
+  const writeLog = params.writeLog ?? writeReportLog
+  const createdIssueNumbers = params.createdIssueNumbers ?? new Set<number>()
+
+  const listResponse = await octokit.issues.listForRepo({
+    owner,
+    repo,
+    state: 'open',
+    labels: IMPROVEMENT_METRICS_REPORT_LABEL,
+    per_page: 10,
+  })
+
+  // Same-run staleness guard: a stale list-after-create response can omit the
+  // issue this run already created. Prefer a known created-ID over a stale list.
+  const existing =
+    listResponse.data.find(issue => createdIssueNumbers.has(issue.number)) ?? listResponse.data[0] ?? null
+
+  if (existing !== null) {
+    const priorBody = existing.body ?? ''
+    const priorTickState = recoverPriorTickState(priorBody)
+    const priorVersion = parseReportVersionMarker(priorBody)
+
+    const edgesWithPriorTicks = edges.map(edge => ({
+      ...edge,
+      ticked: edge.ticked || priorTickState.has(edge.fingerprint),
+    }))
+
+    let renderedBody: string
+    try {
+      renderedBody = renderReportBody(digest, edgesWithPriorTicks, tokens)
+    } catch (error: unknown) {
+      if (error instanceof ReportRenderBlockedError) {
+        writeLog(`improvement-metrics-report: blocked rendering surface "${error.surface}"; no update performed\n`)
+        return {outcome: 'blockedOnPrivacy', issueNumber: null}
+      }
+      throw error
+    }
+
+    if (priorVersion === REPORT_BODY_VERSION && renderedBody === priorBody) {
+      return {outcome: 'noop', issueNumber: existing.number}
+    }
+
+    await octokit.issues.update({owner, repo, issue_number: existing.number, body: renderedBody})
+    return {outcome: 'updated', issueNumber: existing.number}
+  }
+
+  let createdBody: string
+  try {
+    createdBody = renderReportBody(digest, edges, tokens)
+  } catch (error: unknown) {
+    if (error instanceof ReportRenderBlockedError) {
+      writeLog(`improvement-metrics-report: blocked rendering surface "${error.surface}"; no create performed\n`)
+      return {outcome: 'blockedOnPrivacy', issueNumber: null}
+    }
+    throw error
+  }
+
+  const labelConfirmed = await ensureReportLabelExists(octokit, owner, repo, writeLog)
+  if (!labelConfirmed) {
+    writeLog('improvement-metrics-report: report label unavailable; skipping create\n')
+    return {outcome: 'labelUnavailable', issueNumber: null}
+  }
+
+  const createResponse = await octokit.issues.create({
+    owner,
+    repo,
+    title: IMPROVEMENT_METRICS_REPORT_TITLE,
+    body: createdBody,
+    labels: [IMPROVEMENT_METRICS_REPORT_LABEL],
+  })
+  createdIssueNumbers.add(createResponse.data.number)
+
+  return {outcome: 'created', issueNumber: createResponse.data.number}
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+interface DigestFile {
+  digest: MetricsDigest
+  edges: DetectEdge[]
+}
+
+/** Counts-only result JSON written to stdout and IMPROVEMENT_METRICS_RESULT_PATH. */
+interface ReportResult {
+  outcome: UpsertReportIssueOutcome | null
+  tokenLoadFailure: boolean
+  digestReadFailure: boolean
+}
+
+async function readDigestFile(path: string): Promise<DigestFile> {
+  const {readFile} = await import('node:fs/promises')
+  const raw = await readFile(path, 'utf8')
+  return JSON.parse(raw) as DigestFile
+}
+
+/**
+ * CLI entry point for the report step: token-load-before-API fail-closed
+ * ordering, read the digest written by detect, upsert the perpetual report
+ * issue, and write a counts-only result JSON.
+ *
+ * Best-effort: a digest read failure is fail-soft (no write, presence bit set).
+ * A token-load failure is fail-closed (no create/update, presence bit set).
+ */
+async function main(): Promise<void> {
+  const owner = 'fro-bot'
+  const repo = '.github'
+
+  const result: ReportResult = {
+    outcome: null,
+    tokenLoadFailure: false,
+    digestReadFailure: false,
+  }
+
+  const digestPath = process.env.IMPROVEMENT_METRICS_DIGEST_PATH
+  const resultPath = process.env.IMPROVEMENT_METRICS_RESULT_PATH
+
+  const {loadPrivateTokensFromDisk} = await import('./capture-learnings-privacy.ts')
+  const {loadRedactedCanonicalIdsFromDisk} = await import('./status-truth-proposals.ts')
+  const {makePublicOutputTokens} = await import('./status-truth-public-output.ts')
+
+  let tokens: PublicOutputTokens
+  try {
+    const [privateTokens, redactedCanonicalIds] = await Promise.all([
+      loadPrivateTokensFromDisk(),
+      loadRedactedCanonicalIdsFromDisk(),
+    ])
+    tokens = makePublicOutputTokens({privateTokens, redactedCanonicalIds})
+  } catch {
+    result.tokenLoadFailure = true
+    tokens = {loaded: false, error: 'token load failure'}
+  }
+
+  if (!result.tokenLoadFailure && digestPath !== undefined && digestPath !== '') {
+    let digestFile: DigestFile | null = null
+    try {
+      digestFile = await readDigestFile(digestPath)
+    } catch {
+      result.digestReadFailure = true
+    }
+
+    if (digestFile !== null) {
+      const {createOctokitFromEnv} = await import('./capture-learnings-harvest.ts')
+      const rawOctokit = await createOctokitFromEnv()
+      const octokit = (rawOctokit as unknown as {rest: ImprovementMetricsReportOctokitClient}).rest
+
+      const upsertResult = await upsertReportIssue({
+        octokit,
+        owner,
+        repo,
+        digest: digestFile.digest,
+        edges: digestFile.edges,
+        tokens,
+      })
+      result.outcome = upsertResult.outcome
+    }
+  } else if (digestPath === undefined || digestPath === '') {
+    result.digestReadFailure = true
+  }
+
+  const resultJson = `${JSON.stringify(result)}\n`
+  process.stdout.write(resultJson)
+
+  if (resultPath !== undefined && resultPath !== '') {
+    try {
+      const {writeFile} = await import('node:fs/promises')
+      await writeFile(resultPath, resultJson, {flag: 'w'})
+    } catch {
+      process.stderr.write('improvement-metrics-report: could not write result file\n')
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
 }

--- a/scripts/improvement-metrics-report.ts
+++ b/scripts/improvement-metrics-report.ts
@@ -29,8 +29,8 @@ import {
   buildReportVersionMarker,
   IMPROVEMENT_METRICS_REPORT_LABEL,
   IMPROVEMENT_METRICS_REPORT_LABEL_DESCRIPTOR,
-  parseEdgeChecklistLine,
   parseReportVersionMarker,
+  recoverPriorTickState,
 } from './improvement-metrics-core.ts'
 import {applyPublicOutputGate, type PublicOutputTokens} from './status-truth-public-output.ts'
 
@@ -105,7 +105,9 @@ export function renderReportBody(
   lines.push(`Confirmed recidivism (ticked edges): ${digest.confirmedRecidivism}`)
   lines.push(
     `Pending backlog: ${digest.backlogCount}${
-      digest.oldestPendingAgeDays === null ? '' : ` (oldest pending candidate: ${digest.oldestPendingAgeDays}d)`
+      digest.oldestPendingAgeDays === null
+        ? ''
+        : ` (oldest pending candidate: ${digest.oldestPendingAgeDays.toFixed(1)}d)`
     }`,
   )
   lines.push('')
@@ -171,27 +173,6 @@ export function renderRunSummary(digest: MetricsDigest, tokens: PublicOutputToke
   }
 
   return gate.sanitizedContent
-}
-
-// ---------------------------------------------------------------------------
-// Tick-state recovery (mirrors improvement-metrics-detect.ts's recoverPriorTickState)
-// ---------------------------------------------------------------------------
-
-/**
- * Recover ticked edge fingerprints from a prior report issue body by scanning
- * every line for a checklist entry (Unit 1's `parseEdgeChecklistLine`).
- *
- * Duplicated locally (rather than imported from `improvement-metrics-detect.ts`)
- * to keep this module's upsert shell self-contained and independently testable
- * without pulling in the detect module's git/fs I/O surface.
- */
-export function recoverPriorTickState(body: string): Set<string> {
-  const ticked = new Set<string>()
-  for (const line of body.split('\n')) {
-    const entry = parseEdgeChecklistLine(line.trim())
-    if (entry !== null && entry.checked) ticked.add(entry.fingerprint)
-  }
-  return ticked
 }
 
 // ---------------------------------------------------------------------------
@@ -403,7 +384,7 @@ interface ReportResult {
   digestReadFailure: boolean
 }
 
-async function readDigestFile(path: string): Promise<DigestFile> {
+export async function readDigestFile(path: string): Promise<DigestFile> {
   const {readFile} = await import('node:fs/promises')
   const raw = await readFile(path, 'utf8')
   return JSON.parse(raw) as DigestFile

--- a/scripts/improvement-metrics-report.ts
+++ b/scripts/improvement-metrics-report.ts
@@ -1,0 +1,161 @@
+/**
+ * Public-safe report rendering for the improvement-metric loop.
+ *
+ * Pure render functions only — the upsert I/O shell and `main()` are added by
+ * Unit 4. This module never touches octokit, the filesystem, or the network.
+ *
+ * Every rendered surface is routed through `applyPublicOutputGate` before it is
+ * returned. A gate failure blocks that surface outright (throws
+ * `ReportRenderBlockedError`) — there is no advisory-only fallback (R19).
+ *
+ * The candidate checklist is public-safe by construction: `DetectEdge` (from
+ * `improvement-metrics-detect.ts`) carries only `{fingerprint, classKey, eventId,
+ * eventUrl, eventCreatedAt, ticked}` — no source title or body excerpt is even in
+ * scope for these render functions, which makes the R20 denylist structural
+ * rather than a runtime check (R20).
+ *
+ * Strip-only safe: no enums, namespaces, parameter properties, or `any`.
+ */
+
+import type {DetectEdge, MetricsDigest} from './improvement-metrics-detect.ts'
+import {buildEdgeChecklistLine, buildReportVersionMarker} from './improvement-metrics-core.ts'
+import {applyPublicOutputGate, type PublicOutputTokens} from './status-truth-public-output.ts'
+
+// ---------------------------------------------------------------------------
+// Gate-failure contract
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when a rendered surface fails `applyPublicOutputGate`. Fail-closed by
+ * construction: the caller (Unit 4's I/O shell) must catch this and perform no
+ * write, never fall back to an unsanitized or partially-sanitized body (R19).
+ */
+export class ReportRenderBlockedError extends Error {
+  readonly surface: string
+  readonly blockReason: string
+
+  constructor(surface: string, blockReason: string) {
+    super(`improvement-metrics-report: blocked rendering surface "${surface}": ${blockReason}`)
+    this.name = 'ReportRenderBlockedError'
+    this.surface = surface
+    this.blockReason = blockReason
+  }
+}
+
+/** Current report body schema version, embedded via the hidden version marker. */
+export const REPORT_BODY_VERSION = 1
+
+// ---------------------------------------------------------------------------
+// Report body rendering
+// ---------------------------------------------------------------------------
+
+function renderCandidateChecklist(edges: readonly DetectEdge[]): string[] {
+  if (edges.length === 0) {
+    return ['(no pending or confirmed candidates this run)']
+  }
+  const sorted = [...edges].sort((a, b) => a.fingerprint.localeCompare(b.fingerprint))
+  return sorted.map(edge => {
+    const checklistLine = buildEdgeChecklistLine({fingerprint: edge.fingerprint, checked: edge.ticked})
+    return `${checklistLine}\n  - class: \`${edge.classKey}\` — ${edge.eventUrl}`
+  })
+}
+
+/**
+ * Render the perpetual report issue body from the digest + edge list.
+ *
+ * Public-safe by construction: the checklist is built only from each edge's
+ * class key, public issue URL, and checkbox+fingerprint marker — never a
+ * source title, body excerpt, or repo/branch name (R20). Ticked edges still
+ * present in `edges` are re-emitted as `[x]` via `edge.ticked`.
+ *
+ * Below the `insufficient-signal` floor, no trend/interpretation line and no
+ * candidate checklist are rendered (Unit 2 already suppresses candidate
+ * surfacing at that floor, so `edges` is expected empty in that state).
+ *
+ * @throws {ReportRenderBlockedError} if the rendered body fails the public-output gate (R19).
+ */
+export function renderReportBody(
+  digest: MetricsDigest,
+  edges: readonly DetectEdge[],
+  tokens: PublicOutputTokens,
+): string {
+  const lines: string[] = []
+
+  lines.push('# Improvement Metrics')
+  lines.push('')
+  lines.push(`Report state: **${digest.state}**`)
+  lines.push('')
+  lines.push(`Window: ${digest.windowDays} days`)
+  lines.push(`Codified anchors in window: ${digest.anchors}`)
+  lines.push(`Discovery (newly codified classes): ${digest.discovery}`)
+  lines.push(`Prior-window discovery: ${digest.priorDiscovery}`)
+  lines.push(`Confirmed recidivism (ticked edges): ${digest.confirmedRecidivism}`)
+  lines.push(
+    `Pending backlog: ${digest.backlogCount}${
+      digest.oldestPendingAgeDays === null ? '' : ` (oldest pending candidate: ${digest.oldestPendingAgeDays}d)`
+    }`,
+  )
+  lines.push('')
+
+  if (digest.state === 'insufficient-signal') {
+    lines.push('_Below the minimum-volume floor — no trend or interpretation is claimed this run._')
+  } else {
+    lines.push('## Candidate recurrences')
+    lines.push('')
+    lines.push('Tick a checkbox below to confirm a recurrence. Confirmed edges persist across rewrites.')
+    lines.push('')
+    lines.push(...renderCandidateChecklist(edges))
+  }
+
+  lines.push('')
+  lines.push(buildReportVersionMarker(REPORT_BODY_VERSION))
+
+  const body = lines.join('\n')
+
+  const gate = applyPublicOutputGate({
+    surface: 'proposal-body',
+    content: body,
+    tokens,
+    fingerprint: undefined,
+  })
+
+  if (!gate.allowed) {
+    throw new ReportRenderBlockedError('proposal-body', gate.blockReason)
+  }
+
+  return gate.sanitizedContent
+}
+
+// ---------------------------------------------------------------------------
+// Workflow run summary rendering
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the counts-only workflow step-summary line for the report job.
+ *
+ * Counts-only surface: `fingerprint` is always `undefined`, per the gate's
+ * counts-only-surface enforcement.
+ *
+ * @throws {ReportRenderBlockedError} if the rendered summary fails the public-output gate (R19).
+ */
+export function renderRunSummary(digest: MetricsDigest, tokens: PublicOutputTokens): string {
+  const summary =
+    `Improvement Metrics: state=${digest.state} discovery=${digest.discovery}` +
+    ` (prior=${digest.priorDiscovery}) confirmedRecidivism=${digest.confirmedRecidivism}` +
+    ` backlog=${digest.backlogCount}${
+      digest.oldestPendingAgeDays === null ? '' : ` oldestPendingAgeDays=${digest.oldestPendingAgeDays}`
+    } window=${digest.windowDays}d anchors=${digest.anchors}`
+
+  const gate = applyPublicOutputGate({
+    surface: 'workflow-summary-row',
+    content: summary,
+    tokens,
+    fingerprint: undefined,
+  })
+
+  if (!gate.allowed) {
+    throw new ReportRenderBlockedError('workflow-summary-row', gate.blockReason)
+  }
+
+  return gate.sanitizedContent
+}

--- a/scripts/improvement-metrics-workflow.test.ts
+++ b/scripts/improvement-metrics-workflow.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Contract tests for .github/workflows/improvement-metrics.yaml: dry-run
+ * default, live-write token boundary, digest env wiring, full-history
+ * checkout, and no-agent-step perimeter. Style mirrors
+ * capture-patterns-workflow.test.ts.
+ */
+
+import {readFileSync} from 'node:fs'
+import {resolve} from 'node:path'
+import {describe, expect, it} from 'vitest'
+import {parse} from 'yaml'
+
+interface WorkflowStep {
+  name?: string
+  id?: string
+  if?: string
+  run?: string
+  uses?: string
+  env?: Record<string, unknown>
+  with?: Record<string, unknown>
+}
+
+interface WorkflowJob {
+  steps: WorkflowStep[]
+  permissions?: Record<string, string>
+  needs?: string
+  if?: string
+}
+
+function assertImprovementMetricsWorkflow(value: unknown): asserts value is {
+  on: {workflow_dispatch?: {inputs?: Record<string, {default?: string}>}; schedule?: unknown}
+  concurrency?: {group?: string; 'cancel-in-progress'?: boolean}
+  'run-name'?: string
+  jobs: Record<string, WorkflowJob>
+} {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    !('jobs' in value) ||
+    typeof (value as Record<string, unknown>).jobs !== 'object'
+  ) {
+    throw new TypeError('improvement-metrics.yaml does not have expected shape: missing jobs object')
+  }
+}
+
+describe('improvement-metrics.yaml workflow contract', () => {
+  const workflowPath = resolve(import.meta.dirname, '../.github/workflows/improvement-metrics.yaml')
+  const raw = readFileSync(workflowPath, 'utf8')
+  const parsed: unknown = parse(raw)
+  assertImprovementMetricsWorkflow(parsed)
+
+  const detectJob = parsed.jobs.detect
+  const reportJob = parsed.jobs.report
+
+  it('has a manual dispatch trigger with dry_run defaulting to true', () => {
+    const dryRunInput = parsed.on.workflow_dispatch?.inputs?.dry_run
+    expect(dryRunInput).toBeDefined()
+    expect(dryRunInput?.default).toBe('true')
+  })
+
+  it('has no schedule trigger — manual dispatch only', () => {
+    expect(parsed.on).not.toHaveProperty('schedule')
+  })
+
+  it('serializes runs with a static concurrency group and never cancels in-progress runs', () => {
+    expect(parsed.concurrency?.group).toBe('improvement-metrics')
+    expect(parsed.concurrency?.['cancel-in-progress']).toBe(false)
+    expect(String(parsed.concurrency?.group ?? '')).not.toContain('${{')
+  })
+
+  it('does not interpolate inputs into run-name', () => {
+    const runName = parsed['run-name']
+    if (runName !== undefined) {
+      expect(String(runName)).not.toContain('${{')
+    }
+  })
+
+  it('detect job carries only read-only permissions', () => {
+    expect(detectJob).toBeDefined()
+    expect(detectJob?.permissions).toEqual({contents: 'read', issues: 'read'})
+  })
+
+  it('report job carries only read-only contents permission on the job token', () => {
+    expect(reportJob).toBeDefined()
+    expect(reportJob?.permissions).toEqual({contents: 'read'})
+  })
+
+  it('the report job itself is skipped entirely on dry-run — the job-level `if` requires an explicit live dispatch', () => {
+    expect(reportJob?.if).toBeDefined()
+    expect(String(reportJob?.if)).toContain("github.event_name == 'workflow_dispatch'")
+    expect(String(reportJob?.if)).toContain("github.event.inputs.dry_run == 'false'")
+  })
+
+  it('the write-scoped app token is minted only for an explicit live (dry_run=false) manual dispatch', () => {
+    const mintStep = reportJob?.steps.find(step => step.id === 'app-token')
+    expect(mintStep).toBeDefined()
+    expect(mintStep?.if).toContain("github.event_name == 'workflow_dispatch'")
+    expect(mintStep?.if).toContain("github.event.inputs.dry_run == 'false'")
+  })
+
+  it('the app token is scoped to this repository only, with issues:write', () => {
+    const mintStep = reportJob?.steps.find(step => step.id === 'app-token')
+    const withBlock = mintStep?.with
+    expect(String(withBlock?.repositories ?? '')).toContain('github.event.repository.name')
+    expect(withBlock?.['permission-issues']).toBe('write')
+  })
+
+  it('the detect checkout step uses fetch-depth: 0 for full git history', () => {
+    const checkoutStep = detectJob?.steps.find(
+      step => typeof step.uses === 'string' && step.uses.startsWith('actions/checkout@'),
+    )
+    expect(checkoutStep).toBeDefined()
+    expect(checkoutStep?.with?.['fetch-depth']).toBe(0)
+  })
+
+  it('the detect step uses the read-only workflow token explicitly, not the minted app token', () => {
+    const detectStep = detectJob?.steps.find(step => step.id === 'detect')
+    const token = String(detectStep?.env?.GITHUB_TOKEN ?? '')
+    expect(token).toContain('github.token')
+    expect(token).not.toContain('steps.app-token')
+  })
+
+  it('the report step uses only the minted app token and does not fall back to the job token', () => {
+    const reportStep = reportJob?.steps.find(step => step.id === 'report')
+    const token = String(reportStep?.env?.GITHUB_TOKEN ?? '')
+    expect(token).toContain('steps.app-token.outputs.token')
+    expect(token).not.toContain('github.token')
+  })
+
+  it('the detect step writes the digest to IMPROVEMENT_METRICS_DIGEST_PATH under runner.temp', () => {
+    const detectStep = detectJob?.steps.find(step => step.id === 'detect')
+    const digestPath = detectStep?.env?.IMPROVEMENT_METRICS_DIGEST_PATH
+    expect(typeof digestPath).toBe('string')
+    expect(String(digestPath)).toContain('runner.temp')
+  })
+
+  it('the detect and report steps reference the same IMPROVEMENT_METRICS_DIGEST_PATH', () => {
+    const detectStep = detectJob?.steps.find(step => step.id === 'detect')
+    const reportStep = reportJob?.steps.find(step => step.id === 'report')
+    expect(detectStep?.env?.IMPROVEMENT_METRICS_DIGEST_PATH).toBe(reportStep?.env?.IMPROVEMENT_METRICS_DIGEST_PATH)
+  })
+
+  it('the report step wires IMPROVEMENT_METRICS_RESULT_PATH under runner.temp', () => {
+    const reportStep = reportJob?.steps.find(step => step.id === 'report')
+    const resultPath = reportStep?.env?.IMPROVEMENT_METRICS_RESULT_PATH
+    expect(String(resultPath ?? '')).toContain('runner.temp')
+  })
+
+  it('the digest -> report sequence depends on the detect job completing first', () => {
+    expect(reportJob?.needs).toBe('detect')
+  })
+
+  it('the report job has no agent step — the report is fully deterministic', () => {
+    const agentStep = reportJob?.steps.find(
+      step => step.id === 'agent' || (typeof step.uses === 'string' && step.uses.includes('fro-bot/agent')),
+    )
+    expect(agentStep).toBeUndefined()
+  })
+
+  it('the detect and report node|tee pipelines run under pipefail so a node failure fails the step', () => {
+    const detectStep = detectJob?.steps.find(step => step.id === 'detect')
+    const reportStep = reportJob?.steps.find(step => step.id === 'report')
+    expect(String(detectStep?.run ?? '')).toContain('| tee')
+    expect(String((detectStep as WorkflowStep & {shell?: string})?.shell ?? '')).toContain('pipefail')
+    expect(String(reportStep?.run ?? '')).toContain('| tee')
+    expect(String((reportStep as WorkflowStep & {shell?: string})?.shell ?? '')).toContain('pipefail')
+  })
+
+  it('the digest artifact retains for 1 day, not the default longer window', () => {
+    const uploadStep = detectJob?.steps.find(
+      step => typeof step.name === 'string' && step.name.includes('Upload digest artifact'),
+    ) as (WorkflowStep & {with?: {'retention-days'?: number}}) | undefined
+    expect(uploadStep?.with?.['retention-days']).toBe(1)
+  })
+
+  it('the workflow file uses plain operator-facing vocabulary, not internal plan taxonomy', () => {
+    const forbiddenPatterns = [/\bUnit \d/u, /\bU\d\b/u, /\bO8\b/u, /\bA1\b/u, /\bC4\b/u]
+    for (const pattern of forbiddenPatterns) {
+      expect(pattern.test(raw)).toBe(false)
+    }
+  })
+
+  it('never echoes digest file contents or the write token into logs', () => {
+    const suspiciousPatterns = [
+      /echo.*IMPROVEMENT_METRICS_DIGEST_PATH/u,
+      /cat.*IMPROVEMENT_METRICS_DIGEST_PATH/u,
+      /echo.*steps\.app-token\.outputs\.token/u,
+    ]
+    for (const pattern of suspiciousPatterns) {
+      expect(pattern.test(raw)).toBe(false)
+    }
+  })
+})

--- a/scripts/improvement-metrics-workflow.test.ts
+++ b/scripts/improvement-metrics-workflow.test.ts
@@ -157,13 +157,22 @@ describe('improvement-metrics.yaml workflow contract', () => {
     expect(agentStep).toBeUndefined()
   })
 
-  it('the detect and report node|tee pipelines run under pipefail so a node failure fails the step', () => {
-    const detectStep = detectJob?.steps.find(step => step.id === 'detect')
+  it('the report node|tee pipeline runs under pipefail so a node failure fails the step', () => {
     const reportStep = reportJob?.steps.find(step => step.id === 'report')
-    expect(String(detectStep?.run ?? '')).toContain('| tee')
-    expect(String((detectStep as WorkflowStep & {shell?: string})?.shell ?? '')).toContain('pipefail')
     expect(String(reportStep?.run ?? '')).toContain('| tee')
     expect(String((reportStep as WorkflowStep & {shell?: string})?.shell ?? '')).toContain('pipefail')
+  })
+
+  it('the detect step runs under pipefail without a shell', () => {
+    const detectStep = detectJob?.steps.find(step => step.id === 'detect')
+    expect(String((detectStep as WorkflowStep & {shell?: string})?.shell ?? '')).toContain('pipefail')
+  })
+
+  it('the detect step does NOT tee stdout over its own IMPROVEMENT_METRICS_DIGEST_PATH — stdout is a different, flatter shape than the file the script writes, and tee would clobber the file after the write (regression guard for the detect/report wiring defect)', () => {
+    const detectStep = detectJob?.steps.find(step => step.id === 'detect')
+    const run = String(detectStep?.run ?? '')
+    expect(run).not.toContain('tee')
+    expect(run.trim()).toBe('node scripts/improvement-metrics-detect.ts')
   })
 
   it('the digest artifact retains for 1 day, not the default longer window', () => {


### PR DESCRIPTION
## What

A report-only metric loop that measures whether the self-improvement loops actually reduce repeated work. It pairs two numbers per run — **discovery** (distinct classes newly codified into `docs/solutions/` in the window) and **confirmed recidivism** (codified classes that recurred, where a human confirmed the recurrence) — plus a **pending-confirmation backlog**, and rewrites them to a single perpetual report issue.

The report issue is also the confirmation surface: each candidate `(event → class)` recurrence is a checklist line you tick. Ticks persist across every rewrite, keyed by a stable hidden edge fingerprint. Nothing you confirm gets reset by the next run.

## How

Clones the Capture Patterns two-job shape (manual dispatch, dry-run default, scoped token, reusable public-output gate) and drops the agent step — the report is deterministic, no LLM in the loop.

- **Discovery** is counted from each solution doc's git first-commit date, not editable frontmatter — so the trend can't be silently rewritten by an edit, and it's available for every committed doc.
- **Candidate links** come from an asymmetric scorer (a proposal issue has only a title and labels; a codified class has a title, tags, and module) with a strong-match floor; the human tick is the precision gate. Below a minimum corpus volume nothing is surfaced, so a thin corpus can't flood the backlog.
- **Recidivism** counts only ticked edges, so an unmaintained backlog reads as a visible, aging warning rather than a false zero.
- One of four states per run — `insufficient-signal` / `ambiguous` / `healthy` / `failing` — selected deterministically, never a blend.

Every public surface (report body, run summary) passes the existing private-token gate fail-closed. This is the first in-place issue-body rewrite in the repo; the upsert is isolated with tick-preservation and same-run-staleness guards, and a golden-path test drives the real detect → render → upsert path with a mutation-proof gate assertion.

## Verification

`pnpm bootstrap && pnpm check-types && pnpm lint && pnpm test` — green (2540 tests). New coverage: 83 tests across the five metric modules, including the golden-path integration test whose gate assertion fails if the public-output gate is removed from the render path.

Manual dispatch only, dry-run by default — nothing runs or writes until explicitly triggered.
