### PR TITLE
fix: render improvement-metrics class keys with a readable separator

### DIFF
--- a/scripts/improvement-metrics-core.test.ts
+++ b/scripts/improvement-metrics-core.test.ts
@@ -7,6 +7,7 @@ import {
   buildLiveStateSummary,
   buildReportVersionMarker,
   classifySourceType,
+  formatClassKeyForDisplay,
   IMPROVEMENT_METRICS_REPORT_LABEL,
   IMPROVEMENT_METRICS_REPORT_LABEL_DESCRIPTOR,
   parseEdgeChecklistLine,
@@ -55,6 +56,14 @@ describe('buildClassKey', () => {
   it('fails fast on control characters or newlines in a field value', () => {
     expect(() => buildClassKey({module: 'foo\nbar', component: 'x', problem_type: 'y'})).toThrow()
     expect(() => buildClassKey({module: 'foo', component: 'x\u0000y', problem_type: 'z'})).toThrow()
+  })
+})
+
+describe('formatClassKeyForDisplay', () => {
+  it('replaces the internal separator with a readable delimiter', () => {
+    const key = buildClassKey({module: 'foo', component: 'bar', problem_type: 'baz'})
+    expect(formatClassKeyForDisplay(key)).toBe('foo › bar › baz')
+    expect(formatClassKeyForDisplay(key)).not.toContain('\u0001')
   })
 })
 

--- a/scripts/improvement-metrics-core.ts
+++ b/scripts/improvement-metrics-core.ts
@@ -74,6 +74,16 @@ export function buildClassKey(frontmatter: ClassKeyFrontmatter): string {
   return segments.join(CLASS_KEY_SEPARATOR)
 }
 
+/**
+ * Render a class key for human display, replacing the internal control-character
+ * separator with a readable delimiter. Display-only: never feed the result back
+ * into fingerprinting or parsing — the canonical key from `buildClassKey` is the
+ * identity, this is cosmetic.
+ */
+export function formatClassKeyForDisplay(classKey: string): string {
+  return classKey.split(CLASS_KEY_SEPARATOR).join(' › ')
+}
+
 // ---------------------------------------------------------------------------
 // Source-type classification (closed vocabulary)
 // ---------------------------------------------------------------------------

--- a/scripts/improvement-metrics-report.test.ts
+++ b/scripts/improvement-metrics-report.test.ts
@@ -77,7 +77,9 @@ describe('renderReportBody', () => {
     expect(body).toContain('oldest pending candidate: 5.5d')
     expect(body).toContain(edge.fingerprint)
     expect(body).toContain(edge.eventUrl)
-    expect(body).toContain(edge.classKey)
+    // Class key is rendered for display with a readable separator, not the raw control char.
+    expect(body).toContain('best_practice › scripts/foo.ts › unknown')
+    expect(body).not.toContain(edge.classKey)
   })
 
   it('round-trips the version marker', () => {

--- a/scripts/improvement-metrics-report.ts
+++ b/scripts/improvement-metrics-report.ts
@@ -27,6 +27,7 @@ import {isRecord} from './capture-learnings-privacy.ts'
 import {
   buildEdgeChecklistLine,
   buildReportVersionMarker,
+  formatClassKeyForDisplay,
   IMPROVEMENT_METRICS_REPORT_LABEL,
   IMPROVEMENT_METRICS_REPORT_LABEL_DESCRIPTOR,
   parseReportVersionMarker,
@@ -69,7 +70,7 @@ function renderCandidateChecklist(edges: readonly DetectEdge[]): string[] {
   const sorted = [...edges].sort((a, b) => a.fingerprint.localeCompare(b.fingerprint))
   return sorted.map(edge => {
     const checklistLine = buildEdgeChecklistLine({fingerprint: edge.fingerprint, checked: edge.ticked})
-    return `${checklistLine}\n  - class: \`${edge.classKey}\` — ${edge.eventUrl}`
+    return `${checklistLine}\n  - class: \`${formatClassKeyForDisplay(edge.classKey)}\` — ${edge.eventUrl}`
   })
 }
 


### PR DESCRIPTION
## What

The class key rendered in the report issue body carried its internal control-character separator raw, showing as `status-truth › tooling › best_practice` with a literal `^A` between segments on the human-facing checklist.

Adds a display-only `formatClassKeyForDisplay` that swaps the separator for a readable ` › ` at the render boundary. The canonical key still feeds `buildEdgeFingerprint` unchanged, so existing edge fingerprints on the live report issue stay stable — no confirmations are invalidated.

## Verification

`pnpm check-types && pnpm lint && pnpm test` (metric suites) — green, 87 tests. The public-output gate's mutation-proof test still passes; the display format doesn't touch the privacy boundary.
