### PR TITLE
docs: capture improvement-metric loop learnings

### DIFF
--- a/docs/solutions/best-practices/edge-keyed-confirmation-markers-2026-07-10.md
+++ b/docs/solutions/best-practices/edge-keyed-confirmation-markers-2026-07-10.md
@@ -1,0 +1,69 @@
+---
+title: A one-bit confirmation gesture can't encode which of several candidate edges was approved
+date: 2026-07-10
+category: best-practices
+module: improvement-metrics
+problem_type: design_pattern
+component: tooling
+severity: medium
+applies_when:
+  - a human confirmation is the only record of which (event, target) edge was approved
+  - one source event can plausibly map to several candidate targets in the same window
+  - the confirmed edge must stay reproducible across later re-derivations of the same event
+  - confirmation state must survive periodic rewrites of the artifact it lives in
+tags:
+  - confirmation-gesture
+  - edge-identity
+  - fingerprint-hash
+  - many-to-one
+  - checklist-state
+  - improvement-metrics
+---
+
+# A one-bit confirmation gesture can't encode which of several candidate edges was approved
+
+## Context
+
+The improvement-metrics loop asks a human to confirm that a proposal recurred against a codified class. The first design (approved in brainstorm) used a bare `recurrence-confirmed` label on the proposal issue. Plan-review killed it before a line was written: the candidate scorer can emit several `(event → class)` edges for one proposal when multiple classes clear the threshold, and a bare label is one bit of evidence for an N-way choice. A later run can re-rank and re-derive a *different* best-match class for the same label — so "confirmed" silently drifts from "confirmed against class X" to "confirmed against whatever class ranks first this run." The confirmed edge is not reproducible.
+
+## Guidance
+
+**When a confirmation feeds a metric or state machine and the thing being confirmed is one of several candidate relationships, the confirmation artifact must carry the specific edge identity — not just a boolean.**
+
+Encode the edge, then confirm the encoded edge:
+
+- Derive a stable edge key from immutable inputs: `buildEdgeFingerprint(classKey, eventId)` = `sha256(classKey + '\u0001' + eventId)` (`scripts/improvement-metrics-core.ts`). It survives body rewrites, line reordering, and class-name spelling; a line index or username would not.
+- Render each candidate as its own checklist line carrying a hidden marker: `- [ ] <!-- improvement-metrics:edge=<fp> -->` (`buildEdgeChecklistLine`). Ticking *that* line confirms *that* edge.
+- Recover confirmations by fingerprint, not position: `recoverPriorTickState(body)` returns the set of ticked fingerprints; a `[x]` without the hidden marker is uncounted by construction.
+- Preserve tick-state across rewrites: on upsert, `ticked: edge.ticked || priorTickState.has(edge.fingerprint)` — the operator's confirmation is never clobbered by a regeneration, and an edge that drops out of the new run simply disappears (close-on-clear), it does not resurrect.
+
+## Why This Matters
+
+The loop's whole promise is that its counts are recomputable from public artifacts with no durable store. That contract only holds if the confirmation *is* the durable record of the specific edge. A bare label makes the confirmed count non-reproducible the moment the candidate ranking can change — which, with a scoring heuristic over a growing corpus, it always can.
+
+## When to Apply
+
+- A human/machine confirmation is the input to a metric or state machine, and the target is one of several candidate relationships.
+- The matching is computed (scored/ranked) and not injective — different runs may rank differently.
+- The confirmation lives in a rewritable artifact (issue body, comment, file) that is regenerated periodically.
+- The confirmed count must be reconstructable from the artifact alone, with no side channel or human memory.
+
+## Examples
+
+**Before:** a `recurrence-confirmed` label on the proposal issue. Next run re-derives a different best-match class for that proposal; the confirmed `(event → class)` edge is undefined and the count shifts with no real-world event.
+
+**After:** the report issue lists each candidate edge as its own line —
+
+```
+- [x] <!-- improvement-metrics:edge=a3f1…64hex -->
+  - class: `auth-token-refresh␁oauth␁race` — https://github.com/…/issues/402
+```
+
+Re-rendering preserves the tick via `recoverPriorTickState`; confirmed recidivism is the count of ticked fingerprints that reappear in this run's edges. The confirmed edge is exactly reproducible.
+
+## Related
+
+- `docs/solutions/best-practices/closed-vocabulary-identifiers-for-automated-inspection-2026-07-09.md` — the hidden-marker / fingerprint / live-state toolkit this reuses, applied to machine recognition rather than a human gesture
+- `docs/solutions/best-practices/closed-vocabulary-telemetry-keys-from-public-bodies-2026-07-03.md` — marker → visible → sentinel recovery precedence
+- `docs/solutions/best-practices/worker-authored-hash-bound-receipts-2026-07-06.md` — the related hash-bound approval pattern (CAS nonce) from a sibling loop
+- Source PR: #3672 (improvement-metrics loop)

