### PR TITLE
fix: restore Quartz base stylesheet in wiki site

### DIFF
--- a/quartz-site/styles/custom.scss
+++ b/quartz-site/styles/custom.scss
@@ -1,3 +1,4 @@
+@use "./base.scss";
 @use "./variables.scss" as *;
 
 :root {


### PR DESCRIPTION
## What

Fixes the live wiki rendering unstyled — restores the Quartz base stylesheet import that the custom stylesheet had dropped.

## Root cause

Quartz's `quartz/styles/custom.scss` ships as a single line — `@use "./base.scss";` — which pulls in the entire base layout stylesheet (page grid, sidebars, article structure, all the scaffolding). Our overlay **overwrote** that file with brand tokens + `@use "./variables.scss"` but **omitted the `base.scss` import**. So the built `index.css` compiled our theme and custom-component rules but none of Quartz's base layout — colors and `.sources-section`/`.github-source` classes were present, but the structural CSS was gone. The page rendered as unstyled content.

This wasn't a deploy problem: the deployed CSS was byte-identical to a local build (18,738 bytes / 201 rules) — the build itself was producing the broken stylesheet. Vanilla Quartz produces 34,946 bytes / 315 rules, so the overlay was shipping ~16KB / 114 rules short.

## Fix

Add `@use "./base.scss";` ahead of the variables import in the overlay's `custom.scss`.

## Verification

Rebuilt with the workflow's exact overlay against the pinned Quartz SHA: `index.css` goes from **18,738 bytes / 201 rules → 37,249 bytes / 343 rules** — base layout grid restored (`#quartz-body` grid columns, sidebar layout, `.page`) **and** the brand theme retained (`--frobot-*` tokens, `.sources-section`, `.github-source`). Full gate green (`check-types`, `lint`).
