### PR TITLE
fix: overlay whole components dir in wiki publish build

### DIFF
--- a/.github/workflows/publish-wiki.yaml
+++ b/.github/workflows/publish-wiki.yaml
@@ -61,9 +61,10 @@ jobs:
         run: |
           cp quartz-site/quartz.config.ts quartz-build/quartz.config.ts
           cp quartz-site/quartz.layout.ts quartz-build/quartz.layout.ts
-          cp quartz-site/components/Sources.tsx quartz-build/quartz/components/Sources.tsx
-          cp quartz-site/components/GitHubSource.tsx quartz-build/quartz/components/GitHubSource.tsx
-          cp quartz-site/components/index.ts quartz-build/quartz/components/index.ts
+          # Overlay the whole components dir (not an enumerated list) so a new
+          # component file or a component's local import (e.g. url-safety.ts)
+          # is always copied and can't drift out of this manifest.
+          cp quartz-site/components/. quartz-build/quartz/components/ -r
           cp quartz-site/styles/custom.scss quartz-build/quartz/styles/custom.scss
           cp quartz-site/static/. quartz-build/quartz/static/ -r
         shell: bash -Eeuo pipefail {0}


### PR DESCRIPTION
## What

Fixes the Publish Wiki build, which failed on the first run after the wiki site merged:

```
✘ [ERROR] Could not resolve "./url-safety"
    quartz/components/Sources.tsx:2:30
```

## Root cause

The build overlays this repo's `quartz-site/` config and components onto a pinned Quartz checkout. The overlay step copied an **enumerated list** of component files (`Sources.tsx`, `GitHubSource.tsx`, `index.ts`). When the source-link XSS guard landed, it added a new local module — `quartz-site/components/url-safety.ts` — that `Sources.tsx` imports. That file wasn't in the copy list, so the Quartz build tree was missing it and esbuild couldn't resolve the import.

## Fix

Copy the whole `components/` directory instead of naming files one by one, matching how `static/` is already overlaid. Any new component file or local import now comes along automatically and can't drift out of a hand-maintained manifest. Quartz's own stock components are untouched (the overlay only adds/overwrites our files).

## Verification

Reproduced the workflow's exact overlay logic locally against the pinned Quartz SHA (clone → whole-dir overlay → `npm ci` → build): `url-safety.ts` is present and the build succeeds — 43 input files → 321 emitted, no resolve error. `pnpm test` for the workflow-shape test green (19); actionlint clean.