--- a/docs/solutions/best-practices/immutable-history-keys-for-trend-recompute-2026-07-10.md
+++ b/docs/solutions/best-practices/immutable-history-keys-for-trend-recompute-2026-07-10.md
@@ -1,0 +1,66 @@
+---
+title: Key trend recompute on immutable history (git add-date), never editable frontmatter
+date: 2026-07-10
+category: best-practices
+module: improvement-metrics
+problem_type: best_practice
+component: development_workflow
+severity: medium
+applies_when:
+  - a metric recomputes a trend or window-relative count from artifacts on every run
+  - the event timestamp is currently read from an in-file annotation
+  - the annotation is human-editable or non-universal across the corpus
+  - a single edit rewriting past trend numbers would violate an immutability claim
+tags:
+  - trend-stability
+  - git-add-date
+  - immutable-history
+  - recompute
+  - frontmatter-hygiene
+  - improvement-metrics
+---
+
+# Key trend recompute on immutable history (git add-date), never editable frontmatter
+
+## Context
+
+The improvement-metrics loop recomputes its trend every run from public artifacts and persists no snapshot. Discovery counts codified classes whose first appearance falls in a rolling 90-day window. The plan initially sourced that boundary from each solution doc's frontmatter `date`. Plan-review found two defects: frontmatter `date` is **mutable** — editing it silently moves a class between windows and rewrites every past discovery number derived from the metric — and **non-universal** — present on well under half the corpus. The "immutable trend, no store" design was only honest if the history it recomputes from is genuinely immutable, which an editable in-file field is not.
+
+## Guidance
+
+**A metric that recomputes a trend from history each run (instead of persisting snapshots) must key its event timestamps on genuinely immutable history — git commit dates, issue created-at — never on editable in-file annotations.**
+
+Use the file's git first-commit (add) date:
+
+```
+git log --diff-filter=A --follow --format=%aI -- <path>
+```
+
+`--diff-filter=A` selects the add commit; `--follow` survives renames; the earliest entry is the codification event. Fail closed: if no add-date is resolvable for a path that exists on disk, treat git history as unavailable, emit an empty digest, and set a presence bit — never fall back to the editable field. The field carries an explicit contract in code (`SolutionDocRecord.gitAddDate`: "Immutable git first-commit (add) date … NEVER frontmatter `date`").
+
+The recompute needs full history, so the CI job must set `fetch-depth: 0`. A default shallow clone silently turns the metric into "trend over the tip commit" — the explicit `fetch-depth: 0` is the canary that keeps the correctness claim true.
+
+## Why This Matters
+
+Frontmatter `date` is editable text. One correction to it rewrites past `discovery`/`priorDiscovery` numbers even though nothing happened in the world — the trend mutates under an unrelated edit. Git history is append-only; the window boundary becomes a property of the project, not of whichever contributor last touched the file. "No store, recompute from history" is a liability, not a virtue, if the history is mutable.
+
+## When to Apply
+
+- A metric recomputes a trend/aggregate from artifacts on every run rather than persisting snapshots.
+- The event timestamp is sourced from a file, PR, or doc rather than an external event log.
+- The same artifact type is authored and edited by many contributors over time.
+- Correctness rests on "X happened in window W" being stable under later edits to X.
+- A CI job runs the recompute — its checkout depth must be the full history the metric depends on.
+
+## Examples
+
+**Before:** discovery reads `doc.date`; a class sits in window W1. Months later a contributor corrects the frontmatter to the real date; the class moves to W0. Past `discovery=4, priorDiscovery=2` silently becomes `discovery=3, priorDiscovery=3`. The immutable-trend claim is false.
+
+**After:** `gitAddDate` comes from `git log --diff-filter=A --follow --format=%aI`. The commit that added the file is the only authority; editing frontmatter cannot move the class. The workflow forces `fetch-depth: 0` so a shallow clone cannot truncate the history the metric reads.
+
+## Related
+
+- `docs/solutions/workflow-issues/classifying-github-review-events-for-iteration-signals-2026-06-22.md` — the closest match: don't classify a metric off your own mutable signal; ground it in real, immutable data
+- `docs/solutions/best-practices/observability-before-structural-change-2026-06-09.md` — counts-only, derived at evaluation time, no persisted state
+- `docs/solutions/best-practices/closed-vocabulary-telemetry-keys-from-public-bodies-2026-07-03.md` — marker-precedence-over-backfill for recovering historical state
+- Source PR: #3672 (improvement-metrics loop)

--- a/docs/solutions/best-practices/test-the-integration-seam-not-the-endpoints-2026-07-06.md
+++ b/docs/solutions/best-practices/test-the-integration-seam-not-the-endpoints-2026-07-06.md
@@ -1,6 +1,7 @@
 ---
 title: A code path exercised only by pre-built fixtures is an untested seam — test the seam, not the endpoints
 date: 2026-07-06
+last_updated: 2026-07-10
 category: best-practices
 module: scripts/cross-repo-dispatch.ts
 problem_type: best_practice
