### PR TITLE
fix: fetch Git LFS assets in wiki publish build

### DIFF
--- a/.github/workflows/publish-wiki.yaml
+++ b/.github/workflows/publish-wiki.yaml
@@ -41,6 +41,10 @@ jobs:
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
+          # Brand assets (icon.png) are tracked via Git LFS per .gitattributes.
+          # Without this the checkout yields 132-byte LFS pointer files and the
+          # Quartz Favicon (sharp) emitter fails on "unsupported image format".
+          lfs: true
 
       # Quartz is not a dependency in package.json — it's built from a
       # pinned upstream commit SHA into a scratch directory, then overlaid

--- a/scripts/publish-wiki-workflow.test.ts
+++ b/scripts/publish-wiki-workflow.test.ts
@@ -119,6 +119,9 @@ describe('publish-wiki.yaml workflow contract', () => {
     expect(checkoutStep).toBeDefined()
     expect(String(checkoutStep?.with?.ref ?? '')).toContain('github.sha')
     expect(checkoutStep?.with?.['persist-credentials']).toBe(false)
+    // Brand assets (icon.png) are Git LFS tracked; without lfs the build gets
+    // pointer files and the Favicon (sharp) emitter fails. Guard against drift.
+    expect(checkoutStep?.with?.lfs).toBe(true)
   })
 
   it('build step uses the local Quartz binary, never a bare npx quartz', () => {


### PR DESCRIPTION
## What

Fixes the Publish Wiki build, which failed on the site build step:

```
ERROR  Failed to emit from plugin `Favicon`: Input file contains unsupported image format
```

(The trailing esbuild "goroutines are asleep - deadlock" is just the process dying mid-emit — a symptom, not the cause.)

## Root cause

The brand favicon `quartz-site/static/icon.png` is tracked via Git LFS (`.gitattributes` routes all `*.png` through LFS). The publish build's `actions/checkout` didn't enable LFS, so CI checked out the **132-byte LFS pointer file** instead of the 1.4 MB PNG. Quartz's `Favicon` emitter (sharp) then rejected the pointer text as an unsupported image format and aborted the build.

Local builds passed because a working tree has the LFS bytes already materialized — the pointer-only state only appears on a fresh CI checkout.

## Fix

Enable `lfs: true` on the build checkout so the real image bytes are fetched. Also assert `lfs: true` in the workflow-shape test so a future edit that drops it fails at PR time, not at deploy time.

## Verification

Reproduced CI's exact state locally (`GIT_LFS_SKIP_SMUDGE=1` clone → 132-byte pointer → favicon failure), then confirmed the fix: `git lfs pull` → real PNG → clone Quartz at the pinned SHA → overlay → `npm ci` → build succeeds (43 input files → 321 emitted, no ERROR). `pnpm test` for the workflow-shape test green (19); actionlint clean.
