### PR TITLE
docs: capture Quartz v5 migration learnings

### DIFF
--- a/docs/solutions/best-practices/test-the-integration-seam-not-the-endpoints-2026-07-06.md
+++ b/docs/solutions/best-practices/test-the-integration-seam-not-the-endpoints-2026-07-06.md
@@ -111,6 +111,10 @@ stdout, a shell redirect can collapse them onto the same path; you need one test
 shape and one for the pipeline that produced it. Either alone leaves a single line of YAML one revert
 away from re-introducing the bug.
 
+## Sibling class: the seam was exercised, but in the wrong topology
+
+A near-miss variant worth distinguishing: in the wiki publish pipeline's gate-module extraction, the seam *was* verified — the script was run from a foreign working directory to prove its dependency resolved — but the verification ran on a dev machine whose repo-root `node_modules` masked the CI job's empty tree. The seam test existed; the *environment topology* didn't match. That class (false-positive verification) is documented separately in [Verify in the CI topology, not just locally](verify-in-the-ci-topology-not-just-locally-2026-07-11.md); this doc's class is the seam that was never walked at all. The prevention overlaps: a seam test only counts when it reproduces the production shape of the boundary — including which files, trees, and metadata exist on each side.
+
 ## Related
 
 - Source PRs (merge commits): `faa6e2569e110d7cf272bbc9e2d60679d4ba7230` (two-phase parser +

--- a/docs/solutions/best-practices/verify-in-the-ci-topology-not-just-locally-2026-07-11.md
+++ b/docs/solutions/best-practices/verify-in-the-ci-topology-not-just-locally-2026-07-11.md
@@ -1,0 +1,89 @@
+---
+title: Verify in the CI topology, not just locally
+date: 2026-07-11
+category: best-practices
+module: wiki-site
+problem_type: best_practice
+component: testing_framework
+severity: high
+applies_when:
+  - "a claim like 'the script resolves its dependency from a foreign cwd' is verified on a developer machine"
+  - "the runtime environment (CI job) populates different dependency trees than the dev environment"
+  - "module resolution, PATH lookup, or file discovery depends on which directories exist along a search path"
+  - "a workflow job deliberately skips the repo bootstrap and installs deps only in a scratch directory"
+related_components:
+  - development_workflow
+  - tooling
+tags:
+  - false-positive-verification
+  - ci-topology
+  - module-resolution
+  - node-modules
+  - createrequire
+  - environment-divergence
+---
+
+# Verify in the CI topology, not just locally
+
+## Context
+
+While extracting the wiki publish workflow's inline lockfile gates into a tested module (PR #3685), the module's CLI parsed YAML via a bare `await import('yaml')`. I "verified" the concern that mattered — does the import resolve when the script is invoked from a foreign working directory? — by running the script from a `/tmp` directory locally. It passed, and I shipped the claim "Node resolves from the script's own location, not cwd" in the PR description.
+
+The claim was true. The verification was still a false positive. Node resolves bare specifiers by walking **up from the script's location** — `scripts/` → repo-root `node_modules` — and on my machine that tree existed because `pnpm bootstrap` had run. In the publish workflow's build job it never exists: that job deliberately skips the repo setup action and runs `npm ci` only inside a scratch `quartz-build/` directory. The import would have thrown on every publish, killing the supply-chain gate at startup. Review caught it before merge.
+
+## Guidance
+
+A verification only proves a claim for environments that share the **topology** the claim depends on. For module resolution, that topology is "which dependency trees exist along the search path" — not "which directory I ran from."
+
+Before trusting a local check of environment-sensitive behavior:
+
+1. **Name the variable the behavior actually depends on.** "Foreign cwd" was the wrong variable; "which `node_modules` trees exist on the walk-up path" was the right one. A verification that varies the wrong variable proves nothing.
+2. **Enumerate what the CI job actually populates.** Read the workflow: which setup steps run, which directories get installs. A job that skips bootstrap has no repo-root `node_modules`, no matter what your machine has.
+3. **Reproduce the CI topology in a test, including the negative case.** The fix here added a fixture shaped like the CI job — the dependency present *only* in a sibling `quartz-build/node_modules` — plus the negative: no reachable dependency ⇒ the documented failure exit. The negative case is what makes the test meaningful; it fails if resolution quietly falls back to a tree that CI won't have. Fixtures under `/tmp` are outside the repo tree, so the walk-up can never reach repo-root `node_modules` — that isolation is what makes the fixture honest.
+4. **When the runtime should resolve from its working directory, say so in code.** `createRequire(join(cwd, 'some-anchor-file'))` roots resolution explicitly instead of inheriting whatever the script's location happens to see:
+
+```ts
+// Resolves 'yaml' from the WORKING directory's node_modules (the CI job's
+// quartz-build/), not from the script's own location (repo root — empty in CI).
+const requireFromCwd = createRequire(join(cwd, 'quartz.config.yaml'))
+const YAML = requireFromCwd('yaml') as typeof import('yaml')
+```
+
+## Why This Matters
+
+Environment-sensitive false positives are worse than missing tests: they produce *confidently wrong* claims that survive review unless someone re-derives the resolution semantics. Here the broken gate would have failed loud (fail-closed), but the failure mode was "every publish breaks at the coverage gate" — a supply-chain control regressing into an outage. The class generalizes beyond Node resolution: PATH lookups, config-file discovery, git metadata presence (shallow vs full clone), and LFS materialization all differ between a dev machine and a CI job, and all can validate a false claim locally.
+
+## When to Apply
+
+- Any claim of the form "X resolves / is found / is present" verified outside the environment that matters.
+- Workflow jobs that intentionally minimize their environment (least-privilege builds, scratch-directory installs) — minimization is exactly what makes dev-machine verification unrepresentative.
+- Reviewing a PR whose description says "verified locally" for behavior that depends on installed trees, clone depth, or filesystem case-sensitivity.
+
+## Examples
+
+Before — the false-positive verification:
+
+```bash
+# Passes on a dev machine: /tmp cwd, but the script's own walk-up path
+# still reaches the repo's populated node_modules. Proves nothing about CI.
+cd /tmp/cwd-test && node "$REPO/scripts/wiki-lockfile-gates.ts" coverage
+```
+
+After — the CI-shaped test:
+
+```ts
+// Fixture: <tmp>/quartz-build with its own node_modules/yaml — the ONLY
+// yaml on any reachable path. Passes only if resolution roots at cwd.
+const dir = await makeFixture({yamlIn: 'quartz-build/node_modules'})
+expect(runCli(['coverage'], dir).exitCode).toBe(0)
+
+// Negative: no yaml reachable from the fixture ⇒ documented failure exit.
+const bare = await makeFixture({yamlIn: null})
+expect(runCli(['coverage'], bare).exitCode).toBe(2)
+```
+
+## Related
+
+- [Test the integration seam, not the endpoints](test-the-integration-seam-not-the-endpoints-2026-07-06.md) — sibling class: there the seam was never exercised at all; here the verification *ran* but under the wrong topology.
+- [Immutable history keys for trend recompute](immutable-history-keys-for-trend-recompute-2026-07-10.md) — CI topology divergence via clone depth (shallow clones lack the git history a dev machine has).
+- [Node strip-only TypeScript constraints](../runtime-errors/node-strip-only-typescript-2026-04-18.md) — the "local guardrails lied about the production shape" family.

--- a/docs/solutions/workflow-issues/lockfiles-are-advisory-until-gated-2026-07-11.md
+++ b/docs/solutions/workflow-issues/lockfiles-are-advisory-until-gated-2026-07-11.md
@@ -1,0 +1,88 @@
+---
+title: Lockfiles are advisory until the build gates them
+date: 2026-07-11
+category: workflow-issues
+module: wiki-site
+problem_type: workflow_issue
+component: tooling
+severity: high
+applies_when:
+  - "a tool installs dependencies from a lockfile but the build path does not verify the lockfile was honored"
+  - "a dependency can be declared/enabled in config without a corresponding lock entry"
+  - "an installer logs failures but exits zero"
+  - "pinning to immutable commits is a security requirement, not a convenience"
+related_components:
+  - development_workflow
+tags:
+  - lockfile
+  - supply-chain
+  - fail-closed
+  - branch-tip-drift
+  - pin-integrity
+  - quartz
+---
+
+# Lockfiles are advisory until the build gates them
+
+## Context
+
+The wiki site's Quartz v5 migration expanded the build-time supply chain from one pinned repo to ~30 community plugins installed from git, pinned per-commit in a committed `quartz.lock.json`. The plan assumed "committed lockfile ⇒ pinned installs." A prerequisite spike disproved that empirically, three ways:
+
+1. The package's `prebuild` hook **ignores the lockfile entirely** — it installs from config. Only the explicit `quartz plugin install` CLI path reads the lock.
+2. Even on the lockfile path, a plugin that is **enabled in config but missing from the lockfile is silently fetched at branch tip** during `quartz build` — its `.git/HEAD` ends up as `ref: refs/heads/main`, not a pinned SHA. Reproduced live: removing one lock entry and rebuilding produced a floating install with exit 0.
+3. The installer can **log a failure and still exit zero**, so a green install step proves nothing.
+
+A committed lockfile with none of this gated is pin *theater*: it documents intent while the build quietly installs whatever the branch tip serves.
+
+## Guidance
+
+Treat a lockfile as untrusted input to the build until the pipeline proves it was honored. The enforcement shape that works is a **three-way fail-closed gate**:
+
+1. **Pre-install coverage gate** — parse config and lockfile; assert every enabled remote dependency has a lock entry (and no orphan entries, and no source shapes the pin can't cover). This closes the enabled-but-unlocked bypass *before* any network fetch.
+2. **Install via the lockfile-honoring path only** — the exact invocation matters; hooks and convenience wrappers may bypass the lock. Never use re-resolving variants (`--latest`, `--from-config`).
+3. **Post-install integrity gate** — assert each installed dependency's actual state matches its lock pin. For git-cloned deps that's `.git/HEAD` content equal to the lock commit; a `ref:` line (branch checkout) is drift and fails exactly like a wrong SHA. Postconditions are mandatory because the installer's exit code is not evidence.
+
+```text
+coverage gate (fail-closed) → lockfile install → HEAD == lock commit (fail-closed) → build
+```
+
+Each gate's branch logic (orphan detection, source-shape rejection, drift-as-ref detection) belongs in a tested module, not inline workflow scripting — the gate is a security control and gets the same mutation-proof test discipline as any other (a tampered lock must fail the test suite).
+
+## Why This Matters
+
+The bypass is silent and looks exactly like success: green install step, green build, deployed site — with one dependency floating at branch tip, where a compromised upstream commits directly into your next build. The whole point of pinning is defeated by the one dependency that escaped the lock. And because the failure mode is *absence of an error*, no amount of watching logs catches it; only an explicit postcondition comparison does.
+
+## When to Apply
+
+- Any build that installs dependencies from per-repo git pins (Quartz community plugins, vendored actions, git submodule alternatives).
+- Any ecosystem where the lockfile is opt-in at install time rather than enforced (verify, don't assume — the spike that proved Quartz's behavior took minutes and invalidated the plan's central assumption).
+- Security-sensitive pipelines where the pinned-commit claim appears in review or documentation — if the claim isn't machine-enforced, it drifts.
+
+## Examples
+
+The bypass, reproduced:
+
+```bash
+# Remove one plugin's lock entry, keep it enabled in config, rebuild:
+#   → plugin silently installed from branch tip
+#   → .git/HEAD contains "ref: refs/heads/main"  (not a SHA)
+#   → build exit 0
+```
+
+The post-install gate that catches it:
+
+```ts
+for (const [name, entry] of Object.entries(lock.plugins ?? {})) {
+  const head = readHead(name) // .quartz/plugins/<name>/.git/HEAD, trimmed
+  if (head === null) errors.push(`missing plugin directory for "${name}"`)
+  // A "ref: refs/heads/..." line never equals a commit SHA — branch drift
+  // fails identically to a mismatched pin.
+  else if (head !== entry.commit) errors.push(`"${name}" HEAD ${head} != lock ${entry.commit}`)
+}
+```
+
+## Related
+
+- [Credential mint-time permission scoping](../best-practices/credential-mint-time-permission-scoping-2026-06-22.md) — same class one layer over: an assumed protection that is real only if the enforcement boundary actually checks it.
+- [Verify the whole public perimeter](../security-issues/verify-whole-public-perimeter-2026-06-22.md) — enforcement-by-complete-verification: the gate must cover every surface, not the convenient subset.
+- [Verify in the CI topology, not just locally](../best-practices/verify-in-the-ci-topology-not-just-locally-2026-07-11.md) — the companion lesson from the same migration: the gate module itself shipped with a resolution bug that only the CI topology exposed.


### PR DESCRIPTION
## What

Captures two learnings from the wiki-site Quartz v5 migration into `docs/solutions/`.

- **Verify in the CI topology, not just locally** (`best-practices/`) — a dependency-resolution claim verified on a dev machine was false in the CI job that mattered: Node walks up from the script's location, and the repo-root `node_modules` that made the local check pass never exists in the publish build job (it installs only into a scratch dir). The lesson is naming the variable the behavior actually depends on (which trees exist on the search path, not which cwd you ran from), reproducing the CI topology in a fixture with a negative case, and rooting resolution explicitly (`createRequire` at the working directory).

- **Lockfiles are advisory until the build gates them** (`workflow-issues/`) — empirically proven during the migration spike: Quartz v5's plugin lockfile is not enforced by the build. An enabled-but-unlocked plugin installs silently from branch tip (`.git/HEAD` = `ref: refs/heads/main`), the `prebuild` hook ignores the lock entirely, and the installer can fail while exiting 0. Pin integrity requires the three-way fail-closed gate the publish workflow now runs: coverage → lockfile install → `.git/HEAD` postcondition.

Also adds a sibling-class note to the existing integration-seam doc distinguishing "the seam was never walked" from "the verification walked it in the wrong topology," with cross-links both ways.

## Verification

Overlap-checked against the existing corpus (both moderate-overlap → new docs with cross-links, per the documented threshold). `pnpm lint` clean. Docs-only.