@@ -10,6 +11,7 @@ applies_when:
   - a function has unit tests but its real callers feed it differently than the fixtures do
   - bugs keep recurring at the same integration boundary despite green unit suites
   - you are writing a parser for input that legitimately mixes free-text and structured content
+  - the boundary is mediated by a file or shell pipeline between steps, not a function call
 tags:
   - integration-test
   - golden-path
@@ -81,6 +83,34 @@ Two secondary notes worth carrying forward:
    returning `malformed` on a bad line while the other silently continues is a latent divergence —
    reconcile it or document why the scopes differ.
 
+### Recurrence: file-mediated step boundary (improvement-metrics loop, 2026-07-10)
+
+A fourth instance of the same lesson, four days later, in a different module — this time the seam was
+a **file between two workflow steps**, not a function call. The detect step wrote a structured
+`{digest, edges}` object to `IMPROVEMENT_METRICS_DIGEST_PATH`, and a *flatter* `DetectResult` (no
+`digest`/`edges` wrapper) to stdout. The workflow ran `node scripts/improvement-metrics-detect.ts |
+tee "$SAME_PATH"`, so `tee` overwrote the file with the stdout shape after the script's own write.
+The report step read `{digest: undefined, edges: undefined}` and the live path was dead on arrival on
+the first real dispatch. Every unit test passed, because every test crossed the detect → report
+boundary **in-memory**, passing pre-built `{digest, edges}` objects straight into the consumer — none
+ran the detect subprocess against a real file, and none parsed the workflow's `run:` string.
+
+The fix needed **two** complementary regression guards, and they are not interchangeable:
+
+1. A **real-file round-trip** integration test: write the digest with the real writer to a temp path,
+   read it back with the real reader, then drive the consumer end-to-end and assert it produces a
+   result rather than throwing on `undefined`. This fails against the tee-clobber code.
+2. A **workflow-contract** test: parse the workflow YAML and assert the detect step's `run` is exactly
+   `node scripts/improvement-metrics-detect.ts` with no `tee` over its own digest path. This fails the
+   moment someone re-adds the redirect, even if the script's file-write shape is unchanged.
+
+The generalization: the prevention rule extends from *function-mediated composition* to **any step
+boundary that production walks differently than the fixtures do** — a file, a shell pipeline, a
+subprocess. When one side writes a structured artifact to a sink *and* writes a different shape to
+stdout, a shell redirect can collapse them onto the same path; you need one test for the on-disk
+shape and one for the pipeline that produced it. Either alone leaves a single line of YAML one revert
+away from re-introducing the bug.
+
 ## Related
 
 - Source PRs (merge commits): `faa6e2569e110d7cf272bbc9e2d60679d4ba7230` (two-phase parser +
@@ -88,3 +118,10 @@ Two secondary notes worth carrying forward:
   live rehearsal first exposed)
 - `docs/solutions/best-practices/worker-authored-hash-bound-receipts-2026-07-06.md` — the same loop's
   completion half, verified with the same golden-path discipline
+- Fourth recurrence (file-mediated step boundary): PR #3672, `fix(improvement-metrics): stop tee from
+  clobbering the detect digest file` — regression guards in
+  `scripts/improvement-metrics-integration.test.ts` (real-file round-trip) and
+  `scripts/improvement-metrics-workflow.test.ts` (detect step does not tee over its own digest path)
+- `docs/solutions/best-practices/edge-keyed-confirmation-markers-2026-07-10.md` and
+  `docs/solutions/best-practices/immutable-history-keys-for-trend-recompute-2026-07-10.md` — sibling
+  learnings from the same PR


### PR DESCRIPTION
## What

Captures three learnings from the improvement-metrics loop (#3672) into `docs/solutions/`.

- **`edge-keyed-confirmation-markers-2026-07-10.md`** (new) — a one-bit confirmation gesture (a bare label) can't encode which of several candidate `(event → class)` edges a human approved. The confirmation artifact has to carry the edge identity: an edge-keyed checklist line with a stable hidden fingerprint, tick-state preserved across rewrites.
- **`immutable-history-keys-for-trend-recompute-2026-07-10.md`** (new) — a metric that recomputes a trend from history each run must key its timestamps on immutable history (git add-date), never editable frontmatter. An editable field is both mutable (one edit rewrites past trend numbers) and non-universal.
- **`test-the-integration-seam-not-the-endpoints-2026-07-06.md`** (updated) — appends a fourth recurrence of the untested-seam lesson: this time the seam was a file between two workflow steps, clobbered by `tee`. Generalizes the prevention rule from function-mediated composition to any step boundary production walks differently than the fixtures do.

## Why

The first two are novel — the existing corpus covers machine identifier recognition and mutable-signal classification, but not confirmation-gesture cardinality or the git-add-date rule specifically. The third is a high-overlap recurrence of an existing doc, so it's folded in rather than duplicated, keeping the anti-recurrence evidence under one roof.

## Verification

`pnpm lint` clean (covers markdown). Frontmatter validated against the solutions schema. Split from the feature PR (#3672) since these are documentation, not the implementation.
