### PR TITLE
fix: point wiki baseUrl at the fro.bot custom domain

### DIFF
--- a/quartz-site/quartz.config.ts
+++ b/quartz-site/quartz.config.ts
@@ -14,7 +14,7 @@ const config: QuartzConfig = {
     enablePopovers: true,
     analytics: null,
     locale: "en-US",
-    baseUrl: "fro-bot.github.io/.github",
+    baseUrl: "fro.bot/.github",
     ignorePatterns: ["log.md"],
     defaultDateType: "modified",
     theme: {


### PR DESCRIPTION
## What

Points the Quartz `baseUrl` at the live custom domain `fro.bot/.github` (was `fro-bot.github.io/.github`).

## Why

The wiki is served from the `fro.bot` custom domain, but `baseUrl` still named the `github.io` host. Quartz uses `baseUrl` to build **absolute** URLs for OG/social-card tags, canonical links, the sitemap, and RSS — so those all pointed at `fro-bot.github.io` instead of the domain the site actually serves from. Internal navigation uses relative links, so browsing worked; only the absolute-URL surfaces (link previews, SEO canonical, sitemap) were wrong.

Confirmed on the live site before the fix: `og:url` rendered as `https://fro-bot.github.io/.github/index`.

## Verification

Rebuilt locally with the workflow's exact overlay against the pinned Quartz SHA: the baked tags now read `https://fro.bot/.github/...` (verified `og:url`). Full gate green (`check-types`, `lint`).

## Follow-up (settings, not code)

`http://fro.bot/.github/` currently returns 200 rather than redirecting to HTTPS — enable **Enforce HTTPS** in the repo Pages settings once the custom-domain certificate finishes provisioning.
